### PR TITLE
feat: ARM64 build target for linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,8 @@ compile-windows:
 	CGO_ENABLED=0 GOOS=windows GOARCH=386 go build -ldflags "${LINKER_FLAGS} ${RELEASE_BUILD_LINKER_FLAGS}" -o ${DESTINATION}.exe ./cmd/copilot
 
 compile-linux:
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "${LINKER_FLAGS} ${RELEASE_BUILD_LINKER_FLAGS}" -o ${DESTINATION}-amd64 ./cmd/copilot
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "${LINKER_FLAGS} ${RELEASE_BUILD_LINKER_FLAGS}" -o ${DESTINATION}-linux-amd64 ./cmd/copilot
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags "${LINKER_FLAGS} ${RELEASE_BUILD_LINKER_FLAGS}" -o ${DESTINATION}-linux-arm64 ./cmd/copilot
 
 compile-darwin:
 	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -ldflags "${LINKER_FLAGS} ${RELEASE_BUILD_LINKER_FLAGS}" -o ${DESTINATION} ./cmd/copilot

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -19,10 +19,10 @@ phases:
     finally:
       - echo "Built artifacts:"
       - ls -lah ./bin/local
-      - ./bin/local/copilot-amd64 --version
+      - ./bin/local/copilot-linux-amd64 --version
   post_build:
     commands:
-      - VERSION=`./bin/local/copilot-amd64 --version`
+      - VERSION=`./bin/local/copilot-linux-amd64 --version`
       - VERSION=`echo $VERSION | grep -oE "[^ ]+$"`
       - COMMIT_VERSION=`git rev-parse --short HEAD`
       - echo "Creating version-tagged artifacts..."
@@ -30,13 +30,17 @@ phases:
       - mkdir -p $ARTIFACT_DIRECTORY
       - mv ./bin/local/copilot.exe $ARTIFACT_DIRECTORY/copilot-windows-$VERSION.exe
       - mv ./bin/local/copilot $ARTIFACT_DIRECTORY/copilot-darwin-$VERSION
-      - mv ./bin/local/copilot-amd64 $ARTIFACT_DIRECTORY/copilot-linux-$VERSION
+      - cp ./bin/local/copilot-linux-amd64 $ARTIFACT_DIRECTORY/copilot-linux-$VERSION
+      - mv ./bin/local/copilot-linux-amd64 $ARTIFACT_DIRECTORY/copilot-linux-amd64-$VERSION
+      - mv ./bin/local/copilot-linux-arm64 $ARTIFACT_DIRECTORY/copilot-linux-arm64-$VERSION
       - echo "Creating manifest file..."
       - COMMIT_ID=`git rev-parse HEAD`
       - MANIFESTFILE="$COMMIT_ID.manifest"
       - echo $ARTIFACT_DIRECTORY/copilot-windows-$VERSION.exe >> $MANIFESTFILE
       - echo $ARTIFACT_DIRECTORY/copilot-darwin-$VERSION >> $MANIFESTFILE
       - echo $ARTIFACT_DIRECTORY/copilot-linux-$VERSION >> $MANIFESTFILE
+      - echo $ARTIFACT_DIRECTORY/copilot-linux-amd64-$VERSION >> $MANIFESTFILE
+      - echo $ARTIFACT_DIRECTORY/copilot-linux-arm64-$VERSION >> $MANIFESTFILE
     finally:
       - echo "Built artifacts:"
       - ls -lah $ARTIFACT_DIRECTORY


### PR DESCRIPTION
This change produces ARM binaries for Linux. We can't enable
the same for our darwin builds right now since go assumes that
darwin/arm64 is an iOS target:
https://github.com/golang/go/issues/38485

This fixes #1058

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
