### PR TITLE
chore(ecs): describe tasks given a cluster and task ARNs

### DIFF
--- a/internal/pkg/aws/ecs/ecs.go
+++ b/internal/pkg/aws/ecs/ecs.go
@@ -233,6 +233,24 @@ func (e *ECS) RunTask(input RunTaskInput) ([]string, error) {
 	return taskARNs, nil
 }
 
+// DescribeTasks returns the tasks with the taskARNs in the cluster.
+func (e *ECS) DescribeTasks(cluster string, taskARNs []string) ([]*Task, error) {
+	resp, err := e.client.DescribeTasks(&ecs.DescribeTasksInput{
+		Cluster: aws.String(cluster),
+		Tasks: aws.StringSlice(taskARNs),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("describe tasks: %w", err)
+	}
+
+	tasks := make([]*Task, len(resp.Tasks))
+	for idx, task := range resp.Tasks {
+		t := Task(*task)
+		tasks[idx] = &t
+	}
+	return tasks, nil
+}
+
 // TaskStatus returns the status of the running task.
 func (t *Task) TaskStatus() (*TaskStatus, error) {
 	taskID, err := t.taskID(aws.StringValue(t.TaskArn))


### PR DESCRIPTION
This PR adds a method to `ecs` package that describes tasks given a cluster and task ARNs. This is to support `--follow` flag for `task run`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
