### PR TITLE
chore(stack): add task to deploy/cfn/stack package and add template for task

### DIFF
--- a/CHARTER.md
+++ b/CHARTER.md
@@ -5,7 +5,7 @@ Our mission is to help customers build, release and operate applications on Amaz
 
 ## Tenets 🌟
 * **Create modern applications by default.**
-Applications created with the ECS CLI use the best practices of modern applications by default: they are serverless,
+Applications created with the AWS Copilot CLI use the best practices of modern applications by default: they are serverless,
 they use infrastructure-as-code, they are observable, and they are secure.
 * **Users think in terms of architecture, not of infrastructure.**
 Developers creating a new microservice shouldn't have to specify VPCs, load balancer settings, or complex pipeline configuration.
@@ -15,4 +15,4 @@ it fits into their overall architecture; the infrastructure should be generated 
 Modeling, provisioning, and deploying applications are only part of the application lifecycle for the developer.
 The CLI must support workflows around troubleshooting and debugging to help when things go wrong.
 * **Deliver applications continuously.**
-While the ECS CLI can be used to manually deploy changes to an application, we always help customers to move to CI/CD by helping them set up and manage pipelines.
+While the AWS Copilot CLI can be used to manually deploy changes to an application, we always help customers to move to CI/CD by helping them set up and manage pipelines.

--- a/internal/pkg/deploy/cloudformation/stack/name.go
+++ b/internal/pkg/deploy/cloudformation/stack/name.go
@@ -21,3 +21,8 @@ func NameForService(app, env, svc string) string {
 func NameForEnv(app, env string) string {
 	return fmt.Sprintf("%s-%s", app, env)
 }
+
+// NameForTask returns the stack name for a task.
+func NameForTask(task string) string {
+	return fmt.Sprintf("task-%s", task)
+}

--- a/internal/pkg/deploy/cloudformation/stack/task.go
+++ b/internal/pkg/deploy/cloudformation/stack/task.go
@@ -1,0 +1,117 @@
+package stack
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/aws/copilot-cli/internal/pkg/deploy"
+	"github.com/aws/copilot-cli/internal/pkg/template"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+)
+
+const (
+	taskTemplatePath = "task/cf.yml"
+
+	taskNameParamKey         = "TaskName"
+	taskCPUParamKey          = "TaskCPU"
+	taskMemoryParamKey       = "TaskMemory"
+	taskLogRetentionParamKey = "LogRetention"
+
+	taskContainerImageParamKey = "ContainerImage"
+	taskTaskRoleParamKey       = "TaskRole"
+	taskCommandParamKey        = "Command"
+
+	taskLogRetention = "1"
+)
+
+type taskStackConfig struct {
+	Name string
+
+	Cpu    int
+	Memory int
+
+	ImageURL string
+	TaskRole string
+	Command  string
+	EnvVars map[string]string
+
+	parser template.ReadParser
+}
+
+// NewTaskStackConfig sets up a struct that provides stack configurations for CloudFormation
+// to deploy the task resources stack.
+func NewTaskStackConfig(taskOpts *deploy.CreateTaskResourcesInput) *taskStackConfig {
+	return &taskStackConfig{
+		Name:   taskOpts.Name,
+		Cpu:    taskOpts.Cpu,
+		Memory: taskOpts.Memory,
+
+		ImageURL: taskOpts.Image,
+		TaskRole: taskOpts.TaskRole,
+		Command:  taskOpts.Command,
+		EnvVars: taskOpts.EnvVars,
+
+		parser: template.New(),
+	}
+}
+
+// StackName returns the name of the CloudFormation stack for the task.
+func (t *taskStackConfig) StackName() string {
+	return NameForTask(t.Name)
+}
+
+// Template returns the task CloudFormation template.
+func (t *taskStackConfig) Template() (string, error) {
+	content, err := t.parser.Parse(taskTemplatePath, struct{
+		EnvVars map[string]string
+	}{
+		EnvVars: t.EnvVars,
+	})
+	if err != nil {
+		return "", fmt.Errorf("read template for task stack: %w", err)
+	}
+	return content.String(), nil
+}
+
+// Parameters returns the parameter values to be passed to the task CloudFormation template.
+func (t *taskStackConfig) Parameters() ([]*cloudformation.Parameter, error) {
+	return []*cloudformation.Parameter{
+		{
+			ParameterKey:   aws.String(taskNameParamKey),
+			ParameterValue: aws.String(t.Name),
+		},
+		{
+			ParameterKey:   aws.String(taskCPUParamKey),
+			ParameterValue: aws.String(strconv.Itoa(aws.IntValue(&t.Cpu))),
+		},
+		{
+			ParameterKey:   aws.String(taskMemoryParamKey),
+			ParameterValue: aws.String(strconv.Itoa(aws.IntValue(&t.Memory))),
+		},
+		{
+			ParameterKey:   aws.String(taskLogRetentionParamKey),
+			ParameterValue: aws.String(taskLogRetention),
+		},
+		{
+			ParameterKey:   aws.String(taskContainerImageParamKey),
+			ParameterValue: aws.String(t.ImageURL),
+		},
+		{
+			ParameterKey:   aws.String(taskTaskRoleParamKey),
+			ParameterValue: aws.String(t.TaskRole),
+		},
+		{
+			ParameterKey:   aws.String(taskCommandParamKey),
+			ParameterValue: aws.String(t.Command),
+		},
+	}, nil
+}
+
+// Tags returns the tags that should be applied to the task CloudFormation.
+func (t *taskStackConfig) Tags() []*cloudformation.Tag {
+	return mergeAndFlattenTags(map[string]string{
+		deploy.TaskTagKey: t.Name,
+	}, nil)
+}

