### PR TITLE
Add project creation / manifest writing back into init

### DIFF
--- a/pkg/cli/init.go
+++ b/pkg/cli/init.go
@@ -7,6 +7,9 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/AlecAivazis/survey/v2/terminal"
 	"github.com/aws/PRIVATE-amazon-ecs-archer/cmd/archer/template"
+	"github.com/aws/PRIVATE-amazon-ecs-archer/pkg/archer"
+	"github.com/aws/PRIVATE-amazon-ecs-archer/pkg/manifest"
+	"github.com/aws/PRIVATE-amazon-ecs-archer/pkg/store/ssm"
 	"github.com/spf13/cobra"
 )
 
@@ -15,6 +18,12 @@ type InitAppOpts struct {
 	Project string `survey:"project"` // namespace that this application belongs to.
 	Name    string `survey:"name"`    // unique identifier to logically group AWS resources together.
 	Type    string `survey:"Type"`    // The type of application you're trying to build (LoadBalanced, Backend, etc.)
+
+	projStore archer.ProjectStore
+	envStore  archer.EnvironmentStore
+
+	existingProjects []string // existing project names
+
 	// Prompt holds the interfaces to receive and output app configuration data to the terminal.
 	Prompt terminal.Stdio
 }
@@ -23,14 +32,7 @@ type InitAppOpts struct {
 func (opts *InitAppOpts) Ask() error {
 	var qs []*survey.Question
 	if opts.Project == "" {
-		qs = append(qs, &survey.Question{
-			Name: "project",
-			Prompt: &survey.Input{
-				Message: "What is your project's name?",
-				Help:    "Applications under the same project share the same VPC and ECS Cluster and are discoverable via service discovery.",
-			},
-			Validate: validateProjectName,
-		})
+		qs = append(qs, projectQuestion(opts))
 	}
 	if opts.Name == "" {
 		qs = append(qs, &survey.Question{
@@ -42,7 +44,45 @@ func (opts *InitAppOpts) Ask() error {
 			Validate: validateApplicationName,
 		})
 	}
+	if opts.Type == "" {
+		qs = append(qs, manifestQuestion(opts))
+	}
 	return survey.Ask(qs, opts, survey.WithStdio(opts.Prompt.In, opts.Prompt.Out, opts.Prompt.Err))
+}
+
+func manifestQuestion(opts *InitAppOpts) *survey.Question {
+	return &survey.Question{
+		Prompt: &survey.Select{
+			Message: "Which template would you like to use?",
+			Help:    "Pre-defined infrastructure templates.",
+			Options: manifest.TemplateNames,
+			Default: manifest.TemplateNames[0],
+		},
+		Name: "Type",
+	}
+}
+
+func projectQuestion(opts *InitAppOpts) *survey.Question {
+	if len(opts.existingProjects) > 0 {
+		return &survey.Question{
+			Name: "project",
+			Prompt: &survey.Select{
+				Message: "Which project should we use?",
+				Help:    "Choose a project to create a new application in. Applications in the same project share the same VPC, ECS Cluster and are discoverable via service discovery",
+				Options: opts.existingProjects,
+			},
+		}
+	}
+
+	return &survey.Question{
+		Name: "project",
+		Prompt: &survey.Input{
+			Message: "What is your project's name?",
+			Help:    "Applications under the same project share the same VPC and ECS Cluster and are discoverable via service discovery.",
+		},
+		Validate: validateProjectName,
+	}
+
 }
 
 // Validate returns an error if a command line flag provided value is invalid
@@ -58,27 +98,95 @@ func (opts *InitAppOpts) Validate() error {
 	return nil
 }
 
-// InitApp creates the project and application structure
-func (a *InitAppOpts) InitApp() error {
-	//TODO fill in
+// Prepare loads contextual data such as any existing projects, the current workspace, etc
+func (opts *InitAppOpts) Prepare() {
+	// Load existing projects (this is a UI convenience, so we'll ignore errors)
+	existingProjects, _ := opts.projStore.ListProjects()
+	var projectNames []string
+	for _, p := range existingProjects {
+		projectNames = append(projectNames, p.Name)
+	}
+	opts.existingProjects = projectNames
+}
+
+// InitApp creates a project and initializes the workspace
+func (opts *InitAppOpts) InitApp() error {
+	shouldCreateNewProject := true
+	// If the project already exists, skip creating it
+	for _, project := range opts.existingProjects {
+		if opts.Project == project {
+			shouldCreateNewProject = false
+		}
+	}
+	if shouldCreateNewProject {
+		err := opts.projStore.CreateProject(&archer.Project{
+			Name: opts.Project,
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	m, err := manifest.New(opts.Type)
+	if err != nil {
+		return err
+	}
+	m.Render(opts.Name, opts)
+	return nil
+}
+
+// DeployEnv optionally deploys an environment
+func (opts *InitAppOpts) DeployEnv() error {
+	existingEnvs, _ := opts.envStore.ListEnvironments(opts.Project)
+	if len(existingEnvs) > 0 {
+		return nil
+	}
+	deployEnv := false
+	prompt := &survey.Confirm{
+		Message: "Would you like to set up a test environment?",
+		Help:    "You can deploy your app into your test environment.",
+	}
+
+	survey.AskOne(prompt, &deployEnv, survey.WithStdio(opts.Prompt.In, opts.Prompt.Out, opts.Prompt.Err))
+
+	if deployEnv {
+		//TODO deploy env
+		fmt.Println("Deploying env...")
+	}
 	return nil
 }
 
 // BuildInitCmd builds the command to build an application
 func BuildInitCmd() *cobra.Command {
-	opts := InitAppOpts{Prompt: terminal.Stdio{
-		In:  os.Stdin,
-		Out: os.Stderr,
-		Err: os.Stderr,
-	}}
+	opts := InitAppOpts{
+		Prompt: terminal.Stdio{
+			In:  os.Stdin,
+			Out: os.Stderr,
+			Err: os.Stderr,
+		},
+	}
+
 	cmd := &cobra.Command{
 		Use:   "init",
 		Short: "Create a new ECS application",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			ssm, err := ssm.NewStore()
+			if err != nil {
+				return err
+			}
+
+			opts.projStore = ssm
+			opts.envStore = ssm
+
+			opts.Prepare()
 			return opts.Ask()
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return opts.InitApp()
+			err := opts.InitApp()
+			if err != nil {
+				return err
+			}
+			return opts.DeployEnv()
 		},
 	}
 	cmd.Flags().StringVarP(&opts.Project, "project", "p", "", "Name of the project (required).")

--- a/pkg/cli/init_test.go
+++ b/pkg/cli/init_test.go
@@ -1,36 +1,107 @@
 package cli
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/AlecAivazis/survey/v2/terminal"
 	"github.com/Netflix/go-expect"
+	"github.com/aws/PRIVATE-amazon-ecs-archer/mocks"
+	"github.com/aws/PRIVATE-amazon-ecs-archer/pkg/archer"
+	"github.com/golang/mock/gomock"
 	"github.com/hinshun/vt10x"
 	"github.com/stretchr/testify/require"
 )
 
 func TestInit_Ask(t *testing.T) {
-	testCases := map[string]struct {
-		inputProject string
-		inputApp     string
-		input        func(c *expect.Console)
+	ctrl := gomock.NewController(t)
+	mockProjectStore := mocks.NewMockProjectStore(ctrl)
+	defer ctrl.Finish()
 
-		wantedProject string
-		wantedApp     string
+	testCases := map[string]struct {
+		inputProject     string
+		inputApp         string
+		inputType        string
+		input            func(c *expect.Console)
+		wantedProject    string
+		wantedApp        string
+		wantedType       string
+		existingProjects []string
 	}{
-		"with no flags set": {
-			inputProject: "",
-			inputApp:     "",
+		"with no flags set and no projects": {
 			input: func(c *expect.Console) {
 				c.ExpectString("What is your project's name?")
 				c.SendLine("heartbeat")
 				c.ExpectString("What is your application's name?")
 				c.SendLine("api")
+				c.ExpectString("Which template would you like to use?")
+				c.SendLine(string(terminal.KeyEnter))
+				c.ExpectString("Would you like to set up a test environment")
+				c.SendLine("n")
 				c.ExpectEOF()
 			},
-
 			wantedProject: "heartbeat",
 			wantedApp:     "api",
+			wantedType:    "Load Balanced Web App",
+		},
+		"with no flags set and existing projects": {
+			existingProjects: []string{"heartbeat"},
+			input: func(c *expect.Console) {
+				c.ExpectString("Which project should we use?")
+				c.SendLine(string(terminal.KeyEnter))
+				c.ExpectString("What is your application's name?")
+				c.SendLine("api")
+				c.ExpectString("Which template would you like to use?")
+				c.SendLine(string(terminal.KeyEnter))
+				c.ExpectString("Would you like to set up a test environment")
+				c.SendLine("n")
+				c.ExpectEOF()
+			},
+			wantedProject: "heartbeat",
+			wantedApp:     "api",
+			wantedType:    "Load Balanced Web App",
+		},
+		"with only project flag set": {
+			inputProject: "heartbeat",
+			input: func(c *expect.Console) {
+				c.ExpectString("What is your application's name?")
+				c.SendLine("api")
+				c.ExpectString("Which template would you like to use?")
+				c.SendLine(string(terminal.KeyEnter))
+				c.ExpectString("Would you like to set up a test environment")
+				c.SendLine("n")
+				c.ExpectEOF()
+			},
+			wantedProject: "heartbeat",
+			wantedApp:     "api",
+			wantedType:    "Load Balanced Web App",
+		},
+		"with project and app flag set": {
+			inputProject: "heartbeat",
+			inputApp:     "api",
+			input: func(c *expect.Console) {
+				c.ExpectString("Which template would you like to use?")
+				c.SendLine(string(terminal.KeyEnter))
+				c.ExpectString("Would you like to set up a test environment")
+				c.SendLine("n")
+				c.ExpectEOF()
+			},
+			wantedProject: "heartbeat",
+			wantedApp:     "api",
+			wantedType:    "Load Balanced Web App",
+		},
+		"with project, app and template flag set": {
+			inputProject: "heartbeat",
+			inputApp:     "api",
+			inputType:    "Load Balanced Web App",
+			input: func(c *expect.Console) {
+				c.ExpectString("Would you like to set up a test environment")
+				c.SendLine("n")
+				c.ExpectEOF()
+			},
+			wantedProject: "heartbeat",
+			wantedApp:     "api",
+			wantedType:    "Load Balanced Web App",
 		},
 	}
 
@@ -42,13 +113,15 @@ func TestInit_Ask(t *testing.T) {
 			app := &InitAppOpts{
 				Project: tc.inputProject,
 				Name:    tc.inputApp,
+				Type:    tc.inputType,
 				Prompt: terminal.Stdio{
 					In:  mockTerminal.Tty(),
 					Out: mockTerminal.Tty(),
 					Err: mockTerminal.Tty(),
 				},
+				projStore:        mockProjectStore,
+				existingProjects: tc.existingProjects,
 			}
-
 			// Write inputs to the terminal
 			done := make(chan struct{})
 			go func() {
@@ -67,6 +140,61 @@ func TestInit_Ask(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, tc.wantedProject, app.Project, "expected project names to match")
 			require.Equal(t, tc.wantedApp, app.Name, "expected app names to match")
+			require.Equal(t, tc.wantedType, app.Type, "expected template names to match")
+
+		})
+	}
+}
+
+func TestInit_Prepare(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockProjectStore := mocks.NewMockProjectStore(ctrl)
+	defer ctrl.Finish()
+
+	testCases := map[string]struct {
+		inputOpts              InitAppOpts
+		mocking                func()
+		wantedExistingProjects []string
+	}{
+		"with existing projects": {
+			inputOpts: InitAppOpts{
+				Name:    "frontend",
+				Project: "coolproject",
+			},
+			wantedExistingProjects: []string{"project1", "project2"},
+			mocking: func() {
+				mockProjectStore.
+					EXPECT().
+					ListProjects().
+					Return([]*archer.Project{
+						&archer.Project{Name: "project1"},
+						&archer.Project{Name: "project2"},
+					}, nil)
+
+			},
+		},
+		"with error loading projects": {
+			inputOpts: InitAppOpts{
+				Name:    "frontend",
+				Project: "coolproject",
+			},
+			wantedExistingProjects: []string{},
+			mocking: func() {
+				mockProjectStore.
+					EXPECT().
+					ListProjects().
+					Return(nil, fmt.Errorf("error loading projects"))
+
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			tc.mocking()
+			tc.inputOpts.projStore = mockProjectStore
+			tc.inputOpts.Prepare()
+			require.ElementsMatch(t, tc.wantedExistingProjects, tc.inputOpts.existingProjects)
 		})
 	}
 }
@@ -110,6 +238,162 @@ func TestInit_Validate(t *testing.T) {
 	}
 }
 
+//TODO this test currently doesn't mock out the manifest writer.
+// Since that part will change soon, I don't have tests for the
+// manifest writer parts yet.
 func TestInit_InitApp(t *testing.T) {
-	t.Skip("Skipping init, not yet implemented")
+	ctrl := gomock.NewController(t)
+	mockProjectStore := mocks.NewMockProjectStore(ctrl)
+	defer ctrl.Finish()
+
+	testCases := map[string]struct {
+		inputOpts InitAppOpts
+		mocking   func()
+		wantedErr error
+	}{
+		"with an existing project": {
+			inputOpts: InitAppOpts{
+				Name:             "frontend",
+				Project:          "project1",
+				Type:             "Empty",
+				existingProjects: []string{"project1", "project2"},
+			},
+			mocking: func() {
+				mockProjectStore.
+					EXPECT().
+					CreateProject(gomock.Any()).
+					Return(nil).
+					Times(0)
+			},
+		},
+		"with a new project": {
+			inputOpts: InitAppOpts{
+				Name:             "frontend",
+				Project:          "project3",
+				Type:             "Empty",
+				existingProjects: []string{"project1", "project2"},
+			},
+			mocking: func() {
+				mockProjectStore.
+					EXPECT().
+					CreateProject(gomock.Eq(&archer.Project{Name: "project3"})).
+					Return(nil)
+			},
+		},
+		"with an error creating a new project": {
+			inputOpts: InitAppOpts{
+				Name:             "frontend",
+				Project:          "project3",
+				Type:             "Empty",
+				existingProjects: []string{"project1", "project2"},
+			},
+			wantedErr: fmt.Errorf("error creating project"),
+			mocking: func() {
+				mockProjectStore.
+					EXPECT().
+					CreateProject(gomock.Eq(&archer.Project{Name: "project3"})).
+					Return(fmt.Errorf("error creating project"))
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			tc.mocking()
+			tc.inputOpts.projStore = mockProjectStore
+			err := tc.inputOpts.InitApp()
+			if tc.wantedErr == nil {
+				require.NoError(t, err, "There should be no error")
+			} else {
+				require.Error(t, tc.wantedErr, err.Error())
+			}
+		})
+	}
+}
+
+func TestInit_DeployEnv(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockEnvStore := mocks.NewMockEnvironmentStore(ctrl)
+	defer ctrl.Finish()
+
+	testCases := map[string]struct {
+		inputProject string
+		input        func(c *expect.Console)
+		mocking      func()
+		wantedErr    error
+	}{
+		"when there are no envs for a project": {
+			// When a project is first created, and there are
+			// no environments in it - we can offer to create
+			// an env for the user.
+			inputProject: "project",
+			input: func(c *expect.Console) {
+				c.ExpectString("Would you like to set up a test environment?")
+				c.SendLine("n")
+				c.ExpectEOF()
+			},
+			mocking: func() {
+				mockEnvStore.
+					EXPECT().
+					ListEnvironments(gomock.Eq("project")).
+					Return([]*archer.Environment{}, nil)
+			},
+		},
+		"when there are existing envs for a project": {
+			// When a project already has environments, we don't
+			// prompt the user to create a "test" env
+			inputProject: "project",
+			input: func(c *expect.Console) {
+				c.ExpectEOF()
+			},
+			mocking: func() {
+				mockEnvStore.
+					EXPECT().
+					ListEnvironments(gomock.Eq("project")).
+					Return([]*archer.Environment{
+						&archer.Environment{Name: "test"},
+					}, nil)
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// GIVEN
+			mockTerminal, _, _ := vt10x.NewVT10XConsole()
+			defer mockTerminal.Close()
+			app := &InitAppOpts{
+				Project:  tc.inputProject,
+				envStore: mockEnvStore,
+				Prompt: terminal.Stdio{
+					In:  mockTerminal.Tty(),
+					Out: mockTerminal.Tty(),
+					Err: mockTerminal.Tty(),
+				},
+			}
+			// Write inputs to the terminal
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				tc.input(mockTerminal)
+			}()
+
+			tc.mocking()
+
+			// WHEN
+			err := app.DeployEnv()
+
+			// Wait until the terminal receives the input
+			mockTerminal.Tty().Close()
+			<-done
+
+			// THEN
+			if tc.wantedErr == nil {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, tc.wantedErr, err)
+			}
+
+		})
+	}
 }


### PR DESCRIPTION
This change adds:
1. Project listing, if there are existing projects
2. Project creating, if the project is new
3. Adding the manfiest back
4. Stub for deploying an env after everything is complete

Caveat with this change, since we'll be re-working the manifest
reader/writer - I haven't covered that under our unit tests.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
