### PR TITLE
docs(CHARTER): update tenet to mention we wire services in an app

### DIFF
--- a/CHARTER.md
+++ b/CHARTER.md
@@ -3,7 +3,7 @@
 ## Mission
 Our mission is to help customers build, release and operate applications on Amazon ECS with DevOps best practices and production ready infrastructure patterns.
 
-## Tenets 🌟
+## Tenets (unless you know better ones) 🌟
 * **Users think in terms of architecture, not of infrastructure.**
 Developers creating a new microservice shouldn't have to specify VPCs, load balancer settings, or complex pipeline configuration.
 They may not know anything about other AWS services. They should be able to specify what "kind" of application it is and how

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -1,18 +1,18 @@
 # AWS Copilot CLI Charter
 
 ## Mission
-Our mission is to help customers build, release and operate applications on Amazon ECS with dev-ops best practices and production ready infrastructure patterns.
+Our mission is to help customers build, release and operate applications on Amazon ECS with DevOps best practices and production ready infrastructure patterns.
 
 ## Tenets 🌟
-* **Create modern applications by default.**
-Applications created with the AWS Copilot CLI use the best practices of modern applications by default: they are serverless,
-they use infrastructure-as-code, they are observable, and they are secure.
 * **Users think in terms of architecture, not of infrastructure.**
 Developers creating a new microservice shouldn't have to specify VPCs, load balancer settings, or complex pipeline configuration.
 They may not know anything about other AWS services. They should be able to specify what "kind" of application it is and how
 it fits into their overall architecture; the infrastructure should be generated from that.
+* **Create modern applications by default.**
+Modern applications can consist of one or more services, jobs, and supporting resources like databases. 
+Copilot ensures that all parts of an application are wired together securely and sensibly.
+* **Deliver applications continuously.**
+While the AWS Copilot CLI can be used to manually deploy changes to an application, we always help customers to move to CI/CD by helping them set up and manage pipelines.
 * **Operations is part of the workflow.**
 Modeling, provisioning, and deploying applications are only part of the application lifecycle for the developer.
 The CLI must support workflows around troubleshooting and debugging to help when things go wrong.
-* **Deliver applications continuously.**
-While the AWS Copilot CLI can be used to manually deploy changes to an application, we always help customers to move to CI/CD by helping them set up and manage pipelines.


### PR DESCRIPTION
1. Re-order the tenets so that we start from "svc architecture patterns" ➡ "wiring services in an app" ➡ "creating a cd pipeline" ➡ "operating your services".
2. Update the "Create modern applications by default." tenet definition.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
