### PR TITLE
Set spinner output to stderr

### DIFF
--- a/internal/pkg/spinner/spinner.go
+++ b/internal/pkg/spinner/spinner.go
@@ -6,6 +6,7 @@ package spinner
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	spin "github.com/briandowns/spinner"
@@ -21,10 +22,13 @@ type Spinner struct {
 	internal spinner
 }
 
-// New returns a Spinner.
+// New returns a Spinner that outputs to stderr.
 func New() Spinner {
+	s := spin.New(spin.CharSets[14], 125*time.Millisecond)
+	s.Writer = os.Stderr
+
 	return Spinner{
-		internal: spin.New(spin.CharSets[14], 125*time.Millisecond),
+		internal: s,
 	}
 }
 

--- a/internal/pkg/spinner/spinner_test.go
+++ b/internal/pkg/spinner/spinner_test.go
@@ -4,11 +4,27 @@
 package spinner
 
 import (
+	"os"
 	"testing"
+	"time"
 
 	"github.com/aws/PRIVATE-amazon-ecs-archer/internal/pkg/spinner/mocks"
+	spin "github.com/briandowns/spinner"
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
 )
+
+func TestNew(t *testing.T) {
+	t.Run("it should initialize the internal spinner", func(t *testing.T) {
+		got := New()
+
+		v, ok := got.internal.(*spin.Spinner)
+		require.True(t, ok)
+
+		require.Equal(t, os.Stderr, v.Writer)
+		require.Equal(t, 125*time.Millisecond, v.Delay)
+	})
+}
 
 func TestStart(t *testing.T) {
 	ctrl := gomock.NewController(t)


### PR DESCRIPTION
*Issue #*
#80 

*Description of changes:*
Set the spinner output to `os.Stderr` to be pipe friendly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