--- a/internal/pkg/deploy/cloudformation/stack/task_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/task_test.go
@@ -53,8 +53,7 @@ func TestTaskStackConfig_Template(t *testing.T) {
 				tc.mockReadParser(mockReadParser)
 			}
 
-			taskInput := deploy.CreateTaskResourcesInput{
-			}
+			taskInput := deploy.CreateTaskResourcesInput{}
 
 			taskStackConfig := &taskStackConfig{
 				CreateTaskResourcesInput: &taskInput,

--- a/internal/pkg/deploy/cloudformation/stack/task_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/task_test.go
@@ -1,0 +1,120 @@
+package stack
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/aws/copilot-cli/internal/pkg/template"
+	"github.com/aws/copilot-cli/internal/pkg/template/mocks"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testTaskName = "my-task"
+)
+
+func TestTask_Template(t *testing.T) {
+	testCases := map[string]struct {
+		mockReadParser func(m *mocks.MockReadParser)
+
+		wantedTemplate string
+		wantedError    error
+	}{
+		"should return error if unable to read": {
+			mockReadParser: func(m *mocks.MockReadParser) {
+				m.EXPECT().Parse(taskTemplatePath, gomock.Any()).Return(nil, errors.New("error reading template"))
+			},
+			wantedError: errors.New("read template for task stack: error reading template"),
+		},
+		"should return template body when present": {
+			mockReadParser: func(m *mocks.MockReadParser) {
+				m.EXPECT().Parse(taskTemplatePath, gomock.Any()).Return(&template.Content{
+					Buffer: bytes.NewBufferString("This is the task template"),
+				}, nil)
+			},
+			wantedTemplate: "This is the task template",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockReadParser := mocks.NewMockReadParser(ctrl)
+			if tc.mockReadParser != nil {
+				tc.mockReadParser(mockReadParser)
+			}
+
+			taskStack := &taskStackConfig{
+				parser: mockReadParser,
+			}
+
+			got, err := taskStack.Template()
+
+			if tc.wantedError != nil {
+				require.EqualError(t, tc.wantedError, err.Error())
+			} else {
+				require.Equal(t, tc.wantedTemplate, got)
+			}
+		})
+	}
+}
+
+func TestTask_Parameters(t *testing.T) {
+	expectedParams := []*cloudformation.Parameter{
+		{
+			ParameterKey:   aws.String(taskNameParamKey),
+			ParameterValue: aws.String("my-task"),
+		},
+		{
+			ParameterKey:   aws.String(taskContainerImageParamKey),
+			ParameterValue: aws.String("7456.dkr.ecr.us-east-2.amazonaws.com/my-task:0.1"),
+		},
+		{
+			ParameterKey:   aws.String(taskCPUParamKey),
+			ParameterValue: aws.String("256"),
+		},
+		{
+			ParameterKey:   aws.String(taskMemoryParamKey),
+			ParameterValue: aws.String("512"),
+		},
+		{
+			ParameterKey:   aws.String(taskLogRetentionParamKey),
+			ParameterValue: aws.String(taskLogRetention),
+		},
+		{
+			ParameterKey:   aws.String(taskTaskRoleParamKey),
+			ParameterValue: aws.String("task-role"),
+		},
+		{
+			ParameterKey:   aws.String(taskCommandParamKey),
+			ParameterValue: aws.String("echo hooray"),
+		},
+	}
+
+	task := &taskStackConfig{
+		Name:   "my-task",
+		Cpu:    256,
+		Memory: 512,
+
+		ImageURL: "7456.dkr.ecr.us-east-2.amazonaws.com/my-task:0.1",
+		TaskRole: "task-role",
+		Command:  "echo hooray",
+	}
+	params, _ := task.Parameters()
+	require.ElementsMatch(t, expectedParams, params)
+}
+
+func TestTask_StackName(t *testing.T) {
+	task := &taskStackConfig{
+		Name: testTaskName,
+	}
+	got := task.StackName()
+	require.Equal(t, got, fmt.Sprintf("task-%s", testTaskName))
+}

