### PR TITLE
fix: HTTPS Params in "svc package" was always false

### DIFF
--- a/internal/pkg/cli/svc_package.go
+++ b/internal/pkg/cli/svc_package.go
@@ -102,10 +102,11 @@ func newPackageSvcOpts(vars packageSvcVars) (*packageSvcOpts, error) {
 				if err != nil {
 					return nil, fmt.Errorf("init https load balanced web service stack serializer: %w", err)
 				}
-			}
-			serializer, err = stack.NewLoadBalancedWebService(v, env.Name, app.Name, rc)
-			if err != nil {
-				return nil, fmt.Errorf("init load balanced web service stack serializer: %w", err)
+			} else {
+				serializer, err = stack.NewLoadBalancedWebService(v, env.Name, app.Name, rc)
+				if err != nil {
+					return nil, fmt.Errorf("init load balanced web service stack serializer: %w", err)
+				}
 			}
 		case *manifest.BackendService:
 			serializer, err = stack.NewBackendService(v, env.Name, app.Name, rc)


### PR DESCRIPTION
We were missing an else bracket to our if statement
so LB Web Apps were always marked as not HTTPS because
the HTTPS Struct was being redefined.

Note, we need to add some tests for this 100%.


## Manual tests
This is for an app that uses HTTPS: 
`copilot svc package --output-dir infra`

Before:

```json
{
  "Parameters" : { 
    ...
    "HTTPSEnabled": "false"
  },
  "Tags": { 
    ...
  }
}
```

After:

```json
{
  "Parameters" : { 
   ...
    "HTTPSEnabled": "true"
  },
  "Tags": { 
    ...
  }
}
```
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
