### PR TITLE
refactor(cli): apply deploy store APIs to svc logs

### DIFF
--- a/internal/pkg/aws/ecs/ecs.go
+++ b/internal/pkg/aws/ecs/ecs.go
@@ -27,6 +27,7 @@ type api interface {
 	DescribeTaskDefinition(input *ecs.DescribeTaskDefinitionInput) (*ecs.DescribeTaskDefinitionOutput, error)
 	DescribeServices(input *ecs.DescribeServicesInput) (*ecs.DescribeServicesOutput, error)
 	ListTasks(input *ecs.ListTasksInput) (*ecs.ListTasksOutput, error)
+	ListTagsForResource(input *ecs.ListTagsForResourceInput) (*ecs.ListTagsForResourceOutput, error)
 }
 
 // ECS wraps an AWS ECS client.
@@ -104,6 +105,26 @@ func New(s *session.Session) *ECS {
 	return &ECS{
 		client: ecs.New(s),
 	}
+}
+
+// GetTags list the tags for an Amazon ECS resource given its ARN.
+func (e *ECS) GetTags(arn string) (map[string]string, error) {
+	resp, err := e.client.ListTagsForResource(&ecs.ListTagsForResourceInput{
+		ResourceArn: aws.String(arn),
+	})
+	if err != nil {
+		return nil, err
+	}
+	tags := make(map[string]string)
+	for _, tag := range resp.Tags {
+		if tag == nil {
+			continue
+		}
+		if tag.Key != nil && tag.Value != nil {
+			tags[*tag.Key] = *tag.Value
+		}
+	}
+	return tags, nil
 }
 
 // TaskDefinition calls ECS API and returns the task definition.

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -113,6 +113,10 @@ type store interface {
 	serviceStore
 }
 
