### PR TITLE
fix(templates): render service cfn templates when addons have no outputs

### DIFF
--- a/internal/pkg/template/template_integration_test.go
+++ b/internal/pkg/template/template_integration_test.go
@@ -1,0 +1,63 @@
+// +build integration
+
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package template_test
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/aws/copilot-cli/internal/pkg/aws/session"
+	"github.com/aws/copilot-cli/internal/pkg/template"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTemplate_ParseLoadBalancedWebService(t *testing.T) {
+	testCases := map[string]struct {
+		opts template.ServiceOpts
+	}{
+		"renders a valid template by default": {
+			opts: template.ServiceOpts{},
+		},
+		"renders a valid template with addons with no outputs": {
+			opts:  template.ServiceOpts{
+				NestedStack: &template.ServiceNestedStackOpts{
+					StackName: "AddonsStack",
+				},
+			},
+		},
+		"renders a valid template with addons with outputs": {
+			opts:  template.ServiceOpts{
+				NestedStack: &template.ServiceNestedStackOpts{
+					StackName:       "AddonsStack",
+					VariableOutputs: []string{"TableName"},
+					SecretOutputs:   []string{"TablePassword"},
+					PolicyOutputs:   []string{"TablePolicy"},
+				},
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// GIVEN
+			sess, err := session.NewProvider().Default()
+			require.NoError(t, err)
+			cfn := cloudformation.New(sess)
+			tpl := template.New()
+
+			// WHEN
+			content, err := tpl.ParseLoadBalancedWebService(tc.opts)
+			require.NoError(t, err)
+
+			// THEN
+			_, err = cfn.ValidateTemplate(&cloudformation.ValidateTemplateInput{
+				TemplateBody: aws.String(content.String()),
+			})
+			require.NoError(t, err, content.String())
+		})
+	}
+}

--- a/templates/services/common/cf/taskrole.yml
+++ b/templates/services/common/cf/taskrole.yml
@@ -1,8 +1,8 @@
 TaskRole:
   Type: AWS::IAM::Role
-  Properties:{{if .NestedStack}}{{$stackName := .NestedStack.StackName}}
+  Properties:{{if .NestedStack}}{{$stackName := .NestedStack.StackName}}{{if gt (len .NestedStack.PolicyOutputs) 0}}
     ManagedPolicyArns:{{range $managedPolicy := .NestedStack.PolicyOutputs}}
-    - Fn::GetAtt: [{{$stackName}}, Outputs.{{$managedPolicy}}]{{end}}{{end}}
+    - Fn::GetAtt: [{{$stackName}}, Outputs.{{$managedPolicy}}]{{end}}{{end}}{{end}}
     AssumeRolePolicyDocument:
       Statement:
         - Effect: Allow


### PR DESCRIPTION
Previously, if an addon template did not output the ARN of a IAM ManagedPolicy, then the service template would not render with a `ValidationError: [/Resources/TaskRole/Type/ManagedPolicyArns] 'null' values are not allowed in templates`.

Fixes #1073

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
