### PR TITLE
fix: Display correct GitHub URL flag name for 'copilot pipeline init' command

### DIFF
--- a/internal/pkg/cli/pipeline_init.go
+++ b/internal/pkg/cli/pipeline_init.go
@@ -443,7 +443,7 @@ func (o *initPipelineOpts) parseOwnerRepoName(url string) (string, string, error
 	parsedURL := strings.TrimPrefix(url, regexPattern.FindString(url))
 	ownerRepo := strings.Split(parsedURL, string(os.PathSeparator))
 	if len(ownerRepo) != 2 {
-		return "", "", fmt.Errorf("unable to parse the GitHub repository owner and name from %s: please pass the repository URL with the format `--url https://github.com/{owner}/{repositoryName}`", url)
+		return "", "", fmt.Errorf("unable to parse the GitHub repository owner and name from %s: please pass the repository URL with the format `--github-url https://github.com/{owner}/{repositoryName}`", url)
 	}
 	return ownerRepo[0], ownerRepo[1], nil
 }

--- a/internal/pkg/cli/pipeline_init_test.go
+++ b/internal/pkg/cli/pipeline_init_test.go
@@ -180,7 +180,7 @@ func TestInitPipelineOpts_Ask(t *testing.T) {
 			expectedGitHubRepo:        "",
 			expectedGitHubAccessToken: "",
 			expectedEnvironments:      []string{},
-			expectedError:             fmt.Errorf("unable to parse the GitHub repository owner and name from reallybadGoose//notEvenAURL: please pass the repository URL with the format `--url https://github.com/{owner}/{repositoryName}`"),
+			expectedError:             fmt.Errorf("unable to parse the GitHub repository owner and name from reallybadGoose//notEvenAURL: please pass the repository URL with the format `--github-url https://github.com/{owner}/{repositoryName}`"),
 		},
 		"returns error if fail to get GitHub access token": {
 			inEnvironments:      []string{},


### PR DESCRIPTION
When calling `copilot pipeline init`, if Copilot cannot parse the GitHub repo from the provided URL an error message is thrown. There is a reference to a CLI flag, `--url`, which seems to be incorrect. The correct flag is `--github-url`. This PR changes it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
