### PR TITLE
fix(session): set SharedConfigEnable for DefaultWithRegion

### DIFF
--- a/internal/pkg/aws/session/session.go
+++ b/internal/pkg/aws/session/session.go
@@ -55,10 +55,10 @@ func (p *Provider) Default() (*session.Session, error) {
 
 // DefaultWithRegion returns a session configured against the "default" AWS profile and the input region.
 func (p *Provider) DefaultWithRegion(region string) (*session.Session, error) {
-	sess, err := session.NewSession(
-		newConfig().
-			WithRegion(region),
-	)
+	sess, err := session.NewSessionWithOptions(session.Options{
+		Config: *newConfig().WithRegion(region),
+		SharedConfigState: session.SharedConfigEnable,
+	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Setting SharedConfigState to SharedConfigEnable allows the AWS SDK to
load the shared config file (~/.aws/config). Previously, we were
ignoring the config file for the "DefaultWithRegion" method hence why it
wouldn't pick up the credentials_process field in the file.

Fixes #808

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
