### PR TITLE
refactor(describe): reduce repetitive init and method calls

### DIFF
--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -445,9 +445,17 @@ func (o *deploySvcOpts) showAppURI() error {
 	var err error
 	switch o.targetSvc.Type {
 	case manifest.LoadBalancedWebServiceType:
-		svcDescriber, err = describe.NewWebServiceDescriber(o.AppName(), o.Name)
+		svcDescriber, err = describe.NewWebServiceDescriber(&describe.NewServiceDescriberOption{
+			App:         o.AppName(),
+			Svc:         o.Name,
+			ConfigStore: o.store,
+		})
 	case manifest.BackendServiceType:
-		svcDescriber, err = describe.NewBackendServiceDescriber(o.AppName(), o.Name)
+		svcDescriber, err = describe.NewBackendServiceDescriber(&describe.NewServiceDescriberOption{
+			App:         o.AppName(),
+			Svc:         o.Name,
+			ConfigStore: o.store,
+		})
 	default:
 		err = errors.New("unexpected service type")
 	}

--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -445,16 +445,20 @@ func (o *deploySvcOpts) showAppURI() error {
 	var err error
 	switch o.targetSvc.Type {
 	case manifest.LoadBalancedWebServiceType:
-		svcDescriber, err = describe.NewWebServiceDescriber(&describe.NewServiceDescriberOption{
-			App:         o.AppName(),
-			Svc:         o.Name,
-			ConfigStore: o.store,
+		svcDescriber, err = describe.NewWebServiceDescriber(describe.NewWebServiceConfig{
+			NewServiceConfig: describe.NewServiceConfig{
+				App:         o.AppName(),
+				Svc:         o.Name,
+				ConfigStore: o.store,
+			},
 		})
 	case manifest.BackendServiceType:
-		svcDescriber, err = describe.NewBackendServiceDescriber(&describe.NewServiceDescriberOption{
-			App:         o.AppName(),
-			Svc:         o.Name,
-			ConfigStore: o.store,
+		svcDescriber, err = describe.NewBackendServiceDescriber(describe.NewBackendServiceConfig{
+			NewServiceConfig: describe.NewServiceConfig{
+				App:         o.AppName(),
+				Svc:         o.Name,
+				ConfigStore: o.store,
+			},
 		})
 	default:
 		err = errors.New("unexpected service type")

--- a/internal/pkg/cli/svc_show.go
+++ b/internal/pkg/cli/svc_show.go
@@ -4,17 +4,16 @@
 package cli
 
 import (
-	"errors"
 	"fmt"
 	"io"
 
 	"github.com/aws/copilot-cli/internal/pkg/cli/selector"
 	"github.com/aws/copilot-cli/internal/pkg/config"
+	"github.com/aws/copilot-cli/internal/pkg/deploy"
 	"github.com/aws/copilot-cli/internal/pkg/describe"
 	"github.com/aws/copilot-cli/internal/pkg/manifest"
 	"github.com/aws/copilot-cli/internal/pkg/term/color"
 	"github.com/aws/copilot-cli/internal/pkg/term/log"
-	"github.com/aws/copilot-cli/internal/pkg/workspace"
 	"github.com/spf13/cobra"
 )
 
@@ -38,7 +37,6 @@ type showSvcOpts struct {
 	w             io.Writer
 	store         store
 	describer     describer
-	ws            wsSvcReader
 	sel           configSelector
 	initDescriber func(bool) error // Overriden in tests.
 }
@@ -46,17 +44,16 @@ type showSvcOpts struct {
 func newShowSvcOpts(vars showSvcVars) (*showSvcOpts, error) {
 	ssmStore, err := config.NewStore()
 	if err != nil {
-		return nil, fmt.Errorf("connect to environment datastore: %w", err)
+		return nil, fmt.Errorf("connect to config store: %w", err)
 	}
-	ws, err := workspace.New()
+	deployStore, err := deploy.NewStore(ssmStore)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("connect to deploy store: %w", err)
 	}
 
 	opts := &showSvcOpts{
 		showSvcVars: vars,
 		store:       ssmStore,
-		ws:          ws,
 		w:           log.OutputWriter,
 		sel:         selector.NewConfigSelect(vars.prompt, ssmStore),
 	}
@@ -66,18 +63,24 @@ func newShowSvcOpts(vars showSvcVars) (*showSvcOpts, error) {
 		if err != nil {
 			return err
 		}
+		options := &describe.NewServiceDescriberOption{
+			App:         opts.AppName(),
+			Svc:         opts.svcName,
+			ConfigStore: ssmStore,
+			DeployStore: deployStore,
+		}
 		switch svc.Type {
 		case manifest.LoadBalancedWebServiceType:
 			if enableResources {
-				d, err = describe.NewWebServiceDescriberWithResources(opts.AppName(), opts.svcName)
+				d, err = describe.NewWebServiceDescriberWithResources(options)
 			} else {
-				d, err = describe.NewWebServiceDescriber(opts.AppName(), opts.svcName)
+				d, err = describe.NewWebServiceDescriber(options)
 			}
 		case manifest.BackendServiceType:
 			if enableResources {
-				d, err = describe.NewBackendServiceDescriberWithResources(opts.AppName(), opts.svcName)
+				d, err = describe.NewBackendServiceDescriberWithResources(options)
 			} else {
-				d, err = describe.NewBackendServiceDescriber(opts.AppName(), opts.svcName)
+				d, err = describe.NewBackendServiceDescriber(options)
 			}
 		default:
 			return fmt.Errorf("invalid service type %s", svc.Type)
@@ -158,62 +161,17 @@ func (o *showSvcOpts) askApp() error {
 }
 
 func (o *showSvcOpts) askSvcName() error {
-	// return if service name is set by flag
 	if o.svcName != "" {
 		return nil
 	}
-
-	svcNames, err := o.retrieveLocalService()
-	if err != nil {
-		svcNames, err = o.retrieveAllServices()
-		if err != nil {
-			return err
-		}
-	}
-
-	if len(svcNames) == 0 {
-		log.Infof("No services found in application %s.\n", color.HighlightUserInput(o.AppName()))
-		return nil
-	}
-	if len(svcNames) == 1 {
-		o.svcName = svcNames[0]
-		return nil
-	}
-	svcName, err := o.prompt.SelectOne(
-		fmt.Sprintf(svcShowSvcNamePrompt, color.HighlightUserInput(o.AppName())),
-		svcShowSvcNameHelpPrompt,
-		svcNames,
-	)
+	svcName, err := o.sel.Service(fmt.Sprintf(svcShowSvcNamePrompt, color.HighlightUserInput(o.AppName())),
+		svcShowSvcNameHelpPrompt, o.AppName())
 	if err != nil {
 		return fmt.Errorf("select service for application %s: %w", o.AppName(), err)
 	}
 	o.svcName = svcName
 
 	return nil
-}
-
-func (o *showSvcOpts) retrieveLocalService() ([]string, error) {
-	localSvcNames, err := o.ws.ServiceNames()
-	if err != nil {
-		return nil, err
-	}
-	if len(localSvcNames) == 0 {
-		return nil, errors.New("no service found")
-	}
-	return localSvcNames, nil
-}
-
-func (o *showSvcOpts) retrieveAllServices() ([]string, error) {
-	svcs, err := o.store.ListServices(o.AppName())
-	if err != nil {
-		return nil, fmt.Errorf("list services for application %s: %w", o.AppName(), err)
-	}
-	svcNames := make([]string, len(svcs))
-	for ind, svc := range svcs {
-		svcNames[ind] = svc.Name
-	}
-
-	return svcNames, nil
 }
 
 // BuildSvcShowCmd builds the command for showing services in an application.

--- a/internal/pkg/cli/svc_show.go
+++ b/internal/pkg/cli/svc_show.go
@@ -124,11 +124,9 @@ func (o *showSvcOpts) Ask() error {
 // Execute shows the services through the prompt.
 func (o *showSvcOpts) Execute() error {
 	if o.svcName == "" {
-		// If there are no local services in the workspace, we exit without error.
 		return nil
 	}
-	err := o.initDescriber()
-	if err != nil {
+	if err := o.initDescriber(); err != nil {
 		return err
 	}
 	svc, err := o.describer.Describe()

--- a/internal/pkg/cli/svc_show_test.go
+++ b/internal/pkg/cli/svc_show_test.go
@@ -144,78 +144,14 @@ func TestSvcShow_Ask(t *testing.T) {
 			wantedSvc:   "my-svc",
 			wantedError: nil,
 		},
-		"retrieve all service names if fail to retrieve service name from local": {
+		"success": {
 			inputApp: "",
 			inputSvc: "",
 
 			setupMocks: func(m showSvcMocks) {
 				gomock.InOrder(
 					m.sel.EXPECT().Application(svcShowAppNamePrompt, svcShowAppNameHelpPrompt).Return("my-app", nil),
-
-					m.ws.EXPECT().ServiceNames().Return(nil, errors.New("some error")),
-					m.storeSvc.EXPECT().ListServices("my-app").Return([]*config.Service{
-						{Name: "my-svc"},
-						{Name: "archer-svc"},
-					}, nil),
-					m.prompt.EXPECT().SelectOne(fmt.Sprintf(svcShowSvcNamePrompt, "my-app"), svcShowSvcNameHelpPrompt, []string{"my-svc", "archer-svc"}).Return("my-svc", nil).Times(1),
-				)
-			},
-
-			wantedApp:   "my-app",
-			wantedSvc:   "my-svc",
-			wantedError: nil,
-		},
-		"retrieve all service names if no service found in local dir": {
-			inputApp: "",
-			inputSvc: "",
-
-			setupMocks: func(m showSvcMocks) {
-				gomock.InOrder(
-					m.sel.EXPECT().Application(svcShowAppNamePrompt, svcShowAppNameHelpPrompt).Return("my-app", nil),
-
-					m.ws.EXPECT().ServiceNames().Return([]string{}, nil),
-					m.storeSvc.EXPECT().ListServices("my-app").Return([]*config.Service{
-						{Name: "my-svc"},
-						{Name: "archer-svc"},
-					}, nil),
-
-					m.prompt.EXPECT().SelectOne(fmt.Sprintf(svcShowSvcNamePrompt, "my-app"), svcShowSvcNameHelpPrompt, []string{"my-svc", "archer-svc"}).Return("my-svc", nil).Times(1),
-				)
-			},
-
-			wantedApp:   "my-app",
-			wantedSvc:   "my-svc",
-			wantedError: nil,
-		},
-		"retrieve local service names": {
-			inputApp: "",
-			inputSvc: "",
-
-			setupMocks: func(m showSvcMocks) {
-				gomock.InOrder(
-					m.sel.EXPECT().Application(svcShowAppNamePrompt, svcShowAppNameHelpPrompt).Return("my-app", nil),
-
-					m.ws.EXPECT().ServiceNames().Return([]string{"my-svc", "archer-svc"}, nil),
-					m.prompt.EXPECT().SelectOne(fmt.Sprintf(svcShowSvcNamePrompt, "my-app"), svcShowSvcNameHelpPrompt, []string{"my-svc", "archer-svc"}).Return("my-svc", nil).Times(1),
-				)
-			},
-
-			wantedApp:   "my-app",
-			wantedSvc:   "my-svc",
-			wantedError: nil,
-		},
-		"skip selecting if only one service found": {
-			inputApp: "my-app",
-			inputSvc: "",
-
-			setupMocks: func(m showSvcMocks) {
-				gomock.InOrder(
-					m.ws.EXPECT().ServiceNames().Return(nil, errors.New("some error")),
-					m.storeSvc.EXPECT().ListServices("my-app").Return([]*config.Service{
-						{
-							Name: "my-svc",
-						},
-					}, nil),
+					m.sel.EXPECT().Service(fmt.Sprintf(svcShowSvcNamePrompt, "my-app"), svcShowSvcNameHelpPrompt, "my-app").Return("my-svc", nil),
 				)
 			},
 
@@ -233,21 +169,6 @@ func TestSvcShow_Ask(t *testing.T) {
 
 			wantedError: fmt.Errorf("select application name: some error"),
 		},
-		"returns error when fail to list services": {
-			inputApp: "",
-			inputSvc: "",
-
-			setupMocks: func(m showSvcMocks) {
-				gomock.InOrder(
-					m.sel.EXPECT().Application(svcShowAppNamePrompt, svcShowAppNameHelpPrompt).Return("my-app", nil),
-
-					m.ws.EXPECT().ServiceNames().Return(nil, errors.New("some error")),
-					m.storeSvc.EXPECT().ListServices("my-app").Return(nil, fmt.Errorf("some error")),
-				)
-			},
-
-			wantedError: fmt.Errorf("list services for application my-app: some error"),
-		},
 		"returns error when fail to select services": {
 			inputApp: "",
 			inputSvc: "",
@@ -255,14 +176,7 @@ func TestSvcShow_Ask(t *testing.T) {
 			setupMocks: func(m showSvcMocks) {
 				gomock.InOrder(
 					m.sel.EXPECT().Application(svcShowAppNamePrompt, svcShowAppNameHelpPrompt).Return("my-app", nil),
-
-					m.ws.EXPECT().ServiceNames().Return(nil, errors.New("some error")),
-					m.storeSvc.EXPECT().ListServices("my-app").Return([]*config.Service{
-						{Name: "my-svc"},
-						{Name: "archer-svc"},
-					}, nil),
-
-					m.prompt.EXPECT().SelectOne(fmt.Sprintf(svcShowSvcNamePrompt, "my-app"), svcShowSvcNameHelpPrompt, []string{"my-svc", "archer-svc"}).Return("", fmt.Errorf("some error")).Times(1),
+					m.sel.EXPECT().Service(fmt.Sprintf(svcShowSvcNamePrompt, "my-app"), svcShowSvcNameHelpPrompt, "my-app").Return("", errors.New("some error")),
 				)
 			},
 
@@ -298,7 +212,6 @@ func TestSvcShow_Ask(t *testing.T) {
 					},
 				},
 				store: mockStoreReader,
-				ws:    mockWorkspace,
 				sel:   mockSelector,
 			}
 

--- a/internal/pkg/cli/svc_show_test.go
+++ b/internal/pkg/cli/svc_show_test.go
@@ -309,7 +309,7 @@ func TestSvcShow_Execute(t *testing.T) {
 					},
 				},
 				describer:     mockSvcDescriber,
-				initDescriber: func(bool) error { return nil },
+				initDescriber: func() error { return nil },
 				w:             b,
 			}
 

--- a/internal/pkg/cli/svc_status.go
+++ b/internal/pkg/cli/svc_status.go
@@ -53,7 +53,12 @@ func newSvcStatusOpts(vars svcStatusVars) (*svcStatusOpts, error) {
 		w:             log.OutputWriter,
 		sel:           selector.NewConfigSelect(vars.prompt, store),
 		initSvcDescriber: func(o *svcStatusOpts, envName, svcName string) error {
-			d, err := describe.NewServiceDescriber(o.AppName(), envName, svcName)
+			d, err := describe.NewServiceDescriber(&describe.NewServiceDescriberOption{
+				App:         o.AppName(),
+				Svc:         svcName,
+				Env:         envName,
+				ConfigStore: store,
+			})
 			if err != nil {
 				return fmt.Errorf("creating service describer for application %s, environment %s, and service %s: %w", o.AppName(), envName, svcName, err)
 			}
@@ -61,7 +66,12 @@ func newSvcStatusOpts(vars svcStatusVars) (*svcStatusOpts, error) {
 			return nil
 		},
 		initStatusDescriber: func(o *svcStatusOpts) error {
-			d, err := describe.NewServiceStatus(o.AppName(), o.envName, o.svcName)
+			d, err := describe.NewServiceStatus(&describe.NewServiceStatusOption{
+				App:         o.AppName(),
+				Env:         o.envName,
+				Svc:         o.svcName,
+				ConfigStore: store,
+			})
 			if err != nil {
 				return fmt.Errorf("creating status describer for service %s in application %s: %w", o.svcName, o.AppName(), err)
 			}
@@ -134,6 +144,7 @@ func (o *svcStatusOpts) askApp() error {
 	return nil
 }
 
+// TODO: Move the logic to select pkg.
 func (o *svcStatusOpts) askSvcEnvName() error {
 	var err error
 	svcNames := []string{o.svcName}

--- a/internal/pkg/cli/svc_status.go
+++ b/internal/pkg/cli/svc_status.go
@@ -66,7 +66,7 @@ func newSvcStatusOpts(vars svcStatusVars) (*svcStatusOpts, error) {
 			return nil
 		},
 		initStatusDescriber: func(o *svcStatusOpts) error {
-			d, err := describe.NewServiceStatus(&describe.NewServiceStatusOption{
+			d, err := describe.NewServiceStatus(&describe.NewServiceStatusConfig{
 				App:         o.AppName(),
 				Env:         o.envName,
 				Svc:         o.svcName,

--- a/internal/pkg/cli/svc_status.go
+++ b/internal/pkg/cli/svc_status.go
@@ -53,7 +53,7 @@ func newSvcStatusOpts(vars svcStatusVars) (*svcStatusOpts, error) {
 		w:             log.OutputWriter,
 		sel:           selector.NewConfigSelect(vars.prompt, store),
 		initSvcDescriber: func(o *svcStatusOpts, envName, svcName string) error {
-			d, err := describe.NewServiceDescriber(&describe.NewServiceDescriberOption{
+			d, err := describe.NewServiceDescriber(describe.NewServiceConfig{
 				App:         o.AppName(),
 				Svc:         svcName,
 				Env:         envName,

--- a/internal/pkg/describe/backend_service.go
+++ b/internal/pkg/describe/backend_service.go
@@ -26,18 +26,29 @@ type BackendServiceDescriber struct {
 	initServiceDescriber func(string) error
 }
 
+// NewBackendServiceConfig contains fields that initiates BackendServiceDescriber struct.
+type NewBackendServiceConfig struct {
+	NewServiceConfig
+	EnableResources bool
+	DeployStore     deployStoreSvc
+}
+
 // NewBackendServiceDescriber instantiates a backend service describer.
-func NewBackendServiceDescriber(opt *NewServiceDescriberOption) (*BackendServiceDescriber, error) {
+func NewBackendServiceDescriber(opt NewBackendServiceConfig) (*BackendServiceDescriber, error) {
 	describer := &BackendServiceDescriber{
 		app:             opt.App,
 		svc:             opt.Svc,
-		enableResources: false,
+		enableResources: opt.EnableResources,
 		store:           opt.DeployStore,
 		svcDescriber:    make(map[string]svcDescriber),
 	}
 	describer.initServiceDescriber = func(env string) error {
-		opt.Env = env
-		d, err := NewServiceDescriber(opt)
+		d, err := NewServiceDescriber(NewServiceConfig{
+			App:         opt.App,
+			Env:         env,
+			Svc:         opt.Svc,
+			ConfigStore: opt.ConfigStore,
+		})
 		if err != nil {
 			return err
 		}
@@ -45,16 +56,6 @@ func NewBackendServiceDescriber(opt *NewServiceDescriberOption) (*BackendService
 		return nil
 	}
 	return describer, nil
-}
-
-// NewBackendServiceDescriberWithResources instantiates a backend service describer with stack resources.
-func NewBackendServiceDescriberWithResources(opt *NewServiceDescriberOption) (*BackendServiceDescriber, error) {
-	d, err := NewBackendServiceDescriber(opt)
-	if err != nil {
-		return nil, err
-	}
-	d.enableResources = true
-	return d, nil
 }
 
 // URI returns the service discovery namespace and is used to make

--- a/internal/pkg/describe/backend_service.go
+++ b/internal/pkg/describe/backend_service.go
@@ -43,6 +43,9 @@ func NewBackendServiceDescriber(opt NewBackendServiceConfig) (*BackendServiceDes
 		svcDescriber:    make(map[string]svcDescriber),
 	}
 	describer.initServiceDescriber = func(env string) error {
+		if _, ok := describer.svcDescriber[env]; ok {
+			return nil
+		}
 		d, err := NewServiceDescriber(NewServiceConfig{
 			App:         opt.App,
 			Env:         env,
@@ -119,6 +122,10 @@ func (d *BackendServiceDescriber) Describe() (HumanJSONStringer, error) {
 	resources := make(map[string][]*CfnResource)
 	if d.enableResources {
 		for _, env := range environments {
+			err := d.initServiceDescriber(env)
+			if err != nil {
+				return nil, err
+			}
 			stackResources, err := d.svcDescriber[env].ServiceStackResources()
 			if err != nil {
 				return nil, fmt.Errorf("retrieve service resources: %w", err)

--- a/internal/pkg/describe/backend_service_test.go
+++ b/internal/pkg/describe/backend_service_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
-	"github.com/aws/copilot-cli/internal/pkg/config"
 	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation/stack"
 	"github.com/aws/copilot-cli/internal/pkg/describe/mocks"
 	"github.com/golang/mock/gomock"
@@ -116,7 +115,7 @@ func TestBackendServiceDescriber_Describe(t *testing.T) {
 			},
 			wantedBackendSvc: &backendSvcDesc{
 				Service: testSvc,
-				Type:    "",
+				Type:    "Backend Service",
 				App:     testApp,
 				Configurations: []*ServiceConfig{
 					{
@@ -185,13 +184,14 @@ func TestBackendServiceDescriber_Describe(t *testing.T) {
 			tc.setupMocks(mocks)
 
 			d := &BackendServiceDescriber{
-				service: &config.Service{
-					App:  testApp,
-					Name: testSvc,
+				app:             testApp,
+				svc:             testSvc,
+				enableResources: tc.shouldOutputResources,
+				store:           mockStore,
+				svcDescriber: map[string]svcDescriber{
+					"test": mockSvcDescriber,
+					"prod": mockSvcDescriber,
 				},
-				enableResources:      tc.shouldOutputResources,
-				store:                mockStore,
-				svcDescriber:         mockSvcDescriber,
 				initServiceDescriber: func(string) error { return nil },
 			}
 

--- a/internal/pkg/describe/lb_web_service.go
+++ b/internal/pkg/describe/lb_web_service.go
@@ -76,18 +76,29 @@ type WebServiceDescriber struct {
 	svcParams map[string]string
 }
 
+// NewWebServiceConfig contains fields that initiates WebServiceDescriber struct.
+type NewWebServiceConfig struct {
+	NewServiceConfig
+	EnableResources bool
+	DeployStore     deployStoreSvc
+}
+
 // NewWebServiceDescriber instantiates a load balanced service describer.
-func NewWebServiceDescriber(opt *NewServiceDescriberOption) (*WebServiceDescriber, error) {
+func NewWebServiceDescriber(opt NewWebServiceConfig) (*WebServiceDescriber, error) {
 	describer := &WebServiceDescriber{
 		app:             opt.App,
 		svc:             opt.Svc,
-		enableResources: false,
+		enableResources: opt.EnableResources,
 		store:           opt.DeployStore,
 		svcDescriber:    make(map[string]svcDescriber),
 	}
 	describer.initServiceDescriber = func(env string) error {
-		opt.Env = env
-		d, err := NewServiceDescriber(opt)
+		d, err := NewServiceDescriber(NewServiceConfig{
+			App:         opt.App,
+			Env:         env,
+			Svc:         opt.Svc,
+			ConfigStore: opt.ConfigStore,
+		})
 		if err != nil {
 			return err
 		}
@@ -95,16 +106,6 @@ func NewWebServiceDescriber(opt *NewServiceDescriberOption) (*WebServiceDescribe
 		return nil
 	}
 	return describer, nil
-}
-
-// NewWebServiceDescriberWithResources instantiates a load balanced service with stack resources.
-func NewWebServiceDescriberWithResources(opt *NewServiceDescriberOption) (*WebServiceDescriber, error) {
-	d, err := NewWebServiceDescriber(opt)
-	if err != nil {
-		return nil, err
-	}
-	d.enableResources = true
-	return d, nil
 }
 
 // Describe returns info of a web service.

--- a/internal/pkg/describe/lb_web_service.go
+++ b/internal/pkg/describe/lb_web_service.go
@@ -93,6 +93,9 @@ func NewWebServiceDescriber(opt NewWebServiceConfig) (*WebServiceDescriber, erro
 		svcDescriber:    make(map[string]svcDescriber),
 	}
 	describer.initServiceDescriber = func(env string) error {
+		if _, ok := describer.svcDescriber[env]; ok {
+			return nil
+		}
 		d, err := NewServiceDescriber(NewServiceConfig{
 			App:         opt.App,
 			Env:         env,
@@ -156,6 +159,10 @@ func (d *WebServiceDescriber) Describe() (HumanJSONStringer, error) {
 	resources := make(map[string][]*CfnResource)
 	if d.enableResources {
 		for _, env := range environments {
+			err := d.initServiceDescriber(env)
+			if err != nil {
+				return nil, err
+			}
 			stackResources, err := d.svcDescriber[env].ServiceStackResources()
 			if err != nil {
 				return nil, fmt.Errorf("retrieve service resources: %w", err)

--- a/internal/pkg/describe/lb_web_service_test.go
+++ b/internal/pkg/describe/lb_web_service_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
-	"github.com/aws/copilot-cli/internal/pkg/config"
 	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation/stack"
 	"github.com/aws/copilot-cli/internal/pkg/describe/mocks"
 	"github.com/golang/mock/gomock"
@@ -142,11 +141,11 @@ func TestWebServiceDescriber_URI(t *testing.T) {
 			tc.setupMocks(mocks)
 
 			d := &WebServiceDescriber{
-				service: &config.Service{
-					App:  testApp,
-					Name: testSvc,
+				app: testApp,
+				svc: testSvc,
+				svcDescriber: map[string]svcDescriber{
+					"test": mockSvcDescriber,
 				},
-				svcDescriber:         mockSvcDescriber,
 				initServiceDescriber: func(string) error { return nil },
 			}
 
@@ -209,13 +208,11 @@ func TestWebServiceDescriber_Describe(t *testing.T) {
 						stack.EnvOutputPublicLoadBalancerDNSName: testEnvLBDNSName,
 					}, nil),
 					m.svcDescriber.EXPECT().Params().Return(map[string]string{
-						stack.LBWebServiceRulePathParamKey: testSvcPath,
-					}, nil),
-					m.svcDescriber.EXPECT().Params().Return(map[string]string{
 						stack.LBWebServiceContainerPortParamKey: "80",
 						stack.ServiceTaskCountParamKey:          "1",
 						stack.ServiceTaskCPUParamKey:            "256",
 						stack.ServiceTaskMemoryParamKey:         "512",
+						stack.LBWebServiceRulePathParamKey:      testSvcPath,
 					}, nil),
 					m.svcDescriber.EXPECT().EnvVars().Return(nil, mockErr),
 				)
@@ -231,9 +228,7 @@ func TestWebServiceDescriber_Describe(t *testing.T) {
 						stack.EnvOutputPublicLoadBalancerDNSName: testEnvLBDNSName,
 					}, nil),
 					m.svcDescriber.EXPECT().Params().Return(map[string]string{
-						stack.LBWebServiceRulePathParamKey: testSvcPath,
-					}, nil),
-					m.svcDescriber.EXPECT().Params().Return(map[string]string{
+						stack.LBWebServiceRulePathParamKey:      testSvcPath,
 						stack.LBWebServiceContainerPortParamKey: "80",
 						stack.ServiceTaskCountParamKey:          "1",
 						stack.ServiceTaskCPUParamKey:            "256",
@@ -258,9 +253,7 @@ func TestWebServiceDescriber_Describe(t *testing.T) {
 						stack.EnvOutputPublicLoadBalancerDNSName: testEnvLBDNSName,
 					}, nil),
 					m.svcDescriber.EXPECT().Params().Return(map[string]string{
-						stack.LBWebServiceRulePathParamKey: testSvcPath,
-					}, nil),
-					m.svcDescriber.EXPECT().Params().Return(map[string]string{
+						stack.LBWebServiceRulePathParamKey:      testSvcPath,
 						stack.LBWebServiceContainerPortParamKey: "5000",
 						stack.ServiceTaskCountParamKey:          "1",
 						stack.ServiceTaskCPUParamKey:            "256",
@@ -275,9 +268,7 @@ func TestWebServiceDescriber_Describe(t *testing.T) {
 						stack.EnvOutputPublicLoadBalancerDNSName: prodEnvLBDNSName,
 					}, nil),
 					m.svcDescriber.EXPECT().Params().Return(map[string]string{
-						stack.LBWebServiceRulePathParamKey: prodSvcPath,
-					}, nil),
-					m.svcDescriber.EXPECT().Params().Return(map[string]string{
+						stack.LBWebServiceRulePathParamKey:      prodSvcPath,
 						stack.LBWebServiceContainerPortParamKey: "5000",
 						stack.ServiceTaskCountParamKey:          "2",
 						stack.ServiceTaskCPUParamKey:            "512",
@@ -304,7 +295,7 @@ func TestWebServiceDescriber_Describe(t *testing.T) {
 			},
 			wantedWebSvc: &webSvcDesc{
 				Service: testSvc,
-				Type:    "",
+				Type:    "Load Balanced Web Service",
 				App:     testApp,
 				Configurations: []*ServiceConfig{
 					{
@@ -383,13 +374,14 @@ func TestWebServiceDescriber_Describe(t *testing.T) {
 			tc.setupMocks(mocks)
 
 			d := &WebServiceDescriber{
-				service: &config.Service{
-					App:  testApp,
-					Name: testSvc,
+				app:             testApp,
+				svc:             testSvc,
+				enableResources: tc.shouldOutputResources,
+				store:           mockStore,
+				svcDescriber: map[string]svcDescriber{
+					"test": mockSvcDescriber,
+					"prod": mockSvcDescriber,
 				},
-				enableResources:      tc.shouldOutputResources,
-				store:                mockStore,
-				svcDescriber:         mockSvcDescriber,
 				initServiceDescriber: func(string) error { return nil },
 			}
 

--- a/internal/pkg/describe/mocks/mock_lb_web_service.go
+++ b/internal/pkg/describe/mocks/mock_lb_web_service.go
@@ -6,102 +6,9 @@ package mocks
 
 import (
 	cloudformation "github.com/aws/aws-sdk-go/service/cloudformation"
-	ecs "github.com/aws/copilot-cli/internal/pkg/aws/ecs"
-	config "github.com/aws/copilot-cli/internal/pkg/config"
 	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
 )
-
-// MockconfigStoreSvc is a mock of configStoreSvc interface
-type MockconfigStoreSvc struct {
-	ctrl     *gomock.Controller
-	recorder *MockconfigStoreSvcMockRecorder
-}
-
-// MockconfigStoreSvcMockRecorder is the mock recorder for MockconfigStoreSvc
-type MockconfigStoreSvcMockRecorder struct {
-	mock *MockconfigStoreSvc
-}
-
-// NewMockconfigStoreSvc creates a new mock instance
-func NewMockconfigStoreSvc(ctrl *gomock.Controller) *MockconfigStoreSvc {
-	mock := &MockconfigStoreSvc{ctrl: ctrl}
-	mock.recorder = &MockconfigStoreSvcMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use
-func (m *MockconfigStoreSvc) EXPECT() *MockconfigStoreSvcMockRecorder {
-	return m.recorder
-}
-
-// GetEnvironment mocks base method
-func (m *MockconfigStoreSvc) GetEnvironment(appName, environmentName string) (*config.Environment, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetEnvironment", appName, environmentName)
-	ret0, _ := ret[0].(*config.Environment)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetEnvironment indicates an expected call of GetEnvironment
-func (mr *MockconfigStoreSvcMockRecorder) GetEnvironment(appName, environmentName interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEnvironment", reflect.TypeOf((*MockconfigStoreSvc)(nil).GetEnvironment), appName, environmentName)
-}
-
-// ListEnvironments mocks base method
-func (m *MockconfigStoreSvc) ListEnvironments(appName string) ([]*config.Environment, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListEnvironments", appName)
-	ret0, _ := ret[0].([]*config.Environment)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListEnvironments indicates an expected call of ListEnvironments
-func (mr *MockconfigStoreSvcMockRecorder) ListEnvironments(appName interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEnvironments", reflect.TypeOf((*MockconfigStoreSvc)(nil).ListEnvironments), appName)
-}
-
-// MockdeployStoreSvc is a mock of deployStoreSvc interface
-type MockdeployStoreSvc struct {
-	ctrl     *gomock.Controller
-	recorder *MockdeployStoreSvcMockRecorder
-}
-
-// MockdeployStoreSvcMockRecorder is the mock recorder for MockdeployStoreSvc
-type MockdeployStoreSvcMockRecorder struct {
-	mock *MockdeployStoreSvc
-}
-
-// NewMockdeployStoreSvc creates a new mock instance
-func NewMockdeployStoreSvc(ctrl *gomock.Controller) *MockdeployStoreSvc {
-	mock := &MockdeployStoreSvc{ctrl: ctrl}
-	mock.recorder = &MockdeployStoreSvcMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use
-func (m *MockdeployStoreSvc) EXPECT() *MockdeployStoreSvcMockRecorder {
-	return m.recorder
-}
-
-// ListEnvironmentsDeployedTo mocks base method
-func (m *MockdeployStoreSvc) ListEnvironmentsDeployedTo(appName, svcName string) ([]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListEnvironmentsDeployedTo", appName, svcName)
-	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListEnvironmentsDeployedTo indicates an expected call of ListEnvironmentsDeployedTo
-func (mr *MockdeployStoreSvcMockRecorder) ListEnvironmentsDeployedTo(appName, svcName interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEnvironmentsDeployedTo", reflect.TypeOf((*MockdeployStoreSvc)(nil).ListEnvironmentsDeployedTo), appName, svcName)
-}
 
 // MocksvcDescriber is a mock of svcDescriber interface
 type MocksvcDescriber struct {
@@ -169,21 +76,6 @@ func (m *MocksvcDescriber) EnvVars() (map[string]string, error) {
 func (mr *MocksvcDescriberMockRecorder) EnvVars() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnvVars", reflect.TypeOf((*MocksvcDescriber)(nil).EnvVars))
-}
-
-// GetServiceArn mocks base method
-func (m *MocksvcDescriber) GetServiceArn() (*ecs.ServiceArn, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetServiceArn")
-	ret0, _ := ret[0].(*ecs.ServiceArn)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetServiceArn indicates an expected call of GetServiceArn
-func (mr *MocksvcDescriberMockRecorder) GetServiceArn() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceArn", reflect.TypeOf((*MocksvcDescriber)(nil).GetServiceArn))
 }
 
 // ServiceStackResources mocks base method

--- a/internal/pkg/describe/mocks/mock_service.go
+++ b/internal/pkg/describe/mocks/mock_service.go
@@ -7,6 +7,7 @@ package mocks
 import (
 	cloudformation "github.com/aws/aws-sdk-go/service/cloudformation"
 	ecs "github.com/aws/copilot-cli/internal/pkg/aws/ecs"
+	config "github.com/aws/copilot-cli/internal/pkg/config"
 	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
 )
@@ -100,4 +101,95 @@ func (m *MockecsClient) TaskDefinition(taskDefName string) (*ecs.TaskDefinition,
 func (mr *MockecsClientMockRecorder) TaskDefinition(taskDefName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TaskDefinition", reflect.TypeOf((*MockecsClient)(nil).TaskDefinition), taskDefName)
+}
+
+// MockconfigStoreSvc is a mock of configStoreSvc interface
+type MockconfigStoreSvc struct {
+	ctrl     *gomock.Controller
+	recorder *MockconfigStoreSvcMockRecorder
+}
+
+// MockconfigStoreSvcMockRecorder is the mock recorder for MockconfigStoreSvc
+type MockconfigStoreSvcMockRecorder struct {
+	mock *MockconfigStoreSvc
+}
+
+// NewMockconfigStoreSvc creates a new mock instance
+func NewMockconfigStoreSvc(ctrl *gomock.Controller) *MockconfigStoreSvc {
+	mock := &MockconfigStoreSvc{ctrl: ctrl}
+	mock.recorder = &MockconfigStoreSvcMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockconfigStoreSvc) EXPECT() *MockconfigStoreSvcMockRecorder {
+	return m.recorder
+}
+
+// GetEnvironment mocks base method
+func (m *MockconfigStoreSvc) GetEnvironment(appName, environmentName string) (*config.Environment, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEnvironment", appName, environmentName)
+	ret0, _ := ret[0].(*config.Environment)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEnvironment indicates an expected call of GetEnvironment
+func (mr *MockconfigStoreSvcMockRecorder) GetEnvironment(appName, environmentName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEnvironment", reflect.TypeOf((*MockconfigStoreSvc)(nil).GetEnvironment), appName, environmentName)
+}
+
+// ListEnvironments mocks base method
+func (m *MockconfigStoreSvc) ListEnvironments(appName string) ([]*config.Environment, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListEnvironments", appName)
+	ret0, _ := ret[0].([]*config.Environment)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListEnvironments indicates an expected call of ListEnvironments
+func (mr *MockconfigStoreSvcMockRecorder) ListEnvironments(appName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEnvironments", reflect.TypeOf((*MockconfigStoreSvc)(nil).ListEnvironments), appName)
+}
+
+// MockdeployStoreSvc is a mock of deployStoreSvc interface
+type MockdeployStoreSvc struct {
+	ctrl     *gomock.Controller
+	recorder *MockdeployStoreSvcMockRecorder
+}
+
+// MockdeployStoreSvcMockRecorder is the mock recorder for MockdeployStoreSvc
+type MockdeployStoreSvcMockRecorder struct {
+	mock *MockdeployStoreSvc
+}
+
+// NewMockdeployStoreSvc creates a new mock instance
+func NewMockdeployStoreSvc(ctrl *gomock.Controller) *MockdeployStoreSvc {
+	mock := &MockdeployStoreSvc{ctrl: ctrl}
+	mock.recorder = &MockdeployStoreSvcMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockdeployStoreSvc) EXPECT() *MockdeployStoreSvcMockRecorder {
+	return m.recorder
+}
+
+// ListEnvironmentsDeployedTo mocks base method
+func (m *MockdeployStoreSvc) ListEnvironmentsDeployedTo(appName, svcName string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListEnvironmentsDeployedTo", appName, svcName)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListEnvironmentsDeployedTo indicates an expected call of ListEnvironmentsDeployedTo
+func (mr *MockdeployStoreSvcMockRecorder) ListEnvironmentsDeployedTo(appName, svcName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEnvironmentsDeployedTo", reflect.TypeOf((*MockdeployStoreSvc)(nil).ListEnvironmentsDeployedTo), appName, svcName)
 }

--- a/internal/pkg/describe/mocks/mock_status.go
+++ b/internal/pkg/describe/mocks/mock_status.go
@@ -7,6 +7,7 @@ package mocks
 import (
 	cloudwatch "github.com/aws/copilot-cli/internal/pkg/aws/cloudwatch"
 	ecs "github.com/aws/copilot-cli/internal/pkg/aws/ecs"
+	resourcegroups "github.com/aws/copilot-cli/internal/pkg/aws/resourcegroups"
 	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
 )
@@ -47,6 +48,44 @@ func (m *MockalarmStatusGetter) GetAlarmsWithTags(tags map[string]string) ([]clo
 func (mr *MockalarmStatusGetterMockRecorder) GetAlarmsWithTags(tags interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAlarmsWithTags", reflect.TypeOf((*MockalarmStatusGetter)(nil).GetAlarmsWithTags), tags)
+}
+
+// MockresourcesGetter is a mock of resourcesGetter interface
+type MockresourcesGetter struct {
+	ctrl     *gomock.Controller
+	recorder *MockresourcesGetterMockRecorder
+}
+
+// MockresourcesGetterMockRecorder is the mock recorder for MockresourcesGetter
+type MockresourcesGetterMockRecorder struct {
+	mock *MockresourcesGetter
+}
+
+// NewMockresourcesGetter creates a new mock instance
+func NewMockresourcesGetter(ctrl *gomock.Controller) *MockresourcesGetter {
+	mock := &MockresourcesGetter{ctrl: ctrl}
+	mock.recorder = &MockresourcesGetterMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockresourcesGetter) EXPECT() *MockresourcesGetterMockRecorder {
+	return m.recorder
+}
+
+// GetResourcesByTags mocks base method
+func (m *MockresourcesGetter) GetResourcesByTags(resourceType string, tags map[string]string) ([]*resourcegroups.Resource, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetResourcesByTags", resourceType, tags)
+	ret0, _ := ret[0].([]*resourcegroups.Resource)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetResourcesByTags indicates an expected call of GetResourcesByTags
+func (mr *MockresourcesGetterMockRecorder) GetResourcesByTags(resourceType, tags interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResourcesByTags", reflect.TypeOf((*MockresourcesGetter)(nil).GetResourcesByTags), resourceType, tags)
 }
 
 // MockecsServiceGetter is a mock of ecsServiceGetter interface
@@ -100,42 +139,4 @@ func (m *MockecsServiceGetter) Service(clusterName, serviceName string) (*ecs.Se
 func (mr *MockecsServiceGetterMockRecorder) Service(clusterName, serviceName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Service", reflect.TypeOf((*MockecsServiceGetter)(nil).Service), clusterName, serviceName)
-}
-
-// MockserviceArnGetter is a mock of serviceArnGetter interface
-type MockserviceArnGetter struct {
-	ctrl     *gomock.Controller
-	recorder *MockserviceArnGetterMockRecorder
-}
-
-// MockserviceArnGetterMockRecorder is the mock recorder for MockserviceArnGetter
-type MockserviceArnGetterMockRecorder struct {
-	mock *MockserviceArnGetter
-}
-
-// NewMockserviceArnGetter creates a new mock instance
-func NewMockserviceArnGetter(ctrl *gomock.Controller) *MockserviceArnGetter {
-	mock := &MockserviceArnGetter{ctrl: ctrl}
-	mock.recorder = &MockserviceArnGetterMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use
-func (m *MockserviceArnGetter) EXPECT() *MockserviceArnGetterMockRecorder {
-	return m.recorder
-}
-
-// GetServiceArn mocks base method
-func (m *MockserviceArnGetter) GetServiceArn() (*ecs.ServiceArn, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetServiceArn")
-	ret0, _ := ret[0].(*ecs.ServiceArn)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetServiceArn indicates an expected call of GetServiceArn
-func (mr *MockserviceArnGetterMockRecorder) GetServiceArn() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceArn", reflect.TypeOf((*MockserviceArnGetter)(nil).GetServiceArn))
 }

--- a/internal/pkg/describe/service.go
+++ b/internal/pkg/describe/service.go
@@ -70,17 +70,16 @@ type ServiceDescriber struct {
 	stackDescriber stackAndResourcesDescriber
 }
 
-// NewServiceDescriberOption contains fields that initiates ServiceDescriber struct.
-type NewServiceDescriberOption struct {
+// NewServiceConfig contains fields that initiates ServiceDescriber struct.
+type NewServiceConfig struct {
 	App         string
 	Env         string
 	Svc         string
 	ConfigStore configStoreSvc
-	DeployStore deployStoreSvc
 }
 
 // NewServiceDescriber instantiates a new service.
-func NewServiceDescriber(opt *NewServiceDescriberOption) (*ServiceDescriber, error) {
+func NewServiceDescriber(opt NewServiceConfig) (*ServiceDescriber, error) {
 	environment, err := opt.ConfigStore.GetEnvironment(opt.App, opt.Env)
 	if err != nil {
 		return nil, fmt.Errorf("get environment %s: %w", opt.Env, err)

--- a/internal/pkg/describe/status.go
+++ b/internal/pkg/describe/status.go
@@ -52,8 +52,8 @@ type ServiceStatusDesc struct {
 	Alarms  []cloudwatch.AlarmStatus `json:"alarms"`
 }
 
-// NewServiceStatusOption contains fields that initiates ServiceStatus struct.
-type NewServiceStatusOption struct {
+// NewServiceStatusConfig contains fields that initiates ServiceStatus struct.
+type NewServiceStatusConfig struct {
 	App         string
 	Env         string
 	Svc         string
@@ -61,7 +61,7 @@ type NewServiceStatusOption struct {
 }
 
 // NewServiceStatus instantiates a new ServiceStatus struct.
-func NewServiceStatus(opt *NewServiceStatusOption) (*ServiceStatus, error) {
+func NewServiceStatus(opt *NewServiceStatusConfig) (*ServiceStatus, error) {
 	env, err := opt.ConfigStore.GetEnvironment(opt.App, opt.Env)
 	if err != nil {
 		return nil, fmt.Errorf("get environment %s: %w", opt.Env, err)

--- a/internal/pkg/describe/status.go
+++ b/internal/pkg/describe/status.go
@@ -11,23 +11,27 @@ import (
 
 	"github.com/aws/copilot-cli/internal/pkg/aws/cloudwatch"
 	"github.com/aws/copilot-cli/internal/pkg/aws/ecs"
+	rg "github.com/aws/copilot-cli/internal/pkg/aws/resourcegroups"
 	"github.com/aws/copilot-cli/internal/pkg/aws/session"
-	"github.com/aws/copilot-cli/internal/pkg/config"
 	"github.com/aws/copilot-cli/internal/pkg/deploy"
 	"github.com/aws/copilot-cli/internal/pkg/term/color"
+)
+
+const (
+	ecsServiceResourceType = "ecs:service"
 )
 
 type alarmStatusGetter interface {
 	GetAlarmsWithTags(tags map[string]string) ([]cloudwatch.AlarmStatus, error)
 }
 
+type resourcesGetter interface {
+	GetResourcesByTags(resourceType string, tags map[string]string) ([]*rg.Resource, error)
+}
+
 type ecsServiceGetter interface {
 	ServiceTasks(clusterName, serviceName string) ([]*ecs.Task, error)
 	Service(clusterName, serviceName string) (*ecs.Service, error)
-}
-
-type serviceArnGetter interface {
-	GetServiceArn() (*ecs.ServiceArn, error)
 }
 
 // ServiceStatus retrieves status of a service.
@@ -36,9 +40,9 @@ type ServiceStatus struct {
 	EnvName string
 	SvcName string
 
-	Describer serviceArnGetter
-	EcsSvc    ecsServiceGetter
-	CwSvc     alarmStatusGetter
+	EcsSvc ecsServiceGetter
+	CwSvc  alarmStatusGetter
+	rgSvc  resourcesGetter
 }
 
 // ServiceStatusDesc contains the status for a service.
@@ -48,40 +52,53 @@ type ServiceStatusDesc struct {
 	Alarms  []cloudwatch.AlarmStatus `json:"alarms"`
 }
 
+// NewServiceStatusOption contains fields that initiates ServiceStatus struct.
+type NewServiceStatusOption struct {
+	App         string
+	Env         string
+	Svc         string
+	ConfigStore configStoreSvc
+}
+
 // NewServiceStatus instantiates a new ServiceStatus struct.
-func NewServiceStatus(appName, envName, svcName string) (*ServiceStatus, error) {
-	d, err := NewServiceDescriber(appName, envName, svcName)
+func NewServiceStatus(opt *NewServiceStatusOption) (*ServiceStatus, error) {
+	env, err := opt.ConfigStore.GetEnvironment(opt.App, opt.Env)
 	if err != nil {
-		return nil, err
-	}
-	svc, err := config.NewStore()
-	if err != nil {
-		return nil, fmt.Errorf("connect to store: %w", err)
-	}
-	env, err := svc.GetEnvironment(appName, envName)
-	if err != nil {
-		return nil, fmt.Errorf("get environment %s: %w", envName, err)
+		return nil, fmt.Errorf("get environment %s: %w", opt.Env, err)
 	}
 	sess, err := session.NewProvider().FromRole(env.ManagerRoleARN, env.Region)
 	if err != nil {
 		return nil, fmt.Errorf("session for role %s and region %s: %w", env.ManagerRoleARN, env.Region, err)
 	}
-	if err != nil {
-		return nil, fmt.Errorf("creating stack describer for application %s: %w", appName, err)
-	}
 	return &ServiceStatus{
-		AppName:   appName,
-		EnvName:   envName,
-		SvcName:   appName,
-		Describer: d,
-		CwSvc:     cloudwatch.New(sess),
-		EcsSvc:    ecs.New(sess),
+		AppName: opt.App,
+		EnvName: opt.Env,
+		SvcName: opt.Svc,
+		rgSvc:   rg.New(sess),
+		CwSvc:   cloudwatch.New(sess),
+		EcsSvc:  ecs.New(sess),
 	}, nil
 }
 
+func (s *ServiceStatus) getServiceArn() (*ecs.ServiceArn, error) {
+	svcResources, err := s.rgSvc.GetResourcesByTags(ecsServiceResourceType, map[string]string{
+		deploy.AppTagKey:     s.AppName,
+		deploy.EnvTagKey:     s.EnvName,
+		deploy.ServiceTagKey: s.SvcName,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(svcResources) == 0 {
+		return nil, fmt.Errorf("cannot find service arn in service stack resource")
+	}
+	serviceArn := ecs.ServiceArn(svcResources[0].ARN)
+	return &serviceArn, nil
+}
+
 // Describe returns status of a service.
-func (w *ServiceStatus) Describe() (*ServiceStatusDesc, error) {
-	serviceArn, err := w.Describer.GetServiceArn()
+func (s *ServiceStatus) Describe() (*ServiceStatusDesc, error) {
+	serviceArn, err := s.getServiceArn()
 	if err != nil {
 		return nil, fmt.Errorf("get service ARN: %w", err)
 	}
@@ -93,11 +110,11 @@ func (w *ServiceStatus) Describe() (*ServiceStatusDesc, error) {
 	if err != nil {
 		return nil, fmt.Errorf("get service name: %w", err)
 	}
-	service, err := w.EcsSvc.Service(clusterName, serviceName)
+	service, err := s.EcsSvc.Service(clusterName, serviceName)
 	if err != nil {
 		return nil, fmt.Errorf("get service %s: %w", serviceName, err)
 	}
-	tasks, err := w.EcsSvc.ServiceTasks(clusterName, serviceName)
+	tasks, err := s.EcsSvc.ServiceTasks(clusterName, serviceName)
 	if err != nil {
 		return nil, fmt.Errorf("get tasks for service %s: %w", serviceName, err)
 	}
@@ -109,10 +126,10 @@ func (w *ServiceStatus) Describe() (*ServiceStatusDesc, error) {
 		}
 		taskStatus = append(taskStatus, *status)
 	}
-	alarms, err := w.CwSvc.GetAlarmsWithTags(map[string]string{
-		deploy.AppTagKey:     w.AppName,
-		deploy.EnvTagKey:     w.EnvName,
-		deploy.ServiceTagKey: w.SvcName,
+	alarms, err := s.CwSvc.GetAlarmsWithTags(map[string]string{
+		deploy.AppTagKey:     s.AppName,
+		deploy.EnvTagKey:     s.EnvName,
+		deploy.ServiceTagKey: s.SvcName,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("get CloudWatch alarms: %w", err)
@@ -125,8 +142,8 @@ func (w *ServiceStatus) Describe() (*ServiceStatusDesc, error) {
 }
 
 // JSONString returns the stringified ServiceStatusDesc struct with json format.
-func (w *ServiceStatusDesc) JSONString() (string, error) {
-	b, err := json.Marshal(w)
+func (s *ServiceStatusDesc) JSONString() (string, error) {
+	b, err := json.Marshal(s)
 	if err != nil {
 		return "", fmt.Errorf("marshal services: %w", err)
 	}
@@ -134,27 +151,27 @@ func (w *ServiceStatusDesc) JSONString() (string, error) {
 }
 
 // HumanString returns the stringified ServiceStatusDesc struct with human readable format.
-func (w *ServiceStatusDesc) HumanString() string {
+func (s *ServiceStatusDesc) HumanString() string {
 	var b bytes.Buffer
 	writer := tabwriter.NewWriter(&b, minCellWidth, tabWidth, cellPaddingWidth, paddingChar, noAdditionalFormatting)
 	fmt.Fprintf(writer, color.Bold.Sprint("Service Status\n\n"))
 	writer.Flush()
-	fmt.Fprintf(writer, "  %s %v / %v running tasks (%v pending)\n", statusColor(w.Service.Status),
-		w.Service.RunningCount, w.Service.DesiredCount, w.Service.DesiredCount-w.Service.RunningCount)
+	fmt.Fprintf(writer, "  %s %v / %v running tasks (%v pending)\n", statusColor(s.Service.Status),
+		s.Service.RunningCount, s.Service.DesiredCount, s.Service.DesiredCount-s.Service.RunningCount)
 	fmt.Fprintf(writer, color.Bold.Sprint("\nLast Deployment\n\n"))
 	writer.Flush()
-	fmt.Fprintf(writer, "  %s\t%s\n", "Updated At", humanizeTime(w.Service.LastDeploymentAt))
-	fmt.Fprintf(writer, "  %s\t%s\n", "Task Definition", w.Service.TaskDefinition)
+	fmt.Fprintf(writer, "  %s\t%s\n", "Updated At", humanizeTime(s.Service.LastDeploymentAt))
+	fmt.Fprintf(writer, "  %s\t%s\n", "Task Definition", s.Service.TaskDefinition)
 	fmt.Fprintf(writer, color.Bold.Sprint("\nTask Status\n\n"))
 	writer.Flush()
 	fmt.Fprintf(writer, "  %s\t%s\t%s\t%s\t%s\t%s\n", "ID", "Image Digest", "Last Status", "Health Status", "Started At", "Stopped At")
-	for _, task := range w.Tasks {
+	for _, task := range s.Tasks {
 		fmt.Fprintf(writer, task.HumanString())
 	}
 	fmt.Fprintf(writer, color.Bold.Sprint("\nAlarms\n\n"))
 	writer.Flush()
 	fmt.Fprintf(writer, "  %s\t%s\t%s\t%s\n", "Name", "Health", "Last Updated", "Reason")
-	for _, alarm := range w.Alarms {
+	for _, alarm := range s.Alarms {
 		updatedTimeSince := humanizeTime(alarm.UpdatedTimes)
 		fmt.Fprintf(writer, "  %s\t%s\t%s\t%s\n", alarm.Name, alarm.Status, updatedTimeSince, alarm.Reason)
 	}


### PR DESCRIPTION
<!-- Provide summary of changes -->
This PR focuses on
1. Avoid creating member objs repetitively in `describe` pkg when calling `NewXyzDescriber` functions.
2. Add cache to `WebAppDescriber` so that we won't call `Param()` twice for each env.
3. Remove `ServiceStatus` struct's dependency on `ServiceDescriber`.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
