### PR TITLE
chore(cli): deploy and update task resources for `task run`

### DIFF
--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -174,7 +174,7 @@ func (o *runTaskOpts) Execute() error {
 }
 
 func (o *runTaskOpts) deployTaskResources() error {
-	o.spinner.Start(fmt.Sprintf("Provisioning a ECR repository, a CloudWatch log group and necessary permissions for task %s.", color.HighlightUserInput(o.groupName)))
+	o.spinner.Start(fmt.Sprintf("Provisioning an ECR repository, a CloudWatch log group and necessary permissions for task %s.", color.HighlightUserInput(o.groupName)))
 	if err := o.deploy(); err != nil {
 		o.spinner.Stop(log.Serrorln("Failed to provision task resources."))
 		return fmt.Errorf("provision resources for task %s: %w", o.groupName, err)

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -174,17 +174,17 @@ func (o *runTaskOpts) Execute() error {
 }
 
 func (o *runTaskOpts) deployTaskResources() error {
-	o.spinner.Start(fmt.Sprintf("Deploying resources for task %s", color.HighlightUserInput(o.groupName)))
+	o.spinner.Start(fmt.Sprintf("Provisioning a ECR repository, a CloudWatch log group and necessary permissions for task %s.", color.HighlightUserInput(o.groupName)))
 	if err := o.deploy(); err != nil {
-		o.spinner.Stop(log.Serrorln("Failed to deploy task resources."))
-		return fmt.Errorf("deploy resources for task %s: %w", o.groupName, err)
+		o.spinner.Stop(log.Serrorln("Failed to provision task resources."))
+		return fmt.Errorf("provision resources for task %s: %w", o.groupName, err)
 	}
-	o.spinner.Stop(log.Ssuccessln("Successfully deployed task resources."))
+	o.spinner.Stop(log.Ssuccessln("Successfully provisioned task resources."))
 	return nil
 }
 
 func (o *runTaskOpts) updateTaskResources() error {
-	o.spinner.Start(fmt.Sprintf("Updating image to task %s", color.HighlightUserInput(o.groupName)))
+	o.spinner.Start(fmt.Sprintf("Updating image to task %s.", color.HighlightUserInput(o.groupName)))
 	if err := o.deploy(); err != nil {
 		o.spinner.Stop(log.Serrorln("Failed to update task resources."))
 		return fmt.Errorf("update resources for task %s: %w", o.groupName, err)

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -89,7 +89,7 @@ func newTaskRunOpts(vars runTaskVars) (*runTaskOpts, error) {
 		sel:     selector.NewSelect(vars.prompt, store),
 		spinner: termprogress.NewSpinner(),
 
-		resourceDeployer: cloudformation.New(sess),
+		deployer: cloudformation.New(sess),
 	}
 	return &opts, nil
 }
@@ -177,7 +177,7 @@ func (o *runTaskOpts) deployTaskResources() error {
 	o.spinner.Start(fmt.Sprintf("Deploying resources for task %s", color.HighlightUserInput(o.groupName)))
 	if err := o.deploy(); err != nil {
 		o.spinner.Stop(log.Serrorln("Failed to deploy task resources."))
-		return fmt.Errorf("failed to deploy resources for task %s: %w", o.groupName, err)
+		return fmt.Errorf("deploy resources for task %s: %w", o.groupName, err)
 	}
 	o.spinner.Stop(log.Ssuccessln("Successfully deployed task resources."))
 	return nil
@@ -187,14 +187,14 @@ func (o *runTaskOpts) updateTaskResources() error {
 	o.spinner.Start(fmt.Sprintf("Updating image to task %s", color.HighlightUserInput(o.groupName)))
 	if err := o.deploy(); err != nil {
 		o.spinner.Stop(log.Serrorln("Failed to update task resources."))
-		return fmt.Errorf("failed to update resources for task %s: %w", o.groupName, err)
+		return fmt.Errorf("update resources for task %s: %w", o.groupName, err)
 	}
 	o.spinner.Stop(log.Ssuccessln("Successfully updated image to task."))
 	return nil
 }
 
 func (o *runTaskOpts) deploy() error {
-	return o.resourceDeployer.DeployTask(&deploy.CreateTaskResourcesInput{
+	return o.deployer.DeployTask(&deploy.CreateTaskResourcesInput{
 		Name:     o.groupName,
 		CPU:      o.cpu,
 		Memory:   o.memory,

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -6,8 +6,13 @@ package cli
 import (
 	"errors"
 	"fmt"
+	"github.com/aws/copilot-cli/internal/pkg/aws/session"
+	"github.com/aws/copilot-cli/internal/pkg/deploy"
+	"github.com/aws/copilot-cli/internal/pkg/term/log"
+	termprogress "github.com/aws/copilot-cli/internal/pkg/term/progress"
 
 	"github.com/aws/copilot-cli/internal/pkg/config"
+	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation"
 	"github.com/aws/copilot-cli/internal/pkg/term/color"
 	"github.com/aws/copilot-cli/internal/pkg/term/prompt"
 	"github.com/aws/copilot-cli/internal/pkg/term/selector"
@@ -23,7 +28,9 @@ var (
 	errNumNotPositive = errors.New("number of tasks must be positive")
 	errCpuNotPositive = errors.New("CPU units must be positive")
 	errMemNotPositive = errors.New("memory must be positive")
+)
 
+var (
 	fmtTaskRunEnvPrompt       = fmt.Sprintf("In which %s would you like to run this %s?", color.Emphasize("environment"), color.Emphasize("task"))
 	fmtTaskRunGroupNamePrompt = fmt.Sprintf("What would you like to %s your task group?", color.Emphasize("name"))
 
@@ -50,8 +57,8 @@ type runTaskVars struct {
 	securityGroups []string
 	env            string
 
-	envVars  map[string]string
-	command  string
+	envVars map[string]string
+	command string
 }
 
 type runTaskOpts struct {
@@ -61,6 +68,9 @@ type runTaskOpts struct {
 	fs     afero.Fs
 	store  store
 	sel    appEnvSelector
+	spinner progress
+
+	resourceDeployer taskDeployer
 }
 
 func newTaskRunOpts(vars runTaskVars) (*runTaskOpts, error) {
@@ -69,13 +79,19 @@ func newTaskRunOpts(vars runTaskVars) (*runTaskOpts, error) {
 		return nil, fmt.Errorf("new config store: %w", err)
 	}
 
-	return &runTaskOpts{
+	sess, err := session.NewProvider().Default()
+
+	opts := runTaskOpts{
 		runTaskVars: vars,
 
-		fs:    &afero.Afero{Fs: afero.NewOsFs()},
-		store: store,
-		sel:   selector.NewSelect(vars.prompt, store),
-	}, nil
+		fs:      &afero.Afero{Fs: afero.NewOsFs()},
+		store:   store,
+		sel:     selector.NewSelect(vars.prompt, store),
+		spinner: termprogress.NewSpinner(),
+
+		resourceDeployer: cloudformation.New(sess),
+	}
+	return &opts, nil
 }
 
 // Validate returns an error if the flag values passed by the user are invalid.
@@ -138,7 +154,59 @@ func (o *runTaskOpts) Ask() error {
 	return nil
 }
 
+// Execute deploys and runs the task.
 func (o *runTaskOpts) Execute() error {
+	if err := o.deployTaskResources(); err != nil {
+		return err
+	}
+	// NOTE: if image is not provided, then we build the image and push to ECR repo
+	if o.image == "" {
+		if err := o.buildAndPushImage(); err != nil {
+			return err
+		}
+
+		if err := o.updateTaskResources(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (o *runTaskOpts) deployTaskResources() error {
+	o.spinner.Start(fmt.Sprintf("Deploying resources for task %s", color.HighlightUserInput(o.groupName)))
+	if err := o.deploy(); err != nil {
+		o.spinner.Stop(log.Serrorln("Failed to deploy task resources."))
+		return fmt.Errorf("failed to deploy resources for task %s: %w", o.groupName, err)
+	}
+	o.spinner.Stop(log.Ssuccessln("Successfully deployed task resources."))
+	return nil
+}
+
+func (o *runTaskOpts) updateTaskResources() error {
+	o.spinner.Start(fmt.Sprintf("Updating image to task %s", color.HighlightUserInput(o.groupName)))
+	if err := o.deploy(); err != nil {
+		o.spinner.Stop(log.Serrorln("Failed to update task resources."))
+		return fmt.Errorf("failed to update resources for task %s: %w", o.groupName, err)
+	}
+	o.spinner.Stop(log.Ssuccessln("Successfully updated image to task."))
+	return nil
+}
+
+func (o *runTaskOpts) deploy() error {
+	return o.resourceDeployer.DeployTask(&deploy.CreateTaskResourcesInput{
+		Name:     o.groupName,
+		CPU:      o.cpu,
+		Memory:   o.memory,
+		Image:    o.image,
+		TaskRole: o.taskRole,
+		Command:  o.command,
+		EnvVars:  o.envVars,
+	})
+}
+
+func (o *runTaskOpts) buildAndPushImage() error {
+	// TODO: build and push the image
 	return nil
 }
 

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -70,7 +70,7 @@ type runTaskOpts struct {
 	sel    appEnvSelector
 	spinner progress
 
-	resourceDeployer taskDeployer
+	deployer taskDeployer
 }
 
 func newTaskRunOpts(vars runTaskVars) (*runTaskOpts, error) {

--- a/internal/pkg/cli/task_run_test.go
+++ b/internal/pkg/cli/task_run_test.go
@@ -462,8 +462,8 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 				runTaskVars: runTaskVars{
 					image: tc.inImage,
 				},
-				spinner: &mockSpinner{},
-				resourceDeployer: mockDeployer,
+				spinner:  &mockSpinner{},
+				deployer: mockDeployer,
 			}
 
 			err := opts.Execute()
@@ -475,3 +475,4 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 		})
 	}
 }
+

--- a/internal/pkg/cli/task_run_test.go
+++ b/internal/pkg/cli/task_run_test.go
@@ -6,6 +6,8 @@ package cli
 import (
 	"errors"
 	"fmt"
+	"github.com/aws/copilot-cli/internal/pkg/deploy"
+	termprogress "github.com/aws/copilot-cli/internal/pkg/term/progress"
 	"testing"
 
 	"github.com/aws/copilot-cli/internal/pkg/cli/mocks"
@@ -26,6 +28,12 @@ var defaultOpts = basicOpts{
 	inCPU:    256,
 	inMemory: 512,
 }
+
+// NOTE: mock spinner so that it doesn't create log output when testing Execute
+type mockSpinner struct{}
+func (s *mockSpinner) Start(label string) {}
+func (s *mockSpinner) Stop(label string) {}
+func (s *mockSpinner) Events([]termprogress.TabRow) {}
 
 func TestTaskRunOpts_Validate(t *testing.T) {
 	testCases := map[string]struct {
@@ -417,6 +425,52 @@ func TestTaskRunOpts_Ask(t *testing.T) {
 				}
 			} else {
 				require.EqualError(t, tc.wantedError, err.Error())
+			}
+		})
+	}
+}
+
+func TestTaskRunOpts_Execute(t *testing.T) {
+	var mockDeployer *mocks.MocktaskDeployer
+	testCases := map[string]struct {
+		inImage          string
+
+		setupMocks func(ctrl *gomock.Controller)
+
+		wantedError error
+	}{
+		"update image to task resource if image is not provided": {
+			setupMocks: func(ctrl *gomock.Controller) {
+				mockDeployer = mocks.NewMocktaskDeployer(ctrl)
+				// TODO: mock repository
+				mockDeployer.EXPECT().DeployTask(&deploy.CreateTaskResourcesInput{
+					Image: "",
+				}).Times(1).Return(nil)
+				mockDeployer.EXPECT().DeployTask(&deploy.CreateTaskResourcesInput{
+					// TODO: use image.URI() from mockRepository
+				}).Times(1).Return(nil)
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			tc.setupMocks(ctrl)
+
+			opts := &runTaskOpts{
+				runTaskVars: runTaskVars{
+					image: tc.inImage,
+				},
+				spinner: &mockSpinner{},
+				resourceDeployer: mockDeployer,
+			}
+
+			err := opts.Execute()
+			if tc.wantedError != nil {
+				require.EqualError(t, tc.wantedError, err.Error())
+			} else {
+				require.NoError(t, err)
 			}
 		})
 	}

--- a/internal/pkg/cli/task_run_test.go
+++ b/internal/pkg/cli/task_run_test.go
@@ -450,7 +450,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 					Image: "",
 				}).Return(errors.New("error deploying"))
 			},
-			wantedError: fmt.Errorf("deploy resources for task %s: %w", inGroupName, errors.New("error deploying")),
+			wantedError: fmt.Errorf("provision resources for task %s: %w", inGroupName, errors.New("error deploying")),
 		},
 		"error updating resources": {
 			setupMocks: func(ctrl *gomock.Controller) {


### PR DESCRIPTION
This PR implements `Execute` for `task run`

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
