### PR TITLE
fix: add UntagResource permission for KMS key

### DIFF
--- a/e2e/internal/client/cli.go
+++ b/e2e/internal/client/cli.go
@@ -20,6 +20,7 @@ type CLI struct {
 type AppInitRequest struct {
 	AppName string
 	Domain  string
+	Tags    map[string]string
 }
 
 // InitRequest contains the parameters for calling copilot init
@@ -312,12 +313,23 @@ func (cli *CLI) EnvList(appName string) (*EnvListOutput, error) {
 /*AppInit runs:
 copilot app init $a
 	--domain $d (optionally)
+	--resource-tags $k1=$v1,$k2=$k2 (optionally)
 */
 func (cli *CLI) AppInit(opts *AppInitRequest) (string, error) {
 	commands := []string{"app", "init", opts.AppName}
 	if opts.Domain != "" {
 		commands = append(commands, "--domain", opts.Domain)
 	}
+
+	if len(opts.Tags) > 0 {
+		commands = append(commands, "--resource-tags")
+		tags := []string{}
+		for key, val := range opts.Tags {
+			tags = append(tags, fmt.Sprintf("%s=%s", key, val))
+		}
+		commands = append(commands, strings.Join(tags, ","))
+	}
+
 	return cli.exec(exec.Command(cli.path, commands...))
 }
 

--- a/e2e/multi-env-app/multi_env_test.go
+++ b/e2e/multi-env-app/multi_env_test.go
@@ -19,6 +19,9 @@ var _ = Describe("Multiple Env App", func() {
 		BeforeAll(func() {
 			_, initErr = cli.AppInit(&client.AppInitRequest{
 				AppName: appName,
+				Tags: map[string]string{
+					"e2e-test": "multi-env",
+				},
 			})
 		})
 
@@ -220,9 +223,10 @@ var _ = Describe("Multiple Env App", func() {
 				Expect(envShowOutput.Services[0].Name).To(Equal(svcName))
 				Expect(envShowOutput.Services[0].Type).To(Equal("Load Balanced Web Service"))
 
-				Expect(len(envShowOutput.Tags)).To(Equal(2))
+				Expect(len(envShowOutput.Tags)).To(Equal(3))
 				Expect(envShowOutput.Tags["copilot-application"]).To(Equal(appName))
 				Expect(envShowOutput.Tags["copilot-environment"]).To(Equal(envName))
+				Expect(envShowOutput.Tags["e2e-test"]).To(Equal("multi-env"))
 
 				envs[envShowOutput.Environment.Name] = envShowOutput.Environment
 			}

--- a/internal/pkg/deploy/cloudformation/app.go
+++ b/internal/pkg/deploy/cloudformation/app.go
@@ -316,6 +316,7 @@ func (cf CloudFormation) deployAppConfig(appConfig *stack.AppStackConfig, resour
 	//  * We update the StackSet with Version 2, the update completes.
 	//  * Someone else tries to update the StackSet with their stale version 2.
 	//  * "2" has already been used as an operation ID, and the stale write fails.
+
 	return cf.appStackSet.UpdateAndWait(appConfig.StackSetName(), newTemplateToDeploy,
 		stackset.WithOperationID(fmt.Sprintf("%d", resources.Version)),
 		stackset.WithDescription(appConfig.StackSetDescription()),
@@ -350,7 +351,7 @@ func (cf CloudFormation) addNewAppStackInstances(appConfig *stack.AppStackConfig
 }
 
 func (cf CloudFormation) getLastDeployedAppConfig(appConfig *stack.AppStackConfig) (*stack.AppResourcesConfig, error) {
-	// Check the existing deploy stack template. From that template, we'll parse out the list of apps and accounts that
+	// Check the existing deploy stack template. From that template, we'll parse out the list of services and accounts that
 	// are deployed in the stack.
 	descr, err := cf.appStackSet.Describe(appConfig.StackSetName())
 	if err != nil {

--- a/templates/app/cf.yml
+++ b/templates/app/cf.yml
@@ -40,6 +40,7 @@ Resources:
               - "kms:ScheduleKeyDeletion"
               - "kms:CancelKeyDeletion"
               - "kms:Tag*"
+              - "kms:UntagResource"
             Resource: "*"
           -
             # Allow use of the key in the tools account and all environment accounts


### PR DESCRIPTION
There seems to be an issue with the current KMS CF resource
that is causing superfluous tag/untag calls. This new permission
fixes that issue.

A customer encountered this issue (#1199) when using resource tags,
so I've also updated the e2e tests to include setting resource tags.

In the future, this permission will be useful if we want to support
updating tags at the app level (removing a tag, for example) so it's
not entierly a hack :)

Fixes #1199 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
