### PR TITLE
Replace require.Equal with require.ElementsMatch

### DIFF
--- a/pkg/archer/project/store_test.go
+++ b/pkg/archer/project/store_test.go
@@ -56,7 +56,7 @@ func TestStore_List(t *testing.T) {
 			for _, p := range projects {
 				names = append(names, p.Name)
 			}
-			require.Equal(t, tc.wantedProjectNames, names)
+			require.ElementsMatch(t, tc.wantedProjectNames, names)
 		})
 	}
 }


### PR DESCRIPTION
*Issue #, if available:*
#23 
*Description of changes:*
Use [`require.ElementsMatch`](https://godoc.org/github.com/stretchr/testify/require#ElementsMatch) to handle non-deterministic ordering.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
