### PR TITLE
chore(cli): start tasks for `task run`

### DIFF
--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -293,6 +293,10 @@ type taskDeployer interface {
 	DeployTask(input *deploy.CreateTaskResourcesInput) error
 }
 
+type taskRunner interface {
+	Run() ([]string, error)
+}
+
 type deployer interface {
 	environmentDeployer
 	appDeployer

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -2813,6 +2813,44 @@ func (mr *MocktaskDeployerMockRecorder) DeployTask(input interface{}) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeployTask", reflect.TypeOf((*MocktaskDeployer)(nil).DeployTask), input)
 }
 
+// MocktaskRunner is a mock of taskRunner interface
+type MocktaskRunner struct {
+	ctrl     *gomock.Controller
+	recorder *MocktaskRunnerMockRecorder
+}
+
+// MocktaskRunnerMockRecorder is the mock recorder for MocktaskRunner
+type MocktaskRunnerMockRecorder struct {
+	mock *MocktaskRunner
+}
+
+// NewMocktaskRunner creates a new mock instance
+func NewMocktaskRunner(ctrl *gomock.Controller) *MocktaskRunner {
+	mock := &MocktaskRunner{ctrl: ctrl}
+	mock.recorder = &MocktaskRunnerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MocktaskRunner) EXPECT() *MocktaskRunnerMockRecorder {
+	return m.recorder
+}
+
+// Run mocks base method
+func (m *MocktaskRunner) Run() ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Run")
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Run indicates an expected call of Run
+func (mr *MocktaskRunnerMockRecorder) Run() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Run", reflect.TypeOf((*MocktaskRunner)(nil).Run))
+}
+
 // Mockdeployer is a mock of deployer interface
 type Mockdeployer struct {
 	ctrl     *gomock.Controller

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -142,7 +142,7 @@ func newTaskRunOpts(vars runTaskVars) (*runTaskOpts, error) {
 			return err
 		}
 
-		opts.runner, err = opts.configureRunner(sess)
+		opts.runner = opts.configureRunner(sess)
 		if err != nil {
 			return err
 		}
@@ -162,7 +162,7 @@ func (o *runTaskOpts) configureRepository(sess *awssession.Session) (repositoryS
 	return repository, nil
 }
 
-func (o *runTaskOpts) configureRunner(sess *awssession.Session) (taskRunner, error) {
+func (o *runTaskOpts) configureRunner(sess *awssession.Session) taskRunner {
 	vpcGetter := ec2.New(sess)
 	ecsService := ecs.New(sess)
 
@@ -177,7 +177,7 @@ func (o *runTaskOpts) configureRunner(sess *awssession.Session) (taskRunner, err
 			VPCGetter: vpcGetter,
 			ClusterGetter: resourcegroups.New(sess),
 			Starter: ecsService,
-		}, nil
+		}
 	}
 
 	if o.subnets != nil {
@@ -190,7 +190,7 @@ func (o *runTaskOpts) configureRunner(sess *awssession.Session) (taskRunner, err
 
 			ClusterGetter: ecsService,
 			Starter: ecsService,
-		}, nil
+		}
 	}
 
 	return &task.DefaultVPCRunner{
@@ -200,7 +200,7 @@ func (o *runTaskOpts) configureRunner(sess *awssession.Session) (taskRunner, err
 		VPCGetter: vpcGetter,
 		ClusterGetter: ecsService,
 		Starter: ecsService,
-	}, nil
+	}
 
 }
 

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/task"
 	"github.com/aws/copilot-cli/internal/pkg/term/log"
 	termprogress "github.com/aws/copilot-cli/internal/pkg/term/progress"
+	"github.com/dustin/go-humanize/english"
 
 	awssession "github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/copilot-cli/internal/pkg/config"
@@ -115,6 +116,7 @@ func newTaskRunOpts(vars runTaskVars) (*runTaskOpts, error) {
 
 		deployer: cloudformation.New(sess),
 	}
