### PR TITLE
docs(site): add missing document for "env show" command 

### DIFF
--- a/site/content/en/docs/Commands/env/_index.md
+++ b/site/content/en/docs/Commands/env/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "env"
 linkTitle: "env"
-weight: 3
+weight: 4
 expand: true
 ---
 Commands for environments.  

--- a/site/content/en/docs/Commands/env/_index.md
+++ b/site/content/en/docs/Commands/env/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "env"
 linkTitle: "env"
-weight: 4
+weight: 3
 expand: true
 ---
 Commands for environments.  

--- a/site/content/en/docs/Commands/env/delete.md
+++ b/site/content/en/docs/Commands/env/delete.md
@@ -1,7 +1,7 @@
 ---
 title: "env delete"
 linkTitle: "env delete"
-weight: 3
+weight: 4
 ---
 
 ```bash

--- a/site/content/en/docs/Commands/env/show.md
+++ b/site/content/en/docs/Commands/env/show.md
@@ -1,0 +1,27 @@
+---
+title: "env show"
+linkTitle: "env show"
+weight: 3
+---
+
+```bash
+$ copilot env show [flags]
+```
+
+### What does it do?
+`copilot env ls` shows info about a deployed environment, including region, account ID, and services.
+
+### What are the flags?
+```bash
+-h, --help          help for show
+    --json          Optional. Outputs in JSON format.
+-n, --name string   Name of the environment.
+    --resources     Optional. Show the resources in your environment.
+```
+You can use the `--json` flag if you'd like to programmatically parse the results.
+
+### Examples
+Shows info about the environment "test".
+```bash
+$ copilot env show -n test
+```

--- a/site/content/en/docs/Commands/env/show.md
+++ b/site/content/en/docs/Commands/env/show.md
@@ -9,7 +9,7 @@ $ copilot env show [flags]
 ```
 
 ### What does it do?
-`copilot env ls` shows info about a deployed environment, including region, account ID, and services.
+`copilot env show` shows info about a deployed environment, including region, account ID, and services.
 
 ### What are the flags?
 ```bash


### PR DESCRIPTION
Wiki page has the document for `copilot env show` command, but there is no file related to it in this repository. Adding markdown based on wiki's one. Also, wiki page includes wrong explanation.

current: `copilot env ls` shows info about a deployed environment, including region, account ID, and services.
suggest: `copilot env show` shows info about a deployed environment, including region, account ID, and services.

`copilot env ls` is another sub command. `copilot env show` is correct.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
