### PR TITLE
Write manifest file in init command

### DIFF
--- a/internal/pkg/cli/env_add.go
+++ b/internal/pkg/cli/env_add.go
@@ -132,9 +132,9 @@ func BuildEnvAddCmd() *cobra.Command {
 			opts.manager = s
 			opts.projectGetter = s
 
-			// TODO: create this session elsewhere
 			sess, err := session.NewSessionWithOptions(session.Options{
 				SharedConfigState: session.SharedConfigEnable,
+				Profile:           opts.EnvProfile,
 			})
 			if err != nil {
 				return err


### PR DESCRIPTION
<!-- Provide summary of changes -->

We're not writing the manifest! Cleaning that up and
also fixing a bug where we weren't honoring the profile
flag for env add.

Also adds a skip-deploy flag so automation can use the init command (not requiring the customer to respond to a survey question). 

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->
Fixes #76 Fixes #10 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
