### PR TITLE
Move test target dependency to e2e target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ GOBIN=${PWD}/bin/tools
 all: build
 
 .PHONY: build
-build: test
+build:
 	CGO_ENABLED=0 go build -o ./bin/local/archer ./cmd/archer
 
 .PHONY: test
@@ -19,7 +19,7 @@ integ-test:
 	go test -v -run Integration -tags integration ${PACKAGES}
 
 .PHONY: e2e-test
-e2e-test: build
+e2e-test: build test
 	# the target assumes the AWS-* environment variables are exported
 	# -p: The number of test binaries that can be run in parallel
 	# -parallel: Within a single test binary, how many test functions can run in parallel


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Move the `test` target dependency to the `e2e-test` target so that we will build and run tests before kicking off `e2e-test`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
