### PR TITLE
refactor(resourcegroups): use resourcegroupstaggingapi

### DIFF
--- a/internal/pkg/aws/cloudwatch/cloudwatch.go
+++ b/internal/pkg/aws/cloudwatch/cloudwatch.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aws/copilot-cli/internal/pkg/aws/resourcegroups"
+	rg "github.com/aws/copilot-cli/internal/pkg/aws/resourcegroups"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
@@ -19,7 +19,7 @@ import (
 
 const (
 	resourceQueryType      = "TAG_FILTERS_1_0"
-	cloudwatchResourceType = "AWS::CloudWatch::Alarm"
+	cloudwatchResourceType = "cloudwatch:alarm"
 	compositeAlarmType     = "Composite"
 	metricAlarmType        = "Metric"
 )
@@ -29,7 +29,7 @@ type api interface {
 }
 
 type resourceGetter interface {
-	GetResourcesByTags(resourceType string, tags map[string]string) ([]string, error)
+	GetResourcesByTags(resourceType string, tags map[string]string) ([]*rg.Resource, error)
 }
 
 // CloudWatch wraps an Amazon CloudWatch client.
@@ -52,7 +52,7 @@ type AlarmStatus struct {
 func New(s *session.Session) *CloudWatch {
 	return &CloudWatch{
 		cwClient: cloudwatch.New(s),
-		rgClient: resourcegroups.New(s),
+		rgClient: rg.New(s),
 	}
 }
 
@@ -60,13 +60,13 @@ func New(s *session.Session) *CloudWatch {
 func (cw *CloudWatch) GetAlarmsWithTags(tags map[string]string) ([]AlarmStatus, error) {
 	var alarmNames []*string
 
-	arns, err := cw.rgClient.GetResourcesByTags(cloudwatchResourceType, tags)
+	resources, err := cw.rgClient.GetResourcesByTags(cloudwatchResourceType, tags)
 	if err != nil {
 		return nil, err
 	}
 
-	for _, arn := range arns {
-		name, err := cw.getAlarmName(arn)
+	for _, resource := range resources {
+		name, err := cw.getAlarmName(resource.Arn)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/pkg/aws/cloudwatch/cloudwatch.go
+++ b/internal/pkg/aws/cloudwatch/cloudwatch.go
@@ -18,7 +18,6 @@ import (
 )
 
 const (
-	resourceQueryType      = "TAG_FILTERS_1_0"
 	cloudwatchResourceType = "cloudwatch:alarm"
 	compositeAlarmType     = "Composite"
 	metricAlarmType        = "Metric"
@@ -66,7 +65,7 @@ func (cw *CloudWatch) GetAlarmsWithTags(tags map[string]string) ([]AlarmStatus, 
 	}
 
 	for _, resource := range resources {
-		name, err := cw.getAlarmName(resource.Arn)
+		name, err := cw.getAlarmName(resource.ARN)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/pkg/aws/cloudwatch/cloudwatch_test.go
+++ b/internal/pkg/aws/cloudwatch/cloudwatch_test.go
@@ -52,14 +52,14 @@ func TestCloudWatch_GetAlarmsWithTags(t *testing.T) {
 		},
 		"errors if failed to get alarm names because of invalid ARN": {
 			setupMocks: func(m cloudWatchMocks) {
-				m.rg.EXPECT().GetResourcesByTags(cloudwatchResourceType, gomock.Eq(testTags)).Return([]*rg.Resource{{Arn: "badArn"}}, nil)
+				m.rg.EXPECT().GetResourcesByTags(cloudwatchResourceType, gomock.Eq(testTags)).Return([]*rg.Resource{{ARN: "badArn"}}, nil)
 			},
 
 			wantErr: fmt.Errorf("parse alarm ARN badArn: arn: invalid prefix"),
 		},
 		"errors if failed to get alarm names because of bad ARN resource": {
 			setupMocks: func(m cloudWatchMocks) {
-				m.rg.EXPECT().GetResourcesByTags(cloudwatchResourceType, gomock.Eq(testTags)).Return([]*rg.Resource{{Arn: "arn:aws:cloudwatch:us-west-2:1234567890:alarm:badAlarm:Names"}}, nil)
+				m.rg.EXPECT().GetResourcesByTags(cloudwatchResourceType, gomock.Eq(testTags)).Return([]*rg.Resource{{ARN: "arn:aws:cloudwatch:us-west-2:1234567890:alarm:badAlarm:Names"}}, nil)
 			},
 
 			wantErr: fmt.Errorf("cannot parse alarm ARN resource alarm:badAlarm:Names"),
@@ -67,7 +67,7 @@ func TestCloudWatch_GetAlarmsWithTags(t *testing.T) {
 		"errors if failed to describe CloudWatch alarms": {
 			setupMocks: func(m cloudWatchMocks) {
 				gomock.InOrder(
-					m.rg.EXPECT().GetResourcesByTags(cloudwatchResourceType, gomock.Eq(testTags)).Return([]*rg.Resource{{Arn: mockAlarmArn}}, nil),
+					m.rg.EXPECT().GetResourcesByTags(cloudwatchResourceType, gomock.Eq(testTags)).Return([]*rg.Resource{{ARN: mockAlarmArn}}, nil),
 					m.cw.EXPECT().DescribeAlarms(&cloudwatch.DescribeAlarmsInput{
 						NextToken:  nil,
 						AlarmNames: aws.StringSlice([]string{"mockAlarmName"}),
@@ -87,7 +87,7 @@ func TestCloudWatch_GetAlarmsWithTags(t *testing.T) {
 		"success": {
 			setupMocks: func(m cloudWatchMocks) {
 				gomock.InOrder(
-					m.rg.EXPECT().GetResourcesByTags(cloudwatchResourceType, gomock.Eq(testTags)).Return([]*rg.Resource{{Arn: mockAlarmArn}}, nil),
+					m.rg.EXPECT().GetResourcesByTags(cloudwatchResourceType, gomock.Eq(testTags)).Return([]*rg.Resource{{ARN: mockAlarmArn}}, nil),
 					m.cw.EXPECT().DescribeAlarms(&cloudwatch.DescribeAlarmsInput{
 						NextToken:  nil,
 						AlarmNames: aws.StringSlice([]string{"mockAlarmName"}),
@@ -120,7 +120,7 @@ func TestCloudWatch_GetAlarmsWithTags(t *testing.T) {
 		"success with pagination": {
 			setupMocks: func(m cloudWatchMocks) {
 				gomock.InOrder(
-					m.rg.EXPECT().GetResourcesByTags(cloudwatchResourceType, gomock.Eq(testTags)).Return([]*rg.Resource{{Arn: mockArn1}, {Arn: mockArn2}}, nil),
+					m.rg.EXPECT().GetResourcesByTags(cloudwatchResourceType, gomock.Eq(testTags)).Return([]*rg.Resource{{ARN: mockArn1}, {ARN: mockArn2}}, nil),
 					m.cw.EXPECT().DescribeAlarms(&cloudwatch.DescribeAlarmsInput{
 						NextToken:  nil,
 						AlarmNames: aws.StringSlice([]string{"mockAlarmName1", "mockAlarmName2"}),

--- a/internal/pkg/aws/cloudwatch/mocks/mock_cloudwatch.go
+++ b/internal/pkg/aws/cloudwatch/mocks/mock_cloudwatch.go
@@ -6,6 +6,7 @@ package mocks
 
 import (
 	cloudwatch "github.com/aws/aws-sdk-go/service/cloudwatch"
+	resourcegroups "github.com/aws/copilot-cli/internal/pkg/aws/resourcegroups"
 	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
 )
@@ -72,10 +73,10 @@ func (m *MockresourceGetter) EXPECT() *MockresourceGetterMockRecorder {
 }
 
 // GetResourcesByTags mocks base method
-func (m *MockresourceGetter) GetResourcesByTags(resourceType string, tags map[string]string) ([]string, error) {
+func (m *MockresourceGetter) GetResourcesByTags(resourceType string, tags map[string]string) ([]*resourcegroups.Resource, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetResourcesByTags", resourceType, tags)
-	ret0, _ := ret[0].([]string)
+	ret0, _ := ret[0].([]*resourcegroups.Resource)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/internal/pkg/aws/codepipeline/codepipeline.go
+++ b/internal/pkg/aws/codepipeline/codepipeline.go
@@ -200,7 +200,7 @@ func (c *CodePipeline) ListPipelineNamesByTags(tags map[string]string) ([]string
 	}
 
 	for _, resource := range resources {
-		name, err := c.getPipelineName(resource.Arn)
+		name, err := c.getPipelineName(resource.ARN)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/pkg/aws/codepipeline/codepipeline.go
+++ b/internal/pkg/aws/codepipeline/codepipeline.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	pipelineResourceType = "AWS::CodePipeline::Pipeline"
+	pipelineResourceType = "codepipeline:pipeline"
 )
 
 type api interface {
@@ -27,7 +27,7 @@ type api interface {
 }
 
 type resourceGetter interface {
-	GetResourcesByTags(resourceType string, tags map[string]string) ([]string, error)
+	GetResourcesByTags(resourceType string, tags map[string]string) ([]*rg.Resource, error)
 }
 
 // CodePipeline wraps the AWS CodePipeline client.
@@ -194,13 +194,13 @@ func (s *Stage) HumanString() string {
 // ListPipelineNamesByTags retrieves the names of all pipelines for a project.
 func (c *CodePipeline) ListPipelineNamesByTags(tags map[string]string) ([]string, error) {
 	var pipelineNames []string
-	arns, err := c.rgClient.GetResourcesByTags(pipelineResourceType, tags)
+	resources, err := c.rgClient.GetResourcesByTags(pipelineResourceType, tags)
 	if err != nil {
 		return nil, err
 	}
 
-	for _, arn := range arns {
-		name, err := c.getPipelineName(arn)
+	for _, resource := range resources {
+		name, err := c.getPipelineName(resource.Arn)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/pkg/aws/codepipeline/codepipeline_test.go
+++ b/internal/pkg/aws/codepipeline/codepipeline_test.go
@@ -262,7 +262,7 @@ func TestCodePipeline_ListPipelinesForProject(t *testing.T) {
 	mockPipelineName := "pipeline-dinder-badgoose-repo"
 	mockError := errors.New("mockError")
 	mockOutput := []*rg.Resource{
-		{Arn: "arn:aws:codepipeline:us-west-2:1234567890:" + mockPipelineName},
+		{ARN: "arn:aws:codepipeline:us-west-2:1234567890:" + mockPipelineName},
 	}
 	testTags := map[string]string{
 		"copilot-application": mockProjectName,
@@ -295,7 +295,7 @@ func TestCodePipeline_ListPipelinesForProject(t *testing.T) {
 		"should return error for bad arns": {
 			inProjectName: mockProjectName,
 			callMocks: func(m codepipelineMocks) {
-				m.rg.EXPECT().GetResourcesByTags(pipelineResourceType, testTags).Return([]*rg.Resource{{Arn: badArn}}, nil)
+				m.rg.EXPECT().GetResourcesByTags(pipelineResourceType, testTags).Return([]*rg.Resource{{ARN: badArn}}, nil)
 			},
 			expectedOut:   nil,
 			expectedError: fmt.Errorf("parse pipeline ARN: %s", badArn),

--- a/internal/pkg/aws/codepipeline/codepipeline_test.go
+++ b/internal/pkg/aws/codepipeline/codepipeline_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/copilot-cli/internal/pkg/aws/codepipeline/mocks"
+	rg "github.com/aws/copilot-cli/internal/pkg/aws/resourcegroups"
 	"github.com/golang/mock/gomock"
 
 	"github.com/aws/aws-sdk-go/service/codepipeline"
@@ -260,8 +261,8 @@ func TestCodePipeline_ListPipelinesForProject(t *testing.T) {
 	mockProjectName := "dinder"
 	mockPipelineName := "pipeline-dinder-badgoose-repo"
 	mockError := errors.New("mockError")
-	mockOutput := []string{
-		"arn:aws:codepipeline:us-west-2:1234567890:" + mockPipelineName,
+	mockOutput := []*rg.Resource{
+		{Arn: "arn:aws:codepipeline:us-west-2:1234567890:" + mockPipelineName},
 	}
 	testTags := map[string]string{
 		"copilot-application": mockProjectName,
@@ -294,7 +295,7 @@ func TestCodePipeline_ListPipelinesForProject(t *testing.T) {
 		"should return error for bad arns": {
 			inProjectName: mockProjectName,
 			callMocks: func(m codepipelineMocks) {
-				m.rg.EXPECT().GetResourcesByTags(pipelineResourceType, testTags).Return([]string{badArn}, nil)
+				m.rg.EXPECT().GetResourcesByTags(pipelineResourceType, testTags).Return([]*rg.Resource{{Arn: badArn}}, nil)
 			},
 			expectedOut:   nil,
 			expectedError: fmt.Errorf("parse pipeline ARN: %s", badArn),

--- a/internal/pkg/aws/codepipeline/mocks/mock_codepipeline.go
+++ b/internal/pkg/aws/codepipeline/mocks/mock_codepipeline.go
@@ -6,6 +6,7 @@ package mocks
 
 import (
 	codepipeline "github.com/aws/aws-sdk-go/service/codepipeline"
+	resourcegroups "github.com/aws/copilot-cli/internal/pkg/aws/resourcegroups"
 	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
 )
@@ -87,10 +88,10 @@ func (m *MockresourceGetter) EXPECT() *MockresourceGetterMockRecorder {
 }
 
 // GetResourcesByTags mocks base method
-func (m *MockresourceGetter) GetResourcesByTags(resourceType string, tags map[string]string) ([]string, error) {
+func (m *MockresourceGetter) GetResourcesByTags(resourceType string, tags map[string]string) ([]*resourcegroups.Resource, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetResourcesByTags", resourceType, tags)
-	ret0, _ := ret[0].([]string)
+	ret0, _ := ret[0].([]*resourcegroups.Resource)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/internal/pkg/aws/resourcegroups/mocks/mock_resourcegroups.go
+++ b/internal/pkg/aws/resourcegroups/mocks/mock_resourcegroups.go
@@ -5,7 +5,7 @@
 package mocks
 
 import (
-	resourcegroups "github.com/aws/aws-sdk-go/service/resourcegroups"
+	resourcegroupstaggingapi "github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
 	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
 )
@@ -33,17 +33,17 @@ func (m *Mockapi) EXPECT() *MockapiMockRecorder {
 	return m.recorder
 }
 
-// SearchResources mocks base method
-func (m *Mockapi) SearchResources(input *resourcegroups.SearchResourcesInput) (*resourcegroups.SearchResourcesOutput, error) {
+// GetResources mocks base method
+func (m *Mockapi) GetResources(input *resourcegroupstaggingapi.GetResourcesInput) (*resourcegroupstaggingapi.GetResourcesOutput, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SearchResources", input)
-	ret0, _ := ret[0].(*resourcegroups.SearchResourcesOutput)
+	ret := m.ctrl.Call(m, "GetResources", input)
+	ret0, _ := ret[0].(*resourcegroupstaggingapi.GetResourcesOutput)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// SearchResources indicates an expected call of SearchResources
-func (mr *MockapiMockRecorder) SearchResources(input interface{}) *gomock.Call {
+// GetResources indicates an expected call of GetResources
+func (mr *MockapiMockRecorder) GetResources(input interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchResources", reflect.TypeOf((*Mockapi)(nil).SearchResources), input)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResources", reflect.TypeOf((*Mockapi)(nil).GetResources), input)
 }

--- a/internal/pkg/aws/resourcegroups/resourcegroups.go
+++ b/internal/pkg/aws/resourcegroups/resourcegroups.go
@@ -5,21 +5,16 @@
 package resourcegroups
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
 
 	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/resourcegroups"
-)
-
-const (
-	resourceQueryType = "TAG_FILTERS_1_0"
+	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
 )
 
 type api interface {
-	SearchResources(input *resourcegroups.SearchResourcesInput) (*resourcegroups.SearchResourcesOutput, error)
+	GetResources(input *resourcegroupstaggingapi.GetResourcesInput) (*resourcegroupstaggingapi.GetResourcesOutput, error)
 }
 
 // ResourceGroups wraps an AWS ResourceGroups client.
@@ -32,69 +27,63 @@ type tagFilter struct {
 	Values []string
 }
 
-type query struct {
-	ResourceTypeFilters []string
-	TagFilters          []tagFilter
+// Resource contains the ARN and the tags of the resource.
+type Resource struct {
+	Arn  string
+	Tags map[string]string
 }
 
 // New returns a ResourceGroup struct configured against the input session.
 func New(s *session.Session) *ResourceGroups {
 	return &ResourceGroups{
-		client: resourcegroups.New(s),
+		client: resourcegroupstaggingapi.New(s),
 	}
 }
 
-// GetResourcesByTags internally sets the type to TAG_FILTERS_1_0 and generates the query with input resource type and tags.
-func (rg *ResourceGroups) GetResourcesByTags(resourceType string, tags map[string]string) ([]string, error) {
-	var resourceArns []string
-	resourceResp := &resourcegroups.SearchResourcesOutput{}
-
-	query, err := rg.searchResourcesQuery(resourceType, tags)
-	if err != nil {
-		return nil, fmt.Errorf("construct search resource query: %w", err)
+// GetResourcesByTags gets tag set and ARN for the resource with input resource type and tags.
+func (rg *ResourceGroups) GetResourcesByTags(resourceType string, tags map[string]string) ([]*Resource, error) {
+	var resources []*Resource
+	var err error
+	resourceResp := &resourcegroupstaggingapi.GetResourcesOutput{}
+	var tagFilter []*resourcegroupstaggingapi.TagFilter
+	for k, v := range tags {
+		tagFilter = append(tagFilter, &resourcegroupstaggingapi.TagFilter{
+			Key:    aws.String(k),
+			Values: aws.StringSlice([]string{v}),
+		})
 	}
 	for {
-		resourceResp, err = rg.client.SearchResources(&resourcegroups.SearchResourcesInput{
-			NextToken: resourceResp.NextToken,
-			ResourceQuery: &resourcegroups.ResourceQuery{
-				Type:  aws.String(resourceQueryType),
-				Query: aws.String(string(query)),
-			},
+		resourceResp, err = rg.client.GetResources(&resourcegroupstaggingapi.GetResourcesInput{
+			PaginationToken:     resourceResp.PaginationToken,
+			ResourceTypeFilters: aws.StringSlice([]string{resourceType}),
+			TagFilters:          tagFilter,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("search resource group with resource type %s: %w", resourceType, err)
+			return nil, fmt.Errorf("get resource: %w", err)
 		}
-		for _, identifier := range resourceResp.ResourceIdentifiers {
-			arn := aws.StringValue(identifier.ResourceArn)
-			resourceArns = append(resourceArns, arn)
+		for _, resourceTagMapping := range resourceResp.ResourceTagMappingList {
+			tags := make(map[string]string)
+			for _, tag := range resourceTagMapping.Tags {
+				if tag.Key == nil {
+					continue
+				}
+				tags[*tag.Key] = aws.StringValue(tag.Value)
+			}
+			resources = append(resources, &Resource{
+				Arn:  aws.StringValue(resourceTagMapping.ResourceARN),
+				Tags: tags,
+			})
 		}
-		if resourceResp.NextToken == nil {
+		// usually pagination token is "" when it doesn't have any next page. However, since it
+		// is type *string, it is safer for us to check nil value for it as well.
+		if resourceResp.PaginationToken == nil {
 			break
+		} else {
+			if aws.StringValue(resourceResp.PaginationToken) == "" {
+				break
+			}
 		}
 	}
 
-	return resourceArns, nil
-}
-
-// searchResourcesQuery returns a query string with the tag filters used to filter Resources
-func (rg *ResourceGroups) searchResourcesQuery(resourceType string, tags map[string]string) (string, error) {
-	var tagFilters []tagFilter
-	for k, v := range tags {
-		tagFilters = append(tagFilters, tagFilter{
-			Key:    k,
-			Values: []string{v},
-		})
-	}
-
-	q := query{
-		ResourceTypeFilters: []string{resourceType},
-		TagFilters:          tagFilters,
-	}
-	bytes, err := json.Marshal(q)
-
-	if err != nil {
-		return "", err
-	}
-
-	return string(bytes), nil
+	return resources, nil
 }

--- a/internal/pkg/aws/resourcegroups/resourcegroups_test.go
+++ b/internal/pkg/aws/resourcegroups/resourcegroups_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/resourcegroups"
+	rgapi "github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
 	"github.com/aws/copilot-cli/internal/pkg/aws/resourcegroups/mocks"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
@@ -20,64 +20,34 @@ var testTags = map[string]string{
 }
 
 const (
-	testResourceType    = "AWS::CloudWatch::Alarm"
-	testTagsQueryString = `{"ResourceTypeFilters":["AWS::CloudWatch::Alarm"],"TagFilters":[{"Key":"copilot-environment","Values":["test"]}]}` // NOTE only using one tag, since ranging over a map is not idempotent
+	testResourceType = "cloudwatch:alarm"
 
 	testArn  = "arn:aws:cloudwatch:us-west-2:1234567890:alarm:SDc-ReadCapacityUnitsLimit-BasicAlarm"
 	mockArn1 = "arn:aws:cloudwatch:us-west-2:1234567890:alarm:mockAlarmName1"
 	mockArn2 = "arn:aws:cloudwatch:us-west-2:1234567890:alarm:mockAlarmName2"
 )
 
-func TestResourceGroups_SearchResourcesQuery(t *testing.T) {
-	testCases := map[string]struct {
-		inTags         map[string]string
-		inResourceType string
-		expectedQuery  string
-		expectedErr    error
-	}{
-		"returns query string": {
-			inTags:         testTags,
-			inResourceType: testResourceType,
-			expectedQuery:  testTagsQueryString,
-			expectedErr:    nil,
-		},
-	}
-
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			// GIVEN
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
-
-			mockClient := mocks.NewMockapi(ctrl)
-			rg := &ResourceGroups{client: mockClient}
-
-			// WHEN
-			actualQuery, actualErr := rg.searchResourcesQuery(tc.inResourceType, tc.inTags)
-
-			// THEN
-			if actualErr != nil {
-				require.EqualError(t, tc.expectedErr, actualErr.Error())
-			} else {
-				require.Equal(t, tc.expectedQuery, actualQuery)
-			}
-		})
-	}
-}
-
 func TestResourceGroups_GetResourcesByTags(t *testing.T) {
-	mockRequest := &resourcegroups.SearchResourcesInput{
-		NextToken: nil,
-		ResourceQuery: &resourcegroups.ResourceQuery{
-			Type:  aws.String(resourceQueryType),
-			Query: aws.String(testTagsQueryString),
+	mockRequest := &rgapi.GetResourcesInput{
+		PaginationToken:     nil,
+		ResourceTypeFilters: aws.StringSlice([]string{testResourceType}),
+		TagFilters: []*rgapi.TagFilter{
+			{
+				Key:    aws.String("copilot-environment"),
+				Values: aws.StringSlice([]string{"test"}),
+			},
 		},
 	}
-	mockResponse := &resourcegroups.SearchResourcesOutput{
-		ResourceIdentifiers: []*resourcegroups.ResourceIdentifier{
+	mockResponse := &rgapi.GetResourcesOutput{
+		ResourceTagMappingList: []*rgapi.ResourceTagMapping{
 			{
-				ResourceType: aws.String(testResourceType),
-				ResourceArn:  aws.String(testArn),
+				ResourceARN: aws.String(testArn),
+				Tags: []*rgapi.Tag{
+					{
+						Key:   aws.String("copilot-environment"),
+						Value: aws.String("test"),
+					},
+				},
 			},
 		},
 	}
@@ -87,63 +57,76 @@ func TestResourceGroups_GetResourcesByTags(t *testing.T) {
 		inTags         map[string]string
 		inResourceType string
 		setupMocks     func(m *mocks.Mockapi)
-		expectedOut    []string
+		expectedOut    []*Resource
 		expectedErr    error
 	}{
 		"returns list of arns": {
 			inTags:         testTags,
 			inResourceType: testResourceType,
 			setupMocks: func(m *mocks.Mockapi) {
-				m.EXPECT().SearchResources(mockRequest).Return(mockResponse, nil)
+				m.EXPECT().GetResources(mockRequest).Return(mockResponse, nil)
 			},
-			expectedOut: []string{testArn},
+			expectedOut: []*Resource{
+				{
+					Arn:  testArn,
+					Tags: testTags,
+				},
+			},
 			expectedErr: nil,
 		},
 		"wraps error from API call": {
 			inTags:         testTags,
 			inResourceType: testResourceType,
 			setupMocks: func(m *mocks.Mockapi) {
-				m.EXPECT().SearchResources(mockRequest).Return(nil, mockError)
+				m.EXPECT().GetResources(mockRequest).Return(nil, mockError)
 			},
 			expectedOut: nil,
-			expectedErr: fmt.Errorf("search resource group with resource type %s: %w", testResourceType, mockError),
+			expectedErr: fmt.Errorf("get resource: some error"),
 		},
 		"success with pagination": {
 			inTags:         testTags,
 			inResourceType: testResourceType,
 			setupMocks: func(m *mocks.Mockapi) {
 				gomock.InOrder(
-					m.EXPECT().SearchResources(&resourcegroups.SearchResourcesInput{
-						NextToken: nil,
-						ResourceQuery: &resourcegroups.ResourceQuery{
-							Type:  aws.String(resourceQueryType),
-							Query: aws.String(testTagsQueryString),
-						},
-					}).Return(&resourcegroups.SearchResourcesOutput{
-						NextToken: aws.String("mockNextToken"),
-						ResourceIdentifiers: []*resourcegroups.ResourceIdentifier{
+					m.EXPECT().GetResources(mockRequest).Return(&rgapi.GetResourcesOutput{
+						PaginationToken: aws.String("mockNextToken"),
+						ResourceTagMappingList: []*rgapi.ResourceTagMapping{
 							{
-								ResourceArn: aws.String(mockArn1),
+								ResourceARN: aws.String(mockArn1),
+								Tags:        []*rgapi.Tag{{Key: aws.String("copilot-environment"), Value: aws.String("test")}},
 							},
 						},
 					}, nil),
-					m.EXPECT().SearchResources(&resourcegroups.SearchResourcesInput{
-						NextToken: aws.String("mockNextToken"),
-						ResourceQuery: &resourcegroups.ResourceQuery{
-							Type:  aws.String(resourceQueryType),
-							Query: aws.String(testTagsQueryString),
-						},
-					}).Return(&resourcegroups.SearchResourcesOutput{
-						NextToken: nil,
-						ResourceIdentifiers: []*resourcegroups.ResourceIdentifier{
+					m.EXPECT().GetResources(&rgapi.GetResourcesInput{
+						PaginationToken:     aws.String("mockNextToken"),
+						ResourceTypeFilters: aws.StringSlice([]string{testResourceType}),
+						TagFilters: []*rgapi.TagFilter{
 							{
-								ResourceArn: aws.String(mockArn2),
+								Key:    aws.String("copilot-environment"),
+								Values: aws.StringSlice([]string{"test"}),
+							},
+						},
+					}).Return(&rgapi.GetResourcesOutput{
+						PaginationToken: nil,
+						ResourceTagMappingList: []*rgapi.ResourceTagMapping{
+							{
+								ResourceARN: aws.String(mockArn2),
+								Tags:        []*rgapi.Tag{{Key: aws.String("copilot-environment"), Value: aws.String("test")}},
 							},
 						},
 					}, nil),
 				)
 			},
-			expectedOut: []string{mockArn1, mockArn2},
+			expectedOut: []*Resource{
+				{
+					Arn:  mockArn1,
+					Tags: testTags,
+				},
+				{
+					Arn:  mockArn2,
+					Tags: testTags,
+				},
+			},
 			expectedErr: nil,
 		},
 	}

--- a/internal/pkg/aws/resourcegroups/resourcegroups_test.go
+++ b/internal/pkg/aws/resourcegroups/resourcegroups_test.go
@@ -68,7 +68,7 @@ func TestResourceGroups_GetResourcesByTags(t *testing.T) {
 			},
 			expectedOut: []*Resource{
 				{
-					Arn:  testArn,
+					ARN:  testArn,
 					Tags: testTags,
 				},
 			},
@@ -119,11 +119,11 @@ func TestResourceGroups_GetResourcesByTags(t *testing.T) {
 			},
 			expectedOut: []*Resource{
 				{
-					Arn:  mockArn1,
+					ARN:  mockArn1,
 					Tags: testTags,
 				},
 				{
-					Arn:  mockArn2,
+					ARN:  mockArn2,
 					Tags: testTags,
 				},
 			},

--- a/internal/pkg/deploy/deploy.go
+++ b/internal/pkg/deploy/deploy.go
@@ -102,7 +102,7 @@ func (s *Store) ListDeployedServices(appName string, envName string) ([]string, 
 	for ind, resource := range resources {
 		svcName := resource.Tags[ServiceTagKey]
 		if svcName == "" {
-			return nil, fmt.Errorf("service with ARN %s is not tagged with %s", resource.Arn, ServiceTagKey)
+			return nil, fmt.Errorf("service with ARN %s is not tagged with %s", resource.ARN, ServiceTagKey)
 		}
 		svc, err := s.configStore.GetService(appName, svcName)
 		if err != nil {

--- a/internal/pkg/deploy/deploy.go
+++ b/internal/pkg/deploy/deploy.go
@@ -6,9 +6,7 @@ package deploy
 
 import (
 	"fmt"
-	"strings"
 
-	"github.com/aws/aws-sdk-go/aws/arn"
 	rg "github.com/aws/copilot-cli/internal/pkg/aws/resourcegroups"
 	"github.com/aws/copilot-cli/internal/pkg/aws/session"
 	"github.com/aws/copilot-cli/internal/pkg/config"
@@ -24,7 +22,7 @@ const (
 )
 
 const (
-	ecsServiceResourceType = "AWS::ECS::Service"
+	ecsServiceResourceType = "ecs:service"
 )
 
 // Resource represents an AWS resource.
@@ -41,7 +39,7 @@ type ResourceEvent struct {
 }
 
 type resourceGetter interface {
-	GetResourcesByTags(resourceType string, tags map[string]string) ([]string, error)
+	GetResourcesByTags(resourceType string, tags map[string]string) ([]*rg.Resource, error)
 }
 
 // ConfigStoreClient wraps config store methods utilized by deploy store.
@@ -93,18 +91,18 @@ func (s *Store) ListDeployedServices(appName string, envName string) ([]string, 
 	if err != nil {
 		return nil, err
 	}
-	svcARNs, err := s.rgClient.GetResourcesByTags(ecsServiceResourceType, map[string]string{
+	resources, err := s.rgClient.GetResourcesByTags(ecsServiceResourceType, map[string]string{
 		AppTagKey: appName,
 		EnvTagKey: envName,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("get resources by Copilot tags: %w", err)
 	}
-	svcs := make([]string, len(svcARNs))
-	for ind, svcARN := range svcARNs {
-		svcName, err := s.getServiceName(svcARN)
-		if err != nil {
-			return nil, err
+	svcs := make([]string, len(resources))
+	for ind, resource := range resources {
+		svcName := resource.Tags[ServiceTagKey]
+		if svcName == "" {
+			return nil, fmt.Errorf("service with ARN %s is not tagged with %s", resource.Arn, ServiceTagKey)
 		}
 		svc, err := s.configStore.GetService(appName, svcName)
 		if err != nil {
@@ -127,7 +125,7 @@ func (s *Store) ListEnvironmentsDeployedTo(appName string, svcName string) ([]st
 		if err != nil {
 			return nil, err
 		}
-		svcARNs, err := s.rgClient.GetResourcesByTags(ecsServiceResourceType, map[string]string{
+		resources, err := s.rgClient.GetResourcesByTags(ecsServiceResourceType, map[string]string{
 			AppTagKey:     appName,
 			EnvTagKey:     env.Name,
 			ServiceTagKey: svcName,
@@ -136,7 +134,7 @@ func (s *Store) ListEnvironmentsDeployedTo(appName string, svcName string) ([]st
 			return nil, fmt.Errorf("get resources by Copilot tags: %w", err)
 		}
 		// If no resources found, the resp length is 0.
-		if len(svcARNs) != 0 {
+		if len(resources) != 0 {
 			envsWithDeployment = append(envsWithDeployment, env.Name)
 		}
 	}
@@ -161,19 +159,4 @@ func (s *Store) IsDeployed(appName string, envName string, svcName string) (bool
 		return true, nil
 	}
 	return false, nil
-}
-
-// getServiceName gets the ECS service name given a specific ARN.
-// For example: arn:aws:ecs:us-west-2:123456789012:service/my-http-service
-// returns my-http-service
-func (s *Store) getServiceName(svcARN string) (string, error) {
-	resp, err := arn.Parse(svcARN)
-	if err != nil {
-		return "", fmt.Errorf("parse service ARN %s: %w", svcARN, err)
-	}
-	resource := strings.Split(resp.Resource, "/")
-	if len(resource) != 2 {
-		return "", fmt.Errorf(`cannot parse service ARN resource "%s"`, resp.Resource)
-	}
-	return resource[1], nil
 }

--- a/internal/pkg/deploy/deploy_test.go
+++ b/internal/pkg/deploy/deploy_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	rg "github.com/aws/copilot-cli/internal/pkg/aws/resourcegroups"
 	"github.com/aws/copilot-cli/internal/pkg/config"
 	"github.com/aws/copilot-cli/internal/pkg/deploy/mocks"
 	"github.com/golang/mock/gomock"
@@ -16,7 +17,7 @@ import (
 
 type storeMock struct {
 	rgGetter    *mocks.MockresourceGetter
-	configStore *mocks.MockconfigStoreClient
+	configStore *mocks.MockConfigStoreClient
 }
 
 func TestStore_ListDeployedServices(t *testing.T) {
@@ -43,7 +44,7 @@ func TestStore_ListDeployedServices(t *testing.T) {
 
 			wantedError: fmt.Errorf("get resources by Copilot tags: some error"),
 		},
-		"return error if fail to parse service ARN": {
+		"return error if fail to get service name": {
 			inputApp: "mockApp",
 			inputEnv: "mockEnv",
 
@@ -52,26 +53,11 @@ func TestStore_ListDeployedServices(t *testing.T) {
 					m.rgGetter.EXPECT().GetResourcesByTags(ecsServiceResourceType, map[string]string{
 						AppTagKey: "mockApp",
 						EnvTagKey: "mockEnv",
-					}).Return([]string{"mockSvc"}, nil),
+					}).Return([]*rg.Resource{{Arn: "mockARN", Tags: map[string]string{}}}, nil),
 				)
 			},
 
-			wantedError: fmt.Errorf("parse service ARN mockSvc: arn: invalid prefix"),
-		},
-		"return error if fail to get service name from ARN resource": {
-			inputApp: "mockApp",
-			inputEnv: "mockEnv",
-
-			setupMocks: func(m storeMock) {
-				gomock.InOrder(
-					m.rgGetter.EXPECT().GetResourcesByTags(ecsServiceResourceType, map[string]string{
-						AppTagKey: "mockApp",
-						EnvTagKey: "mockEnv",
-					}).Return([]string{"arn:aws:ecs:us-west-2:123456789012:service"}, nil),
-				)
-			},
-
-			wantedError: fmt.Errorf(`cannot parse service ARN resource "service"`),
+			wantedError: fmt.Errorf("service with ARN mockARN is not tagged with %s", ServiceTagKey),
 		},
 		"return error if fail to get config service": {
 			inputApp: "mockApp",
@@ -82,7 +68,7 @@ func TestStore_ListDeployedServices(t *testing.T) {
 					m.rgGetter.EXPECT().GetResourcesByTags(ecsServiceResourceType, map[string]string{
 						AppTagKey: "mockApp",
 						EnvTagKey: "mockEnv",
-					}).Return([]string{"arn:aws:ecs:us-west-2:123456789012:service/mockSvc"}, nil),
+					}).Return([]*rg.Resource{{Arn: "mockARN", Tags: map[string]string{ServiceTagKey: "mockSvc"}}}, nil),
 					m.configStore.EXPECT().GetService("mockApp", "mockSvc").Return(nil, errors.New("some error")),
 				)
 			},
@@ -98,7 +84,8 @@ func TestStore_ListDeployedServices(t *testing.T) {
 					m.rgGetter.EXPECT().GetResourcesByTags(ecsServiceResourceType, map[string]string{
 						AppTagKey: "mockApp",
 						EnvTagKey: "mockEnv",
-					}).Return([]string{"arn:aws:ecs:us-west-2:123456789012:service/mockSvc1", "arn:aws:ecs:us-west-2:123456789012:service/mockSvc2"}, nil),
+					}).Return([]*rg.Resource{{Arn: "mockARN1", Tags: map[string]string{ServiceTagKey: "mockSvc1"}},
+						{Arn: "mockARN2", Tags: map[string]string{ServiceTagKey: "mockSvc2"}}}, nil),
 					m.configStore.EXPECT().GetService("mockApp", "mockSvc1").Return(&config.Service{
 						App:  "mockApp",
 						Name: "mockSvc1",
@@ -119,7 +106,7 @@ func TestStore_ListDeployedServices(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
-			mockConfigStore := mocks.NewMockconfigStoreClient(ctrl)
+			mockConfigStore := mocks.NewMockConfigStoreClient(ctrl)
 			mockRgGetter := mocks.NewMockresourceGetter(ctrl)
 
 			mocks := storeMock{
@@ -212,12 +199,12 @@ func TestStore_ListEnvironmentsDeployedTo(t *testing.T) {
 						AppTagKey:     "mockApp",
 						EnvTagKey:     "mockEnv1",
 						ServiceTagKey: "mockSvc",
-					}).Return([]string{"mockSvcARN"}, nil),
+					}).Return([]*rg.Resource{{Arn: "mockSvcARN"}}, nil),
 					m.rgGetter.EXPECT().GetResourcesByTags(ecsServiceResourceType, map[string]string{
 						AppTagKey:     "mockApp",
 						EnvTagKey:     "mockEnv2",
 						ServiceTagKey: "mockSvc",
-					}).Return([]string{""}, nil),
+					}).Return([]*rg.Resource{}, nil),
 				)
 			},
 
@@ -230,7 +217,7 @@ func TestStore_ListEnvironmentsDeployedTo(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
-			mockConfigStore := mocks.NewMockconfigStoreClient(ctrl)
+			mockConfigStore := mocks.NewMockConfigStoreClient(ctrl)
 			mockRgGetter := mocks.NewMockresourceGetter(ctrl)
 
 			mocks := storeMock{
@@ -298,7 +285,7 @@ func TestStore_IsDeployed(t *testing.T) {
 						AppTagKey:     "mockApp",
 						EnvTagKey:     "mockEnv",
 						ServiceTagKey: "mockSvc",
-					}).Return([]string{}, nil),
+					}).Return([]*rg.Resource{}, nil),
 				)
 			},
 
@@ -315,7 +302,7 @@ func TestStore_IsDeployed(t *testing.T) {
 						AppTagKey:     "mockApp",
 						EnvTagKey:     "mockEnv",
 						ServiceTagKey: "mockSvc",
-					}).Return([]string{"mockSvcARN"}, nil),
+					}).Return([]*rg.Resource{{Arn: "mockSvcARN"}}, nil),
 				)
 			},
 
@@ -328,7 +315,7 @@ func TestStore_IsDeployed(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
-			mockConfigStore := mocks.NewMockconfigStoreClient(ctrl)
+			mockConfigStore := mocks.NewMockConfigStoreClient(ctrl)
 			mockRgGetter := mocks.NewMockresourceGetter(ctrl)
 
 			mocks := storeMock{

--- a/internal/pkg/deploy/deploy_test.go
+++ b/internal/pkg/deploy/deploy_test.go
@@ -53,7 +53,7 @@ func TestStore_ListDeployedServices(t *testing.T) {
 					m.rgGetter.EXPECT().GetResourcesByTags(ecsServiceResourceType, map[string]string{
 						AppTagKey: "mockApp",
 						EnvTagKey: "mockEnv",
-					}).Return([]*rg.Resource{{Arn: "mockARN", Tags: map[string]string{}}}, nil),
+					}).Return([]*rg.Resource{{ARN: "mockARN", Tags: map[string]string{}}}, nil),
 				)
 			},
 
@@ -68,7 +68,7 @@ func TestStore_ListDeployedServices(t *testing.T) {
 					m.rgGetter.EXPECT().GetResourcesByTags(ecsServiceResourceType, map[string]string{
 						AppTagKey: "mockApp",
 						EnvTagKey: "mockEnv",
-					}).Return([]*rg.Resource{{Arn: "mockARN", Tags: map[string]string{ServiceTagKey: "mockSvc"}}}, nil),
+					}).Return([]*rg.Resource{{ARN: "mockARN", Tags: map[string]string{ServiceTagKey: "mockSvc"}}}, nil),
 					m.configStore.EXPECT().GetService("mockApp", "mockSvc").Return(nil, errors.New("some error")),
 				)
 			},
@@ -84,8 +84,8 @@ func TestStore_ListDeployedServices(t *testing.T) {
 					m.rgGetter.EXPECT().GetResourcesByTags(ecsServiceResourceType, map[string]string{
 						AppTagKey: "mockApp",
 						EnvTagKey: "mockEnv",
-					}).Return([]*rg.Resource{{Arn: "mockARN1", Tags: map[string]string{ServiceTagKey: "mockSvc1"}},
-						{Arn: "mockARN2", Tags: map[string]string{ServiceTagKey: "mockSvc2"}}}, nil),
+					}).Return([]*rg.Resource{{ARN: "mockARN1", Tags: map[string]string{ServiceTagKey: "mockSvc1"}},
+						{ARN: "mockARN2", Tags: map[string]string{ServiceTagKey: "mockSvc2"}}}, nil),
 					m.configStore.EXPECT().GetService("mockApp", "mockSvc1").Return(&config.Service{
 						App:  "mockApp",
 						Name: "mockSvc1",
@@ -199,7 +199,7 @@ func TestStore_ListEnvironmentsDeployedTo(t *testing.T) {
 						AppTagKey:     "mockApp",
 						EnvTagKey:     "mockEnv1",
 						ServiceTagKey: "mockSvc",
-					}).Return([]*rg.Resource{{Arn: "mockSvcARN"}}, nil),
+					}).Return([]*rg.Resource{{ARN: "mockSvcARN"}}, nil),
 					m.rgGetter.EXPECT().GetResourcesByTags(ecsServiceResourceType, map[string]string{
 						AppTagKey:     "mockApp",
 						EnvTagKey:     "mockEnv2",
@@ -302,7 +302,7 @@ func TestStore_IsDeployed(t *testing.T) {
 						AppTagKey:     "mockApp",
 						EnvTagKey:     "mockEnv",
 						ServiceTagKey: "mockSvc",
-					}).Return([]*rg.Resource{{Arn: "mockSvcARN"}}, nil),
+					}).Return([]*rg.Resource{{ARN: "mockSvcARN"}}, nil),
 				)
 			},
 

--- a/internal/pkg/deploy/mocks/mock_deploy.go
+++ b/internal/pkg/deploy/mocks/mock_deploy.go
@@ -5,6 +5,7 @@
 package mocks
 
 import (
+	resourcegroups "github.com/aws/copilot-cli/internal/pkg/aws/resourcegroups"
 	config "github.com/aws/copilot-cli/internal/pkg/config"
 	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
@@ -34,10 +35,10 @@ func (m *MockresourceGetter) EXPECT() *MockresourceGetterMockRecorder {
 }
 
 // GetResourcesByTags mocks base method
-func (m *MockresourceGetter) GetResourcesByTags(resourceType string, tags map[string]string) ([]string, error) {
+func (m *MockresourceGetter) GetResourcesByTags(resourceType string, tags map[string]string) ([]*resourcegroups.Resource, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetResourcesByTags", resourceType, tags)
-	ret0, _ := ret[0].([]string)
+	ret0, _ := ret[0].([]*resourcegroups.Resource)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -48,31 +49,31 @@ func (mr *MockresourceGetterMockRecorder) GetResourcesByTags(resourceType, tags 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResourcesByTags", reflect.TypeOf((*MockresourceGetter)(nil).GetResourcesByTags), resourceType, tags)
 }
 
-// MockconfigStoreClient is a mock of configStoreClient interface
-type MockconfigStoreClient struct {
+// MockConfigStoreClient is a mock of ConfigStoreClient interface
+type MockConfigStoreClient struct {
 	ctrl     *gomock.Controller
-	recorder *MockconfigStoreClientMockRecorder
+	recorder *MockConfigStoreClientMockRecorder
 }
 
-// MockconfigStoreClientMockRecorder is the mock recorder for MockconfigStoreClient
-type MockconfigStoreClientMockRecorder struct {
-	mock *MockconfigStoreClient
+// MockConfigStoreClientMockRecorder is the mock recorder for MockConfigStoreClient
+type MockConfigStoreClientMockRecorder struct {
+	mock *MockConfigStoreClient
 }
 
-// NewMockconfigStoreClient creates a new mock instance
-func NewMockconfigStoreClient(ctrl *gomock.Controller) *MockconfigStoreClient {
-	mock := &MockconfigStoreClient{ctrl: ctrl}
-	mock.recorder = &MockconfigStoreClientMockRecorder{mock}
+// NewMockConfigStoreClient creates a new mock instance
+func NewMockConfigStoreClient(ctrl *gomock.Controller) *MockConfigStoreClient {
+	mock := &MockConfigStoreClient{ctrl: ctrl}
+	mock.recorder = &MockConfigStoreClientMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use
-func (m *MockconfigStoreClient) EXPECT() *MockconfigStoreClientMockRecorder {
+func (m *MockConfigStoreClient) EXPECT() *MockConfigStoreClientMockRecorder {
 	return m.recorder
 }
 
 // GetEnvironment mocks base method
-func (m *MockconfigStoreClient) GetEnvironment(appName, environmentName string) (*config.Environment, error) {
+func (m *MockConfigStoreClient) GetEnvironment(appName, environmentName string) (*config.Environment, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetEnvironment", appName, environmentName)
 	ret0, _ := ret[0].(*config.Environment)
@@ -81,13 +82,13 @@ func (m *MockconfigStoreClient) GetEnvironment(appName, environmentName string) 
 }
 
 // GetEnvironment indicates an expected call of GetEnvironment
-func (mr *MockconfigStoreClientMockRecorder) GetEnvironment(appName, environmentName interface{}) *gomock.Call {
+func (mr *MockConfigStoreClientMockRecorder) GetEnvironment(appName, environmentName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEnvironment", reflect.TypeOf((*MockconfigStoreClient)(nil).GetEnvironment), appName, environmentName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEnvironment", reflect.TypeOf((*MockConfigStoreClient)(nil).GetEnvironment), appName, environmentName)
 }
 
 // ListEnvironments mocks base method
-func (m *MockconfigStoreClient) ListEnvironments(appName string) ([]*config.Environment, error) {
+func (m *MockConfigStoreClient) ListEnvironments(appName string) ([]*config.Environment, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListEnvironments", appName)
 	ret0, _ := ret[0].([]*config.Environment)
@@ -96,13 +97,13 @@ func (m *MockconfigStoreClient) ListEnvironments(appName string) ([]*config.Envi
 }
 
 // ListEnvironments indicates an expected call of ListEnvironments
-func (mr *MockconfigStoreClientMockRecorder) ListEnvironments(appName interface{}) *gomock.Call {
+func (mr *MockConfigStoreClientMockRecorder) ListEnvironments(appName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEnvironments", reflect.TypeOf((*MockconfigStoreClient)(nil).ListEnvironments), appName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEnvironments", reflect.TypeOf((*MockConfigStoreClient)(nil).ListEnvironments), appName)
 }
 
 // GetService mocks base method
-func (m *MockconfigStoreClient) GetService(appName, svcName string) (*config.Service, error) {
+func (m *MockConfigStoreClient) GetService(appName, svcName string) (*config.Service, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetService", appName, svcName)
 	ret0, _ := ret[0].(*config.Service)
@@ -111,7 +112,7 @@ func (m *MockconfigStoreClient) GetService(appName, svcName string) (*config.Ser
 }
 
 // GetService indicates an expected call of GetService
-func (mr *MockconfigStoreClientMockRecorder) GetService(appName, svcName interface{}) *gomock.Call {
+func (mr *MockConfigStoreClientMockRecorder) GetService(appName, svcName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetService", reflect.TypeOf((*MockconfigStoreClient)(nil).GetService), appName, svcName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetService", reflect.TypeOf((*MockConfigStoreClient)(nil).GetService), appName, svcName)
 }

--- a/internal/pkg/describe/env.go
+++ b/internal/pkg/describe/env.go
@@ -17,16 +17,16 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation/stack"
 	"github.com/aws/copilot-cli/internal/pkg/term/color"
 
-	"github.com/aws/copilot-cli/internal/pkg/aws/resourcegroups"
+	rg "github.com/aws/copilot-cli/internal/pkg/aws/resourcegroups"
 	"github.com/aws/copilot-cli/internal/pkg/aws/session"
 )
 
 const (
-	cloudformationResourceType = "AWS::CloudFormation::Stack"
+	cloudformationResourceType = "cloudformation:stack"
 )
 
 type resourceGroupsClient interface {
-	GetResourcesByTags(resourceType string, tags map[string]string) ([]string, error)
+	GetResourcesByTags(resourceType string, tags map[string]string) ([]*rg.Resource, error)
 }
 
 // EnvDescription contains the information about an environment.
@@ -80,7 +80,7 @@ func NewEnvDescriber(appName, envName string) (*EnvDescriber, error) {
 		enableResources: false,
 
 		store:          store,
-		rgClient:       resourcegroups.New(sess),
+		rgClient:       rg.New(sess),
 		stackDescriber: stackAndResourcesDescriber(d),
 	}, nil
 }
@@ -131,14 +131,14 @@ func (e *EnvDescriber) filterSvcsForEnv() ([]*config.Service, error) {
 	tags := map[string]string{
 		deploy.EnvTagKey: e.env.Name,
 	}
-	arns, err := e.rgClient.GetResourcesByTags(cloudformationResourceType, tags)
+	resources, err := e.rgClient.GetResourcesByTags(cloudformationResourceType, tags)
 	if err != nil {
 		return nil, fmt.Errorf("get %s resources for env %s: %w", cloudformationResourceType, e.env.Name, err)
 	}
 
 	stacksOfEnvironment := make(map[string]bool)
-	for _, arn := range arns {
-		stack, err := e.getStackName(arn)
+	for _, resource := range resources {
+		stack, err := e.getStackName(resource.Arn)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/pkg/describe/env.go
+++ b/internal/pkg/describe/env.go
@@ -138,7 +138,7 @@ func (e *EnvDescriber) filterSvcsForEnv() ([]*config.Service, error) {
 
 	stacksOfEnvironment := make(map[string]bool)
 	for _, resource := range resources {
-		stack, err := e.getStackName(resource.Arn)
+		stack, err := e.getStackName(resource.ARN)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/pkg/describe/env_test.go
+++ b/internal/pkg/describe/env_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 
+	rg "github.com/aws/copilot-cli/internal/pkg/aws/resourcegroups"
 	"github.com/aws/copilot-cli/internal/pkg/config"
 	"github.com/aws/copilot-cli/internal/pkg/deploy"
 	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation/stack"
@@ -109,13 +110,13 @@ func TestEnvDescriber_Describe(t *testing.T) {
 						Return(nil, mockError),
 				)
 			},
-			wantedError: fmt.Errorf("get AWS::CloudFormation::Stack resources for env testEnv: some error"),
+			wantedError: fmt.Errorf("get cloudformation:stack resources for env testEnv: some error"),
 		},
 		"error if getStackName fails because can't parse resource ARN": {
 			setupMocks: func(m envDescriberMocks) {
 				gomock.InOrder(
-					m.mockResourceGroupsClient.EXPECT().GetResourcesByTags(cloudformationResourceType, rgTags).Return([]string{
-						unparsableARN,
+					m.mockResourceGroupsClient.EXPECT().GetResourcesByTags(cloudformationResourceType, rgTags).Return([]*rg.Resource{
+						{Arn: unparsableARN},
 					}, nil),
 				)
 			},
@@ -124,8 +125,8 @@ func TestEnvDescriber_Describe(t *testing.T) {
 		"error if getStackName fails because resource ARN can't be split": {
 			setupMocks: func(m envDescriberMocks) {
 				gomock.InOrder(
-					m.mockResourceGroupsClient.EXPECT().GetResourcesByTags(cloudformationResourceType, rgTags).Return([]string{
-						noSlashARN,
+					m.mockResourceGroupsClient.EXPECT().GetResourcesByTags(cloudformationResourceType, rgTags).Return([]*rg.Resource{
+						{Arn: noSlashARN},
 					}, nil),
 				)
 			},
@@ -135,9 +136,9 @@ func TestEnvDescriber_Describe(t *testing.T) {
 			shouldOutputResources: false,
 			setupMocks: func(m envDescriberMocks) {
 				gomock.InOrder(
-					m.mockResourceGroupsClient.EXPECT().GetResourcesByTags(cloudformationResourceType, rgTags).Return([]string{
-						testARN1,
-						testARN2,
+					m.mockResourceGroupsClient.EXPECT().GetResourcesByTags(cloudformationResourceType, rgTags).Return([]*rg.Resource{
+						{Arn: testARN1},
+						{Arn: testARN2},
 					}, nil),
 					m.mockStackDescriber.EXPECT().Stack(stack.NameForEnv(testApp.Name, testEnv.Name)).Return(&cloudformation.Stack{
 						Tags: stackTags,
@@ -154,9 +155,9 @@ func TestEnvDescriber_Describe(t *testing.T) {
 			shouldOutputResources: true,
 			setupMocks: func(m envDescriberMocks) {
 				gomock.InOrder(
-					m.mockResourceGroupsClient.EXPECT().GetResourcesByTags(cloudformationResourceType, rgTags).Return([]string{
-						testARN1,
-						testARN2,
+					m.mockResourceGroupsClient.EXPECT().GetResourcesByTags(cloudformationResourceType, rgTags).Return([]*rg.Resource{
+						{Arn: testARN1},
+						{Arn: testARN2},
 					}, nil),
 					m.mockStackDescriber.EXPECT().Stack(stack.NameForEnv(testApp.Name, testEnv.Name)).Return(&cloudformation.Stack{
 						Tags: stackTags,

--- a/internal/pkg/describe/env_test.go
+++ b/internal/pkg/describe/env_test.go
@@ -116,7 +116,7 @@ func TestEnvDescriber_Describe(t *testing.T) {
 			setupMocks: func(m envDescriberMocks) {
 				gomock.InOrder(
 					m.mockResourceGroupsClient.EXPECT().GetResourcesByTags(cloudformationResourceType, rgTags).Return([]*rg.Resource{
-						{Arn: unparsableARN},
+						{ARN: unparsableARN},
 					}, nil),
 				)
 			},
@@ -126,7 +126,7 @@ func TestEnvDescriber_Describe(t *testing.T) {
 			setupMocks: func(m envDescriberMocks) {
 				gomock.InOrder(
 					m.mockResourceGroupsClient.EXPECT().GetResourcesByTags(cloudformationResourceType, rgTags).Return([]*rg.Resource{
-						{Arn: noSlashARN},
+						{ARN: noSlashARN},
 					}, nil),
 				)
 			},
@@ -137,8 +137,8 @@ func TestEnvDescriber_Describe(t *testing.T) {
 			setupMocks: func(m envDescriberMocks) {
 				gomock.InOrder(
 					m.mockResourceGroupsClient.EXPECT().GetResourcesByTags(cloudformationResourceType, rgTags).Return([]*rg.Resource{
-						{Arn: testARN1},
-						{Arn: testARN2},
+						{ARN: testARN1},
+						{ARN: testARN2},
 					}, nil),
 					m.mockStackDescriber.EXPECT().Stack(stack.NameForEnv(testApp.Name, testEnv.Name)).Return(&cloudformation.Stack{
 						Tags: stackTags,
@@ -156,8 +156,8 @@ func TestEnvDescriber_Describe(t *testing.T) {
 			setupMocks: func(m envDescriberMocks) {
 				gomock.InOrder(
 					m.mockResourceGroupsClient.EXPECT().GetResourcesByTags(cloudformationResourceType, rgTags).Return([]*rg.Resource{
-						{Arn: testARN1},
-						{Arn: testARN2},
+						{ARN: testARN1},
+						{ARN: testARN2},
 					}, nil),
 					m.mockStackDescriber.EXPECT().Stack(stack.NameForEnv(testApp.Name, testEnv.Name)).Return(&cloudformation.Stack{
 						Tags: stackTags,

--- a/internal/pkg/describe/mocks/mock_env.go
+++ b/internal/pkg/describe/mocks/mock_env.go
@@ -5,6 +5,7 @@
 package mocks
 
 import (
+	resourcegroups "github.com/aws/copilot-cli/internal/pkg/aws/resourcegroups"
 	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
 )
@@ -33,10 +34,10 @@ func (m *MockresourceGroupsClient) EXPECT() *MockresourceGroupsClientMockRecorde
 }
 
 // GetResourcesByTags mocks base method
-func (m *MockresourceGroupsClient) GetResourcesByTags(resourceType string, tags map[string]string) ([]string, error) {
+func (m *MockresourceGroupsClient) GetResourcesByTags(resourceType string, tags map[string]string) ([]*resourcegroups.Resource, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetResourcesByTags", resourceType, tags)
-	ret0, _ := ret[0].([]string)
+	ret0, _ := ret[0].([]*resourcegroups.Resource)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }


### PR DESCRIPTION
Use resourcegroupstaggingapi instead of use resourcegroups api for `GetResourcesByTags` method. After this change `GetResourcesByTags` will also return all tags for the found resources.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
