### PR TITLE
feat(e2e): run isolated e2e tests as part of the test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ build:
 .PHONY: test
 test:
 	go test -v -race -cover -count=1 ${PACKAGES}
+	go test -v -p 1 --parallel 1 -tags=isolated ./e2e...
 
 .PHONY: integ-test
 integ-test:
@@ -32,7 +33,7 @@ e2e-test-update-golden-files:
 	# The normal flow is the following:
 	#
 	# make e2e-test-update-golden-files // this is expected to fail but will update the golden files
-	# make e2e-test // this should pass because the golden files were updated
+	# make e2e-test or make test // this should pass because the golden files were updated
 	go test -v -p 1 -parallel 1 -tags=e2e ./e2e... --update
 
 .PHONY: tools

--- a/e2e/cli_test/help_msg_test.go
+++ b/e2e/cli_test/help_msg_test.go
@@ -1,4 +1,7 @@
-// +build e2e
+// +build e2e isolated
+
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 package cli_test
 

--- a/e2e/cli_test/suite_test.go
+++ b/e2e/cli_test/suite_test.go
@@ -1,5 +1,11 @@
-// +build e2e
+// +build e2e isolated
 
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// This suite of e2e tests do not require additional intrastructure setup
+// nor do they interact with AWS services so it's ok to run them as part of
+// the normal test target.
 package cli_test
 
 import (


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Some of the e2e tests do not require additional intrastructure setup nor do they interact with AWS services so it's ok to run them as part of the `test` target.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
