### PR TITLE
chore(prompt): add "split" fn to TemplateFuncsNoColor var

### DIFF
--- a/internal/pkg/term/prompt/prompt.go
+++ b/internal/pkg/term/prompt/prompt.go
@@ -98,6 +98,10 @@ func init() {
 	core.TemplateFuncsWithColor["split"] = func(s string, sep string) []string {
 		return strings.Split(s, sep)
 	}
+
+	core.TemplateFuncsNoColor["split"] = func(s, string, sep string) []string {
+		return strings.Split(s, sep)
+	}
 }
 
 // ErrEmptyOptions indicates the input options list was empty.


### PR DESCRIPTION
Survey v2.0.8 introduced a breaking change where they replaced the
`core.TemplateFunc` global variable with two variables:
`core.TemplateFuncsWithColor` and `core.TemplateFuncsNoColor`.

The variable `core.TemplateFuncsNoColor` is now always used while parsing the
prompt templates. Therefore, we need to add the "split" fn to both template
funcs.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
