### PR TITLE
chore(selector): extend `Application` to accept additional options passed from `cli`

### DIFF
--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -347,7 +347,7 @@ type askExecutor interface {
 }
 
 type appSelector interface {
-	Application(prompt, help string) (string, error)
+	Application(prompt, help string, additionalOpts ...string) (string, error)
 }
 
 type appEnvSelector interface {

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -3549,18 +3549,23 @@ func (m *MockappSelector) EXPECT() *MockappSelectorMockRecorder {
 }
 
 // Application mocks base method
-func (m *MockappSelector) Application(prompt, help string) (string, error) {
+func (m *MockappSelector) Application(prompt, help string, additionalOpts ...string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Application", prompt, help)
+	varargs := []interface{}{prompt, help}
+	for _, a := range additionalOpts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Application", varargs...)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Application indicates an expected call of Application
-func (mr *MockappSelectorMockRecorder) Application(prompt, help interface{}) *gomock.Call {
+func (mr *MockappSelectorMockRecorder) Application(prompt, help interface{}, additionalOpts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Application", reflect.TypeOf((*MockappSelector)(nil).Application), prompt, help)
+	varargs := append([]interface{}{prompt, help}, additionalOpts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Application", reflect.TypeOf((*MockappSelector)(nil).Application), varargs...)
 }
 
 // MockappEnvSelector is a mock of appEnvSelector interface
@@ -3587,18 +3592,23 @@ func (m *MockappEnvSelector) EXPECT() *MockappEnvSelectorMockRecorder {
 }
 
 // Application mocks base method
-func (m *MockappEnvSelector) Application(prompt, help string) (string, error) {
+func (m *MockappEnvSelector) Application(prompt, help string, additionalOpts ...string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Application", prompt, help)
+	varargs := []interface{}{prompt, help}
+	for _, a := range additionalOpts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Application", varargs...)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Application indicates an expected call of Application
-func (mr *MockappEnvSelectorMockRecorder) Application(prompt, help interface{}) *gomock.Call {
+func (mr *MockappEnvSelectorMockRecorder) Application(prompt, help interface{}, additionalOpts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Application", reflect.TypeOf((*MockappEnvSelector)(nil).Application), prompt, help)
+	varargs := append([]interface{}{prompt, help}, additionalOpts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Application", reflect.TypeOf((*MockappEnvSelector)(nil).Application), varargs...)
 }
 
 // Environment mocks base method
@@ -3645,18 +3655,23 @@ func (m *MockconfigSelector) EXPECT() *MockconfigSelectorMockRecorder {
 }
 
 // Application mocks base method
-func (m *MockconfigSelector) Application(prompt, help string) (string, error) {
+func (m *MockconfigSelector) Application(prompt, help string, additionalOpts ...string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Application", prompt, help)
+	varargs := []interface{}{prompt, help}
+	for _, a := range additionalOpts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Application", varargs...)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Application indicates an expected call of Application
-func (mr *MockconfigSelectorMockRecorder) Application(prompt, help interface{}) *gomock.Call {
+func (mr *MockconfigSelectorMockRecorder) Application(prompt, help interface{}, additionalOpts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Application", reflect.TypeOf((*MockconfigSelector)(nil).Application), prompt, help)
+	varargs := append([]interface{}{prompt, help}, additionalOpts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Application", reflect.TypeOf((*MockconfigSelector)(nil).Application), varargs...)
 }
 
 // Environment mocks base method
@@ -3718,18 +3733,23 @@ func (m *MockdeploySelector) EXPECT() *MockdeploySelectorMockRecorder {
 }
 
 // Application mocks base method
-func (m *MockdeploySelector) Application(prompt, help string) (string, error) {
+func (m *MockdeploySelector) Application(prompt, help string, additionalOpts ...string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Application", prompt, help)
+	varargs := []interface{}{prompt, help}
+	for _, a := range additionalOpts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Application", varargs...)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Application indicates an expected call of Application
-func (mr *MockdeploySelectorMockRecorder) Application(prompt, help interface{}) *gomock.Call {
+func (mr *MockdeploySelectorMockRecorder) Application(prompt, help interface{}, additionalOpts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Application", reflect.TypeOf((*MockdeploySelector)(nil).Application), prompt, help)
+	varargs := append([]interface{}{prompt, help}, additionalOpts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Application", reflect.TypeOf((*MockdeploySelector)(nil).Application), varargs...)
 }
 
 // DeployedService mocks base method
@@ -3776,18 +3796,23 @@ func (m *MockwsSelector) EXPECT() *MockwsSelectorMockRecorder {
 }
 
 // Application mocks base method
-func (m *MockwsSelector) Application(prompt, help string) (string, error) {
+func (m *MockwsSelector) Application(prompt, help string, additionalOpts ...string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Application", prompt, help)
+	varargs := []interface{}{prompt, help}
+	for _, a := range additionalOpts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Application", varargs...)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Application indicates an expected call of Application
-func (mr *MockwsSelectorMockRecorder) Application(prompt, help interface{}) *gomock.Call {
+func (mr *MockwsSelectorMockRecorder) Application(prompt, help interface{}, additionalOpts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Application", reflect.TypeOf((*MockwsSelector)(nil).Application), prompt, help)
+	varargs := append([]interface{}{prompt, help}, additionalOpts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Application", reflect.TypeOf((*MockwsSelector)(nil).Application), varargs...)
 }
 
 // Environment mocks base method

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	appEnvOptionNone = "None (run in default VPC)"
+	appEnvOptionNone      = "None (run in default VPC)"
 	defaultDockerfilePath = "Dockerfile"
 	imageTagLatest        = "latest"
 )
@@ -73,7 +73,7 @@ type runTaskVars struct {
 	dockerfilePath string
 	imageTag       string
 
-	taskRole string
+	taskRole      string
 	executionRole string
 
 	subnets        []string
@@ -275,10 +275,6 @@ func (o *runTaskOpts) Ask() error {
 
 // Execute deploys and runs the task.
 func (o *runTaskOpts) Execute() error {
-	if o.dockerfilePath == "" {
-		o.dockerfilePath = defaultDockerfilePath
-	}
-
 	if err := o.deployTaskResources(); err != nil {
 		return err
 	}
@@ -358,14 +354,14 @@ func (o *runTaskOpts) updateTaskResources() error {
 
 func (o *runTaskOpts) deploy() error {
 	return o.deployer.DeployTask(&deploy.CreateTaskResourcesInput{
-		Name:     o.groupName,
-		CPU:      o.cpu,
-		Memory:   o.memory,
-		Image:    o.image,
-		TaskRole: o.taskRole,
+		Name:          o.groupName,
+		CPU:           o.cpu,
+		Memory:        o.memory,
+		Image:         o.image,
+		TaskRole:      o.taskRole,
 		ExecutionRole: o.executionRole,
-		Command:  o.command,
-		EnvVars:  o.envVars,
+		Command:       o.command,
+		EnvVars:       o.envVars,
 	})
 }
 
@@ -485,7 +481,7 @@ Run a task with a command.
 			if err != nil {
 				return err
 			}
-			if err := opts.Validate(); err != nil { // validate flags
+			if err := opts.Validate(); err != nil {
 				return err
 			}
 
@@ -507,7 +503,7 @@ Run a task with a command.
 	cmd.Flags().StringVarP(&vars.groupName, taskGroupNameFlag, nameFlagShort, "", taskGroupFlagDescription)
 
 	cmd.Flags().StringVar(&vars.image, imageFlag, "", imageFlagDescription)
-	cmd.Flags().StringVar(&vars.dockerfilePath, dockerFileFlag, "", dockerFileFlagDescription)
+	cmd.Flags().StringVar(&vars.dockerfilePath, dockerFileFlag, defaultDockerfilePath, dockerFileFlagDescription)
 	cmd.Flags().StringVar(&vars.imageTag, imageTagFlag, "", taskImageTagFlagDescription)
 
 	cmd.Flags().StringVar(&vars.taskRole, taskRoleFlag, "", taskRoleFlagDescription)

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -431,7 +431,7 @@ func (o *runTaskOpts) askEnvName() error {
 		return nil
 	}
 
-	// NOTE: if the subnets are not provided, we are not in any workspace and app flag is not specified, use the "None" environment.
+	// If the application is empty then the user wants to run in the default VPC. Do not prompt for an environment name.
 	if o.AppName() == "" || o.subnets != nil {
 		return nil
 	}

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -52,8 +52,8 @@ var (
 	fmtTaskRunEnvPrompt       = fmt.Sprintf("In which %s would you like to run this %s?", color.Emphasize("environment"), color.Emphasize("task"))
 	fmtTaskRunGroupNamePrompt = fmt.Sprintf("What would you like to %s your task group?", color.Emphasize("name"))
 
-	taskRunAppPromptHelp = fmt.Sprintf("Task will be deployed to the selected application. " +
-		"Select %s to run the task in your default VPC instead of any existing application.", color.Emphasize(appEnvOptionNone))
+	taskRunAppPromptHelp = fmt.Sprintf(`Task will be deployed to the selected application. 
+Select %s to run the task in your default VPC instead of any existing application.`, color.Emphasize(appEnvOptionNone))
 	taskRunEnvPromptHelp = fmt.Sprintf("Task will be deployed to the selected environment. "+
 		"Select %s to run the task in your default VPC instead of any existing environment.", color.Emphasize(appEnvOptionNone))
 	taskRunGroupNamePromptHelp = "The group name of the task. Tasks with the same group name share the same set of resources, including CloudFormation stack, CloudWatch log group, task definition and ECR repository."

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -412,7 +412,7 @@ func (o *runTaskOpts) askAppName() error {
 		return nil
 	}
 
-	// NOTE: if we are not in a workspace and app flag is not specified, prompt the user to select an application or "None"
+	// If the application is empty then the user wants to run in the default VPC. Do not prompt for an environment name.
 	app, err := o.sel.Application(taskRunAppPrompt, taskRunAppPromptHelp, appEnvOptionNone)
 	if err != nil {
 		return fmt.Errorf("ask for application: %w", err)

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -48,15 +48,17 @@ var (
 )
 
 var (
-	fmtTaskRunAppPrompt = fmt.Sprintf("In which %s would you like to run this %s?", color.Emphasize("application"), color.Emphasize("task"))
-	fmtTaskRunEnvPrompt       = fmt.Sprintf("In which %s would you like to run this %s?", color.Emphasize("environment"), color.Emphasize("task"))
-	fmtTaskRunGroupNamePrompt = fmt.Sprintf("What would you like to %s your task group?", color.Emphasize("name"))
+	taskRunAppPrompt       = fmt.Sprintf("In which %s would you like to run this %s?", color.Emphasize("application"), color.Emphasize("task"))
+	taskRunEnvPrompt       = fmt.Sprintf("In which %s would you like to run this %s?", color.Emphasize("environment"), color.Emphasize("task"))
+	taskRunGroupNamePrompt = fmt.Sprintf("What would you like to %s your task group?", color.Emphasize("name"))
 
 	taskRunAppPromptHelp = fmt.Sprintf(`Task will be deployed to the selected application. 
 Select %s to run the task in your default VPC instead of any existing application.`, color.Emphasize(appEnvOptionNone))
-	taskRunEnvPromptHelp = fmt.Sprintf("Task will be deployed to the selected environment. "+
-		"Select %s to run the task in your default VPC instead of any existing environment.", color.Emphasize(appEnvOptionNone))
-	taskRunGroupNamePromptHelp = "The group name of the task. Tasks with the same group name share the same set of resources, including CloudFormation stack, CloudWatch log group, task definition and ECR repository."
+	taskRunEnvPromptHelp = fmt.Sprintf(`Task will be deployed to the selected environment.
+Select %s to run the task in your default VPC instead of any existing environment.`, color.Emphasize(appEnvOptionNone))
+	taskRunGroupNamePromptHelp = `The group name of the task. Tasks with the same group name share the same 
+set of resources, including CloudFormation stack, CloudWatch log group, 
+task definition and ECR repository.`
 )
 
 type runTaskVars struct {
@@ -394,7 +396,7 @@ func (o *runTaskOpts) askTaskGroupName() error {
 	// TODO during Execute: list existing tasks like in ListApplications, ask whether to use existing tasks
 
 	groupName, err := o.prompt.Get(
-		fmtTaskRunGroupNamePrompt,
+		taskRunGroupNamePrompt,
 		taskRunGroupNamePromptHelp,
 		basicNameValidation,
 		prompt.WithFinalMessage("Task group name:"))
@@ -411,7 +413,7 @@ func (o *runTaskOpts) askAppName() error {
 	}
 
 	// NOTE: if we are not in a workspace and app flag is not specified, prompt the user to select an application or "None"
-	app, err := o.sel.Application(fmtTaskRunAppPrompt, taskRunAppPromptHelp, appEnvOptionNone)
+	app, err := o.sel.Application(taskRunAppPrompt, taskRunAppPromptHelp, appEnvOptionNone)
 	if err != nil {
 		return fmt.Errorf("ask for application: %w", err)
 	}
@@ -434,7 +436,7 @@ func (o *runTaskOpts) askEnvName() error {
 		return nil
 	}
 
-	env, err := o.sel.Environment(fmtTaskRunEnvPrompt, taskRunEnvPromptHelp, o.AppName(), appEnvOptionNone)
+	env, err := o.sel.Environment(taskRunEnvPrompt, taskRunEnvPromptHelp, o.AppName(), appEnvOptionNone)
 	if err != nil {
 		return fmt.Errorf("ask for environment: %w", err)
 	}

--- a/internal/pkg/cli/task_run_test.go
+++ b/internal/pkg/cli/task_run_test.go
@@ -295,8 +295,6 @@ func TestTaskRunOpts_Validate(t *testing.T) {
 
 func TestTaskRunOpts_Ask(t *testing.T) {
 	testCases := map[string]struct {
-		basicOpts
-
 		inName string
 
 		inEnv   string
@@ -306,64 +304,100 @@ func TestTaskRunOpts_Ask(t *testing.T) {
 		mockPrompt func(m *mocks.Mockprompter)
 
 		wantedError error
+		wantedApp   string
 		wantedEnv   string
 		wantedName  string
 	}{
+		"selected an existing application": {
+			mockPrompt: func(m *mocks.Mockprompter) {
+				m.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+			},
+			mockSel: func(m *mocks.MockappEnvSelector) {
+				m.EXPECT().Application(fmtTaskRunAppPrompt, gomock.Any(), appEnvOptionNone).Return("app", nil)
+				m.EXPECT().Environment(fmtTaskRunEnvPrompt, gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+			},
+			wantedApp: "app",
+		},
+		"selected None app": {
+			mockPrompt: func(m *mocks.Mockprompter) {
+				m.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+			},
+			mockSel: func(m *mocks.MockappEnvSelector) {
+				m.EXPECT().Application(fmtTaskRunAppPrompt, gomock.Any(), appEnvOptionNone).Return(appEnvOptionNone, nil)
+			},
+			wantedApp: "",
+		},
+		"don't prompt for app when under a workspace or app flag is specified": {
+			appName: "my-app",
+			mockPrompt: func(m *mocks.Mockprompter) {
+				m.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+			},
+			mockSel: func(m *mocks.MockappEnvSelector) {
+				m.EXPECT().Application(fmtTaskRunAppPrompt, gomock.Any(), gomock.Any()).Times(0)
+				m.EXPECT().Environment(fmtTaskRunEnvPrompt, gomock.Any(), gomock.Any(), appEnvOptionNone).Times(1)
+			},
+			wantedApp: "my-app",
+		},
 		"selected an existing environment": {
-			basicOpts: defaultOpts,
-
-			inName:  "my-task",
 			appName: "my-app",
 
+			mockPrompt: func(m *mocks.Mockprompter) {
+				m.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+			},
 			mockSel: func(m *mocks.MockappEnvSelector) {
 				m.EXPECT().Environment(fmtTaskRunEnvPrompt, gomock.Any(),
 					"my-app", appEnvOptionNone).Return("test", nil)
 			},
 
 			wantedEnv: "test",
+			wantedApp: "my-app",
 		},
 		"selected None env": {
-			basicOpts: defaultOpts,
-
-			inName:  "my-task",
 			appName: "my-app",
 
+			mockPrompt: func(m *mocks.Mockprompter) {
+				m.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+			},
 			mockSel: func(m *mocks.MockappEnvSelector) {
 				m.EXPECT().Environment(fmtTaskRunEnvPrompt, gomock.Any(),
 					"my-app", appEnvOptionNone).Return(appEnvOptionNone, nil)
 			},
 
 			wantedEnv: "",
+			wantedApp: "my-app",
 		},
 		"don't prompt if env is provided": {
-			basicOpts: defaultOpts,
-
-			inName:  "my-task",
 			inEnv:   "test",
 			appName: "my-app",
 
+			mockPrompt: func(m *mocks.Mockprompter) {
+				m.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+			},
 			mockSel: func(m *mocks.MockappEnvSelector) {
 				m.EXPECT().Environment(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 			},
 
 			wantedEnv: "test",
+			wantedApp: "my-app",
 		},
-		"don't prompt if no workspace": {
-			basicOpts: defaultOpts,
-
-			inName: "my-task",
-
+		"don't prompt if no workspace or selected None app": {
+			mockPrompt: func(m *mocks.Mockprompter) {
+				m.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+			},
 			mockSel: func(m *mocks.MockappEnvSelector) {
+				m.EXPECT().Application(gomock.Any(), gomock.Any(), appEnvOptionNone).Return(appEnvOptionNone, nil)
 				m.EXPECT().Environment(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 			},
 
 			wantedEnv: "",
 		},
 		"prompt for task family name": {
-			basicOpts: defaultOpts,
-
 			mockPrompt: func(m *mocks.Mockprompter) {
 				m.EXPECT().Get(fmtTaskRunGroupNamePrompt, gomock.Any(), gomock.Any(), gomock.Any()).Return("my-task", nil)
+			},
+			mockSel: func(m *mocks.MockappEnvSelector) {
+				m.EXPECT().Application(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+				m.EXPECT().Environment(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 			},
 
 			wantedName: "my-task",
@@ -372,14 +406,18 @@ func TestTaskRunOpts_Ask(t *testing.T) {
 			mockPrompt: func(m *mocks.Mockprompter) {
 				m.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", errors.New("error getting task group name"))
 			},
+			mockSel: func(m *mocks.MockappEnvSelector) {
+				m.EXPECT().Application(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+				m.EXPECT().Environment(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+			},
 			wantedError: errors.New("prompt get task group name: error getting task group name"),
 		},
 		"error selecting environment": {
-			basicOpts: defaultOpts,
-
-			inName:  "my-task",
 			appName: "my-app",
 
+			mockPrompt: func(m *mocks.Mockprompter) {
+				m.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+			},
 			mockSel: func(m *mocks.MockappEnvSelector) {
 				m.EXPECT().Environment(fmtTaskRunEnvPrompt, gomock.Any(), gomock.Any(), appEnvOptionNone).
 					Return("", fmt.Errorf("error selecting environment"))
@@ -411,10 +449,6 @@ func TestTaskRunOpts_Ask(t *testing.T) {
 						appName: tc.appName,
 						prompt:  mockPrompter,
 					},
-					count:  tc.inCount,
-					cpu:    tc.inCPU,
-					memory: tc.inMemory,
-
 					groupName: tc.inName,
 					env:       tc.inEnv,
 				},
@@ -426,6 +460,7 @@ func TestTaskRunOpts_Ask(t *testing.T) {
 			if tc.wantedError == nil {
 				require.NoError(t, err)
 				require.Equal(t, tc.wantedEnv, opts.env)
+				require.Equal(t, tc.wantedApp, opts.AppName())
 				if tc.wantedName != "" {
 					require.Equal(t, tc.wantedName, opts.groupName)
 				}

--- a/internal/pkg/cli/task_run_test.go
+++ b/internal/pkg/cli/task_run_test.go
@@ -313,8 +313,8 @@ func TestTaskRunOpts_Ask(t *testing.T) {
 				m.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 			},
 			mockSel: func(m *mocks.MockappEnvSelector) {
-				m.EXPECT().Application(fmtTaskRunAppPrompt, gomock.Any(), appEnvOptionNone).Return("app", nil)
-				m.EXPECT().Environment(fmtTaskRunEnvPrompt, gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+				m.EXPECT().Application(taskRunAppPrompt, gomock.Any(), appEnvOptionNone).Return("app", nil)
+				m.EXPECT().Environment(taskRunEnvPrompt, gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 			},
 			wantedApp: "app",
 		},
@@ -323,7 +323,7 @@ func TestTaskRunOpts_Ask(t *testing.T) {
 				m.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 			},
 			mockSel: func(m *mocks.MockappEnvSelector) {
-				m.EXPECT().Application(fmtTaskRunAppPrompt, gomock.Any(), appEnvOptionNone).Return(appEnvOptionNone, nil)
+				m.EXPECT().Application(taskRunAppPrompt, gomock.Any(), appEnvOptionNone).Return(appEnvOptionNone, nil)
 			},
 			wantedApp: "",
 		},
@@ -333,8 +333,8 @@ func TestTaskRunOpts_Ask(t *testing.T) {
 				m.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 			},
 			mockSel: func(m *mocks.MockappEnvSelector) {
-				m.EXPECT().Application(fmtTaskRunAppPrompt, gomock.Any(), gomock.Any()).Times(0)
-				m.EXPECT().Environment(fmtTaskRunEnvPrompt, gomock.Any(), gomock.Any(), appEnvOptionNone).Times(1)
+				m.EXPECT().Application(taskRunAppPrompt, gomock.Any(), gomock.Any()).Times(0)
+				m.EXPECT().Environment(taskRunEnvPrompt, gomock.Any(), gomock.Any(), appEnvOptionNone).Times(1)
 			},
 			wantedApp: "my-app",
 		},
@@ -345,7 +345,7 @@ func TestTaskRunOpts_Ask(t *testing.T) {
 				m.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 			},
 			mockSel: func(m *mocks.MockappEnvSelector) {
-				m.EXPECT().Environment(fmtTaskRunEnvPrompt, gomock.Any(),
+				m.EXPECT().Environment(taskRunEnvPrompt, gomock.Any(),
 					"my-app", appEnvOptionNone).Return("test", nil)
 			},
 
@@ -359,7 +359,7 @@ func TestTaskRunOpts_Ask(t *testing.T) {
 				m.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 			},
 			mockSel: func(m *mocks.MockappEnvSelector) {
-				m.EXPECT().Environment(fmtTaskRunEnvPrompt, gomock.Any(),
+				m.EXPECT().Environment(taskRunEnvPrompt, gomock.Any(),
 					"my-app", appEnvOptionNone).Return(appEnvOptionNone, nil)
 			},
 
@@ -393,7 +393,7 @@ func TestTaskRunOpts_Ask(t *testing.T) {
 		},
 		"prompt for task family name": {
 			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().Get(fmtTaskRunGroupNamePrompt, gomock.Any(), gomock.Any(), gomock.Any()).Return("my-task", nil)
+				m.EXPECT().Get(taskRunGroupNamePrompt, gomock.Any(), gomock.Any(), gomock.Any()).Return("my-task", nil)
 			},
 			mockSel: func(m *mocks.MockappEnvSelector) {
 				m.EXPECT().Application(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
@@ -419,7 +419,7 @@ func TestTaskRunOpts_Ask(t *testing.T) {
 				m.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 			},
 			mockSel: func(m *mocks.MockappEnvSelector) {
-				m.EXPECT().Environment(fmtTaskRunEnvPrompt, gomock.Any(), gomock.Any(), appEnvOptionNone).
+				m.EXPECT().Environment(taskRunEnvPrompt, gomock.Any(), gomock.Any(), appEnvOptionNone).
 					Return("", fmt.Errorf("error selecting environment"))
 			},
 

--- a/internal/pkg/cli/task_run_test.go
+++ b/internal/pkg/cli/task_run_test.go
@@ -5,6 +5,7 @@ package cli
 
 import (
 	"errors"
+	"fmt"
 	"github.com/aws/copilot-cli/internal/pkg/deploy"
 	termprogress "github.com/aws/copilot-cli/internal/pkg/term/progress"
 	"testing"
@@ -316,7 +317,7 @@ func TestTaskRunOpts_Ask(t *testing.T) {
 
 			mockSel: func(m *mocks.MockappEnvSelector) {
 				m.EXPECT().Environment(fmtTaskRunEnvPrompt, gomock.Any(),
-					"my-app", envOptionNone).Return("test", nil)
+					"my-app", appEnvOptionNone).Return("test", nil)
 			},
 
 			wantedEnv: "test",
@@ -329,7 +330,7 @@ func TestTaskRunOpts_Ask(t *testing.T) {
 
 			mockSel: func(m *mocks.MockappEnvSelector) {
 				m.EXPECT().Environment(fmtTaskRunEnvPrompt, gomock.Any(),
-					"my-app", envOptionNone).Return(envOptionNone, nil)
+					"my-app", appEnvOptionNone).Return(appEnvOptionNone, nil)
 			},
 
 			wantedEnv: "",
@@ -380,8 +381,8 @@ func TestTaskRunOpts_Ask(t *testing.T) {
 			appName: "my-app",
 
 			mockSel: func(m *mocks.MockappEnvSelector) {
-				m.EXPECT().Environment(fmtTaskRunEnvPrompt, gomock.Any(), gomock.Any(), envOptionNone).
-					Return("", errors.New("error selecting environment"))
+				m.EXPECT().Environment(fmtTaskRunEnvPrompt, gomock.Any(), gomock.Any(), appEnvOptionNone).
+					Return("", fmt.Errorf("error selecting environment"))
 			},
 
 			wantedError: errors.New("ask for environment: error selecting environment"),

--- a/internal/pkg/cli/task_run_test.go
+++ b/internal/pkg/cli/task_run_test.go
@@ -31,14 +31,15 @@ var defaultOpts = basicOpts{
 
 // NOTE: mock spinner so that it doesn't create log output when testing Execute
 type mockSpinner struct{}
-func (s *mockSpinner) Start(label string) {}
-func (s *mockSpinner) Stop(label string) {}
+
+func (s *mockSpinner) Start(label string)           {}
+func (s *mockSpinner) Stop(label string)            {}
 func (s *mockSpinner) Events([]termprogress.TabRow) {}
 
 type runTaskMocks struct {
-	deployer *mocks.MocktaskDeployer
+	deployer   *mocks.MocktaskDeployer
 	repository *mocks.MockrepositoryService
-	runner *mocks.MocktaskRunner
+	runner     *mocks.MocktaskRunner
 }
 
 func TestTaskRunOpts_Validate(t *testing.T) {
@@ -56,8 +57,8 @@ func TestTaskRunOpts_Validate(t *testing.T) {
 		inSubnets        []string
 		inSecurityGroups []string
 
-		inEnvVars  map[string]string
-		inCommand  string
+		inEnvVars map[string]string
+		inCommand string
 
 		appName string
 
@@ -269,7 +270,7 @@ func TestTaskRunOpts_Validate(t *testing.T) {
 					securityGroups: tc.inSecurityGroups,
 					dockerfilePath: tc.inDockerfilePath,
 					envVars:        tc.inEnvVars,
-					command:       tc.inCommand,
+					command:        tc.inCommand,
 				},
 				fs:    &afero.Afero{Fs: afero.NewMemMapFs()},
 				store: mockStore,
@@ -488,7 +489,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 		"error deploying resources": {
 			setupMocks: func(m runTaskMocks) {
 				m.deployer.EXPECT().DeployTask(&deploy.CreateTaskResourcesInput{
-					Name: inGroupName,
+					Name:  inGroupName,
 					Image: "",
 				}).Return(errors.New("error deploying"))
 			},
@@ -503,7 +504,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 				m.repository.EXPECT().BuildAndPush(gomock.Any(), gomock.Any(), imageTagLatest)
 				m.repository.EXPECT().URI().Return(mockRepoURI)
 				m.deployer.EXPECT().DeployTask(&deploy.CreateTaskResourcesInput{
-					Name: inGroupName,
+					Name:  inGroupName,
 					Image: "uri/repo:latest",
 				}).Times(1).Return(errors.New("error updating"))
 			},
@@ -518,14 +519,6 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 			},
 			wantedError: errors.New("run task my-task: error running"),
 		},
-		"use default dockerfile path if not provided": {
-			setupMocks: func(m runTaskMocks) {
-				m.deployer.EXPECT().DeployTask(gomock.Any()).AnyTimes()
-				m.repository.EXPECT().BuildAndPush(gomock.Any(), defaultDockerfilePath, gomock.Any())
-				m.repository.EXPECT().URI().AnyTimes()
-				m.runner.EXPECT().Run().AnyTimes()
-			},
-		},
 		"append 'latest' to image tag": {
 			inTag: tag,
 			setupMocks: func(m runTaskMocks) {
@@ -538,13 +531,13 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 		"update image to task resource if image is not provided": {
 			setupMocks: func(m runTaskMocks) {
 				m.deployer.EXPECT().DeployTask(&deploy.CreateTaskResourcesInput{
-					Name: inGroupName,
+					Name:  inGroupName,
 					Image: "",
 				}).Times(1).Return(nil)
-				m.repository.EXPECT().BuildAndPush(gomock.Any(), defaultDockerfilePath, imageTagLatest)
+				m.repository.EXPECT().BuildAndPush(gomock.Any(), gomock.Any(), imageTagLatest)
 				m.repository.EXPECT().URI().Return(mockRepoURI)
 				m.deployer.EXPECT().DeployTask(&deploy.CreateTaskResourcesInput{
-					Name: inGroupName,
+					Name:  inGroupName,
 					Image: "uri/repo:latest",
 				}).Times(1).Return(nil)
 				m.runner.EXPECT().Run().AnyTimes()
@@ -562,17 +555,17 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 			mockRunner := mocks.NewMocktaskRunner(ctrl)
 
 			mocks := runTaskMocks{
-				deployer: mockDeployer,
+				deployer:   mockDeployer,
 				repository: mockRepo,
-				runner: mockRunner,
+				runner:     mockRunner,
 			}
 			tc.setupMocks(mocks)
 
 			opts := &runTaskOpts{
 				runTaskVars: runTaskVars{
 					groupName: inGroupName,
-					image: tc.inImage,
-					imageTag: tc.inTag,
+					image:     tc.inImage,
+					imageTag:  tc.inTag,
 				},
 				spinner:  &mockSpinner{},
 				deployer: mockDeployer,
@@ -592,4 +585,3 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 		})
 	}
 }
-

--- a/internal/pkg/term/selector/selector.go
+++ b/internal/pkg/term/selector/selector.go
@@ -272,11 +272,16 @@ func (s *Select) Environment(prompt, help, app string, additionalOpts ...string)
 }
 
 // Application fetches all the apps in an account/region and prompts the user to select one.
-func (s *Select) Application(prompt, help string) (string, error) {
+func (s *Select) Application(prompt, help string, additionalOpts ...string) (string, error) {
 	appNames, err := s.retrieveApps()
 	if err != nil {
 		return "", err
 	}
+
+	for _, opt := range additionalOpts {
+		appNames = append(appNames, opt)
+	}
+
 	if len(appNames) == 0 {
 		log.Infof("Couldn't find any applications in this region and account. Try initializing one with %s\n",
 			color.HighlightCode("copilot app init"))


### PR DESCRIPTION
This PR contains the following change:
1. refactor selector to extend `Application` to accept additional options passed from `cli`
2. ask for application in `task run` if no workspace is found and no app flag is provided

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
