### PR TITLE
chore: update task package to reflect aws/ec2 method name changes 

### DIFF
--- a/internal/pkg/task/config_runner_test.go
+++ b/internal/pkg/task/config_runner_test.go
@@ -21,17 +21,17 @@ func TestNetworkConfigRunner_Run(t *testing.T) {
 		subnets        []string
 		securityGroups []string
 
-		mockClusterGetter func(m *mocks.MockdefaultClusterGetter)
-		mockStarter       func(m *mocks.MocktaskRunner)
+		mockClusterGetter func(m *mocks.MockDefaultClusterGetter)
+		mockStarter       func(m *mocks.MockTaskRunner)
 
 		wantedError error
 		wantedARNs  []string
 	}{
 		"failed to get clusters": {
-			mockClusterGetter: func(m *mocks.MockdefaultClusterGetter) {
+			mockClusterGetter: func(m *mocks.MockDefaultClusterGetter) {
 				m.EXPECT().DefaultCluster().Return("", errors.New("error getting default cluster"))
 			},
-			mockStarter: func(m *mocks.MocktaskRunner) {
+			mockStarter: func(m *mocks.MockTaskRunner) {
 				m.EXPECT().RunTask(gomock.Any()).Times(0)
 			},
 			wantedError: fmt.Errorf("get default cluster: error getting default cluster"),
@@ -43,10 +43,10 @@ func TestNetworkConfigRunner_Run(t *testing.T) {
 			subnets:        []string{"subnet-1", "subnet-2"},
 			securityGroups: []string{"sg-1", "sg-2"},
 
-			mockClusterGetter: func(m *mocks.MockdefaultClusterGetter) {
+			mockClusterGetter: func(m *mocks.MockDefaultClusterGetter) {
 				m.EXPECT().DefaultCluster().Return("cluster-1", nil)
 			},
-			mockStarter: func(m *mocks.MocktaskRunner) {
+			mockStarter: func(m *mocks.MockTaskRunner) {
 				m.EXPECT().RunTask(ecs.RunTaskInput{
 					Cluster:        "cluster-1",
 					Count:          1,
@@ -66,10 +66,10 @@ func TestNetworkConfigRunner_Run(t *testing.T) {
 			subnets:        []string{"subnet-1", "subnet-2"},
 			securityGroups: []string{"sg-1", "sg-2"},
 
-			mockClusterGetter: func(m *mocks.MockdefaultClusterGetter) {
+			mockClusterGetter: func(m *mocks.MockDefaultClusterGetter) {
 				m.EXPECT().DefaultCluster().Return("cluster-1", nil)
 			},
-			mockStarter: func(m *mocks.MocktaskRunner) {
+			mockStarter: func(m *mocks.MockTaskRunner) {
 				m.EXPECT().RunTask(ecs.RunTaskInput{
 					Cluster:        "cluster-1",
 					Count:          1,
@@ -89,8 +89,8 @@ func TestNetworkConfigRunner_Run(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
-			mockClusterGetter := mocks.NewMockdefaultClusterGetter(ctrl)
-			mockStarter := mocks.NewMocktaskRunner(ctrl)
+			mockClusterGetter := mocks.NewMockDefaultClusterGetter(ctrl)
+			mockStarter := mocks.NewMockTaskRunner(ctrl)
 
 			tc.mockClusterGetter(mockClusterGetter)
 			tc.mockStarter(mockStarter)
@@ -99,7 +99,7 @@ func TestNetworkConfigRunner_Run(t *testing.T) {
 				Count:     tc.count,
 				GroupName: tc.groupName,
 
-				Subnets: tc.subnets,
+				Subnets:        tc.subnets,
 				SecurityGroups: tc.securityGroups,
 
 				ClusterGetter: mockClusterGetter,

--- a/internal/pkg/task/default_runner.go
+++ b/internal/pkg/task/default_runner.go
@@ -13,7 +13,7 @@ import (
 // DefaultVPCRunner can run an Amazon ECS task in the default VPC and the default cluster.
 type DefaultVPCRunner struct {
 	// Count of the tasks to be launched.
-	Count     int
+	Count int
 	// Group Name fo the tasks that use the same task definition.
 	GroupName string
 
@@ -25,7 +25,7 @@ type DefaultVPCRunner struct {
 
 // Run runs tasks in default cluster and default subnets, and returns the task ARNs.
 func (r *DefaultVPCRunner) Run() ([]string, error) {
-	if err:= r.validateDependencies(); err != nil {
+	if err := r.validateDependencies(); err != nil {
 		return nil, err
 	}
 
@@ -34,7 +34,7 @@ func (r *DefaultVPCRunner) Run() ([]string, error) {
 		return nil, fmt.Errorf("get default cluster: %w", err)
 	}
 
-	subnets, err := r.VPCGetter.GetSubnetIDs(ec2.FilterForDefaultVPCSubnets)
+	subnets, err := r.VPCGetter.SubnetIDs(ec2.FilterForDefaultVPCSubnets)
 	if err != nil {
 		return nil, fmt.Errorf("get default subnet IDs: %w", err)
 	}

--- a/internal/pkg/task/default_runner_test.go
+++ b/internal/pkg/task/default_runner_test.go
@@ -18,34 +18,34 @@ func TestDefaultVPCRunner_Run(t *testing.T) {
 		count     int
 		groupName string
 
-		mockVPCGetter     func(m *mocks.MockvpcGetter)
-		mockClusterGetter func(m *mocks.MockdefaultClusterGetter)
-		mockStarter       func(m *mocks.MocktaskRunner)
+		mockVPCGetter     func(m *mocks.MockVPCGetter)
+		mockClusterGetter func(m *mocks.MockDefaultClusterGetter)
+		mockStarter       func(m *mocks.MockTaskRunner)
 
 		wantedError error
 		wantedARNs  []string
 	}{
 		"failed to get default cluster": {
-			mockClusterGetter: func(m *mocks.MockdefaultClusterGetter) {
+			mockClusterGetter: func(m *mocks.MockDefaultClusterGetter) {
 				m.EXPECT().DefaultCluster().Return("", errors.New("error getting cluster"))
 			},
-			mockVPCGetter: func(m *mocks.MockvpcGetter) {
-				m.EXPECT().GetSubnetIDs().AnyTimes()
-				m.EXPECT().GetSecurityGroups().AnyTimes()
+			mockVPCGetter: func(m *mocks.MockVPCGetter) {
+				m.EXPECT().SubnetIDs().AnyTimes()
+				m.EXPECT().SecurityGroups().AnyTimes()
 			},
-			mockStarter: func(m *mocks.MocktaskRunner) {
+			mockStarter: func(m *mocks.MockTaskRunner) {
 				m.EXPECT().RunTask(gomock.Any()).Times(0)
 			},
 			wantedError: fmt.Errorf("get default cluster: error getting cluster"),
 		},
 		"failed to get subnet": {
-			mockClusterGetter: func(m *mocks.MockdefaultClusterGetter) {
+			mockClusterGetter: func(m *mocks.MockDefaultClusterGetter) {
 				m.EXPECT().DefaultCluster().Return("cluster-1", nil)
 			},
-			mockVPCGetter: func(m *mocks.MockvpcGetter) {
-				m.EXPECT().GetSubnetIDs([]ec2.Filter{ec2.FilterForDefaultVPCSubnets}).Return(nil, errors.New("error getting subnets"))
+			mockVPCGetter: func(m *mocks.MockVPCGetter) {
+				m.EXPECT().SubnetIDs([]ec2.Filter{ec2.FilterForDefaultVPCSubnets}).Return(nil, errors.New("error getting subnets"))
 			},
-			mockStarter: func(m *mocks.MocktaskRunner) {
+			mockStarter: func(m *mocks.MockTaskRunner) {
 				m.EXPECT().RunTask(gomock.Any()).Times(0)
 			},
 			wantedError: errors.New("get default subnet IDs: error getting subnets"),
@@ -53,13 +53,13 @@ func TestDefaultVPCRunner_Run(t *testing.T) {
 		"failed to kick off task": {
 			count:     1,
 			groupName: "my-task",
-			mockClusterGetter: func(m *mocks.MockdefaultClusterGetter) {
+			mockClusterGetter: func(m *mocks.MockDefaultClusterGetter) {
 				m.EXPECT().DefaultCluster().Return("cluster-1", nil)
 			},
-			mockVPCGetter: func(m *mocks.MockvpcGetter) {
-				m.EXPECT().GetSubnetIDs([]ec2.Filter{ec2.FilterForDefaultVPCSubnets}).Return([]string{"subnet-1"}, nil)
+			mockVPCGetter: func(m *mocks.MockVPCGetter) {
+				m.EXPECT().SubnetIDs([]ec2.Filter{ec2.FilterForDefaultVPCSubnets}).Return([]string{"subnet-1"}, nil)
 			},
-			mockStarter: func(m *mocks.MocktaskRunner) {
+			mockStarter: func(m *mocks.MockTaskRunner) {
 				m.EXPECT().RunTask(gomock.Any()).Return(nil, errors.New("error running task"))
 			},
 			wantedError: errors.New("run task my-task: error running task"),
@@ -71,9 +71,9 @@ func TestDefaultVPCRunner_Run(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
-			mockVpcGetter := mocks.NewMockvpcGetter(ctrl)
-			mockClusterGetter := mocks.NewMockdefaultClusterGetter(ctrl)
-			mockStarter := mocks.NewMocktaskRunner(ctrl)
+			mockVpcGetter := mocks.NewMockVPCGetter(ctrl)
+			mockClusterGetter := mocks.NewMockDefaultClusterGetter(ctrl)
+			mockStarter := mocks.NewMockTaskRunner(ctrl)
 
 			tc.mockVPCGetter(mockVpcGetter)
 			tc.mockClusterGetter(mockClusterGetter)

--- a/internal/pkg/task/mocks/mock_task.go
+++ b/internal/pkg/task/mocks/mock_task.go
@@ -12,92 +12,111 @@ import (
 	reflect "reflect"
 )
 
-// MockvpcGetter is a mock of vpcGetter interface
-type MockvpcGetter struct {
+// MockVPCGetter is a mock of VPCGetter interface
+type MockVPCGetter struct {
 	ctrl     *gomock.Controller
-	recorder *MockvpcGetterMockRecorder
+	recorder *MockVPCGetterMockRecorder
 }
 
-// MockvpcGetterMockRecorder is the mock recorder for MockvpcGetter
-type MockvpcGetterMockRecorder struct {
-	mock *MockvpcGetter
+// MockVPCGetterMockRecorder is the mock recorder for MockVPCGetter
+type MockVPCGetterMockRecorder struct {
+	mock *MockVPCGetter
 }
 
-// NewMockvpcGetter creates a new mock instance
-func NewMockvpcGetter(ctrl *gomock.Controller) *MockvpcGetter {
-	mock := &MockvpcGetter{ctrl: ctrl}
-	mock.recorder = &MockvpcGetterMockRecorder{mock}
+// NewMockVPCGetter creates a new mock instance
+func NewMockVPCGetter(ctrl *gomock.Controller) *MockVPCGetter {
+	mock := &MockVPCGetter{ctrl: ctrl}
+	mock.recorder = &MockVPCGetterMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use
-func (m *MockvpcGetter) EXPECT() *MockvpcGetterMockRecorder {
+func (m *MockVPCGetter) EXPECT() *MockVPCGetterMockRecorder {
 	return m.recorder
 }
 
-// GetSubnetIDs mocks base method
-func (m *MockvpcGetter) GetSubnetIDs(filters ...ec2.Filter) ([]string, error) {
+// SubnetIDs mocks base method
+func (m *MockVPCGetter) SubnetIDs(filters ...ec2.Filter) ([]string, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{}
 	for _, a := range filters {
 		varargs = append(varargs, a)
 	}
-	ret := m.ctrl.Call(m, "GetSubnetIDs", varargs...)
+	ret := m.ctrl.Call(m, "SubnetIDs", varargs...)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetSubnetIDs indicates an expected call of GetSubnetIDs
-func (mr *MockvpcGetterMockRecorder) GetSubnetIDs(filters ...interface{}) *gomock.Call {
+// SubnetIDs indicates an expected call of SubnetIDs
+func (mr *MockVPCGetterMockRecorder) SubnetIDs(filters ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSubnetIDs", reflect.TypeOf((*MockvpcGetter)(nil).GetSubnetIDs), filters...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubnetIDs", reflect.TypeOf((*MockVPCGetter)(nil).SubnetIDs), filters...)
 }
 
-// GetSecurityGroups mocks base method
-func (m *MockvpcGetter) GetSecurityGroups(filters ...ec2.Filter) ([]string, error) {
+// SecurityGroups mocks base method
+func (m *MockVPCGetter) SecurityGroups(filters ...ec2.Filter) ([]string, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{}
 	for _, a := range filters {
 		varargs = append(varargs, a)
 	}
-	ret := m.ctrl.Call(m, "GetSecurityGroups", varargs...)
+	ret := m.ctrl.Call(m, "SecurityGroups", varargs...)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetSecurityGroups indicates an expected call of GetSecurityGroups
-func (mr *MockvpcGetterMockRecorder) GetSecurityGroups(filters ...interface{}) *gomock.Call {
+// SecurityGroups indicates an expected call of SecurityGroups
+func (mr *MockVPCGetterMockRecorder) SecurityGroups(filters ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecurityGroups", reflect.TypeOf((*MockvpcGetter)(nil).GetSecurityGroups), filters...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecurityGroups", reflect.TypeOf((*MockVPCGetter)(nil).SecurityGroups), filters...)
 }
 
-// MockresourceGetter is a mock of resourceGetter interface
-type MockresourceGetter struct {
+// PublicSubnetIDs mocks base method
+func (m *MockVPCGetter) PublicSubnetIDs(filters ...ec2.Filter) ([]string, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{}
+	for _, a := range filters {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "PublicSubnetIDs", varargs...)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PublicSubnetIDs indicates an expected call of PublicSubnetIDs
+func (mr *MockVPCGetterMockRecorder) PublicSubnetIDs(filters ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublicSubnetIDs", reflect.TypeOf((*MockVPCGetter)(nil).PublicSubnetIDs), filters...)
+}
+
+// MockResourceGetter is a mock of ResourceGetter interface
+type MockResourceGetter struct {
 	ctrl     *gomock.Controller
-	recorder *MockresourceGetterMockRecorder
+	recorder *MockResourceGetterMockRecorder
 }
 
-// MockresourceGetterMockRecorder is the mock recorder for MockresourceGetter
-type MockresourceGetterMockRecorder struct {
-	mock *MockresourceGetter
+// MockResourceGetterMockRecorder is the mock recorder for MockResourceGetter
+type MockResourceGetterMockRecorder struct {
+	mock *MockResourceGetter
 }
 
-// NewMockresourceGetter creates a new mock instance
-func NewMockresourceGetter(ctrl *gomock.Controller) *MockresourceGetter {
-	mock := &MockresourceGetter{ctrl: ctrl}
-	mock.recorder = &MockresourceGetterMockRecorder{mock}
+// NewMockResourceGetter creates a new mock instance
+func NewMockResourceGetter(ctrl *gomock.Controller) *MockResourceGetter {
+	mock := &MockResourceGetter{ctrl: ctrl}
+	mock.recorder = &MockResourceGetterMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use
-func (m *MockresourceGetter) EXPECT() *MockresourceGetterMockRecorder {
+func (m *MockResourceGetter) EXPECT() *MockResourceGetterMockRecorder {
 	return m.recorder
 }
 
 // GetResourcesByTags mocks base method
-func (m *MockresourceGetter) GetResourcesByTags(resourceType string, tags map[string]string) ([]*resourcegroups.Resource, error) {
+func (m *MockResourceGetter) GetResourcesByTags(resourceType string, tags map[string]string) ([]*resourcegroups.Resource, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetResourcesByTags", resourceType, tags)
 	ret0, _ := ret[0].([]*resourcegroups.Resource)
@@ -106,36 +125,36 @@ func (m *MockresourceGetter) GetResourcesByTags(resourceType string, tags map[st
 }
 
 // GetResourcesByTags indicates an expected call of GetResourcesByTags
-func (mr *MockresourceGetterMockRecorder) GetResourcesByTags(resourceType, tags interface{}) *gomock.Call {
+func (mr *MockResourceGetterMockRecorder) GetResourcesByTags(resourceType, tags interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResourcesByTags", reflect.TypeOf((*MockresourceGetter)(nil).GetResourcesByTags), resourceType, tags)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResourcesByTags", reflect.TypeOf((*MockResourceGetter)(nil).GetResourcesByTags), resourceType, tags)
 }
 
-// MockdefaultClusterGetter is a mock of defaultClusterGetter interface
-type MockdefaultClusterGetter struct {
+// MockDefaultClusterGetter is a mock of DefaultClusterGetter interface
+type MockDefaultClusterGetter struct {
 	ctrl     *gomock.Controller
-	recorder *MockdefaultClusterGetterMockRecorder
+	recorder *MockDefaultClusterGetterMockRecorder
 }
 
-// MockdefaultClusterGetterMockRecorder is the mock recorder for MockdefaultClusterGetter
-type MockdefaultClusterGetterMockRecorder struct {
-	mock *MockdefaultClusterGetter
+// MockDefaultClusterGetterMockRecorder is the mock recorder for MockDefaultClusterGetter
+type MockDefaultClusterGetterMockRecorder struct {
+	mock *MockDefaultClusterGetter
 }
 
-// NewMockdefaultClusterGetter creates a new mock instance
-func NewMockdefaultClusterGetter(ctrl *gomock.Controller) *MockdefaultClusterGetter {
-	mock := &MockdefaultClusterGetter{ctrl: ctrl}
-	mock.recorder = &MockdefaultClusterGetterMockRecorder{mock}
+// NewMockDefaultClusterGetter creates a new mock instance
+func NewMockDefaultClusterGetter(ctrl *gomock.Controller) *MockDefaultClusterGetter {
+	mock := &MockDefaultClusterGetter{ctrl: ctrl}
+	mock.recorder = &MockDefaultClusterGetterMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use
-func (m *MockdefaultClusterGetter) EXPECT() *MockdefaultClusterGetterMockRecorder {
+func (m *MockDefaultClusterGetter) EXPECT() *MockDefaultClusterGetterMockRecorder {
 	return m.recorder
 }
 
 // DefaultCluster mocks base method
-func (m *MockdefaultClusterGetter) DefaultCluster() (string, error) {
+func (m *MockDefaultClusterGetter) DefaultCluster() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DefaultCluster")
 	ret0, _ := ret[0].(string)
@@ -144,36 +163,36 @@ func (m *MockdefaultClusterGetter) DefaultCluster() (string, error) {
 }
 
 // DefaultCluster indicates an expected call of DefaultCluster
-func (mr *MockdefaultClusterGetterMockRecorder) DefaultCluster() *gomock.Call {
+func (mr *MockDefaultClusterGetterMockRecorder) DefaultCluster() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DefaultCluster", reflect.TypeOf((*MockdefaultClusterGetter)(nil).DefaultCluster))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DefaultCluster", reflect.TypeOf((*MockDefaultClusterGetter)(nil).DefaultCluster))
 }
 
-// MocktaskRunner is a mock of taskRunner interface
-type MocktaskRunner struct {
+// MockTaskRunner is a mock of TaskRunner interface
+type MockTaskRunner struct {
 	ctrl     *gomock.Controller
-	recorder *MocktaskRunnerMockRecorder
+	recorder *MockTaskRunnerMockRecorder
 }
 
-// MocktaskRunnerMockRecorder is the mock recorder for MocktaskRunner
-type MocktaskRunnerMockRecorder struct {
-	mock *MocktaskRunner
+// MockTaskRunnerMockRecorder is the mock recorder for MockTaskRunner
+type MockTaskRunnerMockRecorder struct {
+	mock *MockTaskRunner
 }
 
-// NewMocktaskRunner creates a new mock instance
-func NewMocktaskRunner(ctrl *gomock.Controller) *MocktaskRunner {
-	mock := &MocktaskRunner{ctrl: ctrl}
-	mock.recorder = &MocktaskRunnerMockRecorder{mock}
+// NewMockTaskRunner creates a new mock instance
+func NewMockTaskRunner(ctrl *gomock.Controller) *MockTaskRunner {
+	mock := &MockTaskRunner{ctrl: ctrl}
+	mock.recorder = &MockTaskRunnerMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use
-func (m *MocktaskRunner) EXPECT() *MocktaskRunnerMockRecorder {
+func (m *MockTaskRunner) EXPECT() *MockTaskRunnerMockRecorder {
 	return m.recorder
 }
 
 // RunTask mocks base method
-func (m *MocktaskRunner) RunTask(input ecs.RunTaskInput) ([]string, error) {
+func (m *MockTaskRunner) RunTask(input ecs.RunTaskInput) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RunTask", input)
 	ret0, _ := ret[0].([]string)
@@ -182,7 +201,7 @@ func (m *MocktaskRunner) RunTask(input ecs.RunTaskInput) ([]string, error) {
 }
 
 // RunTask indicates an expected call of RunTask
-func (mr *MocktaskRunnerMockRecorder) RunTask(input interface{}) *gomock.Call {
+func (mr *MockTaskRunnerMockRecorder) RunTask(input interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunTask", reflect.TypeOf((*MocktaskRunner)(nil).RunTask), input)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunTask", reflect.TypeOf((*MockTaskRunner)(nil).RunTask), input)
 }

--- a/internal/pkg/task/task.go
+++ b/internal/pkg/task/task.go
@@ -14,8 +14,9 @@ import (
 
 // VpcGetter gets subnets and security groups.
 type VPCGetter interface {
-	GetSubnetIDs(filters ...ec2.Filter) ([]string, error)
-	GetSecurityGroups(filters ...ec2.Filter) ([]string, error)
+	SubnetIDs(filters ...ec2.Filter) ([]string, error)
+	SecurityGroups(filters ...ec2.Filter) ([]string, error)
+	PublicSubnetIDs(filters ...ec2.Filter) ([]string, error)
 }
 
 // ResourceGetter gets resources by tags.
@@ -34,14 +35,14 @@ type TaskRunner interface {
 }
 
 const (
-	startedBy           = "copilot-task"
+	startedBy = "copilot-task"
 )
 
 var (
-	errNoSubnetFound     = errors.New("no subnets found")
-	fmtTaskFamilyName    = "copilot-%s"
+	errNoSubnetFound  = errors.New("no subnets found")
+	fmtTaskFamilyName = "copilot-%s"
 )
 
-func taskFamilyName(groupName string) string{
+func taskFamilyName(groupName string) string {
 	return fmt.Sprintf(fmtTaskFamilyName, groupName)
 }


### PR DESCRIPTION
1. `task` package has references to some methods whose names are updated in #1146. This PR updates `task` package to reflect those name changes.
2. re-mock interfaces in `task` package

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
