### PR TITLE
Option to disable color through environment variable

### DIFF
--- a/cmd/archer/main.go
+++ b/cmd/archer/main.go
@@ -11,11 +11,11 @@ import (
 
 	"github.com/aws/PRIVATE-amazon-ecs-archer/cmd/archer/template"
 	"github.com/aws/PRIVATE-amazon-ecs-archer/internal/pkg/cli"
-	"github.com/aws/PRIVATE-amazon-ecs-archer/internal/pkg/styling"
+	"github.com/aws/PRIVATE-amazon-ecs-archer/internal/pkg/term/color"
 )
 
 func init() {
-	styling.DisableColorBasedOnEnvVar()
+	color.DisableColorBasedOnEnvVar()
 }
 
 func main() {

--- a/internal/pkg/term/color/color.go
+++ b/internal/pkg/term/color/color.go
@@ -1,7 +1,9 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package styling
+// Package color provides utilities to globally enable/disable color
+// output of the CLI
+package color
 
 import (
 	"os"
@@ -22,7 +24,7 @@ func DisableColorBasedOnEnvVar() {
 	if !exists {
 		// if the COLOR environment variable is not set
 		// then follow the settings in the color library
-		// since it's dynamitcally set based on the type of terminal
+		// since it's dynamically set based on the type of terminal
 		// and whether stdout is connected to a terminal or not.
 		core.DisableColor = color.NoColor
 		return

--- a/internal/pkg/term/color/color_test.go
+++ b/internal/pkg/term/color/color_test.go
@@ -1,7 +1,7 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package styling
+package color 
 
 import (
 	"testing"


### PR DESCRIPTION
*Issue #, if available:*
#100.

*Description of changes:*
This option makes it possible to disable color output globally. It is helpful during testing or if the CLI is used in a context where color output does not make sense (for example, run by CI/CD workflow).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