+
 
 	opts.configureRuntimeOpts = func() error {
 		if err := opts.configureRepository(provider); err != nil {
@@ -306,13 +308,13 @@ func (o *runTaskOpts) Execute() error {
 }
 
 func (o *runTaskOpts) runTask() ([]string, error) {
-	o.spinner.Start(fmt.Sprintf("Waiting for %s to be running.", o.groupName))
+	o.spinner.Start(fmt.Sprintf("Waiting for %s to be running for %s.", english.Plural(o.count, "task", ""), o.groupName))
 	taskARNs, err := o.runner.Run()
 	if err != nil {
 		o.spinner.Stop(log.Serrorf("Failed to run %s.\n", o.groupName))
 		return nil, fmt.Errorf("run task %s: %w", o.groupName, err)
 	}
-	o.spinner.Stop(log.Ssuccessf("Task(s) %s is running.\n", o.groupName))
+	o.spinner.Stop(log.Ssuccessf("%s %s %s running.\n", english.PluralWord(o.count, "task", ""), o.groupName, english.Plural(o.count, "is", "are")))
 	return taskARNs, nil
 }
 

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -6,20 +6,24 @@ package cli
 import (
 	"errors"
 	"fmt"
+	"github.com/aws/copilot-cli/internal/pkg/aws/ec2"
 	"github.com/aws/copilot-cli/internal/pkg/aws/ecr"
+	"github.com/aws/copilot-cli/internal/pkg/aws/ecs"
+	"github.com/aws/copilot-cli/internal/pkg/aws/resourcegroups"
 	"github.com/aws/copilot-cli/internal/pkg/aws/session"
 	"github.com/aws/copilot-cli/internal/pkg/deploy"
 	"github.com/aws/copilot-cli/internal/pkg/docker"
 	"github.com/aws/copilot-cli/internal/pkg/repository"
+	"github.com/aws/copilot-cli/internal/pkg/task"
 	"github.com/aws/copilot-cli/internal/pkg/term/log"
 	termprogress "github.com/aws/copilot-cli/internal/pkg/term/progress"
 
+	awssession "github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/copilot-cli/internal/pkg/config"
 	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation"
 	"github.com/aws/copilot-cli/internal/pkg/term/color"
 	"github.com/aws/copilot-cli/internal/pkg/term/prompt"
 	"github.com/aws/copilot-cli/internal/pkg/term/selector"
-	awssession "github.com/aws/aws-sdk-go/aws/session"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
@@ -85,6 +89,7 @@ type runTaskOpts struct {
 
 	// Fields below are configured at runtime.
 	repository repositoryService
+	runner taskRunner
 	configureRuntimeOpts func() error
 }
 
@@ -115,8 +120,7 @@ func newTaskRunOpts(vars runTaskVars) (*runTaskOpts, error) {
 		if err := opts.configureRepository(provider); err != nil {
 			return err
 		}
-		// TODO: configure runner
-		return nil
+		return opts.configureRunner(provider)
 	}
 
 	return &opts, nil
@@ -151,6 +155,52 @@ func (o *runTaskOpts) configureRepository(provider sessionProvider) error {
 	}
 
 	o.repository = repository
+	return nil
+}
+
+func (o *runTaskOpts) configureRunner(provider sessionProvider) error {
+	sess, err := provider.Default()
+	if err != nil {
+		return fmt.Errorf("get default session: %w", err)
+	}
+
+	vpcGetter := ec2.New(sess)
+	ecsService := ecs.New(sess)
+
+	if o.env != "" {
+		o.runner = &task.EnvRunner{
+			Count: o.count,
+			GroupName: o.groupName,
+
+			App: o.AppName(),
+			Env: o.env,
+
+			VPCGetter: vpcGetter,
+			ClusterGetter: resourcegroups.New(sess),
+			Starter: ecsService,
+		}
+	} else if o.subnets != nil {
+		o.runner = &task.NetworkConfigRunner{
+			Count: o.count,
+			GroupName: o.groupName,
+
+			Subnets: o.subnets,
+			SecurityGroups: o.securityGroups,
+
+			ClusterGetter: ecsService,
+			Starter: ecsService,
+		}
+	} else {
+		o.runner = &task.DefaultVPCRunner{
+			Count: o.count,
+			GroupName: o.groupName,
+
+			VPCGetter: vpcGetter,
+			ClusterGetter: ecsService,
+			Starter: ecsService,
+		}
+	}
+
 	return nil
 }
 
@@ -256,8 +306,14 @@ func (o *runTaskOpts) Execute() error {
 }
 
 func (o *runTaskOpts) runTask() ([]string, error) {
-	// TODO: run tasks
-	return nil, nil
+	o.spinner.Start(fmt.Sprintf("Waiting for %s to be running.", o.groupName))
+	taskARNs, err := o.runner.Run()
+	if err != nil {
+		o.spinner.Stop(log.Serrorf("Failed to run %s.\n", o.groupName))
+		return nil, fmt.Errorf("run task %s: %w", o.groupName, err)
+	}
+	o.spinner.Stop(log.Ssuccessf("Task(s) %s is running.\n", o.groupName))
+	return taskARNs, nil
 }
 
 func (o *runTaskOpts) buildAndPushImage() error {

--- a/internal/pkg/cli/task_run_test.go
+++ b/internal/pkg/cli/task_run_test.go
@@ -478,7 +478,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 				m.deployer.EXPECT().DeployTask(gomock.Any()).Return(nil).Times(2)
 				m.repository.EXPECT().BuildAndPush(gomock.Any(), gomock.Any(), imageTagLatest)
 				m.repository.EXPECT().URI().Return(mockRepoURI)
-				m.runner.EXPECT().Run().Return(errors.New("error running"))
+				m.runner.EXPECT().Run().Return(nil, errors.New("error running"))
 			},
 			wantedError: errors.New("run task my-task: error running"),
 		},

--- a/internal/pkg/cli/task_run_test.go
+++ b/internal/pkg/cli/task_run_test.go
@@ -37,6 +37,7 @@ func (s *mockSpinner) Events([]termprogress.TabRow) {}
 type runTaskMocks struct {
 	deployer *mocks.MocktaskDeployer
 	repository *mocks.MockrepositoryService
+	runner *mocks.MocktaskRunner
 }
 
 func TestTaskRunOpts_Validate(t *testing.T) {
@@ -437,6 +438,7 @@ func TestTaskRunOpts_Ask(t *testing.T) {
 func TestTaskRunOpts_Execute(t *testing.T) {
 	const inGroupName = "my-task"
 	mockRepoURI := "uri/repo"
+
 	tag := "tag"
 
 	testCases := map[string]struct {
@@ -471,11 +473,21 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 			},
 			wantedError: errors.New("update resources for task my-task: error updating"),
 		},
+		"error running tasks": {
+			setupMocks: func(m runTaskMocks) {
+				m.deployer.EXPECT().DeployTask(gomock.Any()).Return(nil).Times(2)
+				m.repository.EXPECT().BuildAndPush(gomock.Any(), gomock.Any(), imageTagLatest)
+				m.repository.EXPECT().URI().Return(mockRepoURI)
+				m.runner.EXPECT().Run().Return(errors.New("error running"))
+			},
+			wantedError: errors.New("run task my-task: error running"),
+		},
 		"use default dockerfile path if not provided": {
 			setupMocks: func(m runTaskMocks) {
 				m.deployer.EXPECT().DeployTask(gomock.Any()).AnyTimes()
 				m.repository.EXPECT().BuildAndPush(gomock.Any(), defaultDockerfilePath, gomock.Any())
 				m.repository.EXPECT().URI().AnyTimes()
+				m.runner.EXPECT().Run().AnyTimes()
 			},
 		},
 		"append 'latest' to image tag": {
@@ -484,6 +496,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 				m.deployer.EXPECT().DeployTask(gomock.Any()).AnyTimes()
 				m.repository.EXPECT().BuildAndPush(gomock.Any(), gomock.Any(), imageTagLatest, tag)
 				m.repository.EXPECT().URI().AnyTimes()
+				m.runner.EXPECT().Run().AnyTimes()
 			},
 		},
 		"update image to task resource if image is not provided": {
@@ -498,6 +511,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 					Name: inGroupName,
 					Image: "uri/repo:latest",
 				}).Times(1).Return(nil)
+				m.runner.EXPECT().Run().AnyTimes()
 			},
 		},
 	}
@@ -509,10 +523,12 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 
 			mockDeployer := mocks.NewMocktaskDeployer(ctrl)
 			mockRepo := mocks.NewMockrepositoryService(ctrl)
+			mockRunner := mocks.NewMocktaskRunner(ctrl)
 
 			mocks := runTaskMocks{
 				deployer: mockDeployer,
 				repository: mockRepo,
+				runner: mockRunner,
 			}
 			tc.setupMocks(mocks)
 
@@ -527,6 +543,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 			}
 			opts.configureRuntimeOpts = func() error {
 				opts.repository = mockRepo
+				opts.runner = mockRunner
 				return nil
 			}
 


### PR DESCRIPTION
This PR starts the task(s) for `task run`. This is a part of the series of PRs that implement Execute for task run.

Related #702

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
