### PR TITLE
Add generate-coverage make command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 bin/
+coverage.out
 .idea/*
 .vscode/*
 *.swp

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 
 PACKAGES=./internal...
 GOBIN=${PWD}/bin/tools
+COVERAGE=coverage.out
 
 all: build
 
@@ -12,7 +13,12 @@ build:
 
 .PHONY: test
 test:
-	go test -v -race -cover -count=1 ${PACKAGES}
+	go test -v -race -cover -count=1 -coverprofile ${COVERAGE} ${PACKAGES}
+
+generate-coverage: ${COVERAGE}
+	go tool cover -html=${COVERAGE}
+
+${COVERAGE}: test
 
 .PHONY: integ-test
 integ-test:


### PR DESCRIPTION
Coverage output gets written to `coverage.out`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
