### PR TITLE
feat(cli): implement exec for task run

### DIFF
--- a/internal/pkg/aws/ec2/ec2.go
+++ b/internal/pkg/aws/ec2/ec2.go
@@ -1,0 +1,125 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package ec2 provides a client to make API requests to Amazon Elastic Compute Cloud.
+package ec2
+
+import (
+	"errors"
+	"fmt"
+	"github.com/aws/copilot-cli/internal/pkg/deploy"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/copilot-cli/internal/pkg/config"
+)
+
+var (
+	fmtFilterTagApp = fmt.Sprintf("tag:%s", deploy.AppTagKey)
+	fmtFilterTagEnv = fmt.Sprintf("tag:%s", deploy.EnvTagKey)
+	defaultFilter   = ec2.Filter{
+		Name:   aws.String(filterDefault),
+		Values: aws.StringSlice([]string{"true"}),
+	}
+)
+
+const (
+	filterDefault = "default-for-az"
+)
+
+type api interface {
+	DescribeSubnets(*ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error)
+	DescribeSecurityGroups(*ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error)
+}
+
+type EC2 struct {
+	client api
+}
+
+func New(s *session.Session) *EC2 {
+	return &EC2{
+		client: ec2.New(s),
+	}
+}
+
+// GetDefaultSubnetIDs finds the subnet IDs associated with the environment of the application; if env is a None env,
+// it finds the default subnet IDs.
+func (c *EC2) GetSubnetIDs(app string, env string) ([]string, error) {
+	if env == config.EnvNameNone {
+		return c.getDefaultSubnetIDs()
+	}
+
+	filters := []*ec2.Filter{
+		{
+			Name:   aws.String(fmtFilterTagApp),
+			Values: aws.StringSlice([]string{app}),
+		},
+		{
+			Name:   aws.String(fmtFilterTagEnv),
+			Values: aws.StringSlice([]string{env}),
+		},
+	}
+	return c.getSubnetIDs(filters)
+}
+
+// GetDefaultSubnetIDs finds the security group IDs associated with the environment of the application;
+// if env is a None env, it returns nil
+func (c *EC2) GetSecurityGroups(app string, env string) ([]string, error) {
+	if env == config.EnvNameNone {
+		return nil, nil
+	}
+
+	filters := []*ec2.Filter{
+		{
+			Name:   aws.String(fmtFilterTagApp),
+			Values: aws.StringSlice([]string{app}),
+		},
+		{
+			Name:   aws.String(fmtFilterTagEnv),
+			Values: aws.StringSlice([]string{env}),
+		},
+	}
+
+	return c.getSecurityGroups(filters)
+}
+
+func (c *EC2) getDefaultSubnetIDs() ([]string, error) {
+	return c.getSubnetIDs([]*ec2.Filter{&defaultFilter})
+}
+
+func (c *EC2) getSubnetIDs(filters []*ec2.Filter) ([]string, error) {
+	response, err := c.client.DescribeSubnets(&ec2.DescribeSubnetsInput{
+		Filters: filters,
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("find subnet IDs: %w", err)
+	}
+
+	if len(response.Subnets) == 0 {
+		return nil, errors.New("no subnet ID found")
+	}
+
+	subnetIDs := make([]string, len(response.Subnets))
+	for idx, subnet := range response.Subnets {
+		subnetIDs[idx] = aws.StringValue(subnet.SubnetId)
+	}
+	return subnetIDs, nil
+}
+
+func (c *EC2) getSecurityGroups(filters []*ec2.Filter) ([]string, error) {
+	response, err := c.client.DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{
+		Filters: filters,
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("get security groups from environment: %w", err)
+	}
+
+	securityGroups := make([]string, len(response.SecurityGroups))
+	for idx, sg := range response.SecurityGroups {
+		securityGroups[idx] = aws.StringValue(sg.GroupId)
+	}
+	return securityGroups, nil
+}

--- a/internal/pkg/aws/ec2/ec2.go
+++ b/internal/pkg/aws/ec2/ec2.go
@@ -43,7 +43,7 @@ func New(s *session.Session) *EC2 {
 	}
 }
 