+type deployedEnvironmentLister interface {
+	ListEnvironmentsDeployedTo(appName string, svcName string) ([]string, error)
+}
+
 // Secretsmanager interface.
 
 type secretsManager interface {
@@ -345,6 +349,11 @@ type appEnvWithNoneSelector interface {
 type configSelector interface {
 	appEnvSelector
 	Service(prompt, help, app string) (string, error)
+}
+
+type deploySelector interface {
+	appSelector
+	ServiceEnvironment(prompt, help, app string) (svc string, env string, err error)
 }
 
 type wsSelector interface {

--- a/internal/pkg/cli/svc_logs.go
+++ b/internal/pkg/cli/svc_logs.go
@@ -13,7 +13,7 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/aws/session"
 	"github.com/aws/copilot-cli/internal/pkg/cli/selector"
 	"github.com/aws/copilot-cli/internal/pkg/config"
-	"github.com/aws/copilot-cli/internal/pkg/term/color"
+	"github.com/aws/copilot-cli/internal/pkg/deploy"
 	"github.com/aws/copilot-cli/internal/pkg/term/log"
 	"github.com/spf13/cobra"
 )
@@ -49,24 +49,33 @@ type svcLogsOpts struct {
 	endTime   int64
 
 	w             io.Writer
-	store         store
-	sel           configSelector
-	initCwLogsSvc func(*svcLogsOpts, *config.Environment) error // Overriden in tests.
+	configStore   store
+	deployStore   deployedEnvironmentLister
+	sel           deploySelector
+	initCwLogsSvc func(*svcLogsOpts, string) error // Overriden in tests.
 	cwlogsSvc     map[string]cwlogService
 }
 
 func newSvcLogOpts(vars svcLogsVars) (*svcLogsOpts, error) {
-	store, err := config.NewStore()
+	configStore, err := config.NewStore()
 	if err != nil {
 		return nil, fmt.Errorf("connect to environment config store: %w", err)
 	}
-
+	deployStore, err := deploy.NewStore(configStore)
+	if err != nil {
+		return nil, fmt.Errorf("connect to deploy store: %w", err)
+	}
 	return &svcLogsOpts{
 		svcLogsVars: vars,
 		w:           log.OutputWriter,
-		store:       store,
-		sel:         selector.NewConfigSelect(vars.prompt, store),
-		initCwLogsSvc: func(o *svcLogsOpts, env *config.Environment) error {
+		configStore: configStore,
+		deployStore: deployStore,
+		sel:         selector.NewDeploySelect(vars.prompt, configStore, deployStore),
+		initCwLogsSvc: func(o *svcLogsOpts, envName string) error {
+			env, err := o.configStore.GetEnvironment(o.AppName(), envName)
+			if err != nil {
+				return fmt.Errorf("get envronment: %w", err)
+			}
 			sess, err := session.NewProvider().FromRole(env.ManagerRoleARN, env.Region)
 			if err != nil {
 				return err
@@ -81,7 +90,7 @@ func newSvcLogOpts(vars svcLogsVars) (*svcLogsOpts, error) {
 // Validate returns an error if the values provided by flags are invalid.
 func (o *svcLogsOpts) Validate() error {
 	if o.AppName() != "" {
-		_, err := o.store.GetApplication(o.AppName())
+		_, err := o.configStore.GetApplication(o.AppName())
 		if err != nil {
 			return err
 		}
@@ -140,6 +149,9 @@ func (o *svcLogsOpts) Execute() error {
 	logEventsOutput := &cloudwatchlogs.LogEventsOutput{
 		LastEventTime: make(map[string]int64),
 	}
+	if err := o.initCwLogsSvc(o, o.envName); err != nil {
+		return err
+	}
 	var err error
 	for {
 		logEventsOutput, err = o.cwlogsSvc[o.envName].TaskLogEvents(logGroupName, logEventsOutput.LastEventTime, o.generateGetLogEventOpts()...)
@@ -186,93 +198,17 @@ func (o *svcLogsOpts) generateGetLogEventOpts() []cloudwatchlogs.GetLogEventsOpt
 }
 
 func (o *svcLogsOpts) askSvcEnvName() error {
-	var svcNames []string
-	var envs []*config.Environment
-	var err error
-	if o.svcName == "" {
-		svcNames, err = o.retrieveSvcNames()
-		if err != nil {
-			return err
-		}
-		if len(svcNames) == 0 {
-			return fmt.Errorf("no services found in application %s", color.HighlightUserInput(o.AppName()))
-		}
-	} else {
-		svc, err := o.store.GetService(o.AppName(), o.svcName)
-		if err != nil {
-			return fmt.Errorf("get service: %w", err)
-		}
-		svcNames = []string{svc.Name}
-	}
-
-	if o.envName == "" {
-		envs, err = o.store.ListEnvironments(o.AppName())
-		if err != nil {
-			return fmt.Errorf("list environments: %w", err)
-		}
-		if len(envs) == 0 {
-			return fmt.Errorf("no environments found in application %s", color.HighlightUserInput(o.AppName()))
-		}
-	} else {
-		env, err := o.store.GetEnvironment(o.AppName(), o.envName)
-		if err != nil {
-			return fmt.Errorf("get environment: %w", err)
-		}
-		envs = []*config.Environment{env}
-	}
-
-	svcEnvs := make(map[string]svcEnv)
-	var svcEnvNames []string
-	for _, svcName := range svcNames {
-		for _, env := range envs {
-			if err := o.initCwLogsSvc(o, env); err != nil {
-				return err
-			}
-			logGroup := fmt.Sprintf(logGroupNamePattern, o.AppName(), env.Name, svcName)
-			deployed, err := o.cwlogsSvc[env.Name].LogGroupExists(logGroup)
-			if err != nil {
-				return fmt.Errorf("check if the log group %s exists: %w", logGroup, err)
-			}
-			if !deployed {
-				continue
-			}
-			svcEnv := svcEnv{
-				svcName: svcName,
-				envName: env.Name,
-			}
-			svcEnvName := svcEnv.String()
-			svcEnvs[svcEnvName] = svcEnv
-			svcEnvNames = append(svcEnvNames, svcEnvName)
-		}
-	}
-	if len(svcEnvNames) == 0 {
-		return fmt.Errorf("no deployed services found in application %s", color.HighlightUserInput(o.AppName()))
-	}
-
-	// return if only one deployed service found
-	if len(svcEnvNames) == 1 {
-		o.svcName = svcEnvs[svcEnvNames[0]].svcName
-		o.envName = svcEnvs[svcEnvNames[0]].envName
-		log.Infof("Showing logs of service %s deployed in environment %s\n", color.HighlightUserInput(o.svcName), color.HighlightUserInput(o.envName))
-		return nil
-	}
-
-	svcEnvName, err := o.prompt.SelectOne(
-		fmt.Sprintf(svcLogNamePrompt),
-		svcLogNameHelpPrompt,
-		svcEnvNames,
-	)
+	svcName, envName, err := o.sel.ServiceEnvironment(svcLogNamePrompt, svcLogNameHelpPrompt, o.AppName())
 	if err != nil {
 		return fmt.Errorf("select deployed services for application %s: %w", o.AppName(), err)
 	}
-	o.svcName = svcEnvs[svcEnvName].svcName
-	o.envName = svcEnvs[svcEnvName].envName
-
+	o.svcName = svcName
+	o.envName = envName
 	return nil
 }
 
 func (o *svcLogsOpts) retrieveSvcNames() ([]string, error) {
-	svcs, err := o.store.ListServices(o.AppName())
+	svcs, err := o.configStore.ListServices(o.AppName())
 	if err != nil {
 		return nil, fmt.Errorf("list services for application %s: %w", o.AppName(), err)
 	}

--- a/internal/pkg/cli/svc_logs_test.go
+++ b/internal/pkg/cli/svc_logs_test.go
@@ -133,7 +133,7 @@ func TestSvcLogs_Validate(t *testing.T) {
 						appName: tc.inputApp,
 					},
 				},
-				store:         mockstore,
+				configStore:   mockstore,
 				initCwLogsSvc: func(*svcLogsOpts, *config.Environment) error { return nil },
 			}
 
@@ -548,7 +548,7 @@ func TestSvcLogs_Ask(t *testing.T) {
 						prompt:  mockPrompter,
 					},
 				},
-				store:         mockstore,
+				configStore:   mockstore,
 				sel:           mockSel,
 				initCwLogsSvc: func(*svcLogsOpts, *config.Environment) error { return nil },
 				cwlogsSvc:     tc.mockcwlogService(ctrl),

--- a/templates/environment/cf.yml
+++ b/templates/environment/cf.yml
@@ -361,7 +361,8 @@ Resources:
               "ecs:ListTaskDefinitionFamilies",
               "ecs:DescribeTaskDefinition",
               "ecs:ListTaskDefinitions",
-              "ecs:ListClusters"
+              "ecs:ListClusters",
+              "ecs:ListTagsForResource"
             ]
             Resource: "*"
           - Sid: CloudFormation


### PR DESCRIPTION
<!-- Provide summary of changes -->
Part of #1069.

Note that parsing service name by calling ecs API to get the service tag costs 1.60 seconds on average, while using regex to get service name from its ARN costs 1.55 seconds on average. (one service and one environment. The difference might be a little bit more obvious if there are more than 5 combinations)
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
