### PR TITLE
chore(docker): add support for multiple tagging to docker pkg

### DIFF
--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -155,9 +155,9 @@ type stackSerializer interface {
 }
 
 type dockerService interface {
-	Build(uri, tag, path string) error
+	Build(uri, path, imageTag string, additionalTags ...string) error
 	Login(uri, username, password string) error
-	Push(uri, tag string) error
+	Push(uri, imageTag string, additionalTags ...string) error
 }
 
 type runner interface {

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -1414,17 +1414,22 @@ func (m *MockdockerService) EXPECT() *MockdockerServiceMockRecorder {
 }
 
 // Build mocks base method
-func (m *MockdockerService) Build(uri, tag, path string) error {
+func (m *MockdockerService) Build(uri, path, imageTag string, additionalTags ...string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Build", uri, tag, path)
+	varargs := []interface{}{uri, path, imageTag}
+	for _, a := range additionalTags {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Build", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Build indicates an expected call of Build
-func (mr *MockdockerServiceMockRecorder) Build(uri, tag, path interface{}) *gomock.Call {
+func (mr *MockdockerServiceMockRecorder) Build(uri, path, imageTag interface{}, additionalTags ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Build", reflect.TypeOf((*MockdockerService)(nil).Build), uri, tag, path)
+	varargs := append([]interface{}{uri, path, imageTag}, additionalTags...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Build", reflect.TypeOf((*MockdockerService)(nil).Build), varargs...)
 }
 
 // Login mocks base method
@@ -1442,17 +1447,22 @@ func (mr *MockdockerServiceMockRecorder) Login(uri, username, password interface
 }
 
 // Push mocks base method
-func (m *MockdockerService) Push(uri, tag string) error {
+func (m *MockdockerService) Push(uri, imageTag string, additionalTags ...string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Push", uri, tag)
+	varargs := []interface{}{uri, imageTag}
+	for _, a := range additionalTags {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Push", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Push indicates an expected call of Push
-func (mr *MockdockerServiceMockRecorder) Push(uri, tag interface{}) *gomock.Call {
+func (mr *MockdockerServiceMockRecorder) Push(uri, imageTag interface{}, additionalTags ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Push", reflect.TypeOf((*MockdockerService)(nil).Push), uri, tag)
+	varargs := append([]interface{}{uri, imageTag}, additionalTags...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Push", reflect.TypeOf((*MockdockerService)(nil).Push), varargs...)
 }
 
 // Mockrunner is a mock of runner interface

--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -294,7 +294,7 @@ func (o *deploySvcOpts) pushToECRRepo() error {
 		return err
 	}
 
-	if err := o.docker.Build(uri, o.ImageTag, path); err != nil {
+	if err := o.docker.Build(uri, path, o.ImageTag); err != nil {
 		return fmt.Errorf("build Dockerfile at %s with tag %s: %w", path, o.ImageTag, err)
 	}
 

--- a/internal/pkg/docker/docker.go
+++ b/internal/pkg/docker/docker.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/aws/copilot-cli/internal/pkg/term/command"
-	"github.com/aws/copilot-cli/internal/pkg/term/log"
 )
 
 // Runner represents a command that can be run.
@@ -67,11 +66,6 @@ func (r Runner) Push(uri, imageTag string, additionalTags ...string) error {
 
 		err := r.Run("docker", []string{"push", path})
 		if err != nil {
-			// TODO: improve the error handling here.
-			// if you try to push an *existing* image that has Digest A and tag T then no error (also no image push).
-			// if you try to push an *existing* image that has Digest B and tag T (that belongs to another image Digest A) then docker spits out an unclear error.
-			log.Warningf("the image with tag %s may already exist.\n", imageTag)
-
 			return fmt.Errorf("docker push %s: %w", path, err)
 		}
 	}

--- a/internal/pkg/docker/docker.go
+++ b/internal/pkg/docker/docker.go
@@ -43,6 +43,7 @@ func (r Runner) Build(uri, path, imageTag string, additionalTags ...string) erro
 	if err != nil {
 		return fmt.Errorf("building image: %w", err)
 	}
+
 	return nil
 }
 

--- a/internal/pkg/docker/docker.go
+++ b/internal/pkg/docker/docker.go
@@ -5,7 +5,6 @@
 package docker
 
 import (
-	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -30,30 +29,12 @@ func New() Runner {
 	}
 }
 
-// Build will run a `docker build` command with the input uri, tag, and Dockerfile path.
-func (r Runner) Build(uri, imageTag, path string) error {
-	imageName := imageName(uri, imageTag)
-	dfDir := filepath.Dir(path)
-
-	err := r.Run("docker", []string{"build", "-t", imageName, dfDir, "-f", path})
-
-	if err != nil {
-		return fmt.Errorf("building image: %w", err)
-	}
-
-	return nil
-}
-
-// BuildWithMultipleTags is the same as Build but is able to accept multiple tags.
-func (r Runner) BuildWithMultipleTags(uri, path string, imageTags []string) error {
-	if len(imageTags) == 0 {
-		return errors.New("must provide at least one image tag")
-	}
-
+// Build will run a `docker build` command with the input uri, Dockerfile path, and tags.
+func (r Runner) Build(uri, path, imageTag string, additionalTags ...string) error {
 	dfDir := filepath.Dir(path)
 
 	args := []string{"build"}
-	for _, tag := range imageTags {
+	for _, tag := range append(additionalTags, imageTag) {
 		args = append(args, "-t", imageName(uri, tag))
 	}
 	args = append(args, dfDir, "-f", path)
@@ -78,39 +59,20 @@ func (r Runner) Login(uri, username, password string) error {
 	return nil
 }
 
-// Push will run `docker push` command against the Service repository URI with the input uri and image tag.
-func (r Runner) Push(uri, imageTag string) error {
-	path := imageName(uri, imageTag)
-
-	err := r.Run("docker", []string{"push", path})
-
-	if err != nil {
-		// TODO: improve the error handling here.
-		// if you try to push an *existing* image that has Digest A and tag T then no error (also no image push).
-		// if you try to push an *existing* image that has Digest B and tag T (that belongs to another image Digest A) then docker spits out an unclear error.
-		log.Warningf("the image with tag %s may already exist.\n", imageTag)
-
-		return fmt.Errorf("docker push: %w", err)
-	}
-
-	return nil
-}
-
-// PushWithMultipleTags is the same as Push but but is able to accept multiple tags.
-func (r Runner) PushWithMultipleTags(uri string, imageTags []string) error {
-	var errMsg []string
-
-	for _, imageTag := range imageTags {
+// Push will run `docker push` command against the repository URI with the input uri and image tags.
+func (r Runner) Push(uri, imageTag string, additionalTags ...string) error {
+	for _, imageTag := range append(additionalTags, imageTag) {
 		path := imageName(uri, imageTag)
 
-		errPush := r.Run("docker", []string{"push", path})
-		if errPush != nil {
-			errMsg = append(errMsg, fmt.Sprintf("push tag %s: %v", imageTag, errPush))
-		}
-	}
+		err := r.Run("docker", []string{"push", path})
+		if err != nil {
+			// TODO: improve the error handling here.
+			// if you try to push an *existing* image that has Digest A and tag T then no error (also no image push).
+			// if you try to push an *existing* image that has Digest B and tag T (that belongs to another image Digest A) then docker spits out an unclear error.
+			log.Warningf("the image with tag %s may already exist.\n", imageTag)
 
-	if len(errMsg) != 0 {
-		return fmt.Errorf("docker push with multiple tags: %s", strings.Join(errMsg, "; "))
+			return fmt.Errorf("docker push %s: %w", path, err)
+		}
 	}
 
 	return nil

--- a/internal/pkg/docker/docker_test.go
+++ b/internal/pkg/docker/docker_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestBuild(t *testing.T) {
+	mockError := errors.New("mockError")
+
 	mockURI := "mockURI"
 	mockPath := "mockPath/to/mockDockerfile"
 
@@ -23,7 +25,6 @@ func TestBuild(t *testing.T) {
 	var mockRunner *mocks.Mockrunner
 
 	tests := map[string]struct {
-		tags       []string
 		path       string
 		setupMocks func(controller *gomock.Controller)
 
@@ -37,9 +38,9 @@ func TestBuild(t *testing.T) {
 					"-t", imageName(mockURI, mockTag2),
 					"-t", imageName(mockURI, mockTag3),
 					"-t", imageName(mockURI, mockTag1),
-					"mockPath/to", "-f", "mockPath/to/mockDockerfile"}).Return(errors.New("error"))
+					"mockPath/to", "-f", "mockPath/to/mockDockerfile"}).Return(mockError)
 			},
-			wantedError: fmt.Errorf("building image: error"),
+			wantedError: fmt.Errorf("building image: %w", mockError),
 		},
 		"success with additional tags": {
 			path: mockPath,
@@ -122,6 +123,7 @@ func TestLogin(t *testing.T) {
 
 func TestPush(t *testing.T) {
 	mockError := errors.New("mockError")
+
 	mockURI := "mockURI"
 
 	mockTag1 := "tag1"


### PR DESCRIPTION
This PR adds support for building and pushing images with multiple tagging, while keeping the original build/push intact.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
