### PR TITLE
docs: correct option name for example command.

### DIFF
--- a/site/content/en/docs/Commands/svc/init.md
+++ b/site/content/en/docs/Commands/svc/init.md
@@ -39,7 +39,7 @@ Backend Service Flags
 Each service type has its own optional and required flags besides the common required flags.
 To create a "frontend" load balanced web service you could run:  
 
-`$ copilot svc init --name frontend --app-type "Load Balanced Web Service" --dockerfile ./frontend/Dockerfile`
+`$ copilot svc init --name frontend --svc-type "Load Balanced Web Service" --dockerfile ./frontend/Dockerfile`
 
 ### What does it look like?
 <img class="img-fluid" src="https://raw.githubusercontent.com/kohidave/copilot-demos/master/svc-init.svg?sanitize=true" style="margin-bottom: 20px;">


### PR DESCRIPTION
current: $ copilot svc init --name frontend **--app-type** "Load Balanced Web Service" --dockerfile ./frontend/Dockerfile
suggest: $ copilot svc init --name frontend **--svc-type** "Load Balanced Web Service" --dockerfile ./frontend/Dockerfile

--app-type option does not exist. --svc-type is correct.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
