### PR TITLE
bug(test): handle different newline character for Windows

### DIFF
--- a/internal/pkg/manifest/lb_fargate_manifest_test.go
+++ b/internal/pkg/manifest/lb_fargate_manifest_test.go
@@ -4,6 +4,7 @@
 package manifest
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -81,5 +82,5 @@ stages:
 
 	// THEN
 	require.NoError(t, err)
-	require.Equal(t, wantedContent, string(b))
+	require.Equal(t, wantedContent, strings.Replace(string(b), "\r\n", "\n", -1))
 }


### PR DESCRIPTION
*Issue #, if available:*
Closes #68

*Description of changes:*
When the test executes on Windows, the new line character used is "\r\n" rather than "\n".

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