-// GetDefaultSubnetIDs finds the subnet IDs associated with the environment of the application; if env is a None env,
+// GetSubnetIDs finds the subnet IDs associated with the environment of the application; if env is a None env,
 // it finds the default subnet IDs.
 func (c *EC2) GetSubnetIDs(app string, env string) ([]string, error) {
 	if env == config.EnvNameNone {
@@ -63,7 +63,7 @@ func (c *EC2) GetSubnetIDs(app string, env string) ([]string, error) {
 	return c.getSubnetIDs(filters)
 }
 
-// GetDefaultSubnetIDs finds the security group IDs associated with the environment of the application;
+// GetSecurityGroups finds the security group IDs associated with the environment of the application;
 // if env is a None env, it returns nil
 func (c *EC2) GetSecurityGroups(app string, env string) ([]string, error) {
 	if env == config.EnvNameNone {
@@ -94,11 +94,11 @@ func (c *EC2) getSubnetIDs(filters []*ec2.Filter) ([]string, error) {
 	})
 
 	if err != nil {
-		return nil, fmt.Errorf("find subnet IDs: %w", err)
+		return nil, fmt.Errorf("find subnets: %w", err)
 	}
 
 	if len(response.Subnets) == 0 {
-		return nil, errors.New("no subnet ID found")
+		return nil, errors.New("no subnets found")
 	}
 
 	subnetIDs := make([]string, len(response.Subnets))

--- a/internal/pkg/aws/ecs/ecs.go
+++ b/internal/pkg/aws/ecs/ecs.go
@@ -182,14 +182,14 @@ func (e *ECS) ServiceTasks(clusterName, serviceName string) ([]*Task, error) {
 }
 
 // DefaultClusters returns the default clusters in the account and region
-func (e *ECS) DefaultClusters() ([]string, error) {
+func (e *ECS) DefaultCluster() (string, error) {
 	resp, err := e.client.DescribeClusters(&ecs.DescribeClustersInput{})
 	if err != nil {
-		return nil, fmt.Errorf("get default clusters: %w", err)
+		return "", fmt.Errorf("get default cluster: %w", err)
 	}
 
 	if len(resp.Clusters) == 0 {
-		return nil, errors.New("no default cluster is found")
+		return "", errors.New("no default cluster is found")
 	}
 
 	clusters := make([]string, len(resp.Clusters))
@@ -197,7 +197,7 @@ func (e *ECS) DefaultClusters() ([]string, error) {
 		clusters[idx] = aws.StringValue(cluster.ClusterArn)
 	}
 
-	return clusters, nil
+	return clusters[0], nil
 }
 
 // RunTask runs a number of tasks with the task definition and network configurations in a cluster, and returns after

--- a/internal/pkg/aws/ecs/ecs_test.go
+++ b/internal/pkg/aws/ecs/ecs_test.go
@@ -328,6 +328,176 @@ func TestECS_Tasks(t *testing.T) {
 	}
 }
 
+func TestECS_DefaultCluster(t *testing.T) {
+	testCases := map[string]struct {
+		mockECSClient func(m *mocks.Mockapi)
+
+		wantedError    error
+		wantedClusters []string
+	}{
+		"get default clusters success": {
+			mockECSClient: func(m *mocks.Mockapi) {
+				m.EXPECT().
+					DescribeClusters(&ecs.DescribeClustersInput{}).
+					Return(&ecs.DescribeClustersOutput{
+						Clusters: []*ecs.Cluster{
+							&ecs.Cluster{
+								ClusterArn:  aws.String("arn:aws:ecs:us-east-1:0123456:cluster/cluster1"),
+								ClusterName: aws.String("cluster1"),
+							},
+							&ecs.Cluster{
+								ClusterArn:  aws.String("arn:aws:ecs:us-east-1:0123456:cluster/cluster2"),
+								ClusterName: aws.String("cluster2"),
+							},
+						},
+					}, nil)
+			},
+
+			wantedClusters: []string{"arn:aws:ecs:us-east-1:0123456:cluster/cluster1", "arn:aws:ecs:us-east-1:0123456:cluster/cluster2"},
+		},
+		"failed to get default clusters": {
+			mockECSClient: func(m *mocks.Mockapi) {
+				m.EXPECT().
+					DescribeClusters(&ecs.DescribeClustersInput{}).
+					Return(nil, errors.New("error"))
+			},
+			wantedError: fmt.Errorf("get default clusters: %s", "error"),
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockECSClient := mocks.NewMockapi(ctrl)
+			tc.mockECSClient(mockECSClient)
+
+			ecs := ECS{
+				client: mockECSClient,
+			}
+			clusters, err := ecs.DefaultClusters()
+			if tc.wantedError != nil {
+				require.EqualError(t, tc.wantedError, err.Error())
+			} else {
+				require.Equal(t, tc.wantedClusters, clusters)
+			}
+		})
+	}
+}
+
+func TestECS_RunTask(t *testing.T) {
+	type input struct {
+		cluster        string
+		count          int64
+		subnets        []string
+		securityGroups []string
+		taskFamilyName string
+	}
+
+	runTaskInput := input{
+		cluster:        "my-cluster",
+		count:          3,
+		subnets:        []string{"subnet-1", "subnet-2"},
+		securityGroups: []string{"sg-1", "sg-2"},
+		taskFamilyName: "my-task",
+	}
+
+	testCases := map[string]struct {
+		input
+
+		mockECSClient func(m *mocks.Mockapi)
+
+		wantedError error
+	}{
+		"run task success": {
+			input: runTaskInput,
+			mockECSClient: func(m *mocks.Mockapi) {
+				m.EXPECT().RunTask(&ecs.RunTaskInput{
+					Cluster:        aws.String("my-cluster"),
+					Count:          aws.Int64(3),
+					LaunchType:     aws.String(ecs.LaunchTypeFargate),
+					StartedBy:      aws.String(runTaskStartedBy),
+					TaskDefinition: aws.String("my-task"),
+					NetworkConfiguration: &ecs.NetworkConfiguration{
+						AwsvpcConfiguration: &ecs.AwsVpcConfiguration{
+							AssignPublicIp: aws.String(ecs.AssignPublicIpEnabled),
+							Subnets:        aws.StringSlice([]string{"subnet-1", "subnet-2"}),
+							SecurityGroups: aws.StringSlice([]string{"sg-1", "sg-2"}),
+						},
+					},
+				}).
+					Return(&ecs.RunTaskOutput{
+						Tasks: []*ecs.Task{
+							&ecs.Task{
+								TaskArn: aws.String("task-1"),
+							},
+							&ecs.Task{
+								TaskArn: aws.String("task-2"),
+							},
+							&ecs.Task{
+								TaskArn: aws.String("task-3"),
+							},
+						},
+				}, nil)
+				m.EXPECT().WaitUntilTasksRunning(&ecs.DescribeTasksInput{
+					Cluster: aws.String("my-cluster"),
+					Tasks: aws.StringSlice([]string{"task-1", "task-2", "task-3"}),
+				}).Times(1)
+			},
+		},
+		"run task failed": {
+			input: runTaskInput,
+
+			mockECSClient: func(m *mocks.Mockapi) {
+				m.EXPECT().RunTask(&ecs.RunTaskInput{
+					Cluster:        aws.String("my-cluster"),
+					Count:          aws.Int64(3),
+					LaunchType:     aws.String(ecs.LaunchTypeFargate),
+					StartedBy:      aws.String(runTaskStartedBy),
+					TaskDefinition: aws.String("my-task"),
+					NetworkConfiguration: &ecs.NetworkConfiguration{
+						AwsvpcConfiguration: &ecs.AwsVpcConfiguration{
+							AssignPublicIp: aws.String(ecs.AssignPublicIpEnabled),
+							Subnets:        aws.StringSlice([]string{"subnet-1", "subnet-2"}),
+							SecurityGroups: aws.StringSlice([]string{"sg-1", "sg-2"}),
+						},
+					},
+				}).
+					Return(&ecs.RunTaskOutput{}, errors.New("error"))
+				m.EXPECT().WaitUntilTasksRunning(gomock.Any()).Times(0)
+			},
+			wantedError: errors.New("run task(s) with group name my-task: error"),
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockECSClient := mocks.NewMockapi(ctrl)
+			tc.mockECSClient(mockECSClient)
+
+			ecs := ECS{
+				client: mockECSClient,
+			}
+
+			err := ecs.RunTask(RunTaskInput{
+				Count:          tc.count,
+				Cluster:        tc.cluster,
+				TaskFamilyName: tc.taskFamilyName,
+				Subnets:        tc.subnets,
+				SecurityGroups: tc.securityGroups,
+			})
+
+			if tc.wantedError != nil {
+				require.EqualError(t, tc.wantedError, err.Error())
+			}
+		})
+	}
+}
+
 func TestTaskDefinition_EnvVars(t *testing.T) {
 	testCases := map[string]struct {
 		inContainers []*ecs.ContainerDefinition

--- a/internal/pkg/aws/ecs/ecs_test.go
+++ b/internal/pkg/aws/ecs/ecs_test.go
@@ -333,7 +333,7 @@ func TestECS_DefaultCluster(t *testing.T) {
 		mockECSClient func(m *mocks.Mockapi)
 
 		wantedError    error
-		wantedClusters []string
+		wantedClusters string
 	}{
 		"get default clusters success": {
 			mockECSClient: func(m *mocks.Mockapi) {
@@ -353,7 +353,7 @@ func TestECS_DefaultCluster(t *testing.T) {
 					}, nil)
 			},
 
-			wantedClusters: []string{"arn:aws:ecs:us-east-1:0123456:cluster/cluster1", "arn:aws:ecs:us-east-1:0123456:cluster/cluster2"},
+			wantedClusters: "arn:aws:ecs:us-east-1:0123456:cluster/cluster1",
 		},
 		"failed to get default clusters": {
 			mockECSClient: func(m *mocks.Mockapi) {
@@ -361,7 +361,7 @@ func TestECS_DefaultCluster(t *testing.T) {
 					DescribeClusters(&ecs.DescribeClustersInput{}).
 					Return(nil, errors.New("error"))
 			},
-			wantedError: fmt.Errorf("get default clusters: %s", "error"),
+			wantedError: fmt.Errorf("get default cluster: %s", "error"),
 		},
 	}
 
@@ -376,7 +376,7 @@ func TestECS_DefaultCluster(t *testing.T) {
 			ecs := ECS{
 				client: mockECSClient,
 			}
-			clusters, err := ecs.DefaultClusters()
+			clusters, err := ecs.DefaultCluster()
 			if tc.wantedError != nil {
 				require.EqualError(t, tc.wantedError, err.Error())
 			} else {

--- a/internal/pkg/aws/ecs/mocks/mock_ecs.go
+++ b/internal/pkg/aws/ecs/mocks/mock_ecs.go
@@ -92,3 +92,47 @@ func (mr *MockapiMockRecorder) ListTasks(input interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTasks", reflect.TypeOf((*Mockapi)(nil).ListTasks), input)
 }
+
+// DescribeClusters mocks base method
+func (m *Mockapi) DescribeClusters(input *ecs.DescribeClustersInput) (*ecs.DescribeClustersOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeClusters", input)
+	ret0, _ := ret[0].(*ecs.DescribeClustersOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeClusters indicates an expected call of DescribeClusters
+func (mr *MockapiMockRecorder) DescribeClusters(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeClusters", reflect.TypeOf((*Mockapi)(nil).DescribeClusters), input)
+}
+
+// RunTask mocks base method
+func (m *Mockapi) RunTask(input *ecs.RunTaskInput) (*ecs.RunTaskOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RunTask", input)
+	ret0, _ := ret[0].(*ecs.RunTaskOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RunTask indicates an expected call of RunTask
+func (mr *MockapiMockRecorder) RunTask(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunTask", reflect.TypeOf((*Mockapi)(nil).RunTask), input)
+}
+
+// WaitUntilTasksRunning mocks base method
+func (m *Mockapi) WaitUntilTasksRunning(input *ecs.DescribeTasksInput) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitUntilTasksRunning", input)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WaitUntilTasksRunning indicates an expected call of WaitUntilTasksRunning
+func (mr *MockapiMockRecorder) WaitUntilTasksRunning(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilTasksRunning", reflect.TypeOf((*Mockapi)(nil).WaitUntilTasksRunning), input)
+}

--- a/internal/pkg/cli/flag.go
+++ b/internal/pkg/cli/flag.go
@@ -59,10 +59,10 @@ const (
 	memoryFlag         = "memory"
 	imageFlag          = "image"
 	taskRoleFlag       = "task-role"
-	subnetFlag         = "subnet"
+	subnetsFlag        = "subnets"
 	securityGroupsFlag = "security-groups"
 	envVarsFlag        = "env-vars"
-	commandsFlag       = "commands"
+	commandFlag        = "command"
 )
 
 // Short flag names.
@@ -137,14 +137,15 @@ Must be of the format '<keyName>:<dataType>'.`
 	storageLSIConfigFlagDescription = `Optional. Attribute to use as an alternate sort key. May be specified up to 5 times.
 Must be of the format '<keyName>:<dataType>'.`
 
-	countFlagDescription          = "Optional. The number of tasks to set up. Default 1."
-	cpuFlagDescription            = "Optional. The number of CPU units to reserve for each task. Default 256 (1/4 vCPU)."
-	memoryFlagDescription         = "Optional. The amount of memory to reserve in MiB for each task. Default 512."
+	countFlagDescription          = "Optional. The number of tasks to set up."
+	cpuFlagDescription            = "Optional. The number of CPU units to reserve for each task."
+	memoryFlagDescription         = "Optional. The amount of memory to reserve in MiB for each task."
 	imageFlagDescription          = "Optional. The image to run instead of building a Dockerfile."
 	taskRoleFlagDescription       = "Optional. The role for the task to use."
-	subnetFlagDescription         = "Optional. The subnet id for the task to use."
-	securityGroupsFlagDescription = "Optional. The security group id(s) for the task to use. Can be specified multiple times."
+	subnetsFlagDescription        = "Optional. The subnet IDs for the task to use."
+	securityGroupsFlagDescription = "Optional. The security group ID(s) for the task to use. Can be specified multiple times."
 	envVarsFlagDescription        = "Optional. Environment variables specified by key=value separated with commas."
-	commandsFlagDescription       = "Optional. List of commands that are passed to docker run. Can be specified multiple times."
+	commandFlagDescription        = "Optional. The command that is passed to docker run to override the default command."
 	taskGroupFlagDescription      = "The group name of the task. Tasks with the same group name share the same set of resources."
+	taskImageTagDescription       = "Optional. The task's image tag."
 )

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -133,9 +133,18 @@ type ecrService interface {
 	GetECRAuth() (ecr.Auth, error)
 }
 
+type vpcService interface {
+	GetSubnetIDs(app string, env string) ([]string, error)
+	GetSecurityGroups(app string, env string) ([]string, error)
+}
+
 type cwlogService interface {
 	TaskLogEvents(logGroupName string, streamLastEventTime map[string]int64, opts ...cloudwatchlogs.GetLogEventsOpts) (*cloudwatchlogs.LogEventsOutput, error)
 	LogGroupExists(logGroupName string) (bool, error)
+}
+
+type ecsService interface {
+	DefaultClusters() ([]string, error)
 }
 
 type templater interface {
@@ -242,6 +251,14 @@ type environmentDeployer interface {
 	StreamEnvironmentCreation(env *deploy.CreateEnvironmentInput) (<-chan []deploy.ResourceEvent, <-chan deploy.CreateEnvironmentResponse)
 	DeleteEnvironment(appName, envName string) error
 	GetEnvironment(appName, envName string) (*config.Environment, error)
+}
+
+type taskResourceDeployer interface {
+	DeployTask(input *deploy.CreateTaskResourcesInput) error
+}
+
+type taskStarter interface {
+	RunTask(input ecs.RunTaskInput) error
 }
 
 type svcDeleter interface {

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -144,7 +144,7 @@ type cwlogService interface {
 }
 
 type ecsService interface {
-	DefaultClusters() ([]string, error)
+	DefaultCluster() (string, error)
 }
 
 type templater interface {

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -1306,19 +1306,19 @@ func (m *MockecsService) EXPECT() *MockecsServiceMockRecorder {
 	return m.recorder
 }
 
-// DefaultClusters mocks base method
-func (m *MockecsService) DefaultClusters() ([]string, error) {
+// DefaultCluster mocks base method
+func (m *MockecsService) DefaultCluster() (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DefaultClusters")
-	ret0, _ := ret[0].([]string)
+	ret := m.ctrl.Call(m, "DefaultCluster")
+	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// DefaultClusters indicates an expected call of DefaultClusters
-func (mr *MockecsServiceMockRecorder) DefaultClusters() *gomock.Call {
+// DefaultCluster indicates an expected call of DefaultCluster
+func (mr *MockecsServiceMockRecorder) DefaultCluster() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DefaultClusters", reflect.TypeOf((*MockecsService)(nil).DefaultClusters))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DefaultCluster", reflect.TypeOf((*MockecsService)(nil).DefaultCluster))
 }
 
 // Mocktemplater is a mock of templater interface

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -6,9 +6,6 @@ package mocks
 
 import (
 	encoding "encoding"
-	io "io"
-	reflect "reflect"
-
 	session "github.com/aws/aws-sdk-go/aws/session"
 	cloudwatchlogs "github.com/aws/copilot-cli/internal/pkg/aws/cloudwatchlogs"
 	codepipeline "github.com/aws/copilot-cli/internal/pkg/aws/codepipeline"
@@ -22,6 +19,8 @@ import (
 	command "github.com/aws/copilot-cli/internal/pkg/term/command"
 	workspace "github.com/aws/copilot-cli/internal/pkg/workspace"
 	gomock "github.com/golang/mock/gomock"
+	io "io"
+	reflect "reflect"
 )
 
 // MockactionCommand is a mock of actionCommand interface
@@ -1173,6 +1172,59 @@ func (mr *MockecrServiceMockRecorder) GetECRAuth() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetECRAuth", reflect.TypeOf((*MockecrService)(nil).GetECRAuth))
 }
 
+// MockvpcService is a mock of vpcService interface
+type MockvpcService struct {
+	ctrl     *gomock.Controller
+	recorder *MockvpcServiceMockRecorder
+}
+
+// MockvpcServiceMockRecorder is the mock recorder for MockvpcService
+type MockvpcServiceMockRecorder struct {
+	mock *MockvpcService
+}
+
+// NewMockvpcService creates a new mock instance
+func NewMockvpcService(ctrl *gomock.Controller) *MockvpcService {
+	mock := &MockvpcService{ctrl: ctrl}
+	mock.recorder = &MockvpcServiceMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockvpcService) EXPECT() *MockvpcServiceMockRecorder {
+	return m.recorder
+}
+
+// GetSubnetIDs mocks base method
+func (m *MockvpcService) GetSubnetIDs(app, env string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSubnetIDs", app, env)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSubnetIDs indicates an expected call of GetSubnetIDs
+func (mr *MockvpcServiceMockRecorder) GetSubnetIDs(app, env interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSubnetIDs", reflect.TypeOf((*MockvpcService)(nil).GetSubnetIDs), app, env)
+}
+
+// GetSecurityGroups mocks base method
+func (m *MockvpcService) GetSecurityGroups(app, env string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSecurityGroups", app, env)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSecurityGroups indicates an expected call of GetSecurityGroups
+func (mr *MockvpcServiceMockRecorder) GetSecurityGroups(app, env interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecurityGroups", reflect.TypeOf((*MockvpcService)(nil).GetSecurityGroups), app, env)
+}
+
 // MockcwlogService is a mock of cwlogService interface
 type MockcwlogService struct {
 	ctrl     *gomock.Controller
@@ -1229,6 +1281,44 @@ func (m *MockcwlogService) LogGroupExists(logGroupName string) (bool, error) {
 func (mr *MockcwlogServiceMockRecorder) LogGroupExists(logGroupName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogGroupExists", reflect.TypeOf((*MockcwlogService)(nil).LogGroupExists), logGroupName)
+}
+
+// MockecsService is a mock of ecsService interface
+type MockecsService struct {
+	ctrl     *gomock.Controller
+	recorder *MockecsServiceMockRecorder
+}
+
+// MockecsServiceMockRecorder is the mock recorder for MockecsService
+type MockecsServiceMockRecorder struct {
+	mock *MockecsService
+}
+
+// NewMockecsService creates a new mock instance
+func NewMockecsService(ctrl *gomock.Controller) *MockecsService {
+	mock := &MockecsService{ctrl: ctrl}
+	mock.recorder = &MockecsServiceMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockecsService) EXPECT() *MockecsServiceMockRecorder {
+	return m.recorder
+}
+
+// DefaultClusters mocks base method
+func (m *MockecsService) DefaultClusters() ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DefaultClusters")
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DefaultClusters indicates an expected call of DefaultClusters
+func (mr *MockecsServiceMockRecorder) DefaultClusters() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DefaultClusters", reflect.TypeOf((*MockecsService)(nil).DefaultClusters))
 }
 
 // Mocktemplater is a mock of templater interface
@@ -2308,6 +2398,80 @@ func (m *MockenvironmentDeployer) GetEnvironment(appName, envName string) (*conf
 func (mr *MockenvironmentDeployerMockRecorder) GetEnvironment(appName, envName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEnvironment", reflect.TypeOf((*MockenvironmentDeployer)(nil).GetEnvironment), appName, envName)
+}
+
+// MocktaskResourceDeployer is a mock of taskResourceDeployer interface
+type MocktaskResourceDeployer struct {
+	ctrl     *gomock.Controller
+	recorder *MocktaskResourceDeployerMockRecorder
+}
+
+// MocktaskResourceDeployerMockRecorder is the mock recorder for MocktaskResourceDeployer
+type MocktaskResourceDeployerMockRecorder struct {
+	mock *MocktaskResourceDeployer
+}
+
+// NewMocktaskResourceDeployer creates a new mock instance
+func NewMocktaskResourceDeployer(ctrl *gomock.Controller) *MocktaskResourceDeployer {
+	mock := &MocktaskResourceDeployer{ctrl: ctrl}
+	mock.recorder = &MocktaskResourceDeployerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MocktaskResourceDeployer) EXPECT() *MocktaskResourceDeployerMockRecorder {
+	return m.recorder
+}
+
+// DeployTask mocks base method
+func (m *MocktaskResourceDeployer) DeployTask(input *deploy.CreateTaskResourcesInput) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeployTask", input)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeployTask indicates an expected call of DeployTask
+func (mr *MocktaskResourceDeployerMockRecorder) DeployTask(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeployTask", reflect.TypeOf((*MocktaskResourceDeployer)(nil).DeployTask), input)
+}
+
+// MocktaskStarter is a mock of taskStarter interface
+type MocktaskStarter struct {
+	ctrl     *gomock.Controller
+	recorder *MocktaskStarterMockRecorder
+}
+
+// MocktaskStarterMockRecorder is the mock recorder for MocktaskStarter
+type MocktaskStarterMockRecorder struct {
+	mock *MocktaskStarter
+}
+
+// NewMocktaskStarter creates a new mock instance
+func NewMocktaskStarter(ctrl *gomock.Controller) *MocktaskStarter {
+	mock := &MocktaskStarter{ctrl: ctrl}
+	mock.recorder = &MocktaskStarterMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MocktaskStarter) EXPECT() *MocktaskStarterMockRecorder {
+	return m.recorder
+}
+
+// RunTask mocks base method
+func (m *MocktaskStarter) RunTask(input ecs.RunTaskInput) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RunTask", input)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RunTask indicates an expected call of RunTask
+func (mr *MocktaskStarterMockRecorder) RunTask(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunTask", reflect.TypeOf((*MocktaskStarter)(nil).RunTask), input)
 }
 
 // MocksvcDeleter is a mock of svcDeleter interface

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -7,9 +7,20 @@ import (
 	"errors"
 	"fmt"
 
+	awscfn "github.com/aws/copilot-cli/internal/pkg/aws/cloudformation"
+	"github.com/aws/copilot-cli/internal/pkg/aws/ec2"
+	"github.com/aws/copilot-cli/internal/pkg/aws/ecr"
+	"github.com/aws/copilot-cli/internal/pkg/aws/ecs"
+	"github.com/aws/copilot-cli/internal/pkg/aws/resourcegroups"
+	"github.com/aws/copilot-cli/internal/pkg/aws/session"
 	"github.com/aws/copilot-cli/internal/pkg/cli/selector"
 	"github.com/aws/copilot-cli/internal/pkg/config"
+	"github.com/aws/copilot-cli/internal/pkg/deploy"
+	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation"
+	"github.com/aws/copilot-cli/internal/pkg/docker"
 	"github.com/aws/copilot-cli/internal/pkg/term/color"
+	"github.com/aws/copilot-cli/internal/pkg/term/log"
+	termprogress "github.com/aws/copilot-cli/internal/pkg/term/progress"
 	"github.com/aws/copilot-cli/internal/pkg/term/prompt"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -26,37 +37,57 @@ var (
 	taskRunEnvPromptHelp = fmt.Sprintf("Task will be deployed to the selected environment. "+
 		"Select %s to run the task in your default VPC instead of any existing environment.", color.Emphasize(config.EnvNameNone))
 	taskRunGroupNamePromptHelp = "The group name of the task. Tasks with the same group name share the same set of resources, including CloudFormation stack, CloudWatch log group, task definition and ECR repository."
+
+	fmtTaskFamilyName = "copilot-%s"
+	fmtRepoName       = "copilot-%s"
+	fmtImageURL       = "%s:%s"
+)
+
+const (
+	defaultImageTag       = "copilot"
+	defaultDockerfilePath = "./Dockerfile"
+	clusterResourceType   = "AWS::ECS::Cluster"
 )
 
 type runTaskVars struct {
 	*GlobalOpts
-	count  int8
-	cpu    int16
-	memory int16
+	count  int64
+	cpu    int
+	memory int
 
 	groupName string
 
 	image          string
 	dockerfilePath string
+	imageTag       string
 
 	taskRole string
 
-	subnet         string
+	subnets        []string
 	securityGroups []string
 	env            string
 
-	envVars  map[string]string
-	commands []string
+	envVars map[string]string
+	command string
 }
 
 type runTaskOpts struct {
 	runTaskVars
 
 	// Interfaces to interact with dependencies.
-	fs     afero.Fs
-	store  store
-	parser dockerfileParser
-	sel    appEnvWithNoneSelector
+	fs    afero.Fs
+	store store
+	sel   appEnvWithNoneSelector
+
+	docker           dockerService
+	ecrGetter        ecrService
+	vpcGetter        vpcService
+	resourceGetter   resourceGroupsClient
+	ecsGetter        ecsService
+	resourceDeployer taskResourceDeployer
+	starter          taskStarter
+
+	spinner progress
 }
 
 func newTaskRunOpts(vars runTaskVars) (*runTaskOpts, error) {
@@ -65,12 +96,23 @@ func newTaskRunOpts(vars runTaskVars) (*runTaskOpts, error) {
 		return nil, fmt.Errorf("new config store: %w", err)
 	}
 
+	sess, err := session.NewProvider().Default()
 	return &runTaskOpts{
 		runTaskVars: vars,
 
 		fs:    &afero.Afero{Fs: afero.NewOsFs()},
 		store: store,
 		sel:   selector.NewSelect(vars.prompt, store),
+
+		docker:           docker.New(),
+		ecrGetter:        ecr.New(sess),
+		vpcGetter:        ec2.New(sess),
+		resourceDeployer: cloudformation.New(sess),
+		resourceGetter:   resourcegroups.New(sess),
+		ecsGetter:        ecs.New(sess),
+		starter:          ecs.New(sess),
+
+		spinner: termprogress.NewSpinner(),
 	}, nil
 }
 
@@ -104,7 +146,7 @@ func (o *runTaskOpts) Validate() error {
 		}
 	}
 
-	if o.env != "" && (o.subnet != "" || o.securityGroups != nil) {
+	if o.env != "" && (o.subnets != nil || o.securityGroups != nil) {
 		return errors.New("neither subnet nor security groups should be specified if environment is specified")
 	}
 
@@ -134,6 +176,155 @@ func (o *runTaskOpts) Ask() error {
 	return nil
 }
 
+// Execute create or update task resources and run the task.
+func (o *runTaskOpts) Execute() error {
+	if o.image == "" && o.dockerfilePath == "" {
+		o.dockerfilePath = defaultDockerfilePath
+	}
+
+	if o.imageTag == "" {
+		o.imageTag = defaultImageTag
+	}
+
+	if err := o.getNetworkConfig(); err != nil {
+		return err
+	}
+
+	cluster, err := o.getCluster()
+	if err != nil {
+		return err
+	}
+
+	if err := o.createAndUpdateTaskResources(); err != nil {
+		return err
+	}
+
+	//if image is not provided, then we build the image and push to ECR repo
+	if o.image == "" {
+		uri, err := o.pushToECRRepo()
+		if err != nil {
+			return err
+		}
+		o.image = fmt.Sprintf(fmtImageURL, uri, o.imageTag)
+
+		// update image to stack
+		if err := o.createAndUpdateTaskResources(); err != nil {
+			return err
+		}
+	}
+
+	return o.runTask(cluster)
+}
+
+func (o *runTaskOpts) getCluster() (string, error) {
+	if o.env == config.EnvNameNone {
+		clusters, err := o.ecsGetter.DefaultClusters()
+		if err != nil {
+			return "", fmt.Errorf("get default cluster: %w", err)
+		}
+		return clusters[0], nil
+	}
+
+	clusters, err := o.resourceGetter.GetResourcesByTags(clusterResourceType, map[string]string{
+		deploy.AppTagKey: o.AppName(),
+		deploy.EnvTagKey: o.env,
+	})
+
+	if err != nil {
+		return "", fmt.Errorf("get cluster: %w", err)
+	}
+
+	return clusters[0], nil
+}
+
+func (o *runTaskOpts) runTask(cluster string) error {
+	o.spinner.Start(fmt.Sprintf("Waiting for %s to be running.", o.groupName))
+	err := o.starter.RunTask(ecs.RunTaskInput{
+		Cluster:        cluster,
+		Count:          o.count,
+		Subnets:        o.subnets,
+		SecurityGroups: o.securityGroups,
+		TaskFamilyName: fmt.Sprintf(fmtTaskFamilyName, o.groupName),
+	})
+
+	if err != nil {
+		o.spinner.Stop(log.Serrorln(fmt.Sprintf("Failed to run %s", o.groupName)))
+		return fmt.Errorf("run task %s: %w", o.groupName, err)
+	}
+
+	o.spinner.Stop(log.Ssuccessln(fmt.Sprintf("Task(s) %s is running.", o.groupName)))
+	return nil
+}
+
+func (o *runTaskOpts) getNetworkConfig() error {
+	if o.subnets == nil {
+		subnets, err := o.vpcGetter.GetSubnetIDs(o.AppName(), o.env)
+		if err != nil {
+			return fmt.Errorf("get subnet IDs from environment %s: %w", o.env, err)
+		}
+		o.subnets = subnets
+	}
+
+	// if the task is to be run in None environment (default environment), leave security groups as nil since it is not
+	// a required field for run task
+	if o.securityGroups == nil {
+		securityGroups, err := o.vpcGetter.GetSecurityGroups(o.AppName(), o.env)
+		if err != nil {
+			return fmt.Errorf("get security groups from environment %s: %w", o.env, err)
+		}
+		o.securityGroups = securityGroups
+	}
+	return nil
+}
+
+func (o *runTaskOpts) createAndUpdateTaskResources() error {
+	o.spinner.Start(fmt.Sprintf("Deploying resources for task %s", color.HighlightUserInput(o.groupName)))
+	if err := o.resourceDeployer.DeployTask(&deploy.CreateTaskResourcesInput{
+		Name:     o.groupName,
+		Cpu:      o.cpu,
+		Memory:   o.memory,
+		Image:    o.image,
+		TaskRole: o.taskRole,
+		Command:  o.command,
+		EnvVars:  o.envVars,
+	}); err != nil {
+		var errChangeSetEmpty *awscfn.ErrChangeSetEmpty
+		if !errors.As(err, &errChangeSetEmpty) {
+			o.spinner.Stop(log.Serrorln("Failed to deploy task resources."))
+			return fmt.Errorf("failed to deploy resources for task %s: %w", o.groupName, err)
+		}
+	}
+	o.spinner.Stop("\n")
+	return nil
+}
+
+func (o *runTaskOpts) pushToECRRepo() (string, error) {
+	repoName := fmt.Sprintf(fmtRepoName, o.groupName)
+
+	uri, err := o.ecrGetter.GetRepository(repoName)
+	if err != nil {
+		return "", fmt.Errorf("get ECR repository URI: %w", err)
+	}
+
+	if err := o.docker.Build(uri, o.imageTag, o.dockerfilePath); err != nil {
+		return "", fmt.Errorf("build Dockerfile at %s with tag %s: %w", o.dockerfilePath, o.imageTag, err)
+	}
+
+	auth, err := o.ecrGetter.GetECRAuth()
+	if err != nil {
+		return "", fmt.Errorf("get ECR auth data: %w", err)
+	}
+
+	if err := o.docker.Login(uri, auth.Username, auth.Password); err != nil {
+		return "", fmt.Errorf("login to repo %s: %w", repoName, err)
+	}
+
+	if err := o.docker.Push(uri, o.imageTag); err != nil {
+		return "", fmt.Errorf("push to repo: %w", err)
+	}
+	return uri, nil
+}
+
 func (o *runTaskOpts) validateAppName() error {
 	if _, err := o.store.GetApplication(o.appName); err != nil {
 		return fmt.Errorf("get application: %w", err)
@@ -158,7 +349,7 @@ func (o *runTaskOpts) askTaskGroupName() error {
 		return nil
 	}
 
-	// TODO during Execute: list existing tasks like in ListApplications, ask whether to use existing tasks
+	// TODO: maybe list existing tasks like in ListApplications, ask whether to use existing tasks; require to implement task store first
 
 	groupName, err := o.prompt.Get(
 		fmtTaskRunGroupNamePrompt,
@@ -177,7 +368,7 @@ func (o *runTaskOpts) askEnvName() error {
 		return nil
 	}
 
-	if o.AppName() == "" {
+	if o.AppName() == "" || o.subnets != nil {
 		o.env = config.EnvNameNone
 		return nil
 	}
@@ -221,28 +412,33 @@ Run a task with environment variables.
 			if err := opts.Ask(); err != nil {
 				return err
 			}
+
+			if err := opts.Execute(); err != nil {
+				return err
+			}
 			return nil
 		}),
 	}
 
-	cmd.Flags().Int8Var(&vars.count, countFlag, 1, countFlagDescription)
-	cmd.Flags().Int16Var(&vars.cpu, cpuFlag, 256, cpuFlagDescription)
-	cmd.Flags().Int16Var(&vars.memory, memoryFlag, 512, memoryFlagDescription)
+	cmd.Flags().Int64Var(&vars.count, countFlag, 1, countFlagDescription)
+	cmd.Flags().IntVar(&vars.cpu, cpuFlag, 256, cpuFlagDescription)
+	cmd.Flags().IntVar(&vars.memory, memoryFlag, 512, memoryFlagDescription)
 
 	cmd.Flags().StringVarP(&vars.groupName, taskGroupNameFlag, nameFlagShort, "", taskGroupFlagDescription)
 
 	cmd.Flags().StringVar(&vars.image, imageFlag, "", imageFlagDescription)
 	cmd.Flags().StringVar(&vars.dockerfilePath, dockerFileFlag, "", dockerFileFlagDescription)
+	cmd.Flags().StringVar(&vars.imageTag, imageTagFlag, "", imageFlagDescription)
 
 	cmd.Flags().StringVar(&vars.taskRole, taskRoleFlag, "", taskRoleFlagDescription)
 
 	cmd.Flags().StringVar(&vars.appName, appFlag, "", appFlagDescription)
 	cmd.Flags().StringVar(&vars.env, envFlag, "", envFlagDescription)
-	cmd.Flags().StringVar(&vars.subnet, subnetFlag, "", subnetFlagDescription)
+	cmd.Flags().StringSliceVar(&vars.subnets, subnetFlag, nil, subnetFlagDescription)
 	cmd.Flags().StringSliceVar(&vars.securityGroups, securityGroupsFlag, nil, securityGroupsFlagDescription)
 
 	cmd.Flags().StringToStringVar(&vars.envVars, envVarsFlag, nil, envVarsFlagDescription)
-	cmd.Flags().StringSliceVar(&vars.commands, commandsFlag, nil, commandsFlagDescription)
+	cmd.Flags().StringVar(&vars.command, commandsFlag, "", commandsFlagDescription)
 
 	return cmd
 }

--- a/internal/pkg/deploy/cloudformation/stack/name.go
+++ b/internal/pkg/deploy/cloudformation/stack/name.go
@@ -21,3 +21,8 @@ func NameForService(app, env, svc string) string {
 func NameForEnv(app, env string) string {
 	return fmt.Sprintf("%s-%s", app, env)
 }
+
+// NameForEnv returns the stack name for a task.
+func NameForTask(task string) string {
+	return fmt.Sprintf("task-%s", task)
+}

--- a/internal/pkg/deploy/cloudformation/stack/svc.go
+++ b/internal/pkg/deploy/cloudformation/stack/svc.go
@@ -16,6 +16,10 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/template"
 )
 
+const (
+	logRetention = "30"
+)
+
 // Template rendering configuration common across services.
 const (
 	svcParamsTemplatePath = "services/params.json.tmpl"
@@ -96,7 +100,7 @@ func (s *svc) Parameters() []*cloudformation.Parameter {
 		},
 		{
 			ParameterKey:   aws.String(ServiceLogRetentionParamKey),
-			ParameterValue: aws.String("30"),
+			ParameterValue: aws.String(logRetention),
 		},
 		{
 			ParameterKey:   aws.String(ServiceAddonsTemplateURLParamKey),

--- a/internal/pkg/deploy/cloudformation/stack/task.go
+++ b/internal/pkg/deploy/cloudformation/stack/task.go
@@ -1,0 +1,110 @@
+package stack
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/aws/copilot-cli/internal/pkg/deploy"
+	"github.com/aws/copilot-cli/internal/pkg/template"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+)
+
+const (
+	taskTemplatePath = "task/cf.yml"
+	taskLogRetention = "30"
+
+	TaskNameParamKey         = "TaskName"
+	TaskCPUParamKey          = "TaskCPU"
+	TaskMemoryParamKey       = "TaskMemory"
+	TaskLogRetentionParamKey = "LogRetention"
+
+	TaskContainerImageParamKey = "ContainerImage"
+	TaskTaskRoleParamKey       = "TaskRole"
+	TaskCommandParamKey        = "Command"
+)
+
+type taskStackConfig struct {
+	Name string
+
+	Cpu    int
+	Memory int
+
+	ImageURL string
+	TaskRole string
+	Command  string
+	EnvVars map[string]string
+
+	parser template.ReadParser
+}
+
+func NewTaskStackConfig(taskOpts *deploy.CreateTaskResourcesInput) *taskStackConfig {
+	return &taskStackConfig{
+		Name:   taskOpts.Name,
+		Cpu:    taskOpts.Cpu,
+		Memory: taskOpts.Memory,
+
+		ImageURL: taskOpts.Image,
+		TaskRole: taskOpts.TaskRole,
+		Command:  taskOpts.Command,
+		EnvVars: taskOpts.EnvVars,
+
+		parser: template.New(),
+	}
+}
+
+func (t *taskStackConfig) StackName() string {
+	return NameForTask(t.Name)
+}
+
+func (t *taskStackConfig) Template() (string, error) {
+	content, err := t.parser.Parse(taskTemplatePath, struct{
+		EnvVars map[string]string
+	}{
+		EnvVars: t.EnvVars,
+	})
+	if err != nil {
+		return "", fmt.Errorf("read template for task stack: %w", err)
+	}
+	return content.String(), nil
+}
+
+func (t *taskStackConfig) Parameters() ([]*cloudformation.Parameter, error) {
+	return []*cloudformation.Parameter{
+		{
+			ParameterKey:   aws.String(TaskNameParamKey),
+			ParameterValue: aws.String(t.Name),
+		},
+		{
+			ParameterKey:   aws.String(TaskCPUParamKey),
+			ParameterValue: aws.String(strconv.Itoa(aws.IntValue(&t.Cpu))),
+		},
+		{
+			ParameterKey:   aws.String(TaskMemoryParamKey),
+			ParameterValue: aws.String(strconv.Itoa(aws.IntValue(&t.Memory))),
+		},
+		{
+			ParameterKey:   aws.String(TaskLogRetentionParamKey),
+			ParameterValue: aws.String(taskLogRetention),
+		},
+		{
+			ParameterKey:   aws.String(TaskContainerImageParamKey),
+			ParameterValue: aws.String(t.ImageURL),
+		},
+		{
+			ParameterKey:   aws.String(TaskTaskRoleParamKey),
+			ParameterValue: aws.String(t.TaskRole),
+		},
+		{
+			ParameterKey:   aws.String(TaskCommandParamKey),
+			ParameterValue: aws.String(t.Command),
+		},
+	}, nil
+}
+
+func (t *taskStackConfig) Tags() []*cloudformation.Tag {
+	return mergeAndFlattenTags(map[string]string{
+		deploy.TaskTagKey: t.Name,
+	}, nil)
+}

--- a/internal/pkg/deploy/cloudformation/stack/task.go
+++ b/internal/pkg/deploy/cloudformation/stack/task.go
@@ -13,7 +13,6 @@ import (
 
 const (
 	taskTemplatePath = "task/cf.yml"
-	taskLogRetention = "30"
 
 	TaskNameParamKey         = "TaskName"
 	TaskCPUParamKey          = "TaskCPU"
@@ -86,7 +85,7 @@ func (t *taskStackConfig) Parameters() ([]*cloudformation.Parameter, error) {
 		},
 		{
 			ParameterKey:   aws.String(TaskLogRetentionParamKey),
-			ParameterValue: aws.String(taskLogRetention),
+			ParameterValue: aws.String(logRetention),
 		},
 		{
 			ParameterKey:   aws.String(TaskContainerImageParamKey),

--- a/internal/pkg/deploy/cloudformation/stack/task_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/task_test.go
@@ -86,7 +86,7 @@ func TestTask_Parameters(t *testing.T) {
 		},
 		{
 			ParameterKey:   aws.String(TaskLogRetentionParamKey),
-			ParameterValue: aws.String(taskLogRetention),
+			ParameterValue: aws.String(logRetention),
 		},
 		{
 			ParameterKey:   aws.String(TaskTaskRoleParamKey),

--- a/internal/pkg/deploy/cloudformation/stack/task_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/task_test.go
@@ -1,0 +1,120 @@
+package stack
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/aws/copilot-cli/internal/pkg/template"
+	"github.com/aws/copilot-cli/internal/pkg/template/mocks"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testTaskName = "my-task"
+)
+
+func TestTask_Template(t *testing.T) {
+	testCases := map[string]struct {
+		mockReadParser func(m *mocks.MockReadParser)
+
+		wantedTemplate string
+		wantedError    error
+	}{
+		"should return error if unable to read": {
+			mockReadParser: func(m *mocks.MockReadParser) {
+				m.EXPECT().Parse(taskTemplatePath, gomock.Any()).Return(nil, errors.New("error reading template"))
+			},
+			wantedError: errors.New("read template for task stack: error reading template"),
+		},
+		"should return template body when present": {
+			mockReadParser: func(m *mocks.MockReadParser) {
+				m.EXPECT().Parse(taskTemplatePath, gomock.Any()).Return(&template.Content{
+					Buffer: bytes.NewBufferString("This is the task template"),
+				}, nil)
+			},
+			wantedTemplate: "This is the task template",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockReadParser := mocks.NewMockReadParser(ctrl)
+			if tc.mockReadParser != nil {
+				tc.mockReadParser(mockReadParser)
+			}
+
+			taskStack := &taskStackConfig{
+				parser: mockReadParser,
+			}
+
+			got, err := taskStack.Template()
+
+			if tc.wantedError != nil {
+				require.EqualError(t, tc.wantedError, err.Error())
+			} else {
+				require.Equal(t, tc.wantedTemplate, got)
+			}
+		})
+	}
+}
+
+func TestTask_Parameters(t *testing.T) {
+	expectedParams := []*cloudformation.Parameter{
+		{
+			ParameterKey:   aws.String(TaskNameParamKey),
+			ParameterValue: aws.String("my-task"),
+		},
+		{
+			ParameterKey:   aws.String(TaskContainerImageParamKey),
+			ParameterValue: aws.String("7456.dkr.ecr.us-east-2.amazonaws.com/my-task:0.1"),
+		},
+		{
+			ParameterKey:   aws.String(TaskCPUParamKey),
+			ParameterValue: aws.String("256"),
+		},
+		{
+			ParameterKey:   aws.String(TaskMemoryParamKey),
+			ParameterValue: aws.String("512"),
+		},
+		{
+			ParameterKey:   aws.String(TaskLogRetentionParamKey),
+			ParameterValue: aws.String(taskLogRetention),
+		},
+		{
+			ParameterKey:   aws.String(TaskTaskRoleParamKey),
+			ParameterValue: aws.String("task-role"),
+		},
+		{
+			ParameterKey:   aws.String(TaskCommandParamKey),
+			ParameterValue: aws.String("echo hooray"),
+		},
+	}
+
+	task := &taskStackConfig{
+		Name:   "my-task",
+		Cpu:    256,
+		Memory: 512,
+
+		ImageURL: "7456.dkr.ecr.us-east-2.amazonaws.com/my-task:0.1",
+		TaskRole: "task-role",
+		Command:  "echo hooray",
+	}
+	params, _ := task.Parameters()
+	require.ElementsMatch(t, expectedParams, params)
+}
+
+func TestTask_StackName(t *testing.T) {
+	task := &taskStackConfig{
+		Name: testTaskName,
+	}
+	got := task.StackName()
+	require.Equal(t, got, fmt.Sprintf("task-%s", testTaskName))
+}

--- a/internal/pkg/deploy/cloudformation/task.go
+++ b/internal/pkg/deploy/cloudformation/task.go
@@ -1,0 +1,30 @@
+package cloudformation
+
+import (
+	"errors"
+
+	"github.com/aws/copilot-cli/internal/pkg/deploy"
+
+	"github.com/aws/copilot-cli/internal/pkg/aws/cloudformation"
+	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation/stack"
+)
+
+// DeployTask deploys a task stack and waits until the deployment is done.
+// If the task stack doesn't exist, then it creates the stack.
+// If the task stack already exists, it updates the stack.
+func (cf CloudFormation) DeployTask(input *deploy.CreateTaskResourcesInput) error {
+	conf := stack.NewTaskStackConfig(input)
+	stack, err := toStack(conf)
+	if err != nil {
+		return err
+	}
+
+	if err := cf.cfnClient.CreateAndWait(stack); err != nil {
+		var errAlreadyExists *cloudformation.ErrStackAlreadyExists
+		if !errors.As(err, &errAlreadyExists) {
+			return err
+		}
+		return cf.cfnClient.UpdateAndWait(stack)
+	}
+	return nil
+}

--- a/internal/pkg/deploy/cloudformation/task_test.go
+++ b/internal/pkg/deploy/cloudformation/task_test.go
@@ -1,0 +1,62 @@
+package cloudformation
+
+import (
+	"testing"
+
+	"github.com/aws/copilot-cli/internal/pkg/deploy"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/aws/copilot-cli/internal/pkg/aws/cloudformation"
+
+	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation/mocks"
+	"github.com/golang/mock/gomock"
+)
+
+func TestCloudFormation_DeployTask(t *testing.T) {
+	const (
+		stackName     = "copilot-my-task"
+		stackTemplate = "my-task template"
+	)
+	mockTask := &deploy.CreateTaskResourcesInput{
+		Name: "my-task",
+	}
+
+	testCases := map[string]struct {
+		mockCfnClient func(m *mocks.MockcfnClient)
+	}{
+		"create a new stack": {
+			mockCfnClient: func(m *mocks.MockcfnClient) {
+				m.EXPECT().CreateAndWait(gomock.Any()).Return(nil)
+				m.EXPECT().UpdateAndWait(gomock.Any()).Times(0)
+			},
+		},
+		"update the stack": {
+			mockCfnClient: func(m *mocks.MockcfnClient) {
+				m.EXPECT().CreateAndWait(gomock.Any()).Return(&cloudformation.ErrStackAlreadyExists{
+					Name: "my-task",
+				})
+				m.EXPECT().UpdateAndWait(gomock.Any()).Times(1).Return(nil)
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockCfnClient := mocks.NewMockcfnClient(ctrl)
+			if tc.mockCfnClient != nil {
+				tc.mockCfnClient(mockCfnClient)
+			}
+
+			cf := CloudFormation{
+				cfnClient: mockCfnClient,
+			}
+
+			err := cf.DeployTask(mockTask)
+			require.NoError(t, err)
+		})
+	}
+}

--- a/internal/pkg/deploy/deploy.go
+++ b/internal/pkg/deploy/deploy.go
@@ -21,6 +21,8 @@ const (
 	EnvTagKey = "copilot-environment"
 	// ServiceTagKey is tag key for Copilot svc.
 	ServiceTagKey = "copilot-service"
+	// TaskTagKey is tag key for Copilot task.
+	TaskTagKey = "copilot-task"
 )
 
 const (

--- a/internal/pkg/deploy/task.go
+++ b/internal/pkg/deploy/task.go
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package deploy holds the structures to deploy infrastructure resources.
+// This file defines service deployment resources.
+package deploy
+
+type CreateTaskResourcesInput struct {
+	Name     string
+	Cpu      int
+	Memory   int
+	Image    string
+	TaskRole string
+	Command  string
+	EnvVars  map[string]string
+}

--- a/templates/task/cf.yml
+++ b/templates/task/cf.yml
@@ -1,0 +1,105 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+AWSTemplateFormatVersion: "2010-09-09"
+Description: "CloudFormation template that represents a task on Amazon ECS."
+Parameters:
+  TaskName:
+    Type: String
+  TaskCPU:
+    Type: String
+  TaskMemory:
+    Type: String
+  LogRetention:
+    Type: Number
+    Default: 30
+  ContainerImage:
+    Type: String
+  TaskRole:
+    Type: String
+  Command:
+    Type: String
+Conditions:
+  HasImage:
+    !Not [!Equals [!Ref ContainerImage, ""]]
+  UseDefaultTaskRole:
+    !Equals [!Ref TaskRole, ""]
+  HasCommand:
+    !Not [!Equals [!Ref Command, ""]]
+Resources:
+  TaskDefinition:
+    Condition: HasImage
+    Type: AWS::ECS::TaskDefinition
+    DependsOn: ECRRepo
+    Properties:
+      ContainerDefinitions:
+        -
+          Image: !Ref ContainerImage
+          Command: !If [HasCommand, !Split [" ", !Ref Command], !Ref "AWS::NoValue"]
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-region: !Ref AWS::Region
+              awslogs-group: !Ref LogGroup
+              awslogs-stream-prefix: copilot-task
+          Name: !Ref TaskName
+          {{if .EnvVars}}Environment:{{range $name, $value := .EnvVars}}
+          - Name: {{$name}}
+          - Value: {{$value}}{{end}}{{end}}
+      Family: !Join ['-', ["copilot", !Ref TaskName]]
+      RequiresCompatibilities:
+        - "FARGATE"
+      NetworkMode: awsvpc
+      Cpu: !Ref TaskCPU
+      Memory: !Ref TaskMemory
+      ExecutionRoleArn: !Ref ExecutionRole
+      TaskRoleArn:
+        !If [UseDefaultTaskRole, !Ref DefaultTaskRole, !Ref TaskRole]
+  DefaultTaskRole:
+    Condition: UseDefaultTaskRole
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: 'sts:AssumeRole'
+  ExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: 'sts:AssumeRole'
+      ManagedPolicyArns:
+        - 'arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy'
+  ECRRepo:
+    Type: AWS::ECR::Repository
+    Properties:
+      RepositoryName: !Join ["-", ["copilot", !Ref TaskName]]
+      RepositoryPolicyText:
+        Version: '2008-10-17'
+        Statement:
+          - Sid: AllowPushPull
+            Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+            Action:
+              - ecr:GetDownloadUrlForLayer
+              - ecr:BatchGetImage
+              - ecr:BatchCheckLayerAvailability
+              - ecr:PutImage
+              - ecr:InitiateLayerUpload
+              - ecr:UploadLayerPart
+              - ecr:CompleteLayerUpload
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Join ['', ["/copilot/", !Ref TaskName]]
+      RetentionInDays: !Ref LogRetention
+Outputs:
+  ECRRepo:
+    Description: ECR Repo used to store images of task.
+    Value: !GetAtt ECRRepo.Arn

--- a/templates/task/cf.yml
+++ b/templates/task/cf.yml
@@ -11,7 +11,6 @@ Parameters:
     Type: String
   LogRetention:
     Type: Number
-    Default: 30
   ContainerImage:
     Type: String
   TaskRole:
@@ -41,10 +40,10 @@ Resources:
               awslogs-region: !Ref AWS::Region
               awslogs-group: !Ref LogGroup
               awslogs-stream-prefix: copilot-task
-          Name: !Ref TaskName
-          {{if .EnvVars}}Environment:{{range $name, $value := .EnvVars}}
-          - Name: {{$name}}
-          - Value: {{$value}}{{end}}{{end}}
+          Name: !Ref TaskName{{if .EnvVars}}
+          Environment:{{range $name, $value := .EnvVars}}
+            - Name: {{$name}}
+              Value: {{$value}}{{end}}{{end}}
       Family: !Join ['-', ["copilot", !Ref TaskName]]
       RequiresCompatibilities:
         - "FARGATE"


### PR DESCRIPTION
The PR implements execute for task run command. Specifically, it does the following:
1. modifies ecs package, and adds a ec2 package
2. modifies deploy, cloudformation and stack packages
3. creates a cloudformation template for task run
4. modifies cli package

Related #702

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
