### PR TITLE
 Add Store package for managing project config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,3 +10,7 @@ build:
 .PHONY: test
 test:
 	go test -v -race -cover ./pkg/...
+
+.PHONY: integ-test
+integ-test:
+	go test -v -run Integration -tags integration ./pkg/...

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,7 @@ github.com/aws/aws-sdk-go v1.23.8 h1:G/azJoBN0pnhB3B+0eeC4yyVFYIIad6bbzg6wwtImqk
 github.com/aws/aws-sdk-go v1.23.8/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.23.9 h1:UYWPGrBMlrW5VCYeWMbog1T/kqZzkvvheUDQaaUAhqI=
 github.com/aws/aws-sdk-go v1.23.9/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.23.12 h1:2UnxgNO6Y5J1OrkXS8XNp0UatDxD1bWHiDT62RDPggI=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=

--- a/pkg/archer/store/env.go
+++ b/pkg/archer/store/env.go
@@ -1,0 +1,27 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package store
+
+import "encoding/json"
+
+// Environment represents the configuration of a particular Environment in a Project. It includes
+// the location of the Environment (account and region), the name of the environment, as well as the project
+// the environment belongs to.
+type Environment struct {
+	Project   string `json:"project"`   // Name of the project this environment belongs to.
+	Name      string `json:"name"`      // Name of the environment, must be unique within a project.
+	Region    string `json:"region"`    // Name of the region this environment is stored in.
+	AccountID string `json:"accountID"` // Account ID of the account this environment is stored in.
+	Prod      bool   `json:"prod"`      // Whether or not this environment is a production environment.
+}
+
+// Marshal serializes the environment into a JSON document and returns it.
+// If an error occurred during the serialization, the empty string and the error is returned.
+func (e *Environment) Marshal() (string, error) {
+	b, err := json.Marshal(e)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}

--- a/pkg/archer/store/env_test.go
+++ b/pkg/archer/store/env_test.go
@@ -1,0 +1,26 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package store
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnvironment_Marshal(t *testing.T) {
+	// GIVEN
+	environ := &Environment{
+		Name:      "test",
+		Region:    "us-west-2",
+		AccountID: "11111111111",
+		Project:   "chicken",
+		Prod:      false,
+	}
+	want := `{"project":"chicken","name":"test","region":"us-west-2","accountID":"11111111111","prod":false}`
+
+	// WHEN
+	got, _ := environ.Marshal()
+	require.Equal(t, want, got)
+}

--- a/pkg/archer/store/errors.go
+++ b/pkg/archer/store/errors.go
@@ -1,0 +1,50 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package store
+
+import "fmt"
+
+// ErrNoSuchProject means a project couldn't be found within a specific account and region.
+type ErrNoSuchProject struct {
+	ProjectName string
+	AccountID   string
+	Region      string
+}
+
+func (e *ErrNoSuchProject) Error() string {
+	return fmt.Sprintf("couldn't find a project named %s in account %s and region %s",
+		e.ProjectName, e.AccountID, e.Region)
+}
+
+// ErrProjectAlreadyExists means a project already exists and can't be created again.
+type ErrProjectAlreadyExists struct {
+	ProjectName string
+}
+
+func (e *ErrProjectAlreadyExists) Error() string {
+	return fmt.Sprintf("a project named %s already exists",
+		e.ProjectName)
+}
+
+// ErrEnvironmentAlreadyExists means that an environment is already created in a specific project.
+type ErrEnvironmentAlreadyExists struct {
+	EnvironmentName string
+	ProjectName     string
+}
+
+func (e *ErrEnvironmentAlreadyExists) Error() string {
+	return fmt.Sprintf("environment %s already exists in project %s",
+		e.EnvironmentName, e.ProjectName)
+}
+
+// ErrNoSuchEnvironment means a specific environment couldn't be found in a specific project.
+type ErrNoSuchEnvironment struct {
+	ProjectName     string
+	EnvironmentName string
+}
+
+func (e *ErrNoSuchEnvironment) Error() string {
+	return fmt.Sprintf("couldn't find environment %s in the project %s",
+		e.EnvironmentName, e.ProjectName)
+}

--- a/pkg/archer/store/errors_test.go
+++ b/pkg/archer/store/errors_test.go
@@ -1,0 +1,30 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package store
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestErrNoSuchProject(t *testing.T) {
+	err := &ErrNoSuchProject{ProjectName: "chicken", AccountID: "12345", Region: "us-west-2"}
+	require.EqualError(t, err, "couldn't find a project named chicken in account 12345 and region us-west-2")
+}
+
+func TestErrProjectAlreadyExists(t *testing.T) {
+	err := &ErrProjectAlreadyExists{ProjectName: "chicken"}
+	require.EqualError(t, err, "a project named chicken already exists")
+}
+
+func TestErrEnvironmentAlreadyExists(t *testing.T) {
+	err := &ErrEnvironmentAlreadyExists{EnvironmentName: "test", ProjectName: "chicken"}
+	require.EqualError(t, err, "environment test already exists in project chicken")
+}
+
+func TestErrNoSuchEnvironment(t *testing.T) {
+	err := &ErrNoSuchEnvironment{EnvironmentName: "test", ProjectName: "chicken"}
+	require.EqualError(t, err, "couldn't find environment test in the project chicken")
+}

