### PR TITLE
Update command templates to enable children and new groups

### DIFF
--- a/cmd/archer/env.go
+++ b/cmd/archer/env.go
@@ -1,0 +1,39 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package init provides the init command.
+package main
+
+import (
+	"github.com/aws/PRIVATE-amazon-ecs-archer/cmd/archer/template"
+	"github.com/spf13/cobra"
+)
+
+func buildEnvCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "env",
+		Short: "Environment commands",
+		Long: `Command for working with environments.
+
+An environment is a logical grouping of your applications.`,
+	}
+	cmd.AddCommand(buildEnvAddCmd())
+	cmd.SetUsageTemplate(template.Usage)
+	cmd.Annotations = map[string]string{
+		"group": "Develop 👷‍♀️",
+	}
+	return cmd
+}
+
+func buildEnvAddCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "add [name]",
+		Short: "Add a new environment to your project",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/cmd/archer/init.go
+++ b/cmd/archer/init.go
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Package init provides the init command.
-package init
+package main
 
 import (
 	"github.com/aws/PRIVATE-amazon-ecs-archer/cmd/archer/template"
@@ -10,13 +10,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Build returns the init command.
-func Build() *cobra.Command {
+func buildInitCmd() *cobra.Command {
 	opts := archerApp.InitOpts{}
 	app := archerApp.New()
 	cmd := &cobra.Command{
 		Use:   "init",
-		Short: "Create a new ECS application ✨",
+		Short: "Create a new ECS application",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			return app.Ask()
 		},
@@ -29,7 +28,7 @@ func Build() *cobra.Command {
 	cmd.Flags().StringVarP(&opts.ManifestTemplate, "template", "t", "", "Template of the application to bootstrap the infrastructure")
 	cmd.SetUsageTemplate(template.Usage)
 	cmd.Annotations = map[string]string{
-		"group": "Getting Started",
+		"group": "Getting Started ✨",
 	}
 	return cmd
 }

--- a/cmd/archer/main.go
+++ b/cmd/archer/main.go
@@ -7,7 +7,6 @@ package main
 import (
 	"os"
 
-	initCmd "github.com/aws/PRIVATE-amazon-ecs-archer/cmd/archer/init"
 	"github.com/aws/PRIVATE-amazon-ecs-archer/cmd/archer/template"
 	"github.com/spf13/cobra"
 )
@@ -33,7 +32,8 @@ func buildRootCmd() *cobra.Command {
 		SilenceUsage: true,
 	}
 
-	cmd.AddCommand(initCmd.Build())
+	cmd.AddCommand(buildInitCmd())
+	cmd.AddCommand(buildEnvCmd())
 	cmd.SetUsageTemplate(template.RootUsage)
 	return cmd
 }

--- a/cmd/archer/template/template.go
+++ b/cmd/archer/template/template.go
@@ -12,10 +12,10 @@ import (
 )
 
 // RootUsage is the text template for the root command.
-const RootUsage = `{{h1 "Commands"}}
-  {{h2 "Getting Started"}}{{range .Commands}}{{if isInGroup . "Getting Started"}}
-    {{rpad .Name .NamePadding}} {{.Short}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
-
+const RootUsage = `{{h1 "Commands"}}{{ $cmds := .Commands }}{{$groups := mkSlice "Getting Started ✨" "Develop 👷‍♀️" }}{{range $group := $groups }}
+  {{h2 $group}}{{range $cmd := $cmds}}{{if isInGroup $cmd $group}}
+    {{rpad $cmd.Name $cmd.NamePadding}} {{$cmd.Short}} 
+{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
 {{h1 "Flags"}}
 {{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
 
@@ -28,7 +28,10 @@ const RootUsage = `{{h1 "Commands"}}
 // Usage is the text template for a single command.
 const Usage = `{{h1 "Usage"}}{{if .Runnable}}
   {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
-  {{.CommandPath}} [command]{{end}}{{if .HasAvailableLocalFlags}}
+  {{.CommandPath}} [command]
+
+{{h1 "Available Commands"}}{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
 
 {{h1 "Flags"}}
 {{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
@@ -43,6 +46,7 @@ func init() {
 	cobra.AddTemplateFunc("isInGroup", isInGroup)
 	cobra.AddTemplateFunc("h1", h1)
 	cobra.AddTemplateFunc("h2", h2)
+	cobra.AddTemplateFunc("mkSlice", mkSlice)
 }
 
 func isInGroup(cmd *cobra.Command, group string) bool {
@@ -59,4 +63,8 @@ func h2(text string) string {
 	var s strings.Builder
 	color.New(color.Bold).Fprintf(&s, text)
 	return s.String()
+}
+
+func mkSlice(args ...interface{}) []interface{} {
+	return args
 }


### PR DESCRIPTION
The existing template doesn't allow you to easily add a new group to the root "archer" command.
Furthermore, the usage template wouldn't show child commands. This PR fixes the template.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
