### PR TITLE
fix: do not remove svc from app when running `svc delete --env`

### DIFF
--- a/internal/pkg/cli/svc_delete_test.go
+++ b/internal/pkg/cli/svc_delete_test.go
@@ -115,6 +115,7 @@ func TestDeleteSvcOpts_Ask(t *testing.T) {
 	tests := map[string]struct {
 		skipConfirmation bool
 		inName           string
+		envName          string
 
 		mockstore  func(m *mocks.Mockstore)
 		mockPrompt func(m *mocks.Mockprompter)
@@ -231,6 +232,20 @@ func TestDeleteSvcOpts_Ask(t *testing.T) {
 
 			wantedName: testSvcName,
 		},
+		"should return error nil if user confirms svc delete --env": {
+			inName:           testSvcName,
+			envName:          "test",
+			skipConfirmation: false,
+			mockstore:        func(m *mocks.Mockstore) {},
+			mockPrompt: func(m *mocks.Mockprompter) {
+				m.EXPECT().Confirm(
+					fmt.Sprintf(fmtSvcDeleteFromEnvConfirmPrompt, testSvcName, "test"),
+					fmt.Sprintf(svcDeleteFromEnvConfirmHelp, "test"),
+				).Times(1).Return(true, nil)
+			},
+
+			wantedName: testSvcName,
+		},
 	}
 
 	for name, test := range tests {
@@ -250,7 +265,8 @@ func TestDeleteSvcOpts_Ask(t *testing.T) {
 						appName: testAppName,
 						prompt:  mockPrompter,
 					},
-					Name: test.inName,
+					Name:    test.inName,
+					EnvName: test.envName,
 				},
 				store: mockStore,
 			}
@@ -329,6 +345,9 @@ func TestDeleteSvcOpts_Execute(t *testing.T) {
 			},
 			wantedError: nil,
 		},
+		// A service can be deployed to multiple
+		// environments - and deleting it in one
+		// should not delete it form the entire app.
 		"happy path with environment passed in as flag": {
 			inAppName: mockAppName,
 			inSvcName: mockSvcName,
@@ -341,17 +360,15 @@ func TestDeleteSvcOpts_Execute(t *testing.T) {
 					mocks.spinner.EXPECT().Start(fmt.Sprintf(fmtSvcDeleteStart, mockSvcName, mockEnvName)),
 					mocks.svcCFN.EXPECT().DeleteService(gomock.Any()).Return(nil),
 					mocks.spinner.EXPECT().Stop(log.Ssuccessf(fmtSvcDeleteComplete, mockSvcName, mockEnvName)),
-					// emptyECRRepos
-					mocks.ecr.EXPECT().ClearRepository(mockRepo).Return(nil),
 
-					// removeSvcFromApp
-					mocks.store.EXPECT().GetApplication(mockAppName).Return(mockApp, nil),
-					mocks.spinner.EXPECT().Start(fmt.Sprintf(fmtSvcDeleteResourcesStart, mockSvcName, mockAppName)),
-					mocks.appCFN.EXPECT().RemoveServiceFromApp(mockApp, mockSvcName).Return(nil),
-					mocks.spinner.EXPECT().Stop(log.Ssuccessf(fmtSvcDeleteResourcesComplete, mockSvcName, mockAppName)),
+					// It should **not** emptyECRRepos
+					mocks.ecr.EXPECT().ClearRepository(gomock.Any()).Return(nil).Times(0),
 
-					// deleteSSMParam
-					mocks.store.EXPECT().DeleteService(mockAppName, mockSvcName).Return(nil),
+					// It should **not** removeSvcFromApp
+					mocks.appCFN.EXPECT().RemoveServiceFromApp(gomock.Any(), gomock.Any()).Return(nil).Times(0),
+
+					// It should **not** deleteSSMParam
+					mocks.store.EXPECT().DeleteService(gomock.Any(), gomock.Any()).Return(nil).Times(0),
 				)
 			},
 			wantedError: nil,


### PR DESCRIPTION
Right now, when a customer runs `copilot svc delete --env e` copilot will delete the svc from the entire application, including the ECR repo and the SSM parameter.

The expected behavior is for copilot to only remove the service from the environment `e` - but for the service to still exist within the app. 

This change updates the service_delete code to skip removing the service from the application when the service is only being removed from one environment. 

This change might result in the service's app resources (ECR Repo, S3 Bucket, and KMS key) lingering around even if the service isn't deployed to any environment. Customers can always run `copilot svc delete` to clean up those resources. I'm hesitant to add any smarts into deleting those resources (like reference counting them) - just because I think it'll over complicate things.

fixes #1126, https://github.com/aws/copilot-cli/issues/1006

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, 
copy, and redistribute this contribution, under the terms of your choice.
