### PR TITLE
feat(cli): enable 'storage init' command

### DIFF
--- a/cmd/copilot/main.go
+++ b/cmd/copilot/main.go
@@ -60,7 +60,7 @@ func buildRootCmd() *cobra.Command {
 	cmd.AddCommand(cli.BuildSvcCmd())
 
 	// "Addons" command group
-	//cmd.AddCommand(cli.BuildStorageCmd())
+	cmd.AddCommand(cli.BuildStorageCmd())
 
 	// "Operational" command group.
 

--- a/cmd/copilot/template/template.go
+++ b/cmd/copilot/template/template.go
@@ -12,8 +12,8 @@ import (
 )
 
 // RootUsage is the text template for the root command.
-var RootUsage = fmt.Sprintf("{{h1 \"Commands\"}}{{ $cmds := .Commands }}{{$groups := mkSlice \"%s\" \"%s\" \"%s\" \"%s\" }}{{range $group := $groups }} \n",
-	group.GettingStarted, group.Develop, group.Release, group.Settings) +
+var RootUsage = fmt.Sprintf("{{h1 \"Commands\"}}{{ $cmds := .Commands }}{{$groups := mkSlice \"%s\" \"%s\" \"%s\" \"%s\" \"%s\" }}{{range $group := $groups }} \n",
+	group.GettingStarted, group.Develop, group.Release, group.Addons, group.Settings) +
 	`  {{h2 $group}}{{$groupCmds := (filterCmdsByGroup $cmds $group)}}
 {{- range $j, $cmd := $groupCmds}}{{$lines := split $cmd.Short "\n"}}
 {{- range $i, $line := $lines}}

--- a/internal/pkg/cli/storage_init.go
+++ b/internal/pkg/cli/storage_init.go
@@ -571,7 +571,7 @@ func BuildStorageInitCmd() *cobra.Command {
 		Use:    "init",
 		Short:  "Creates a new storage table in an environment.",
 		Example: `
-  Create a "my-bucket" S3 bucket bucket attached to the "frontend" service.
+  Create an S3 bucket named "my-bucket" attached to the "frontend" service.
   /code $ copilot storage init -n my-bucket -t S3 -s frontend
   Create a basic DynamoDB table named "my-table" attached to the "frontend" service.
   /code $ copilot storage init -n my-table -t DynamoDB -s frontend --partition-key Email:S --sort-key UserId:N --no-lsi


### PR DESCRIPTION
<!-- Provide summary of changes -->
This command enables the `copilot storage init` command, adds the `Addons` group to the help menu, and builds the `storage` and `storage init` commands. 

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
