### PR TITLE
Add deploy logic to init command

### DIFF
--- a/internal/pkg/cli/init_test.go
+++ b/internal/pkg/cli/init_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/AlecAivazis/survey/v2/terminal"
 	"github.com/Netflix/go-expect"
 	"github.com/aws/PRIVATE-amazon-ecs-archer/internal/pkg/archer"
+	cli_mocks "github.com/aws/PRIVATE-amazon-ecs-archer/internal/pkg/cli/mocks"
 	"github.com/aws/PRIVATE-amazon-ecs-archer/mocks"
 	"github.com/golang/mock/gomock"
 	"github.com/hinshun/vt10x"
@@ -246,48 +247,54 @@ func TestInit_Validate(t *testing.T) {
 // manifest writer parts yet.
 func TestInit_Execute(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	mockProjectStore := mocks.NewMockProjectStore(ctrl)
-	mockEnvStore := mocks.NewMockEnvironmentStore(ctrl)
 	defer ctrl.Finish()
 
+	mockProjectStore := mocks.NewMockProjectStore(ctrl)
+	mockEnvStore := mocks.NewMockEnvironmentStore(ctrl)
+	mockSpinner := cli_mocks.NewMockspinner(ctrl)
+	mockDeployer := mocks.NewMockEnvironmentDeployer(ctrl)
+
+	mockError := fmt.Errorf("error")
+
 	testCases := map[string]struct {
-		inputOpts InitAppOpts
-		input     func(c *expect.Console)
-		mocking   func()
-		wantedErr error
+		inputOpts    InitAppOpts
+		consoleInput func(c *expect.Console)
+		mocking      func()
+		want         error
 	}{
-		"with an existing project": {
+		"should not prompt to create test environment given existing environments": {
 			inputOpts: InitAppOpts{
 				Name:             "frontend",
 				Project:          "project1",
 				Type:             "Empty",
 				existingProjects: []string{"project1", "project2"},
 			},
-			input: func(c *expect.Console) {
+			consoleInput: func(c *expect.Console) {
 				c.ExpectEOF()
 			},
 			mocking: func() {
 				mockProjectStore.
 					EXPECT().
 					CreateProject(gomock.Any()).
-					Return(nil).
 					Times(0)
 				mockEnvStore.
 					EXPECT().
 					ListEnvironments(gomock.Eq("project1")).
 					Return([]*archer.Environment{
 						{Name: "test"},
-					}, nil)
+					}, nil).
+					Times(1)
 			},
+			want: nil,
 		},
-		"with a new project": {
+		"should create a new project without a test environment": {
 			inputOpts: InitAppOpts{
 				Name:             "frontend",
 				Project:          "project3",
 				Type:             "Empty",
 				existingProjects: []string{"project1", "project2"},
 			},
-			input: func(c *expect.Console) {
+			consoleInput: func(c *expect.Console) {
 				c.ExpectString("Would you like to set up a test environment?")
 				c.SendLine("n")
 				c.ExpectEOF()
@@ -296,34 +303,150 @@ func TestInit_Execute(t *testing.T) {
 				mockProjectStore.
 					EXPECT().
 					CreateProject(gomock.Eq(&archer.Project{Name: "project3"})).
-					Return(nil)
+					Return(nil).
+					Times(1)
 				mockEnvStore.
 					EXPECT().
 					ListEnvironments(gomock.Eq("project3")).
-					Return([]*archer.Environment{}, nil)
+					Return(make([]*archer.Environment, 0), nil).
+					Times(1)
 			},
+			want: nil,
 		},
-		"with an error creating a new project": {
+		"should echo error returned from call to CreateProject": {
+			inputOpts: InitAppOpts{
+				Project:          "project3",
+				existingProjects: []string{"project1", "project2"},
+			},
+			consoleInput: func(c *expect.Console) {
+				c.ExpectEOF()
+			},
+			mocking: func() {
+				mockProjectStore.
+					EXPECT().
+					CreateProject(gomock.Eq(&archer.Project{Name: "project3"})).
+					Return(mockError)
+			},
+			want: mockError,
+		},
+		"should echo error returned from call to deployer.DeployEnvironment": {
 			inputOpts: InitAppOpts{
 				Name:             "frontend",
 				Project:          "project3",
 				Type:             "Empty",
 				existingProjects: []string{"project1", "project2"},
 			},
-			input: func(c *expect.Console) {
+			consoleInput: func(c *expect.Console) {
+				c.ExpectString("Would you like to set up a test environment?")
+				c.SendLine("Y")
 				c.ExpectEOF()
 			},
-			wantedErr: fmt.Errorf("error creating project"),
 			mocking: func() {
 				mockProjectStore.
 					EXPECT().
 					CreateProject(gomock.Eq(&archer.Project{Name: "project3"})).
-					Return(fmt.Errorf("error creating project"))
+					Return(nil).
+					Times(1)
 				mockEnvStore.
 					EXPECT().
-					ListEnvironments(gomock.Any()).
-					Times(0)
+					ListEnvironments(gomock.Eq("project3")).
+					Return([]*archer.Environment{}, nil).
+					Times(1)
+				mockSpinner.EXPECT().Start("Deploying env...").Times(1)
+				mockDeployer.EXPECT().
+					DeployEnvironment(gomock.Eq(archer.Environment{
+						Project: "project3",
+						Name:    defaultEnvironmentName,
+					}), gomock.Eq(true)).
+					Return(mockError).
+					Times(1)
+				mockSpinner.EXPECT().Stop("Error!").Times(1)
 			},
+			want: mockError,
+		},
+		"should echo error returned from call to deployer.Wait": {
+			inputOpts: InitAppOpts{
+				Name:             "frontend",
+				Project:          "project3",
+				Type:             "Empty",
+				existingProjects: []string{"project1", "project2"},
+			},
+			consoleInput: func(c *expect.Console) {
+				c.ExpectString("Would you like to set up a test environment?")
+				c.SendLine("Y")
+				c.ExpectEOF()
+			},
+			mocking: func() {
+				mockProjectStore.
+					EXPECT().
+					CreateProject(gomock.Eq(&archer.Project{Name: "project3"})).
+					Return(nil).
+					Times(1)
+				mockEnvStore.
+					EXPECT().
+					ListEnvironments(gomock.Eq("project3")).
+					Return([]*archer.Environment{}, nil).
+					Times(1)
+				mockSpinner.EXPECT().Start("Deploying env...").Times(1)
+				mockDeployer.EXPECT().
+					DeployEnvironment(gomock.Eq(archer.Environment{
+						Project: "project3",
+						Name:    defaultEnvironmentName,
+					}), gomock.Eq(true)).
+					Return(nil).
+					Times(1)
+				mockDeployer.EXPECT().
+					Wait(gomock.Eq(archer.Environment{
+						Project: "project3",
+						Name:    defaultEnvironmentName,
+					})).
+					Return(mockError).
+					Times(1)
+				mockSpinner.EXPECT().Stop("Error!").Times(1)
+			},
+			want: mockError,
+		},
+		"should create a new test environment": {
+			inputOpts: InitAppOpts{
+				Name:             "frontend",
+				Project:          "project3",
+				Type:             "Empty",
+				existingProjects: []string{"project1", "project2"},
+			},
+			consoleInput: func(c *expect.Console) {
+				c.ExpectString("Would you like to set up a test environment?")
+				c.SendLine("Y")
+				c.ExpectEOF()
+			},
+			mocking: func() {
+				mockProjectStore.
+					EXPECT().
+					CreateProject(gomock.Eq(&archer.Project{Name: "project3"})).
+					Return(nil).
+					Times(1)
+				mockEnvStore.
+					EXPECT().
+					ListEnvironments(gomock.Eq("project3")).
+					Return([]*archer.Environment{}, nil).
+					Times(1)
+				mockSpinner.EXPECT().Start("Deploying env...").Times(1)
+				mockDeployer.EXPECT().
+					DeployEnvironment(gomock.Eq(archer.Environment{
+						Project: "project3",
+						Name:    defaultEnvironmentName,
+					}), gomock.Eq(true)).
+					Return(nil).
+					Times(1)
+				mockDeployer.EXPECT().
+					Wait(gomock.Eq(archer.Environment{
+						Project: "project3",
+						Name:    defaultEnvironmentName,
+					})).
+					Return(nil).
+					Times(1)
+				mockSpinner.EXPECT().Stop("Done!").Times(1)
+			},
+			want: nil,
 		},
 	}
 
@@ -336,7 +459,7 @@ func TestInit_Execute(t *testing.T) {
 			done := make(chan struct{})
 			go func() {
 				defer close(done)
-				tc.input(mockTerminal)
+				tc.consoleInput(mockTerminal)
 			}()
 
 			tc.mocking()
@@ -347,19 +470,16 @@ func TestInit_Execute(t *testing.T) {
 			}
 			tc.inputOpts.projStore = mockProjectStore
 			tc.inputOpts.envStore = mockEnvStore
+			tc.inputOpts.spinner = mockSpinner
+			tc.inputOpts.deployer = mockDeployer
 
 			// WHEN
-			err := tc.inputOpts.Execute()
+			got := tc.inputOpts.Execute()
 
 			// THEN
 			mockTerminal.Tty().Close()
 			<-done
-
-			if tc.wantedErr == nil {
-				require.NoError(t, err, "There should be no error")
-			} else {
-				require.Error(t, tc.wantedErr, err.Error())
-			}
+			require.Equal(t, tc.want, got)
 		})
 	}
 }

--- a/internal/pkg/deploy/cloudformation/cloudformation.go
+++ b/internal/pkg/deploy/cloudformation/cloudformation.go
@@ -40,6 +40,8 @@ func New(sess *session.Session) CloudFormation {
 
 // DeployEnvironment creates an environment CloudFormation stack
 func (cf CloudFormation) DeployEnvironment(env archer.Environment, includeLoadBalancer bool) error {
+	// TODO: move load balancer method flag into the Environment structure
+	// https://github.com/aws/PRIVATE-amazon-ecs-archer/issues/57
 	template, err := cf.box.FindString(environmentTemplate)
 
 	if err != nil {


### PR DESCRIPTION
*Issue #, if available:*
#40 

*Description of changes:*
Add deploy logic to `init` command with supporting unit tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
