### PR TITLE
chore(aws): update ecs and ec2 packages to support task run command

### DIFF
--- a/internal/pkg/aws/ec2/ec2.go
+++ b/internal/pkg/aws/ec2/ec2.go
@@ -57,7 +57,7 @@ func New(s *session.Session) *EC2 {
 	}
 }
 
-// GetSubnetIDs finds the subnet IDs with optional filters
+// GetSubnetIDs finds the subnet IDs with optional filters.
 func (c *EC2) GetSubnetIDs(filters ...Filter) ([]string, error) {
 	inputFilters := toEC2Filter(filters)
 
@@ -76,7 +76,7 @@ func (c *EC2) GetSubnetIDs(filters ...Filter) ([]string, error) {
 	return subnetIDs, nil
 }
 
-// GetSecurityGroups finds the security group IDs with optional filters
+// GetSecurityGroups finds the security group IDs with optional filters.
 func (c *EC2) GetSecurityGroups(filters ...Filter) ([]string, error) {
 	inputFilters := toEC2Filter(filters)
 

--- a/internal/pkg/aws/ec2/ec2.go
+++ b/internal/pkg/aws/ec2/ec2.go
@@ -1,0 +1,105 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package ec2 provides a client to make API requests to Amazon Elastic Compute Cloud.
+package ec2
+
+import (
+	"fmt"
+	"github.com/aws/copilot-cli/internal/pkg/deploy"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+
+const (
+	defaultForAZFilterName = "default-for-az"
+)
+
+// Names for tag filters
+var (
+	TagFilterNameForApp = fmt.Sprintf("tag:%s", deploy.AppTagKey)
+	TagFilterNameForEnv = fmt.Sprintf("tag:%s", deploy.EnvTagKey)
+)
+
+var (
+	// FilterForDefaultVPCSubnets is a pre-defined filter for the default subnets at the availability zone.
+	FilterForDefaultVPCSubnets = Filter {
+		Name:   defaultForAZFilterName,
+		Values: []string{"true"},
+	}
+)
+
+type api interface {
+	DescribeSubnets(*ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error)
+	DescribeSecurityGroups(*ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error)
+}
+
+// Filter contains the name and values of a filter.
+type Filter struct {
+	Name string
+	Values []string
+}
+
+// EC2 wraps an AWS EC2 client.
+type EC2 struct {
+	client api
+}
+
+// New returns a EC2 configured against the input session.
+func New(s *session.Session) *EC2 {
+	return &EC2{
+		client: ec2.New(s),
+	}
+}
+
+// GetSubnetIDs finds the subnet IDs using filters.
+func (c *EC2) GetSubnetIDs(filters []Filter) ([]string, error) {
+	inputFilters := toEC2Filter(filters)
+
+	response, err := c.client.DescribeSubnets(&ec2.DescribeSubnetsInput{
+		Filters: inputFilters,
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("get subnets: %w", err)
+	}
+
+	subnetIDs := make([]string, len(response.Subnets))
+	for idx, subnet := range response.Subnets {
+		subnetIDs[idx] = aws.StringValue(subnet.SubnetId)
+	}
+	return subnetIDs, nil
+}
+
+// GetSecurityGroups finds the security group IDs using filters
+func (c *EC2) GetSecurityGroups(filters []Filter) ([]string, error) {
+	inputFilters := toEC2Filter(filters)
+
+	response, err := c.client.DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{
+		Filters: inputFilters,
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("get security groups: %w", err)
+	}
+
+	securityGroups := make([]string, len(response.SecurityGroups))
+	for idx, sg := range response.SecurityGroups {
+		securityGroups[idx] = aws.StringValue(sg.GroupId)
+	}
+	return securityGroups, nil
+}
+
+func toEC2Filter(filters []Filter) []*ec2.Filter {
+	var ec2Filter []*ec2.Filter
+	for _, filter := range filters {
+		ec2Filter = append(ec2Filter, &ec2.Filter{
+			Name: aws.String(filter.Name),
+			Values: aws.StringSlice(filter.Values),
+		})
+	}
+	return ec2Filter
+}

--- a/internal/pkg/aws/ec2/ec2.go
+++ b/internal/pkg/aws/ec2/ec2.go
@@ -39,7 +39,9 @@ type api interface {
 
 // Filter contains the name and values of a filter.
 type Filter struct {
+	// Name is the name of a filter that will be applied to subnets, for available filter names see: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSubnets.html
 	Name string
+	// Value is the value of the filter
 	Values []string
 }
 
@@ -55,8 +57,8 @@ func New(s *session.Session) *EC2 {
 	}
 }
 
-// GetSubnetIDs finds the subnet IDs using filters.
-func (c *EC2) GetSubnetIDs(filters []Filter) ([]string, error) {
+// GetSubnetIDs finds the subnet IDs with optional filters
+func (c *EC2) GetSubnetIDs(filters ...Filter) ([]string, error) {
 	inputFilters := toEC2Filter(filters)
 
 	response, err := c.client.DescribeSubnets(&ec2.DescribeSubnetsInput{
@@ -74,8 +76,8 @@ func (c *EC2) GetSubnetIDs(filters []Filter) ([]string, error) {
 	return subnetIDs, nil
 }
 
-// GetSecurityGroups finds the security group IDs using filters
-func (c *EC2) GetSecurityGroups(filters []Filter) ([]string, error) {
+// GetSecurityGroups finds the security group IDs with optional filters
+func (c *EC2) GetSecurityGroups(filters ...Filter) ([]string, error) {
 	inputFilters := toEC2Filter(filters)
 
 	response, err := c.client.DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{

--- a/internal/pkg/aws/ecs/ecs.go
+++ b/internal/pkg/aws/ecs/ecs.go
@@ -181,7 +181,7 @@ func (e *ECS) ServiceTasks(clusterName, serviceName string) ([]*Task, error) {
 	return tasks, nil
 }
 
-// DefaultCluster returns the default clusters in the account and region.
+// DefaultCluster returns the default cluster ARN in the account and region.
 func (e *ECS) DefaultCluster() (string, error) {
 	resp, err := e.client.DescribeClusters(&ecs.DescribeClustersInput{})
 	if err != nil {

--- a/internal/pkg/aws/ecs/ecs.go
+++ b/internal/pkg/aws/ecs/ecs.go
@@ -189,7 +189,7 @@ func (e *ECS) DefaultCluster() (string, error) {
 	}
 
 	if len(resp.Clusters) == 0 {
-		return "", &ErrNoDefaultCluster{}
+		return "", ErrNoDefaultCluster
 	}
 
 	// NOTE: right now at most 1 default cluster is possible, so cluster[0] must be the default cluster

--- a/internal/pkg/aws/ecs/ecs.go
+++ b/internal/pkg/aws/ecs/ecs.go
@@ -5,6 +5,7 @@
 package ecs
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -27,6 +28,9 @@ type api interface {
 	DescribeTaskDefinition(input *ecs.DescribeTaskDefinitionInput) (*ecs.DescribeTaskDefinitionOutput, error)
 	DescribeServices(input *ecs.DescribeServicesInput) (*ecs.DescribeServicesOutput, error)
 	ListTasks(input *ecs.ListTasksInput) (*ecs.ListTasksOutput, error)
+	DescribeClusters(input *ecs.DescribeClustersInput) (*ecs.DescribeClustersOutput, error)
+	RunTask(input *ecs.RunTaskInput) (*ecs.RunTaskOutput, error)
+	WaitUntilTasksRunning(input *ecs.DescribeTasksInput) error
 }
 
 // ECS wraps an AWS ECS client.
@@ -99,6 +103,15 @@ type Image struct {
 	Digest string
 }
 
+type RunTaskInput struct {
+	Cluster        string
+	Count          int
+	Subnets        []string
+	SecurityGroups []string
+	TaskFamilyName string
+	StartedBy      string
+}
+
 // New returns a Service configured against the input session.
 func New(s *session.Session) *ECS {
 	return &ECS{
@@ -166,6 +179,58 @@ func (e *ECS) ServiceTasks(clusterName, serviceName string) ([]*Task, error) {
 		}
 	}
 	return tasks, nil
+}
+
+// DefaultCluster returns the default clusters in the account and region.
+func (e *ECS) DefaultCluster() (string, error) {
+	resp, err := e.client.DescribeClusters(&ecs.DescribeClustersInput{})
+	if err != nil {
+		return "", fmt.Errorf("get default cluster: %w", err)
+	}
+
+	if len(resp.Clusters) == 0 {
+		return "", errors.New("no default cluster is found")
+	}
+
+	// NOTE: right now at most 1 default cluster is possible, so cluster[0] must be the default cluster
+	cluster := resp.Clusters[0]
+	return aws.StringValue(cluster.ClusterArn), nil
+}
+
+// RunTask runs a number of tasks with the task definition and network configurations in a cluster, and returns after
+// the task(s) is running or fails to run, along with task ARNs if possible.
+func (e *ECS) RunTask(input RunTaskInput) ([]string, error) {
+	resp, err := e.client.RunTask(&ecs.RunTaskInput{
+		Cluster:        aws.String(input.Cluster),
+		Count:          aws.Int64(int64(input.Count)),
+		LaunchType:     aws.String(ecs.LaunchTypeFargate),
+		StartedBy:      aws.String(input.StartedBy),
+		TaskDefinition: aws.String(input.TaskFamilyName),
+		NetworkConfiguration: &ecs.NetworkConfiguration{
+			AwsvpcConfiguration: &ecs.AwsVpcConfiguration{
+				AssignPublicIp: aws.String(ecs.AssignPublicIpEnabled),
+				Subnets:        aws.StringSlice(input.Subnets),
+				SecurityGroups: aws.StringSlice(input.SecurityGroups),
+			},
+		},
+	})
+	if err != nil {
+		return []string{}, fmt.Errorf("run task(s) %s: %w", input.TaskFamilyName, err)
+	}
+
+	taskArns := make([]string, len(resp.Tasks))
+	for idx, task := range resp.Tasks {
+		taskArns[idx] = aws.StringValue(task.TaskArn)
+	}
+
+	if err := e.client.WaitUntilTasksRunning(&ecs.DescribeTasksInput{
+		Cluster: aws.String(input.Cluster),
+		Tasks:   aws.StringSlice(taskArns),
+	}); err != nil {
+		return taskArns, fmt.Errorf("wait for tasks to be running: %w", err)
+	}
+
+	return taskArns, nil
 }
 
 // TaskStatus returns the status of the running task.

--- a/internal/pkg/aws/ecs/ecs_test.go
+++ b/internal/pkg/aws/ecs/ecs_test.go
@@ -328,6 +328,184 @@ func TestECS_Tasks(t *testing.T) {
 	}
 }
 
+func TestECS_DefaultCluster(t *testing.T) {
+	testCases := map[string]struct {
+		mockECSClient func(m *mocks.Mockapi)
+
+		wantedError    error
+		wantedClusters string
+	}{
+		"get default clusters success": {
+			mockECSClient: func(m *mocks.Mockapi) {
+				m.EXPECT().
+					DescribeClusters(&ecs.DescribeClustersInput{}).
+					Return(&ecs.DescribeClustersOutput{
+						Clusters: []*ecs.Cluster{
+							&ecs.Cluster{
+								ClusterArn:  aws.String("arn:aws:ecs:us-east-1:0123456:cluster/cluster1"),
+								ClusterName: aws.String("cluster1"),
+							},
+							&ecs.Cluster{
+								ClusterArn:  aws.String("arn:aws:ecs:us-east-1:0123456:cluster/cluster2"),
+								ClusterName: aws.String("cluster2"),
+							},
+						},
+					}, nil)
+			},
+
+			wantedClusters: "arn:aws:ecs:us-east-1:0123456:cluster/cluster1",
+		},
+		"failed to get default clusters": {
+			mockECSClient: func(m *mocks.Mockapi) {
+				m.EXPECT().
+					DescribeClusters(&ecs.DescribeClustersInput{}).
+					Return(nil, errors.New("error"))
+			},
+			wantedError: fmt.Errorf("get default cluster: %s", "error"),
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockECSClient := mocks.NewMockapi(ctrl)
+			tc.mockECSClient(mockECSClient)
+
+			ecs := ECS{
+				client: mockECSClient,
+			}
+			clusters, err := ecs.DefaultCluster()
+			if tc.wantedError != nil {
+				require.EqualError(t, tc.wantedError, err.Error())
+			} else {
+				require.Equal(t, tc.wantedClusters, clusters)
+			}
+		})
+	}
+}
+
+func TestECS_RunTask(t *testing.T) {
+	type input struct {
+		cluster        string
+		count          int
+		subnets        []string
+		securityGroups []string
+		taskFamilyName string
+		startedBy      string
+	}
+
+	runTaskInput := input{
+		cluster:        "my-cluster",
+		count:          3,
+		subnets:        []string{"subnet-1", "subnet-2"},
+		securityGroups: []string{"sg-1", "sg-2"},
+		taskFamilyName: "my-task",
+		startedBy:      "task",
+	}
+
+	testCases := map[string]struct {
+		input
+
+		mockECSClient func(m *mocks.Mockapi)
+
+		wantedError error
+		wantedArns  []string
+	}{
+		"run task success": {
+			input: runTaskInput,
+			mockECSClient: func(m *mocks.Mockapi) {
+				m.EXPECT().RunTask(&ecs.RunTaskInput{
+					Cluster:        aws.String("my-cluster"),
+					Count:          aws.Int64(3),
+					LaunchType:     aws.String(ecs.LaunchTypeFargate),
+					StartedBy:      aws.String("task"),
+					TaskDefinition: aws.String("my-task"),
+					NetworkConfiguration: &ecs.NetworkConfiguration{
+						AwsvpcConfiguration: &ecs.AwsVpcConfiguration{
+							AssignPublicIp: aws.String(ecs.AssignPublicIpEnabled),
+							Subnets:        aws.StringSlice([]string{"subnet-1", "subnet-2"}),
+							SecurityGroups: aws.StringSlice([]string{"sg-1", "sg-2"}),
+						},
+					},
+				}).
+					Return(&ecs.RunTaskOutput{
+						Tasks: []*ecs.Task{
+							&ecs.Task{
+								TaskArn: aws.String("task-1"),
+							},
+							&ecs.Task{
+								TaskArn: aws.String("task-2"),
+							},
+							&ecs.Task{
+								TaskArn: aws.String("task-3"),
+							},
+						},
+				}, nil)
+				m.EXPECT().WaitUntilTasksRunning(&ecs.DescribeTasksInput{
+					Cluster: aws.String("my-cluster"),
+					Tasks: aws.StringSlice([]string{"task-1", "task-2", "task-3"}),
+				}).Times(1)
+			},
+
+			wantedArns: []string{"task-1", "task-2", "task-3"},
+		},
+		"run task failed": {
+			input: runTaskInput,
+
+			mockECSClient: func(m *mocks.Mockapi) {
+				m.EXPECT().RunTask(&ecs.RunTaskInput{
+					Cluster:        aws.String("my-cluster"),
+					Count:          aws.Int64(3),
+					LaunchType:     aws.String(ecs.LaunchTypeFargate),
+					StartedBy:      aws.String("task"),
+					TaskDefinition: aws.String("my-task"),
+					NetworkConfiguration: &ecs.NetworkConfiguration{
+						AwsvpcConfiguration: &ecs.AwsVpcConfiguration{
+							AssignPublicIp: aws.String(ecs.AssignPublicIpEnabled),
+							Subnets:        aws.StringSlice([]string{"subnet-1", "subnet-2"}),
+							SecurityGroups: aws.StringSlice([]string{"sg-1", "sg-2"}),
+						},
+					},
+				}).
+					Return(&ecs.RunTaskOutput{}, errors.New("error"))
+				m.EXPECT().WaitUntilTasksRunning(gomock.Any()).Times(0)
+			},
+			wantedError: errors.New("run task(s) my-task: error"),
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockECSClient := mocks.NewMockapi(ctrl)
+			tc.mockECSClient(mockECSClient)
+
+			ecs := ECS{
+				client: mockECSClient,
+			}
+
+			arns, err := ecs.RunTask(RunTaskInput{
+				Count:          tc.count,
+				Cluster:        tc.cluster,
+				TaskFamilyName: tc.taskFamilyName,
+				Subnets:        tc.subnets,
+				SecurityGroups: tc.securityGroups,
+				StartedBy:      tc.startedBy,
+			})
+
+			if tc.wantedError != nil {
+				require.EqualError(t, tc.wantedError, err.Error())
+			} else {
+				require.Equal(t, tc.wantedArns, arns)
+			}
+		})
+	}
+}
+
 func TestTaskDefinition_EnvVars(t *testing.T) {
 	testCases := map[string]struct {
 		inContainers []*ecs.ContainerDefinition

--- a/internal/pkg/aws/ecs/errors.go
+++ b/internal/pkg/aws/ecs/errors.go
@@ -1,0 +1,11 @@
+package ecs
+
+import "fmt"
+
+// ErrNoDefaultCluster occurs when the default cluster is not found.
+type ErrNoDefaultCluster struct {}
+
+func (e *ErrNoDefaultCluster) Error() string {
+    return fmt.Sprintf("no default cluster is found")
+}
+

--- a/internal/pkg/aws/ecs/errors.go
+++ b/internal/pkg/aws/ecs/errors.go
@@ -1,11 +1,10 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package ecs
 
-import "fmt"
+import "errors"
 
 // ErrNoDefaultCluster occurs when the default cluster is not found.
-type ErrNoDefaultCluster struct {}
-
-func (e *ErrNoDefaultCluster) Error() string {
-    return fmt.Sprintf("no default cluster is found")
-}
+var ErrNoDefaultCluster = errors.New("default cluster does not exist")
 

--- a/internal/pkg/aws/ecs/errors.go
+++ b/internal/pkg/aws/ecs/errors.go
@@ -7,4 +7,3 @@ import "errors"
 
 // ErrNoDefaultCluster occurs when the default cluster is not found.
 var ErrNoDefaultCluster = errors.New("default cluster does not exist")
-

--- a/internal/pkg/aws/ecs/mocks/mock_ecs.go
+++ b/internal/pkg/aws/ecs/mocks/mock_ecs.go
@@ -92,3 +92,47 @@ func (mr *MockapiMockRecorder) ListTasks(input interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTasks", reflect.TypeOf((*Mockapi)(nil).ListTasks), input)
 }
+
+// DescribeClusters mocks base method
+func (m *Mockapi) DescribeClusters(input *ecs.DescribeClustersInput) (*ecs.DescribeClustersOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeClusters", input)
+	ret0, _ := ret[0].(*ecs.DescribeClustersOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeClusters indicates an expected call of DescribeClusters
+func (mr *MockapiMockRecorder) DescribeClusters(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeClusters", reflect.TypeOf((*Mockapi)(nil).DescribeClusters), input)
+}
+
+// RunTask mocks base method
+func (m *Mockapi) RunTask(input *ecs.RunTaskInput) (*ecs.RunTaskOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RunTask", input)
+	ret0, _ := ret[0].(*ecs.RunTaskOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RunTask indicates an expected call of RunTask
+func (mr *MockapiMockRecorder) RunTask(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunTask", reflect.TypeOf((*Mockapi)(nil).RunTask), input)
+}
+
+// WaitUntilTasksRunning mocks base method
+func (m *Mockapi) WaitUntilTasksRunning(input *ecs.DescribeTasksInput) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitUntilTasksRunning", input)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WaitUntilTasksRunning indicates an expected call of WaitUntilTasksRunning
+func (mr *MockapiMockRecorder) WaitUntilTasksRunning(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilTasksRunning", reflect.TypeOf((*Mockapi)(nil).WaitUntilTasksRunning), input)
+}


### PR DESCRIPTION
This PR includes the following changes to aws package:
1. adds a ec2 package to get subnet and security groups
2. add runtask and defaultCluster method to ecs package

Related #702 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
