### PR TITLE
fix: returns the healthcheck command in an array of string

### DIFF
--- a/internal/pkg/docker/dockerfile/dockerfile.go
+++ b/internal/pkg/docker/dockerfile/dockerfile.go
@@ -250,8 +250,6 @@ func parseHealthCheck(content string) (*HealthCheck, error) {
 		return nil, err
 	}
 
-	// cmdIndex holds the starting index of "CMD"
-	// command extracts the CMD out of the command
 	// if HEALTHCHECK instruction is not "NONE", there must be a "CMD" instruction otherwise will error out
 	cmdIndex := strings.Index(content, "CMD")
 	command := content[cmdIndex+len(cmdLength):]

--- a/internal/pkg/docker/dockerfile/dockerfile.go
+++ b/internal/pkg/docker/dockerfile/dockerfile.go
@@ -40,6 +40,7 @@ const (
 	retriesDefault = 2
 
 	hcInstrStartIndex = len("HEALTHCHECK ")
+	cmdLength         = "CMD "
 	cmdShell          = "CMD-SHELL"
 )
 
@@ -249,10 +250,11 @@ func parseHealthCheck(content string) (*HealthCheck, error) {
 		return nil, err
 	}
 
-	// cmdIndex holds the starting and ending index of "CMD"
+	// cmdIndex holds the starting index of "CMD", -1 if not present
 	// command extracts the CMD out of the command
-	cmdIndex := regexp.MustCompile("CMD").FindStringIndex(content)
-	command := content[cmdIndex[1]+1:]
+	// if HEALTHCHECK instruction is not "NONE", there must be a "CMD" instruction otherwise will error out
+	cmdIndex := strings.Index(content, "CMD")
+	command := content[cmdIndex+len(cmdLength):]
 
 	return &HealthCheck{
 		Interval:    interval,

--- a/internal/pkg/docker/dockerfile/dockerfile.go
+++ b/internal/pkg/docker/dockerfile/dockerfile.go
@@ -40,6 +40,7 @@ const (
 	retriesDefault = 2
 
 	hcInstrStartIndex = len("HEALTHCHECK ")
+	cmdShell          = "CMD-SHELL"
 )
 
 var (
@@ -248,12 +249,17 @@ func parseHealthCheck(content string) (*HealthCheck, error) {
 		return nil, err
 	}
 
+	// cmdIndex holds the starting and ending index of "CMD"
+	// command extracts the CMD out of the command
+	cmdIndex := regexp.MustCompile("CMD").FindStringIndex(content)
+	command := content[cmdIndex[1]+1:]
+
 	return &HealthCheck{
 		Interval:    interval,
 		Timeout:     timeout,
 		StartPeriod: startPeriod,
 		Retries:     retries,
-		Cmd:         []string{regexp.MustCompile("CMD.*").FindString(content)},
+		Cmd:         []string{cmdShell, command},
 	}, nil
 }
 

--- a/internal/pkg/docker/dockerfile/dockerfile.go
+++ b/internal/pkg/docker/dockerfile/dockerfile.go
@@ -250,7 +250,7 @@ func parseHealthCheck(content string) (*HealthCheck, error) {
 		return nil, err
 	}
 
-	// cmdIndex holds the starting index of "CMD", -1 if not present
+	// cmdIndex holds the starting index of "CMD"
 	// command extracts the CMD out of the command
 	// if HEALTHCHECK instruction is not "NONE", there must be a "CMD" instruction otherwise will error out
 	cmdIndex := strings.Index(content, "CMD")

--- a/internal/pkg/docker/dockerfile/dockerfile_test.go
+++ b/internal/pkg/docker/dockerfile/dockerfile_test.go
@@ -239,6 +239,14 @@ func TestDockerfile_GetHealthCheck(t *testing.T) {
 			dockerfile: []byte(`HEALTHCHECK --interval=5m --randomFlag=4s CMD curl -f http://localhost/ || exit 1`),
 			wantedErr:  fmt.Errorf("parse instructions: Unknown flag: randomFlag"),
 		},
+		"healthcheck does not contain CMD": {
+			dockerfile: []byte(`HEALTHCHECK --interval=5m curl -f http://localhost/ || exit 1`),
+			wantedErr:  fmt.Errorf("parse instructions: Unknown type \"CURL\" in HEALTHCHECK (try CMD)"),
+		},
+		"healthcheck does not contain command": {
+			dockerfile: []byte(`HEALTHCHECK --interval=5m CMD`),
+			wantedErr:  fmt.Errorf("parse instructions: Missing command after HEALTHCHECK CMD"),
+		},
 	}
 
 	for name, tc := range testCases {

--- a/internal/pkg/docker/dockerfile/dockerfile_test.go
+++ b/internal/pkg/docker/dockerfile/dockerfile_test.go
@@ -198,6 +198,9 @@ EXPOSE 8080/tcp 5000`),
 }
 
 func TestDockerfile_GetHealthCheck(t *testing.T) {
+	var (
+		cmdShell = "CMD-SHELL"
+	)
 	testCases := map[string]struct {
 		dockerfilePath string
 		dockerfile     []byte
@@ -212,7 +215,7 @@ func TestDockerfile_GetHealthCheck(t *testing.T) {
 				Timeout:     5 * time.Second,
 				StartPeriod: 0,
 				Retries:     2,
-				Cmd:         []string{"CMD curl -f http://localhost/ || exit 1"},
+				Cmd:         []string{cmdShell, "curl -f http://localhost/ || exit 1"},
 			},
 		},
 		"correctly parses healthcheck with user's values": {
@@ -224,7 +227,7 @@ func TestDockerfile_GetHealthCheck(t *testing.T) {
 				Timeout:     3 * time.Second,
 				StartPeriod: 2 * time.Second,
 				Retries:     3,
-				Cmd:         []string{"CMD curl -f http://localhost/ || exit 1"},
+				Cmd:         []string{cmdShell, "curl -f http://localhost/ || exit 1"},
 			},
 		},
 		"correctly parses healthcheck with NONE": {

--- a/internal/pkg/docker/dockerfile/dockerfile_test.go
+++ b/internal/pkg/docker/dockerfile/dockerfile_test.go
@@ -198,9 +198,6 @@ EXPOSE 8080/tcp 5000`),
 }
 
 func TestDockerfile_GetHealthCheck(t *testing.T) {
-	var (
-		cmdShell = "CMD-SHELL"
-	)
 	testCases := map[string]struct {
 		dockerfilePath string
 		dockerfile     []byte


### PR DESCRIPTION
Address #1079 

## svc logs

![image](https://user-images.githubusercontent.com/51001622/86387352-e641e700-bc47-11ea-82e0-ca9cd83f5d9b.png)

## aws console

![image](https://user-images.githubusercontent.com/51001622/86387435-05d90f80-bc48-11ea-974e-a5272749db13.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
