### PR TITLE
fix(storage): add bucket policy to force SSL connections

### DIFF
--- a/templates/addons/s3/cf.yml
+++ b/templates/addons/s3/cf.yml
@@ -23,6 +23,25 @@ Resources:
         BlockPublicAcls: true
         BlockPublicPolicy: true
 
+  {{logicalIDSafe .Name}}BucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    DeletionPolicy: Retain
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: ForceHTTPS
+            Effect: Deny
+            Principal: '*'
+            Action: 's3:*'
+            Resource: 
+              - !Sub ${ {{logicalIDSafe .Name}}.Arn}/*
+              - !Sub ${ {{logicalIDSafe .Name}}.Arn}
+            Condition: 
+              Bool:
+                "aws:SecureTransport": false
+      Bucket: !Ref {{logicalIDSafe .Name}}
+
   {{logicalIDSafe .Name}}AccessPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:


### PR DESCRIPTION
<!-- Provide summary of changes -->
This PR adds a bucket policy to the CF generated by `storage init`. It now requires SSL connections in order to perform any action on a bucket. 

Related #769 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
