### PR TITLE
docs(site): add missing document for "pipeline show/status" command

### DIFF
--- a/site/content/en/docs/Commands/pipeline/delete.md
+++ b/site/content/en/docs/Commands/pipeline/delete.md
@@ -1,24 +1,24 @@
 ---
 title: "pipeline delete"
 linkTitle: "pipeline delete"
-weight: 3
+weight: 5
 ---
 
 ```bash
 $ copilot pipeline delete [flags]
 ```
 
-## What does it do?
+### What does it do?
 `copilot pipeline delete` deletes the pipeline associated with your workspace.
 
-## What are the flags?
+### What are the flags?
 ```bash
     --delete-secret   Deletes AWS Secrets Manager secret associated with a pipeline source repository.
 -h, --help            help for delete
     --yes             Skips confirmation prompt.
 ```
 
-## Examples
+### Examples
 Delete the pipeline associated with your workspace.
 ```bash
 $ copilot pipeline delete

--- a/site/content/en/docs/Commands/pipeline/show.md
+++ b/site/content/en/docs/Commands/pipeline/show.md
@@ -1,0 +1,29 @@
+---
+title: "pipeline show"
+linkTitle: "pipeline show"
+weight: 3
+---
+```bash
+$ copilot pipeline show [flags]
+```
+
+### What does it do?
+`copilot pipeline show` shows configuration information about a deployed pipeline for an application, including the account, region, and stages.
+
+### What are the flags?
+```bash
+-a, --app string    Name of the application.
+-h, --help          help for show
+    --json          Optional. Outputs in JSON format.
+-n, --name string   Name of the pipeline.
+    --resources     Optional. Show the resources in your pipeline.
+```
+
+### Examples
+Shows info about the pipeline in the "myapp" application.
+```bash
+$ copilot pipeline show --app myapp --resources
+```
+
+### What does it look like?
+<img class="img-fluid" src="https://raw.githubusercontent.com/kohidave/copilot-demos/master/pipeline-show.svg?sanitize=true">

--- a/site/content/en/docs/Commands/pipeline/status.md
+++ b/site/content/en/docs/Commands/pipeline/status.md
@@ -1,0 +1,28 @@
+---
+title: "pipeline status"
+linkTitle: "pipeline status"
+weight: 4
+---
+```bash
+$ copilot pipeline status [flags]
+```
+
+### What does it do?
+`copilot pipeline status` shows the status of the stages in a deployed pipeline.
+
+### What are the flags?
+```bash
+-a, --app string    Name of the application.
+-h, --help          help for status
+    --json          Optional. Outputs in JSON format.
+-n, --name string   Name of the pipeline.
+```
+
+### Examples
+Shows status of the pipeline "pipeline-myapp-myrepo".
+```bash
+$ copilot pipeline status -n pipeline-myapp-myrepo
+```
+
+### What does it look like?
+<img class="img-fluid" src="https://raw.githubusercontent.com/kohidave/copilot-demos/master/pipeline-status.svg?sanitize=true">


### PR DESCRIPTION
Wiki page has the document for `copilot pipeline show` and `copilot pipeline status` command, but there is no file related to them in this repository. Adding markdown based on wiki's one.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
