### PR TITLE
chore(cli): update image to task for `task run`

### DIFF
--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -124,18 +124,19 @@ func newTaskRunOpts(vars runTaskVars) (*runTaskOpts, error) {
 
 func (o *runTaskOpts) configureRepository(provider sessionProvider) error {
 	var sess *awssession.Session
+	var err error
 	if o.env != "" {
 		env, err := o.targetEnv()
 		if err != nil {
 			return err
 		}
 
-		sess, err := provider.FromRole(env.ManagerRoleARN, env.Region)
+		sess, err = provider.FromRole(env.ManagerRoleARN, env.Region)
 		if err != nil {
 			return fmt.Errorf("get session from role %s and region %s: %w", env.ManagerRoleARN, env.Region, err)
 		}
 	} else {
-		sess, err := provider.Default()
+		sess, err = provider.Default()
 		if err != nil {
 			return fmt.Errorf("get default session: %w", err)
 		}

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -343,7 +343,7 @@ func (o *runTaskOpts) askEnvName() error {
 		return nil
 	}
 
-	// NOTE: if we are not in any workspace and app flag is not specified, use the "None" environment.
+	// NOTE: if the subnets are not provided, we are not in any workspace and app flag is not specified, use the "None" environment.
 	if o.AppName() == "" || o.subnets != nil {
 		return nil
 	}

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -225,7 +225,7 @@ func (o *runTaskOpts) Execute() error {
 		return err
 	}
 
-	// NOTE: repository has to be configured after task resources are deployed
+	// NOTE: repository has to be configured only after task resources are deployed
 	if err := o.configureRuntimeOpts(); err != nil {
 		return err
 	}

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -24,9 +24,9 @@ import (
 )
 
 const (
-	envOptionNone = "None (run in default VPC)"
+	envOptionNone         = "None (run in default VPC)"
 	defaultDockerfilePath = "Dockerfile"
-	imageTagLatest = "latest"
+	imageTagLatest        = "latest"
 )
 
 const (
@@ -78,9 +78,9 @@ type runTaskOpts struct {
 	runTaskVars
 
 	// Interfaces to interact with dependencies.
-	fs     afero.Fs
-	store  store
-	sel    appEnvSelector
+	fs      afero.Fs
+	store   store
+	sel     appEnvSelector
 	spinner progress
 
 	deployer taskDeployer
@@ -111,6 +111,7 @@ func newTaskRunOpts(vars runTaskVars) (*runTaskOpts, error) {
 
 		deployer: cloudformation.New(sess),
 	}
+
 	opts.configureRuntimeOpts = func() error {
 		if err := opts.configureRepository(provider); err != nil {
 			return err
@@ -343,7 +344,7 @@ func (o *runTaskOpts) askEnvName() error {
 	}
 
 	// NOTE: if we are not in any workspace and app flag is not specified, use the "None" environment.
-	if  o.AppName() == "" || o.subnets != nil {
+	if o.AppName() == "" || o.subnets != nil {
 		return nil
 	}
 

--- a/internal/pkg/cli/task_run_test.go
+++ b/internal/pkg/cli/task_run_test.go
@@ -471,7 +471,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 				mockRepo.EXPECT().URI().Return(mockRepoURI)
 				mockDeployer.EXPECT().DeployTask(&deploy.CreateTaskResourcesInput{
 					Name: inGroupName,
-					Image: mockRepoURI,
+					Image: fmt.Sprintf(fmtImageURI, mockRepoURI, imageTagLatest),
 				}).Times(1).Return(errors.New("error updating"))
 			},
 			wantedError: fmt.Errorf("update resources for task %s: %w", inGroupName, errors.New("error updating")),
@@ -510,7 +510,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 				mockRepo.EXPECT().URI().Return(mockRepoURI)
 				mockDeployer.EXPECT().DeployTask(&deploy.CreateTaskResourcesInput{
 					Name: inGroupName,
-					Image: mockRepoURI,
+					Image: fmt.Sprintf(fmtImageURI, mockRepoURI, imageTagLatest),
 				}).Times(1).Return(nil)
 			},
 		},
@@ -531,7 +531,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 				deployer: mockDeployer,
 			}
 			opts.configureRuntimeOpts = func() error {
-				opts.runtimeOpts.repository = mockRepo
+				opts.repository = mockRepo
 				return nil
 			}
 

--- a/internal/pkg/cli/task_run_test.go
+++ b/internal/pkg/cli/task_run_test.go
@@ -5,7 +5,6 @@ package cli
 
 import (
 	"errors"
-	"fmt"
 	"github.com/aws/copilot-cli/internal/pkg/deploy"
 	termprogress "github.com/aws/copilot-cli/internal/pkg/term/progress"
 	"testing"
@@ -34,6 +33,11 @@ type mockSpinner struct{}
 func (s *mockSpinner) Start(label string) {}
 func (s *mockSpinner) Stop(label string) {}
 func (s *mockSpinner) Events([]termprogress.TabRow) {}
+
+type runTaskMocks struct {
+	deployer *mocks.MocktaskDeployer
+	repository *mocks.MockrepositoryService
+}
 
 func TestTaskRunOpts_Validate(t *testing.T) {
 	testCases := map[string]struct {
@@ -178,7 +182,7 @@ func TestTaskRunOpts_Validate(t *testing.T) {
 					Region:          "us-east-1",
 				})
 			},
-			wantedError: fmt.Errorf("get application: couldn't find an application named my-app in account 115 and region us-east-1"),
+			wantedError: errors.New("get application: couldn't find an application named my-app in account 115 and region us-east-1"),
 		},
 		"env exists in app": {
 			basicOpts: defaultOpts,
@@ -214,7 +218,7 @@ func TestTaskRunOpts_Validate(t *testing.T) {
 					Name: "my-app",
 				}, nil)
 			},
-			wantedError: fmt.Errorf("get environment %s config: couldn't find environment dev in the application my-app", "dev"),
+			wantedError: errors.New("get environment dev config: couldn't find environment dev in the application my-app"),
 		},
 		"no workspace": {
 			basicOpts: defaultOpts,
@@ -376,7 +380,7 @@ func TestTaskRunOpts_Ask(t *testing.T) {
 
 			mockSel: func(m *mocks.MockappEnvSelector) {
 				m.EXPECT().Environment(fmtTaskRunEnvPrompt, gomock.Any(), gomock.Any(), envOptionNone).
-					Return("", fmt.Errorf("error selecting environment"))
+					Return("", errors.New("error selecting environment"))
 			},
 
 			wantedError: errors.New("ask for environment: error selecting environment"),
@@ -431,9 +435,6 @@ func TestTaskRunOpts_Ask(t *testing.T) {
 }
 
 func TestTaskRunOpts_Execute(t *testing.T) {
-	var mockDeployer *mocks.MocktaskDeployer
-	var mockRepo *mocks.MockrepositoryService
-
 	const inGroupName = "my-task"
 	mockRepoURI := "uri/repo"
 	tag := "tag"
@@ -442,75 +443,60 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 		inImage string
 		inTag   string
 
-		setupMocks func(ctrl *gomock.Controller)
+		setupMocks func(m runTaskMocks)
 
 		wantedError error
 	}{
 		"error deploying resources": {
-			setupMocks: func(ctrl *gomock.Controller) {
-				mockDeployer = mocks.NewMocktaskDeployer(ctrl)
-				mockRepo = mocks.NewMockrepositoryService(ctrl)
-
-				mockDeployer.EXPECT().DeployTask(&deploy.CreateTaskResourcesInput{
+			setupMocks: func(m runTaskMocks) {
+				m.deployer.EXPECT().DeployTask(&deploy.CreateTaskResourcesInput{
 					Name: inGroupName,
 					Image: "",
 				}).Return(errors.New("error deploying"))
 			},
-			wantedError: fmt.Errorf("provision resources for task %s: %w", inGroupName, errors.New("error deploying")),
+			wantedError: errors.New("provision resources for task my-task: error deploying"),
 		},
 		"error updating resources": {
-			setupMocks: func(ctrl *gomock.Controller) {
-				mockDeployer = mocks.NewMocktaskDeployer(ctrl)
-				mockRepo = mocks.NewMockrepositoryService(ctrl)
-
-				mockDeployer.EXPECT().DeployTask(&deploy.CreateTaskResourcesInput{
+			setupMocks: func(m runTaskMocks) {
+				m.deployer.EXPECT().DeployTask(&deploy.CreateTaskResourcesInput{
 					Name:  inGroupName,
 					Image: "",
 				}).Return(nil)
-				mockRepo.EXPECT().BuildAndPush(gomock.Any(), gomock.Any(), imageTagLatest)
-				mockRepo.EXPECT().URI().Return(mockRepoURI)
-				mockDeployer.EXPECT().DeployTask(&deploy.CreateTaskResourcesInput{
+				m.repository.EXPECT().BuildAndPush(gomock.Any(), gomock.Any(), imageTagLatest)
+				m.repository.EXPECT().URI().Return(mockRepoURI)
+				m.deployer.EXPECT().DeployTask(&deploy.CreateTaskResourcesInput{
 					Name: inGroupName,
-					Image: fmt.Sprintf(fmtImageURI, mockRepoURI, imageTagLatest),
+					Image: "uri/repo:latest",
 				}).Times(1).Return(errors.New("error updating"))
 			},
-			wantedError: fmt.Errorf("update resources for task %s: %w", inGroupName, errors.New("error updating")),
+			wantedError: errors.New("update resources for task my-task: error updating"),
 		},
 		"use default dockerfile path if not provided": {
-			setupMocks: func(ctrl *gomock.Controller) {
-				mockDeployer = mocks.NewMocktaskDeployer(ctrl)
-				mockRepo = mocks.NewMockrepositoryService(ctrl)
-
-				mockDeployer.EXPECT().DeployTask(gomock.Any()).AnyTimes()
-				mockRepo.EXPECT().BuildAndPush(gomock.Any(), defaultDockerfilePath, gomock.Any())
-				mockRepo.EXPECT().URI().AnyTimes()
+			setupMocks: func(m runTaskMocks) {
+				m.deployer.EXPECT().DeployTask(gomock.Any()).AnyTimes()
+				m.repository.EXPECT().BuildAndPush(gomock.Any(), defaultDockerfilePath, gomock.Any())
+				m.repository.EXPECT().URI().AnyTimes()
 			},
 		},
 		"append 'latest' to image tag": {
 			inTag: tag,
-			setupMocks: func(ctrl *gomock.Controller) {
-				mockDeployer = mocks.NewMocktaskDeployer(ctrl)
-				mockRepo = mocks.NewMockrepositoryService(ctrl)
-
-				mockDeployer.EXPECT().DeployTask(gomock.Any()).AnyTimes()
-				mockRepo.EXPECT().BuildAndPush(gomock.Any(), gomock.Any(), imageTagLatest, tag)
-				mockRepo.EXPECT().URI().AnyTimes()
+			setupMocks: func(m runTaskMocks) {
+				m.deployer.EXPECT().DeployTask(gomock.Any()).AnyTimes()
+				m.repository.EXPECT().BuildAndPush(gomock.Any(), gomock.Any(), imageTagLatest, tag)
+				m.repository.EXPECT().URI().AnyTimes()
 			},
 		},
 		"update image to task resource if image is not provided": {
-			setupMocks: func(ctrl *gomock.Controller) {
-				mockDeployer = mocks.NewMocktaskDeployer(ctrl)
-				mockRepo = mocks.NewMockrepositoryService(ctrl)
-
-				mockDeployer.EXPECT().DeployTask(&deploy.CreateTaskResourcesInput{
+			setupMocks: func(m runTaskMocks) {
+				m.deployer.EXPECT().DeployTask(&deploy.CreateTaskResourcesInput{
 					Name: inGroupName,
 					Image: "",
 				}).Times(1).Return(nil)
-				mockRepo.EXPECT().BuildAndPush(gomock.Any(), defaultDockerfilePath, imageTagLatest)
-				mockRepo.EXPECT().URI().Return(mockRepoURI)
-				mockDeployer.EXPECT().DeployTask(&deploy.CreateTaskResourcesInput{
+				m.repository.EXPECT().BuildAndPush(gomock.Any(), defaultDockerfilePath, imageTagLatest)
+				m.repository.EXPECT().URI().Return(mockRepoURI)
+				m.deployer.EXPECT().DeployTask(&deploy.CreateTaskResourcesInput{
 					Name: inGroupName,
-					Image: fmt.Sprintf(fmtImageURI, mockRepoURI, imageTagLatest),
+					Image: "uri/repo:latest",
 				}).Times(1).Return(nil)
 			},
 		},
@@ -519,7 +505,16 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			tc.setupMocks(ctrl)
+			defer ctrl.Finish()
+
+			mockDeployer := mocks.NewMocktaskDeployer(ctrl)
+			mockRepo := mocks.NewMockrepositoryService(ctrl)
+
+			mocks := runTaskMocks{
+				deployer: mockDeployer,
+				repository: mockRepo,
+			}
+			tc.setupMocks(mocks)
 
 			opts := &runTaskOpts{
 				runTaskVars: runTaskVars{

--- a/internal/pkg/cli/task_run_test.go
+++ b/internal/pkg/cli/task_run_test.go
@@ -449,6 +449,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 		"error deploying resources": {
 			setupMocks: func(ctrl *gomock.Controller) {
 				mockDeployer = mocks.NewMocktaskDeployer(ctrl)
+				mockRepo = mocks.NewMockrepositoryService(ctrl)
 
 				mockDeployer.EXPECT().DeployTask(&deploy.CreateTaskResourcesInput{
 					Name: inGroupName,
@@ -460,14 +461,17 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 		"error updating resources": {
 			setupMocks: func(ctrl *gomock.Controller) {
 				mockDeployer = mocks.NewMocktaskDeployer(ctrl)
+				mockRepo = mocks.NewMockrepositoryService(ctrl)
 
 				mockDeployer.EXPECT().DeployTask(&deploy.CreateTaskResourcesInput{
 					Name:  inGroupName,
 					Image: "",
 				}).Return(nil)
+				mockRepo.EXPECT().BuildAndPush(gomock.Any(), gomock.Any(), imageTagLatest)
+				mockRepo.EXPECT().URI().Return(mockRepoURI)
 				mockDeployer.EXPECT().DeployTask(&deploy.CreateTaskResourcesInput{
 					Name: inGroupName,
-					// TODO: use image.URI() from mockRepository
+					Image: mockRepoURI,
 				}).Times(1).Return(errors.New("error updating"))
 			},
 			wantedError: fmt.Errorf("update resources for task %s: %w", inGroupName, errors.New("error updating")),

--- a/internal/pkg/cli/task_run_test.go
+++ b/internal/pkg/cli/task_run_test.go
@@ -214,7 +214,7 @@ func TestTaskRunOpts_Validate(t *testing.T) {
 					Name: "my-app",
 				}, nil)
 			},
-			wantedError: errors.New("get environment: couldn't find environment dev in the application my-app"),
+			wantedError: fmt.Errorf("get environment %s config: couldn't find environment dev in the application my-app", "dev"),
 		},
 		"no workspace": {
 			basicOpts: defaultOpts,


### PR DESCRIPTION
This PR builds and pushes image and updates image to task definition for `task run`. This is a part of the series of PRs that implement `Execute` for `task run`. 

Related #702 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
