### PR TITLE
perf(makefile): remove -race for go build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,16 +39,16 @@ release-docker:
 	@echo "Built binaries under ./local/"
 
 compile-local:
-	go build -race -ldflags "${LINKER_FLAGS}" -o ${DESTINATION} ./cmd/copilot
+	go build -ldflags "${LINKER_FLAGS}" -o ${DESTINATION} ./cmd/copilot
 
 compile-windows:
-	CGO_ENABLED=0 GOOS=windows GOARCH=386 go build -race -ldflags "${LINKER_FLAGS} ${RELEASE_BUILD_LINKER_FLAGS}" -o ${DESTINATION}.exe ./cmd/copilot
+	CGO_ENABLED=0 GOOS=windows GOARCH=386 go build -ldflags "${LINKER_FLAGS} ${RELEASE_BUILD_LINKER_FLAGS}" -o ${DESTINATION}.exe ./cmd/copilot
 
 compile-linux:
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -race -ldflags "${LINKER_FLAGS} ${RELEASE_BUILD_LINKER_FLAGS}" -o ${DESTINATION}-amd64 ./cmd/copilot
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "${LINKER_FLAGS} ${RELEASE_BUILD_LINKER_FLAGS}" -o ${DESTINATION}-amd64 ./cmd/copilot
 
 compile-darwin:
-	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -race -ldflags "${LINKER_FLAGS} ${RELEASE_BUILD_LINKER_FLAGS}" -o ${DESTINATION} ./cmd/copilot
+	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -ldflags "${LINKER_FLAGS} ${RELEASE_BUILD_LINKER_FLAGS}" -o ${DESTINATION} ./cmd/copilot
 
 packr-build: tools package-custom-resources
 	@echo "Packaging static files" &&\


### PR DESCRIPTION
<!-- Provide summary of changes -->
Remove -race from go build because it could increase memory usage by 5-10x and execution time by 2-20x. https://golang.org/doc/articles/race_detector.html#Runtime_Overheads
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
