### PR TITLE
chore(cli): remove unused option --deploy from example for "pipeline init".

### DIFF
--- a/internal/pkg/cli/pipeline_init.go
+++ b/internal/pkg/cli/pipeline_init.go
@@ -510,8 +510,7 @@ func BuildPipelineInitCmd() *cobra.Command {
   /code $ copilot pipeline init \
   /code  --github-url https://github.com/gitHubUserName/myFrontendApp.git \
   /code  --github-access-token file://myGitHubToken \
-  /code  --environments "stage,prod" \
-  /code  --deploy`,
+  /code  --environments "stage,prod"`,
 		RunE: runCmdE(func(cmd *cobra.Command, args []string) error {
 			opts, err := newInitPipelineOpts(vars)
 			if err != nil {

--- a/site/content/en/docs/Commands/pipeline/init.md
+++ b/site/content/en/docs/Commands/pipeline/init.md
@@ -25,6 +25,5 @@ Create a pipeline for the services in your workspace.
 $ copilot pipeline init \
 --github-url https://github.com/gitHubUserName/myFrontendApp.git \
 --github-access-token file://myGitHubToken \
---environments "test,prod" \
---deploy
+--environments "test,prod"
 ```


### PR DESCRIPTION
`copilot pipeline init -h` shows the example command with unused option "--deploy". This PR removes it.

Related #1202

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
