### PR TITLE
chore(cli): refactor cli to use repository pkg

### DIFF
--- a/internal/pkg/aws/ecr/ecr.go
+++ b/internal/pkg/aws/ecr/ecr.go
@@ -44,7 +44,7 @@ func New(s *session.Session) ECR {
 }
 
 // Auth returns the basic authentication credentials needed to push images.
-func (c ECR) Auth() (string, string, error) {
+func (c ECR) Auth() (username string, password string, err error) {
 	response, err := c.client.GetAuthorizationToken(&ecr.GetAuthorizationTokenInput{})
 
 	if err != nil {
@@ -58,9 +58,7 @@ func (c ECR) Auth() (string, string, error) {
 	}
 
 	tokenStrings := strings.Split(string(authToken), ":")
-
-	username, password := tokenStrings[0], tokenStrings[1]
-	return username, password, nil
+	return tokenStrings[0], tokenStrings[1], nil
 }
 
 // RepositoryURI returns the ECR repository URI.

--- a/internal/pkg/aws/ecr/ecr.go
+++ b/internal/pkg/aws/ecr/ecr.go
@@ -63,7 +63,7 @@ func (c ECR) Auth() (string, string, error) {
 	return username, password, nil
 }
 
-// GetRepository returns the ECR repository URI.
+// RepositoryURI returns the ECR repository URI.
 func (c ECR) RepositoryURI(name string) (string, error) {
 	result, err := c.client.DescribeRepositories(&ecr.DescribeRepositoriesInput{
 		RepositoryNames: aws.StringSlice([]string{name}),

--- a/internal/pkg/aws/ecr/ecr_test.go
+++ b/internal/pkg/aws/ecr/ecr_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetECRAuth(t *testing.T) {
+func TestAuth(t *testing.T) {
 	mockError := errors.New("error")
 
 	mockUsername := "mockUsername"
@@ -28,7 +28,8 @@ func TestGetECRAuth(t *testing.T) {
 	testCases := map[string]struct {
 		mockECRClient func(m *mocks.Mockapi)
 
-		wantAuth Auth
+		wantedUsername string
+		wantedPassword string
 		wantErr  error
 	}{
 		"should return wrapped error given error returned from GetAuthorizationToken": {
@@ -47,10 +48,8 @@ func TestGetECRAuth(t *testing.T) {
 					},
 				}, nil)
 			},
-			wantAuth: Auth{
-				Username: mockUsername,
-				Password: mockPassword,
-			},
+			wantedUsername: mockUsername,
+			wantedPassword: mockPassword,
 		},
 	}
 
@@ -67,16 +66,17 @@ func TestGetECRAuth(t *testing.T) {
 				mockECRAPI,
 			}
 
-			gotAuth, gotErr := client.GetECRAuth()
+			gotUsername, gotPassword, gotErr := client.Auth()
 
-			require.Equal(t, tc.wantAuth, gotAuth)
+			require.Equal(t, tc.wantedUsername, gotUsername)
+			require.Equal(t, tc.wantedPassword, gotPassword)
 			require.Equal(t, tc.wantErr, gotErr)
 		})
 
 	}
 }
 
-func TestGetRepository(t *testing.T) {
+func TestRepositoryURI(t *testing.T) {
 	mockError := errors.New("error")
 
 	mockRepoName := "mockRepoName"
@@ -133,7 +133,7 @@ func TestGetRepository(t *testing.T) {
 				mockECRAPI,
 			}
 
-			gotURI, gotErr := client.GetRepository(mockRepoName)
+			gotURI, gotErr := client.RepositoryURI(mockRepoName)
 
 			require.Equal(t, tc.wantURI, gotURI)
 			require.Equal(t, tc.wantErr, gotErr)

--- a/internal/pkg/cli/init.go
+++ b/internal/pkg/cli/init.go
@@ -13,7 +13,6 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/cli/group"
 	"github.com/aws/copilot-cli/internal/pkg/config"
 	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation"
-	"github.com/aws/copilot-cli/internal/pkg/docker"
 	"github.com/aws/copilot-cli/internal/pkg/docker/dockerfile"
 	"github.com/aws/copilot-cli/internal/pkg/term/color"
 	"github.com/aws/copilot-cli/internal/pkg/term/command"
@@ -149,7 +148,6 @@ func newInitOpts(vars initVars) (*initOpts, error) {
 		ws:           ws,
 		sel:          selector.NewWorkspaceSelect(prompt, ssm, ws),
 		spinner:      spin,
-		docker:       docker.New(),
 		cmd:          command.New(),
 		sessProvider: sessProvider,
 	}

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -5,12 +5,12 @@ package cli
 
 import (
 	"encoding"
+	"github.com/aws/copilot-cli/internal/pkg/repository"
 	"io"
 
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/copilot-cli/internal/pkg/aws/cloudwatchlogs"
 	"github.com/aws/copilot-cli/internal/pkg/aws/codepipeline"
-	"github.com/aws/copilot-cli/internal/pkg/aws/ecr"
 	"github.com/aws/copilot-cli/internal/pkg/aws/ecs"
 	"github.com/aws/copilot-cli/internal/pkg/config"
 	"github.com/aws/copilot-cli/internal/pkg/deploy"
@@ -135,9 +135,8 @@ type secretDeleter interface {
 	DeleteSecret(secretName string) error
 }
 
-type ecrService interface {
-	GetRepository(name string) (string, error)
-	GetECRAuth() (ecr.Auth, error)
+type imageBuilderPusher interface {
+	BuildAndPush(docker repository.ContainerLoginBuildPusher, dockerfilePath string, tag string, additionalTags ...string) error
 }
 
 type cwlogService interface {
@@ -284,6 +283,11 @@ type appDeployer interface {
 type appResourcesGetter interface {
 	GetAppResourcesByRegion(app *config.Application, region string) (*stack.AppRegionalResources, error)
 	GetRegionalAppResources(app *config.Application) ([]*stack.AppRegionalResources, error)
+}
+
+
+type taskDeployer interface {
+	DeployTask(input *deploy.CreateTaskResourcesInput) error
 }
 
 type deployer interface {

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -139,6 +139,15 @@ type imageBuilderPusher interface {
 	BuildAndPush(docker repository.ContainerLoginBuildPusher, dockerfilePath string, tag string, additionalTags ...string) error
 }
 
+type repositoryURIGetter interface {
+	URI() string
+}
+
+type repositoryService interface {
+	repositoryURIGetter
+	imageBuilderPusher
+}
+
 type cwlogService interface {
 	TaskLogEvents(logGroupName string, streamLastEventTime map[string]int64, opts ...cloudwatchlogs.GetLogEventsOpts) (*cloudwatchlogs.LogEventsOutput, error)
 	LogGroupExists(logGroupName string) (bool, error)
@@ -151,12 +160,6 @@ type templater interface {
 type stackSerializer interface {
 	templater
 	SerializedParameters() (string, error)
-}
-
-type dockerService interface {
-	Build(uri, path, imageTag string, additionalTags ...string) error
-	Login(uri, username, password string) error
-	Push(uri, imageTag string, additionalTags ...string) error
 }
 
 type runner interface {

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -9,13 +9,13 @@ import (
 	session "github.com/aws/aws-sdk-go/aws/session"
 	cloudwatchlogs "github.com/aws/copilot-cli/internal/pkg/aws/cloudwatchlogs"
 	codepipeline "github.com/aws/copilot-cli/internal/pkg/aws/codepipeline"
-	ecr "github.com/aws/copilot-cli/internal/pkg/aws/ecr"
 	ecs "github.com/aws/copilot-cli/internal/pkg/aws/ecs"
 	config "github.com/aws/copilot-cli/internal/pkg/config"
 	deploy "github.com/aws/copilot-cli/internal/pkg/deploy"
 	stack "github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation/stack"
 	describe "github.com/aws/copilot-cli/internal/pkg/describe"
 	dockerfile "github.com/aws/copilot-cli/internal/pkg/docker/dockerfile"
+	repository "github.com/aws/copilot-cli/internal/pkg/repository"
 	command "github.com/aws/copilot-cli/internal/pkg/term/command"
 	selector "github.com/aws/copilot-cli/internal/pkg/term/selector"
 	workspace "github.com/aws/copilot-cli/internal/pkg/workspace"
@@ -1188,57 +1188,46 @@ func (mr *MocksecretDeleterMockRecorder) DeleteSecret(secretName interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSecret", reflect.TypeOf((*MocksecretDeleter)(nil).DeleteSecret), secretName)
 }
 
-// MockecrService is a mock of ecrService interface
-type MockecrService struct {
+// MockimageBuilderPusher is a mock of imageBuilderPusher interface
+type MockimageBuilderPusher struct {
 	ctrl     *gomock.Controller
-	recorder *MockecrServiceMockRecorder
+	recorder *MockimageBuilderPusherMockRecorder
 }
 
-// MockecrServiceMockRecorder is the mock recorder for MockecrService
-type MockecrServiceMockRecorder struct {
-	mock *MockecrService
+// MockimageBuilderPusherMockRecorder is the mock recorder for MockimageBuilderPusher
+type MockimageBuilderPusherMockRecorder struct {
+	mock *MockimageBuilderPusher
 }
 
-// NewMockecrService creates a new mock instance
-func NewMockecrService(ctrl *gomock.Controller) *MockecrService {
-	mock := &MockecrService{ctrl: ctrl}
-	mock.recorder = &MockecrServiceMockRecorder{mock}
+// NewMockimageBuilderPusher creates a new mock instance
+func NewMockimageBuilderPusher(ctrl *gomock.Controller) *MockimageBuilderPusher {
+	mock := &MockimageBuilderPusher{ctrl: ctrl}
+	mock.recorder = &MockimageBuilderPusherMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use
-func (m *MockecrService) EXPECT() *MockecrServiceMockRecorder {
+func (m *MockimageBuilderPusher) EXPECT() *MockimageBuilderPusherMockRecorder {
 	return m.recorder
 }
 
-// GetRepository mocks base method
-func (m *MockecrService) GetRepository(name string) (string, error) {
+// BuildAndPush mocks base method
+func (m *MockimageBuilderPusher) BuildAndPush(docker repository.ContainerLoginBuildPusher, dockerfilePath, tag string, additionalTags ...string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRepository", name)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	varargs := []interface{}{docker, dockerfilePath, tag}
+	for _, a := range additionalTags {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "BuildAndPush", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-// GetRepository indicates an expected call of GetRepository
-func (mr *MockecrServiceMockRecorder) GetRepository(name interface{}) *gomock.Call {
+// BuildAndPush indicates an expected call of BuildAndPush
+func (mr *MockimageBuilderPusherMockRecorder) BuildAndPush(docker, dockerfilePath, tag interface{}, additionalTags ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRepository", reflect.TypeOf((*MockecrService)(nil).GetRepository), name)
-}
-
-// GetECRAuth mocks base method
-func (m *MockecrService) GetECRAuth() (ecr.Auth, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetECRAuth")
-	ret0, _ := ret[0].(ecr.Auth)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetECRAuth indicates an expected call of GetECRAuth
-func (mr *MockecrServiceMockRecorder) GetECRAuth() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetECRAuth", reflect.TypeOf((*MockecrService)(nil).GetECRAuth))
+	varargs := append([]interface{}{docker, dockerfilePath, tag}, additionalTags...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildAndPush", reflect.TypeOf((*MockimageBuilderPusher)(nil).BuildAndPush), varargs...)
 }
 
 // MockcwlogService is a mock of cwlogService interface
@@ -2767,6 +2756,43 @@ func (m *MockappResourcesGetter) GetRegionalAppResources(app *config.Application
 func (mr *MockappResourcesGetterMockRecorder) GetRegionalAppResources(app interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegionalAppResources", reflect.TypeOf((*MockappResourcesGetter)(nil).GetRegionalAppResources), app)
+}
+
+// MocktaskDeployer is a mock of taskDeployer interface
+type MocktaskDeployer struct {
+	ctrl     *gomock.Controller
+	recorder *MocktaskDeployerMockRecorder
+}
+
+// MocktaskDeployerMockRecorder is the mock recorder for MocktaskDeployer
+type MocktaskDeployerMockRecorder struct {
+	mock *MocktaskDeployer
+}
+
+// NewMocktaskDeployer creates a new mock instance
+func NewMocktaskDeployer(ctrl *gomock.Controller) *MocktaskDeployer {
+	mock := &MocktaskDeployer{ctrl: ctrl}
+	mock.recorder = &MocktaskDeployerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MocktaskDeployer) EXPECT() *MocktaskDeployerMockRecorder {
+	return m.recorder
+}
+
+// DeployTask mocks base method
+func (m *MocktaskDeployer) DeployTask(input *deploy.CreateTaskResourcesInput) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeployTask", input)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeployTask indicates an expected call of DeployTask
+func (mr *MocktaskDeployerMockRecorder) DeployTask(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeployTask", reflect.TypeOf((*MocktaskDeployer)(nil).DeployTask), input)
 }
 
 // Mockdeployer is a mock of deployer interface

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -1230,6 +1230,99 @@ func (mr *MockimageBuilderPusherMockRecorder) BuildAndPush(docker, dockerfilePat
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildAndPush", reflect.TypeOf((*MockimageBuilderPusher)(nil).BuildAndPush), varargs...)
 }
 
+// MockrepositoryURIGetter is a mock of repositoryURIGetter interface
+type MockrepositoryURIGetter struct {
+	ctrl     *gomock.Controller
+	recorder *MockrepositoryURIGetterMockRecorder
+}
+
+// MockrepositoryURIGetterMockRecorder is the mock recorder for MockrepositoryURIGetter
+type MockrepositoryURIGetterMockRecorder struct {
+	mock *MockrepositoryURIGetter
+}
+
+// NewMockrepositoryURIGetter creates a new mock instance
+func NewMockrepositoryURIGetter(ctrl *gomock.Controller) *MockrepositoryURIGetter {
+	mock := &MockrepositoryURIGetter{ctrl: ctrl}
+	mock.recorder = &MockrepositoryURIGetterMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockrepositoryURIGetter) EXPECT() *MockrepositoryURIGetterMockRecorder {
+	return m.recorder
+}
+
+// URI mocks base method
+func (m *MockrepositoryURIGetter) URI() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "URI")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// URI indicates an expected call of URI
+func (mr *MockrepositoryURIGetterMockRecorder) URI() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "URI", reflect.TypeOf((*MockrepositoryURIGetter)(nil).URI))
+}
+
+// MockrepositoryService is a mock of repositoryService interface
+type MockrepositoryService struct {
+	ctrl     *gomock.Controller
+	recorder *MockrepositoryServiceMockRecorder
+}
+
+// MockrepositoryServiceMockRecorder is the mock recorder for MockrepositoryService
+type MockrepositoryServiceMockRecorder struct {
+	mock *MockrepositoryService
+}
+
+// NewMockrepositoryService creates a new mock instance
+func NewMockrepositoryService(ctrl *gomock.Controller) *MockrepositoryService {
+	mock := &MockrepositoryService{ctrl: ctrl}
+	mock.recorder = &MockrepositoryServiceMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockrepositoryService) EXPECT() *MockrepositoryServiceMockRecorder {
+	return m.recorder
+}
+
+// URI mocks base method
+func (m *MockrepositoryService) URI() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "URI")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// URI indicates an expected call of URI
+func (mr *MockrepositoryServiceMockRecorder) URI() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "URI", reflect.TypeOf((*MockrepositoryService)(nil).URI))
+}
+
+// BuildAndPush mocks base method
+func (m *MockrepositoryService) BuildAndPush(docker repository.ContainerLoginBuildPusher, dockerfilePath, tag string, additionalTags ...string) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{docker, dockerfilePath, tag}
+	for _, a := range additionalTags {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "BuildAndPush", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BuildAndPush indicates an expected call of BuildAndPush
+func (mr *MockrepositoryServiceMockRecorder) BuildAndPush(docker, dockerfilePath, tag interface{}, additionalTags ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{docker, dockerfilePath, tag}, additionalTags...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildAndPush", reflect.TypeOf((*MockrepositoryService)(nil).BuildAndPush), varargs...)
+}
+
 // MockcwlogService is a mock of cwlogService interface
 type MockcwlogService struct {
 	ctrl     *gomock.Controller
@@ -1377,81 +1470,6 @@ func (m *MockstackSerializer) SerializedParameters() (string, error) {
 func (mr *MockstackSerializerMockRecorder) SerializedParameters() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SerializedParameters", reflect.TypeOf((*MockstackSerializer)(nil).SerializedParameters))
-}
-
-// MockdockerService is a mock of dockerService interface
-type MockdockerService struct {
-	ctrl     *gomock.Controller
-	recorder *MockdockerServiceMockRecorder
-}
-
-// MockdockerServiceMockRecorder is the mock recorder for MockdockerService
-type MockdockerServiceMockRecorder struct {
-	mock *MockdockerService
-}
-
-// NewMockdockerService creates a new mock instance
-func NewMockdockerService(ctrl *gomock.Controller) *MockdockerService {
-	mock := &MockdockerService{ctrl: ctrl}
-	mock.recorder = &MockdockerServiceMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use
-func (m *MockdockerService) EXPECT() *MockdockerServiceMockRecorder {
-	return m.recorder
-}
-
-// Build mocks base method
-func (m *MockdockerService) Build(uri, path, imageTag string, additionalTags ...string) error {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{uri, path, imageTag}
-	for _, a := range additionalTags {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "Build", varargs...)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Build indicates an expected call of Build
-func (mr *MockdockerServiceMockRecorder) Build(uri, path, imageTag interface{}, additionalTags ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{uri, path, imageTag}, additionalTags...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Build", reflect.TypeOf((*MockdockerService)(nil).Build), varargs...)
-}
-
-// Login mocks base method
-func (m *MockdockerService) Login(uri, username, password string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Login", uri, username, password)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Login indicates an expected call of Login
-func (mr *MockdockerServiceMockRecorder) Login(uri, username, password interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Login", reflect.TypeOf((*MockdockerService)(nil).Login), uri, username, password)
-}
-
-// Push mocks base method
-func (m *MockdockerService) Push(uri, imageTag string, additionalTags ...string) error {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{uri, imageTag}
-	for _, a := range additionalTags {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "Push", varargs...)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Push indicates an expected call of Push
-func (mr *MockdockerServiceMockRecorder) Push(uri, imageTag interface{}, additionalTags ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{uri, imageTag}, additionalTags...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Push", reflect.TypeOf((*MockdockerService)(nil).Push), varargs...)
 }
 
 // Mockrunner is a mock of runner interface

--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -49,15 +49,15 @@ type deploySvcVars struct {
 type deploySvcOpts struct {
 	deploySvcVars
 
-	store        store
-	ws           wsSvcReader
+	store              store
+	ws                 wsSvcReader
 	imageBuilderPusher imageBuilderPusher
-	s3           artifactUploader
-	cmd          runner
-	addons       templater
-	appCFN       appResourcesGetter
-	svcCFN       cloudformation.CloudFormation
-	sessProvider sessionProvider
+	s3                 artifactUploader
+	cmd                runner
+	addons             templater
+	appCFN             appResourcesGetter
+	svcCFN             cloudformation.CloudFormation
+	sessProvider       sessionProvider
 
 	spinner progress
 	sel     wsSelector
@@ -261,6 +261,9 @@ func (o *deploySvcOpts) configureClients() error {
 	repoName := fmt.Sprintf("%s/%s", o.appName, o.Name)
 	registry := ecr.New(defaultSessEnvRegion)
 	o.imageBuilderPusher, err = repository.New(repoName, registry)
+	if err != nil {
+		return fmt.Errorf("initiate image builder pusher: %w", err)
+	}
 
 	o.s3 = s3.New(defaultSessEnvRegion)
 


### PR DESCRIPTION
This PR contains the following changes:
1. refactor `ecr` package to change method signatures of `GetECRAuth(Auth, error)` to `Auth(string,string,error)` and `GetRepository(name string)(string,error)` to `RepositoryURI(name string)(string,error)` 
2. refactor `cli` package to use `repository` pkg (related PR #1161)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