--- a/internal/pkg/deploy/deploy.go
+++ b/internal/pkg/deploy/deploy.go
@@ -21,6 +21,8 @@ const (
 	EnvTagKey = "copilot-environment"
 	// ServiceTagKey is tag key for Copilot svc.
 	ServiceTagKey = "copilot-service"
+	// TaskTagKey is tag key for Copilot task.
+	TaskTagKey = "copilot-task"
 )
 
 const (

--- a/internal/pkg/deploy/task.go
+++ b/internal/pkg/deploy/task.go
@@ -1,0 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package deploy holds the structures to deploy infrastructure resources.
+// This file defines service deployment resources.
+package deploy
+
+// CreateTaskResourcesInput holds the fields required to create a task stack.
+type CreateTaskResourcesInput struct {
+	Name     string
+	Cpu      int
+	Memory   int
+	Image    string
+	TaskRole string
+	Command  string
+	EnvVars  map[string]string
+}

--- a/internal/pkg/deploy/task.go
+++ b/internal/pkg/deploy/task.go
@@ -8,10 +8,14 @@ package deploy
 // CreateTaskResourcesInput holds the fields required to create a task stack.
 type CreateTaskResourcesInput struct {
 	Name     string
-	Cpu      int
+	CPU      int
 	Memory   int
+
 	Image    string
 	TaskRole string
 	Command  string
 	EnvVars  map[string]string
+
+	App      string
+	Env      string
 }

--- a/templates/task/cf.yml
+++ b/templates/task/cf.yml
@@ -1,0 +1,106 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+AWSTemplateFormatVersion: "2010-09-09"
+Description: "CloudFormation template that represents a task on Amazon ECS."
+Parameters:
+  TaskName:
+    Type: String
+  TaskCPU:
+    Type: String
+  TaskMemory:
+    Type: String
+  LogRetention:
+    Type: Number
+  ContainerImage:
+    Type: String
+  TaskRole:
+    Type: String
+  Command:
+    Type: String
+Conditions:
+  HasImage:
+    !Not [!Equals [!Ref ContainerImage, ""]]
+  UseDefaultTaskRole:
+    !Equals [!Ref TaskRole, ""]
+  HasCommand:
+    !Not [!Equals [!Ref Command, ""]]
+Resources:
+  TaskDefinition:
+    Condition: HasImage
+    Type: AWS::ECS::TaskDefinition
+    DependsOn: ECRRepo
+    Properties:
+      ContainerDefinitions:
+        -
+          Image: !Ref ContainerImage
+          Command: !If [HasCommand, !Split [" ", !Ref Command], !Ref "AWS::NoValue"]
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-region: !Ref AWS::Region
+              awslogs-group: !Ref LogGroup
+              awslogs-stream-prefix: copilot-task
+          Name: !Ref TaskName{{if .EnvVars}}
+          Environment:{{range $name, $value := .EnvVars}}
+          - Name: {{$name}}
+          Value: {{$value}}{{end}}{{end}}
+      Family: !Join ['-', ["copilot", !Ref TaskName]]
+      RequiresCompatibilities:
+        - "FARGATE"
+      NetworkMode: awsvpc
+      Cpu: !Ref TaskCPU
+      Memory: !Ref TaskMemory
+      ExecutionRoleArn: !Ref ExecutionRole
+      TaskRoleArn:
+        !If [UseDefaultTaskRole, !Ref DefaultTaskRole, !Ref TaskRole]
+  DefaultTaskRole:
+    Condition: UseDefaultTaskRole
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: 'sts:AssumeRole'
+  ExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: 'sts:AssumeRole'
+      ManagedPolicyArns:
+        - 'arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy'
+  ECRRepo:
+    Type: AWS::ECR::Repository
+    Properties:
+      RepositoryName: !Join ["-", ["copilot", !Ref TaskName]]
+      RepositoryPolicyText:
+        Version: '2008-10-17'
+        Statement:
+          - Sid: AllowPushPull
+            Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+            Action:
+              - ecr:GetDownloadUrlForLayer
+              - ecr:BatchGetImage
+              - ecr:BatchCheckLayerAvailability
+              - ecr:PutImage
+              - ecr:InitiateLayerUpload
+              - ecr:UploadLayerPart
+              - ecr:CompleteLayerUpload
+      LifecyclePolicy: # TODO: inject the JSON string instead of hard-coding it here
+        LifecyclePolicyText: "{\"rules\":[{\"rulePriority\":1,\"selection\":{\"tagStatus\":\"untagged\",\"countType\":\"sinceImagePushed\",\"countUnit\":\"days\",\"countNumber\":5},\"action\":{\"type\":\"expire\"}}]}"
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Join ['', ["/copilot/", !Ref TaskName]]
+      RetentionInDays: !Ref LogRetention
+Outputs:
+  ECRRepo:
+    Description: ECR Repo used to store images of task.
+    Value: !GetAtt ECRRepo.Arn

--- a/templates/task/cf.yml
+++ b/templates/task/cf.yml
@@ -18,6 +18,7 @@ Parameters:
   Command:
     Type: String
 Conditions:
+  # NOTE: Image cannot be pushed until the ECR repo is created, at which time ContainerImage would be "".
   HasImage:
     !Not [!Equals [!Ref ContainerImage, ""]]
   UseDefaultTaskRole:
@@ -26,7 +27,7 @@ Conditions:
     !Not [!Equals [!Ref Command, ""]]
 Resources:
   TaskDefinition:
-    Condition: HasImage
+    Condition: HasImage # NOTE: We only create TaskDefinition if an image is provided
     Type: AWS::ECS::TaskDefinition
     DependsOn: ECRRepo
     Properties:


### PR DESCRIPTION
This PR adds a CloudFormation template for a task stack, and implement stack configuration methods for task.

Related #702 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