--- a/pkg/archer/store/project.go
+++ b/pkg/archer/store/project.go
@@ -1,0 +1,22 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package store
+
+import "encoding/json"
+
+// Project is a named collection of environments.
+type Project struct {
+	Name    string `json:"name"`    // Name of a project. Must be unique amongst other projects in the same account
+	Version string `json:"version"` // The version of the project layout.
+}
+
+// Marshal serializes the project into a JSON document and returns it.
+// If an error occurred during the serialization, the empty string and the error is returned.
+func (e *Project) Marshal() (string, error) {
+	b, err := json.Marshal(e)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}

--- a/pkg/archer/store/project_test.go
+++ b/pkg/archer/store/project_test.go
@@ -1,0 +1,24 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package store
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestProject_Marshal(t *testing.T) {
+	// GIVEN
+	project := &Project{
+		Name:    "chicken",
+		Version: "1.0",
+	}
+
+	want := `{"name":"chicken","version":"1.0"}`
+
+	// WHEN
+	got, _ := project.Marshal()
+	require.Equal(t, want, got)
+}

--- a/pkg/archer/store/ssm.go
+++ b/pkg/archer/store/ssm.go
@@ -1,0 +1,246 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Package store implements CRUD operations for Package, Environment and
+Pipeline configuration. This configuration contains the archer projects
+a customer has, and the environments and pipelines associated with each
+project.
+*/
+package store
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ssm"
+	"github.com/aws/aws-sdk-go/service/ssm/ssmiface"
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/aws/aws-sdk-go/service/sts/stsiface"
+)
+
+// Parameter name formats for resources in a project. Projects are laid out in SSM
+// based on path - each parameter's key has a certain format, and you can have
+// heirarchies based on that format. Projects are at the root of the heirarchy.
+// Searching SSM for all parameters with the `rootProjectPath` key will give you
+// all the project keys, for example.
+const (
+	rootProjectPath  = "/archer/"
+	fmtProjectPath   = "/archer/%s"
+	rootEnvParamPath = "/archer/%s/environments/"
+	fmtEnvParamPath  = "/archer/%s/environments/%s" // path for an environment in a project
+)
+
+// SSM store is in charge of fetching and creating Projects, Environment and Pipeline
+// configuration in SSM.
+type SSM struct {
+	systemManager ssmiface.SSMAPI
+	tokenService  stsiface.STSAPI
+	sessionRegion string
+}
+
+// NewSSM returns a Store allowing you to query or create Projects or Environments.
+func NewSSM() (*SSM, error) {
+	sess, err := session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &SSM{
+		systemManager: ssm.New(sess),
+		tokenService:  sts.New(sess),
+		sessionRegion: *sess.Config.Region,
+	}, nil
+}
+
+// CreateProject instanciates a new project, validates its uniqueness and stores it in SSM.
+func (store *SSM) CreateProject(project *Project) error {
+	projectPath := fmt.Sprintf(fmtProjectPath, project.Name)
+
+	data, err := project.Marshal()
+	if err != nil {
+		return err
+	}
+
+	paramOutput, err := store.systemManager.PutParameter(&ssm.PutParameterInput{
+		Name:        aws.String(projectPath),
+		Description: aws.String("An ECS-CLI Project"),
+		Type:        aws.String(ssm.ParameterTypeString),
+		Value:       aws.String(data),
+	})
+
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			case ssm.ErrCodeParameterAlreadyExists:
+				return &ErrProjectAlreadyExists{
+					ProjectName: project.Name,
+				}
+			}
+		}
+		return err
+	}
+
+	log.Printf("Created Project with version %v", *paramOutput.Version)
+	return nil
+
+}
+
+// GetProject fetches a project by name. If it can't be found, return a ErrNoSuchProject
+func (store *SSM) GetProject(projectName string) (*Project, error) {
+	projectPath := fmt.Sprintf(fmtProjectPath, projectName)
+	projectParam, err := store.systemManager.GetParameter(&ssm.GetParameterInput{
+		Name: aws.String(projectPath),
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	if projectParam.Parameter.Value == nil {
+		account, region := store.getCallerAccountAndRegion()
+		return nil, &ErrNoSuchProject{
+			ProjectName: projectName,
+			AccountID:   account,
+			Region:      region,
+		}
+	}
+	var project Project
+	err = json.Unmarshal([]byte(*projectParam.Parameter.Value), &project)
+	if err != nil {
+		return nil, err
+	}
+	return &project, nil
+}
+
+// ListProjects returns the list of existing projects in the customer's account and region.
+func (store *SSM) ListProjects() ([]*Project, error) {
+	params, err := store.systemManager.GetParametersByPath(&ssm.GetParametersByPathInput{
+		Path:      aws.String(rootProjectPath),
+		Recursive: aws.Bool(false),
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	var projects []*Project
+	for _, param := range params.Parameters {
+		var project Project
+		err := json.Unmarshal([]byte(*param.Value), &project)
+
+		if err != nil {
+			return nil, err
+		}
+		projects = append(projects, &project)
+	}
+
+	return projects, nil
+}
+
+// CreateEnvironment instanciates a new environment within an existing project. Returns ErrEnvironmentAlreadyExists
+// if the environment already exists in the project.
+func (store *SSM) CreateEnvironment(environment *Environment) error {
+	_, err := store.GetProject(environment.Project)
+	if err != nil {
+		return err
+	}
+	environmentPath := fmt.Sprintf(fmtEnvParamPath, environment.Project, environment.Name)
+	data, err := environment.Marshal()
+	if err != nil {
+		return err
+	}
+
+	paramOutput, err := store.systemManager.PutParameter(&ssm.PutParameterInput{
+		Name:        aws.String(environmentPath),
+		Description: aws.String(fmt.Sprintf("The %s deployment stage", environment.Name)),
+		Type:        aws.String(ssm.ParameterTypeString),
+		Value:       aws.String(data),
+	})
+
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			case ssm.ErrCodeParameterAlreadyExists:
+				return &ErrEnvironmentAlreadyExists{
+					EnvironmentName: environment.Name,
+					ProjectName:     environment.Project}
+			}
+		}
+		return err
+	}
+
+	log.Printf("Created Environment with version %v", *paramOutput.Version)
+	return nil
+
+}
+
+// GetEnvironment gets an environment belonging to a particular project by name. If no environment is found
+// it returns ErrNoSuchEnvironment.
+func (store *SSM) GetEnvironment(projectName string, environmentName string) (*Environment, error) {
+	environmentPath := fmt.Sprintf(fmtEnvParamPath, projectName, environmentName)
+	environmentParam, err := store.systemManager.GetParameter(&ssm.GetParameterInput{
+		Name: aws.String(environmentPath),
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	if environmentParam.Parameter.Value == nil {
+		return nil, &ErrNoSuchEnvironment{
+			ProjectName:     projectName,
+			EnvironmentName: environmentName,
+		}
+	}
+
+	var env Environment
+	err = json.Unmarshal([]byte(*environmentParam.Parameter.Value), &env)
+	return &env, err
+}
+
+// ListEnvironments returns all environments belonging to a particular project.
+func (store *SSM) ListEnvironments(projectName string) ([]*Environment, error) {
+	environmentsPath := fmt.Sprintf(rootEnvParamPath, projectName)
+	params, err := store.systemManager.GetParametersByPath(&ssm.GetParametersByPathInput{
+		Path:      aws.String(environmentsPath),
+		Recursive: aws.Bool(false),
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	var environments []*Environment
+	for _, param := range params.Parameters {
+		var env Environment
+		err := json.Unmarshal([]byte(*param.Value), &env)
+
+		if err != nil {
+			return nil, err
+		}
+
+		environments = append(environments, &env)
+	}
+
+	return environments, nil
+}
+
+// Retrieves the caller's Account ID with a best effort. If it fails to fetch the Account ID,
+// this returns "unknown".
+func (store *SSM) getCallerAccountAndRegion() (string, string) {
+	identity, err := store.tokenService.GetCallerIdentity(&sts.GetCallerIdentityInput{})
+	region := store.sessionRegion
+	if err != nil {
+		log.Printf("Failed to get caller's Account ID %v", err)
+		return "unknown", region
+	}
+	return *identity.Account, region
+}

--- a/pkg/archer/store/ssm_integration_test.go
+++ b/pkg/archer/store/ssm_integration_test.go
@@ -1,0 +1,102 @@
+// +build integration
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package store_test
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/aws/PRIVATE-amazon-ecs-archer/pkg/archer/store"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+func Test_Project_Integration(t *testing.T) {
+	s, _ := store.NewSSM()
+	projectToCreate := store.Project{Name: randStringBytes(10), Version: "1.0"}
+	t.Run("Create, Get and List Projects", func(t *testing.T) {
+		// Create our first project
+		err := s.CreateProject(&projectToCreate)
+		require.NoError(t, err)
+
+		// Can't overwrite an existing project
+		err = s.CreateProject(&projectToCreate)
+		require.EqualError(t, &store.ErrProjectAlreadyExists{ProjectName: projectToCreate.Name}, err.Error())
+
+		// Fetch the project back from SSM
+		project, err := s.GetProject(projectToCreate.Name)
+		require.NoError(t, err)
+		require.Equal(t, projectToCreate, *project)
+
+		// List returns a non-empty list of projects
+		projects, err := s.ListProjects()
+		require.NoError(t, err)
+		require.NotEmpty(t, projects)
+	})
+}
+
+func Test_Environment_Integration(t *testing.T) {
+	s, _ := store.NewSSM()
+	projectToCreate := store.Project{Name: randStringBytes(10), Version: "1.0"}
+	testEnvironment := store.Environment{Name: "test", Project: projectToCreate.Name, Region: "us-west-2", AccountID: " 1234"}
+	prodEnvironment := store.Environment{Name: "prod", Project: projectToCreate.Name, Region: "us-west-2", AccountID: " 1234"}
+
+	t.Run("Create, Get and List Projects", func(t *testing.T) {
+		// Create our first project
+		err := s.CreateProject(&projectToCreate)
+		require.NoError(t, err)
+
+		// Make sure there are no envs with our new project
+		envs, err := s.ListEnvironments(projectToCreate.Name)
+		require.NoError(t, err)
+		require.Empty(t, envs)
+
+		// Add our environments
+		err = s.CreateEnvironment(&testEnvironment)
+		require.NoError(t, err)
+
+		err = s.CreateEnvironment(&prodEnvironment)
+		require.NoError(t, err)
+
+		// Make sure we can't add a duplicate environment
+		err = s.CreateEnvironment(&prodEnvironment)
+		require.EqualError(t, &store.ErrEnvironmentAlreadyExists{ProjectName: projectToCreate.Name, EnvironmentName: prodEnvironment.Name}, err.Error())
+
+		// Wait for consistency to kick in (ssm path commands are eventually consistent)
+		time.Sleep(5 * time.Second)
+
+		// Make sure all the environments are under our project
+		envs, err = s.ListEnvironments(projectToCreate.Name)
+		require.NoError(t, err)
+		var environments []store.Environment
+		for _, e := range envs {
+			environments = append(environments, *e)
+		}
+		require.ElementsMatch(t, environments, []store.Environment{testEnvironment, prodEnvironment})
+
+		// Fetch our saved environments, one by one
+		env, err := s.GetEnvironment(projectToCreate.Name, testEnvironment.Name)
+		require.NoError(t, err)
+		require.Equal(t, testEnvironment, *env)
+
+		env, err = s.GetEnvironment(projectToCreate.Name, prodEnvironment.Name)
+		require.NoError(t, err)
+		require.Equal(t, prodEnvironment, *env)
+	})
+}
+
+const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+func randStringBytes(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letterBytes[rand.Intn(len(letterBytes))]
+	}
+	return string(b)
+}

--- a/pkg/archer/store/ssm_test.go
+++ b/pkg/archer/store/ssm_test.go
@@ -1,0 +1,565 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package store
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/ssm"
+	"github.com/aws/aws-sdk-go/service/ssm/ssmiface"
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/aws/aws-sdk-go/service/sts/stsiface"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStore_ListProjects(t *testing.T) {
+
+	testProject := Project{Name: "chicken", Version: "1.0"}
+	testProjectString, _ := testProject.Marshal()
+
+	cowProject := Project{Name: "cow", Version: "1.0"}
+	cowProjectString, _ := cowProject.Marshal()
+
+	testCases := map[string]struct {
+		mockGetParametersByPath func(t *testing.T, param *ssm.GetParametersByPathInput) (*ssm.GetParametersByPathOutput, error)
+
+		wantedProjectNames []string
+		wantedErr          error
+	}{
+		"with multiple existing projects": {
+			mockGetParametersByPath: func(t *testing.T, param *ssm.GetParametersByPathInput) (output *ssm.GetParametersByPathOutput, e error) {
+				require.Equal(t, rootProjectPath, *param.Path)
+				return &ssm.GetParametersByPathOutput{
+					Parameters: []*ssm.Parameter{
+						{
+							Name:  aws.String("/archer/chicken"),
+							Value: aws.String(testProjectString),
+						},
+						{
+							Name:  aws.String("/archer/cow"),
+							Value: aws.String(cowProjectString),
+						},
+					},
+				}, nil
+			},
+
+			wantedProjectNames: []string{"chicken", "cow"},
+			wantedErr:          nil,
+		},
+		"with malfored json": {
+			mockGetParametersByPath: func(t *testing.T, param *ssm.GetParametersByPathInput) (output *ssm.GetParametersByPathOutput, e error) {
+				require.Equal(t, rootProjectPath, *param.Path)
+				return &ssm.GetParametersByPathOutput{
+					Parameters: []*ssm.Parameter{
+						{
+							Name:  aws.String("/archer/chicken"),
+							Value: aws.String("oops"),
+						},
+					},
+				}, nil
+			},
+			wantedErr: fmt.Errorf("invalid character 'o' looking for beginning of value"),
+		},
+		"with SSM error": {
+			mockGetParametersByPath: func(t *testing.T, param *ssm.GetParametersByPathInput) (output *ssm.GetParametersByPathOutput, e error) {
+				require.Equal(t, rootProjectPath, *param.Path)
+				return nil, fmt.Errorf("broken")
+			},
+
+			wantedProjectNames: nil,
+			wantedErr:          fmt.Errorf("broken"),
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// GIVEN
+			store := &SSM{
+				systemManager: &mockSSM{
+					t:                       t,
+					mockGetParametersByPath: tc.mockGetParametersByPath,
+				},
+			}
+
+			// WHEN
+			projects, err := store.ListProjects()
+
+			// THEN
+			if tc.wantedErr != nil {
+				require.EqualError(t, err, tc.wantedErr.Error())
+			} else {
+				var names []string
+				for _, p := range projects {
+					names = append(names, p.Name)
+				}
+				require.Equal(t, tc.wantedProjectNames, names)
+
+			}
+		})
+	}
+}
+
+func TestStore_GetProject(t *testing.T) {
+
+	testProject := Project{Name: "chicken", Version: "1.0"}
+	testProjectString, _ := testProject.Marshal()
+	testProjectPath := fmt.Sprintf(fmtProjectPath, testProject.Name)
+
+	testCases := map[string]struct {
+		mockGetParameter      func(t *testing.T, param *ssm.GetParameterInput) (*ssm.GetParameterOutput, error)
+		mockGetCallerIdentity func(t *testing.T, param *sts.GetCallerIdentityInput) (*sts.GetCallerIdentityOutput, error)
+		wantedProject         Project
+		wantedErr             error
+	}{
+		"with existing project": {
+			mockGetParameter: func(t *testing.T, param *ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {
+				require.Equal(t, testProjectPath, *param.Name)
+				return &ssm.GetParameterOutput{
+					Parameter: &ssm.Parameter{
+						Name:  aws.String(testProjectPath),
+						Value: aws.String(testProjectString),
+					},
+				}, nil
+			},
+
+			wantedProject: testProject,
+			wantedErr:     nil,
+		},
+		"with no existing project": {
+			mockGetParameter: func(t *testing.T, param *ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {
+				require.Equal(t, testProjectPath, *param.Name)
+				return &ssm.GetParameterOutput{
+					Parameter: &ssm.Parameter{},
+				}, nil
+			},
+			mockGetCallerIdentity: func(t *testing.T, input *sts.GetCallerIdentityInput) (*sts.GetCallerIdentityOutput, error) {
+				return &sts.GetCallerIdentityOutput{
+					Account: aws.String("12345"),
+				}, nil
+			},
+			wantedErr: &ErrNoSuchProject{
+				ProjectName: "chicken",
+				AccountID:   "12345",
+				Region:      "us-west-2",
+			},
+		},
+		"with no existing project and failed STS call": {
+			mockGetParameter: func(t *testing.T, param *ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {
+				require.Equal(t, testProjectPath, *param.Name)
+				return &ssm.GetParameterOutput{
+					Parameter: &ssm.Parameter{},
+				}, nil
+			},
+			mockGetCallerIdentity: func(t *testing.T, input *sts.GetCallerIdentityInput) (*sts.GetCallerIdentityOutput, error) {
+				return nil, fmt.Errorf("Error")
+			},
+			wantedErr: &ErrNoSuchProject{
+				ProjectName: "chicken",
+				AccountID:   "unknown",
+				Region:      "us-west-2",
+			},
+		},
+		"with malfored json": {
+			mockGetParameter: func(t *testing.T, param *ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {
+				require.Equal(t, testProjectPath, *param.Name)
+				return &ssm.GetParameterOutput{
+					Parameter: &ssm.Parameter{
+						Name:  aws.String(testProjectPath),
+						Value: aws.String("oops"),
+					},
+				}, nil
+			},
+
+			wantedErr: fmt.Errorf("invalid character 'o' looking for beginning of value"),
+		},
+		"with SSM error": {
+			mockGetParameter: func(t *testing.T, param *ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {
+				require.Equal(t, testProjectPath, *param.Name)
+				return nil, fmt.Errorf("broken")
+			},
+			wantedErr: fmt.Errorf("broken"),
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// GIVEN
+			store := &SSM{
+				systemManager: &mockSSM{
+					t:                t,
+					mockGetParameter: tc.mockGetParameter,
+				},
+				tokenService: &mockSTS{
+					t:                     t,
+					mockGetCallerIdentity: tc.mockGetCallerIdentity,
+				},
+				sessionRegion: "us-west-2",
+			}
+
+			// WHEN
+			project, err := store.GetProject("chicken")
+
+			// THEN
+			if tc.wantedErr != nil {
+				require.EqualError(t, err, tc.wantedErr.Error())
+			} else {
+				require.Equal(t, tc.wantedProject, *project)
+			}
+		})
+	}
+}
+
+func TestStore_CreateProject(t *testing.T) {
+	testProject := Project{Name: "chicken", Version: "1.0"}
+	testProjectString, _ := testProject.Marshal()
+	testProjectPath := fmt.Sprintf(fmtProjectPath, testProject.Name)
+
+	testCases := map[string]struct {
+		mockPutParameter func(t *testing.T, param *ssm.PutParameterInput) (*ssm.PutParameterOutput, error)
+		wantedErr        error
+	}{
+		"with no existing project": {
+			mockPutParameter: func(t *testing.T, param *ssm.PutParameterInput) (*ssm.PutParameterOutput, error) {
+				require.Equal(t, testProjectPath, *param.Name)
+				require.Equal(t, testProjectString, *param.Value)
+
+				return &ssm.PutParameterOutput{
+					Version: aws.Int64(1),
+				}, nil
+			},
+			wantedErr: nil,
+		},
+		"with existing project": {
+			mockPutParameter: func(t *testing.T, param *ssm.PutParameterInput) (*ssm.PutParameterOutput, error) {
+				require.Equal(t, testProjectPath, *param.Name)
+				return nil, awserr.New(ssm.ErrCodeParameterAlreadyExists, "Already exists", fmt.Errorf("Already Exists"))
+			},
+			wantedErr: &ErrProjectAlreadyExists{
+				ProjectName: "chicken",
+			},
+		},
+		"with SSM error": {
+			mockPutParameter: func(t *testing.T, param *ssm.PutParameterInput) (*ssm.PutParameterOutput, error) {
+				require.Equal(t, testProjectPath, *param.Name)
+				return nil, fmt.Errorf("broken")
+			},
+			wantedErr: fmt.Errorf("broken"),
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// GIVEN
+			store := &SSM{
+				systemManager: &mockSSM{
+					t:                t,
+					mockPutParameter: tc.mockPutParameter,
+				},
+			}
+
+			// WHEN
+			err := store.CreateProject(&Project{Name: "chicken", Version: "1.0"})
+
+			// THEN
+			if tc.wantedErr != nil {
+				require.EqualError(t, err, tc.wantedErr.Error())
+			}
+		})
+	}
+}
+
+func TestStore_ListEnvironments(t *testing.T) {
+
+	testEnvironment := Environment{Name: "test", AccountID: "12345", Project: "chicken", Region: "us-west-2s"}
+	testEnvironmentString, _ := testEnvironment.Marshal()
+	testEnvironmentPath := fmt.Sprintf(fmtEnvParamPath, testEnvironment.Project, testEnvironment.Name)
+
+	prodEnvironment := Environment{Name: "prod", AccountID: "12345", Project: "chicken", Region: "us-west-2s"}
+	prodEnvironmentString, _ := prodEnvironment.Marshal()
+	prodEnvironmentPath := fmt.Sprintf(fmtEnvParamPath, prodEnvironment.Project, prodEnvironment.Name)
+
+	environmentPath := fmt.Sprintf(rootEnvParamPath, testEnvironment.Project)
+
+	testCases := map[string]struct {
+		mockGetParametersByPath func(t *testing.T, param *ssm.GetParametersByPathInput) (*ssm.GetParametersByPathOutput, error)
+
+		wantedEnvironments []Environment
+		wantedErr          error
+	}{
+		"with multiple existing environments": {
+			mockGetParametersByPath: func(t *testing.T, param *ssm.GetParametersByPathInput) (output *ssm.GetParametersByPathOutput, e error) {
+				require.Equal(t, environmentPath, *param.Path)
+				return &ssm.GetParametersByPathOutput{
+					Parameters: []*ssm.Parameter{
+						{
+							Name:  aws.String(testEnvironmentPath),
+							Value: aws.String(testEnvironmentString),
+						},
+						{
+							Name:  aws.String(prodEnvironmentPath),
+							Value: aws.String(prodEnvironmentString),
+						},
+					},
+				}, nil
+			},
+
+			wantedEnvironments: []Environment{testEnvironment, prodEnvironment},
+			wantedErr:          nil,
+		},
+		"with malfored json": {
+			mockGetParametersByPath: func(t *testing.T, param *ssm.GetParametersByPathInput) (output *ssm.GetParametersByPathOutput, e error) {
+				require.Equal(t, environmentPath, *param.Path)
+				return &ssm.GetParametersByPathOutput{
+					Parameters: []*ssm.Parameter{
+						{
+							Name:  aws.String(testEnvironmentPath),
+							Value: aws.String("oops"),
+						},
+					},
+				}, nil
+			},
+			wantedErr: fmt.Errorf("invalid character 'o' looking for beginning of value"),
+		},
+		"with SSM error": {
+			mockGetParametersByPath: func(t *testing.T, param *ssm.GetParametersByPathInput) (output *ssm.GetParametersByPathOutput, e error) {
+				require.Equal(t, environmentPath, *param.Path)
+				return nil, fmt.Errorf("broken")
+			},
+			wantedErr: fmt.Errorf("broken"),
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// GIVEN
+			store := &SSM{
+				systemManager: &mockSSM{
+					t:                       t,
+					mockGetParametersByPath: tc.mockGetParametersByPath,
+				},
+			}
+
+			// WHEN
+			envPointers, err := store.ListEnvironments("chicken")
+			// THEN
+			if tc.wantedErr != nil {
+				require.EqualError(t, err, tc.wantedErr.Error())
+			} else {
+				var environments []Environment
+				for _, e := range envPointers {
+					environments = append(environments, *e)
+				}
+				require.Equal(t, tc.wantedEnvironments, environments)
+
+			}
+		})
+	}
+}
+func TestStore_GetEnvironment(t *testing.T) {
+	testEnvironment := Environment{Name: "test", AccountID: "12345", Project: "chicken", Region: "us-west-2s"}
+	testEnvironmentString, _ := testEnvironment.Marshal()
+	testEnvironmentPath := fmt.Sprintf(fmtEnvParamPath, testEnvironment.Project, testEnvironment.Name)
+
+	testCases := map[string]struct {
+		mockGetParameter  func(t *testing.T, param *ssm.GetParameterInput) (*ssm.GetParameterOutput, error)
+		wantedEnvironment Environment
+		wantedErr         error
+	}{
+		"with existing environment": {
+			mockGetParameter: func(t *testing.T, param *ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {
+				require.Equal(t, testEnvironmentPath, *param.Name)
+				return &ssm.GetParameterOutput{
+					Parameter: &ssm.Parameter{
+						Name:  aws.String(testEnvironmentPath),
+						Value: aws.String(testEnvironmentString),
+					},
+				}, nil
+			},
+			wantedEnvironment: testEnvironment,
+			wantedErr:         nil,
+		},
+		"with no existing environment": {
+			mockGetParameter: func(t *testing.T, param *ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {
+				require.Equal(t, testEnvironmentPath, *param.Name)
+				return &ssm.GetParameterOutput{
+					Parameter: &ssm.Parameter{},
+				}, nil
+			},
+			wantedErr: &ErrNoSuchEnvironment{
+				ProjectName:     testEnvironment.Project,
+				EnvironmentName: testEnvironment.Name,
+			},
+		},
+		"with malfored json": {
+			mockGetParameter: func(t *testing.T, param *ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {
+				require.Equal(t, testEnvironmentPath, *param.Name)
+				return &ssm.GetParameterOutput{
+					Parameter: &ssm.Parameter{
+						Name:  aws.String(testEnvironmentPath),
+						Value: aws.String("oops"),
+					},
+				}, nil
+			},
+			wantedErr: fmt.Errorf("invalid character 'o' looking for beginning of value"),
+		},
+		"with SSM error": {
+			mockGetParameter: func(t *testing.T, param *ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {
+				return nil, fmt.Errorf("broken")
+			},
+			wantedErr: fmt.Errorf("broken"),
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// GIVEN
+			store := &SSM{
+				systemManager: &mockSSM{
+					t:                t,
+					mockGetParameter: tc.mockGetParameter,
+				},
+			}
+
+			// WHEN
+			env, err := store.GetEnvironment("chicken", "test")
+
+			// THEN
+			if tc.wantedErr != nil {
+				require.EqualError(t, err, tc.wantedErr.Error())
+			} else {
+				require.Equal(t, tc.wantedEnvironment, *env)
+			}
+		})
+	}
+}
+
+func TestStore_CreateEnvironment(t *testing.T) {
+
+	testProject := Project{Name: "chicken", Version: "1.0"}
+	testProjectString, _ := testProject.Marshal()
+	testProjectPath := fmt.Sprintf(fmtProjectPath, testProject.Name)
+
+	testEnvironment := Environment{Name: "test", Project: testProject.Name, AccountID: "1234", Region: "us-west-2"}
+	testEnvironmentString, _ := testEnvironment.Marshal()
+	testEnvironmentPath := fmt.Sprintf(fmtEnvParamPath, testEnvironment.Project, testEnvironment.Name)
+
+	testCases := map[string]struct {
+		mockGetParameter func(t *testing.T, param *ssm.GetParameterInput) (*ssm.GetParameterOutput, error)
+		mockPutParameter func(t *testing.T, param *ssm.PutParameterInput) (*ssm.PutParameterOutput, error)
+		wantedErr        error
+	}{
+		"with no existing environment": {
+			mockPutParameter: func(t *testing.T, param *ssm.PutParameterInput) (*ssm.PutParameterOutput, error) {
+				require.Equal(t, testEnvironmentPath, *param.Name)
+				require.Equal(t, testEnvironmentString, *param.Value)
+				return &ssm.PutParameterOutput{
+					Version: aws.Int64(1),
+				}, nil
+			},
+			mockGetParameter: func(t *testing.T, param *ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {
+				require.Equal(t, testProjectPath, *param.Name)
+				return &ssm.GetParameterOutput{
+					Parameter: &ssm.Parameter{
+						Name:  aws.String(testProjectPath),
+						Value: aws.String(testProjectString),
+					},
+				}, nil
+			},
+
+			wantedErr: nil,
+		},
+		"with existing environment": {
+			mockPutParameter: func(t *testing.T, param *ssm.PutParameterInput) (*ssm.PutParameterOutput, error) {
+				require.Equal(t, testEnvironmentPath, *param.Name)
+				return nil, awserr.New(ssm.ErrCodeParameterAlreadyExists, "Already exists", fmt.Errorf("Already Exists"))
+			},
+			mockGetParameter: func(t *testing.T, param *ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {
+				require.Equal(t, testProjectPath, *param.Name)
+				return &ssm.GetParameterOutput{
+					Parameter: &ssm.Parameter{
+						Name:  aws.String(testProjectPath),
+						Value: aws.String(testProjectString),
+					},
+				}, nil
+			},
+			wantedErr: &ErrEnvironmentAlreadyExists{
+				EnvironmentName: testEnvironment.Name,
+				ProjectName:     testEnvironment.Project,
+			},
+		},
+		"with SSM error": {
+			mockPutParameter: func(t *testing.T, param *ssm.PutParameterInput) (*ssm.PutParameterOutput, error) {
+				return nil, fmt.Errorf("broken")
+			},
+			mockGetParameter: func(t *testing.T, param *ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {
+				require.Equal(t, testProjectPath, *param.Name)
+				return &ssm.GetParameterOutput{
+					Parameter: &ssm.Parameter{
+						Name:  aws.String(testProjectPath),
+						Value: aws.String(testProjectString),
+					},
+				}, nil
+			},
+			wantedErr: fmt.Errorf("broken"),
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// GIVEN
+			store := &SSM{
+				systemManager: &mockSSM{
+					t:                t,
+					mockPutParameter: tc.mockPutParameter,
+					mockGetParameter: tc.mockGetParameter,
+				},
+			}
+
+			// WHEN
+			err := store.CreateEnvironment(&Environment{
+				Name:      testEnvironment.Name,
+				Project:   testEnvironment.Project,
+				AccountID: testEnvironment.AccountID,
+				Region:    testEnvironment.Region})
+
+			// THEN
+			if tc.wantedErr != nil {
+				require.EqualError(t, err, tc.wantedErr.Error())
+			}
+		})
+	}
+}
+
+type mockSSM struct {
+	ssmiface.SSMAPI
+	t                       *testing.T
+	mockPutParameter        func(t *testing.T, param *ssm.PutParameterInput) (*ssm.PutParameterOutput, error)
+	mockGetParametersByPath func(t *testing.T, param *ssm.GetParametersByPathInput) (*ssm.GetParametersByPathOutput, error)
+	mockGetParameter        func(t *testing.T, param *ssm.GetParameterInput) (*ssm.GetParameterOutput, error)
+}
+
+func (m *mockSSM) PutParameter(in *ssm.PutParameterInput) (*ssm.PutParameterOutput, error) {
+	return m.mockPutParameter(m.t, in)
+}
+
+func (m *mockSSM) GetParametersByPath(in *ssm.GetParametersByPathInput) (*ssm.GetParametersByPathOutput, error) {
+	return m.mockGetParametersByPath(m.t, in)
+}
+
+func (m *mockSSM) GetParameter(in *ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {
+	return m.mockGetParameter(m.t, in)
+}
+
+type mockSTS struct {
+	stsiface.STSAPI
+	t                     *testing.T
+	mockGetCallerIdentity func(t *testing.T, input *sts.GetCallerIdentityInput) (*sts.GetCallerIdentityOutput, error)
+}
+
+func (m *mockSTS) GetCallerIdentity(input *sts.GetCallerIdentityInput) (*sts.GetCallerIdentityOutput, error) {
+	return m.mockGetCallerIdentity(m.t, input)
+}


### PR DESCRIPTION
This package is for managing the remote project configuration including:
1. Which projects exist
2. The name of those projects
3. The environments for each project
4. The configuration for each environment

This configuration is stored and fetched from ssm.

I would love to get your feedback on the name of this package,
I really don't like it. Some alternatives include "storage"?

The next step after this PR is to refactor the project and env packages
to remove their own implementation of the project store.

✨

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
