### PR TITLE
chore(ec2): add ListVpcSubnets method and pagination

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/fatih/structs v1.1.0
 	github.com/gobuffalo/packd v1.0.0
 	github.com/gobuffalo/packr/v2 v2.8.0
-	github.com/golang/mock v1.4.3
+	github.com/golang/mock v1.4.4
 	github.com/google/uuid v1.1.1
 	github.com/hinshun/vt10x v0.0.0-20180809195222-d55458df857c // indirect
 	github.com/imdario/mergo v0.3.9

--- a/go.sum
+++ b/go.sum
@@ -157,8 +157,8 @@ github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4er
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFUx0Y=
-github.com/golang/mock v1.4.3 h1:GV+pQPG/EUUbkh47niozDcADz6go/dUwhVzdUQHIVRw=
-github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
+github.com/golang/mock v1.4.4 h1:l75CXGRSwbaYNpl/Z2X1XIIAMSCquvXgpVZDhwEIJsc=
+github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -563,7 +563,6 @@ golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299 h1:DYfZAGf2WMFjMxbgTjaC+2HC7NkNAQs+6Q8b9WEB/F4=
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
@@ -674,5 +673,3 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 k8s.io/kubernetes v1.13.0/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
-rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
-rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/internal/pkg/aws/ec2/ec2.go
+++ b/internal/pkg/aws/ec2/ec2.go
@@ -6,6 +6,7 @@ package ec2
 
 import (
 	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -40,6 +41,12 @@ type Filter struct {
 	Values []string
 }
 
+// Subnets contains subnets in a VPC.
+type Subnets struct {
+	PublicSubnets  []string
+	PrivateSubnets []string
+}
+
 // EC2 wraps an AWS EC2 client.
 type EC2 struct {
 	client api
@@ -50,6 +57,26 @@ func New(s *session.Session) *EC2 {
 	return &EC2{
 		client: ec2.New(s),
 	}
+}
+
+// ListVpcSubnets lists all subnets given a VPC ID.
+func (c *EC2) ListVpcSubnets(vpcID string) (*Subnets, error) {
+	respSubnets, err := c.subnets(Filter{
+		Name:   "vpc-id",
+		Values: []string{vpcID},
+	})
+	if err != nil {
+		return nil, err
+	}
+	var subnets Subnets
+	for _, subnet := range respSubnets {
+		if aws.BoolValue(subnet.MapPublicIpOnLaunch) {
+			subnets.PublicSubnets = append(subnets.PublicSubnets, aws.StringValue(subnet.SubnetId))
+		} else {
+			subnets.PrivateSubnets = append(subnets.PrivateSubnets, aws.StringValue(subnet.SubnetId))
+		}
+	}
+	return &subnets, nil
 }
 
 // SubnetIDs finds the subnet IDs with optional filters.
@@ -103,16 +130,21 @@ func (c *EC2) SecurityGroups(filters ...Filter) ([]string, error) {
 
 func (c *EC2) subnets(filters ...Filter) ([]*ec2.Subnet, error) {
 	inputFilters := toEC2Filter(filters)
+	var subnets []*ec2.Subnet
+	nextToken := aws.String("")
 
-	response, err := c.client.DescribeSubnets(&ec2.DescribeSubnetsInput{
-		Filters: inputFilters,
-	})
-
-	if err != nil {
-		return nil, fmt.Errorf("describe subnets: %w", err)
+	for nextToken != nil {
+		response, err := c.client.DescribeSubnets(&ec2.DescribeSubnetsInput{
+			Filters: inputFilters,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("describe subnets: %w", err)
+		}
+		subnets = append(subnets, response.Subnets...)
+		nextToken = response.NextToken
 	}
 
-	return response.Subnets, nil
+	return subnets, nil
 }
 
 func toEC2Filter(filters []Filter) []*ec2.Filter {

--- a/internal/pkg/aws/ec2/ec2_test.go
+++ b/internal/pkg/aws/ec2/ec2_test.go
@@ -6,22 +6,23 @@ package ec2
 import (
 	"errors"
 	"fmt"
+	"testing"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/copilot-cli/internal/pkg/aws/ec2/mocks"
 	"github.com/aws/copilot-cli/internal/pkg/deploy"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 var (
 	inAppEnvFilters = []Filter{
-		Filter{
-			Name: fmt.Sprintf(TagFilterName, deploy.AppTagKey),
+		{
+			Name:   fmt.Sprintf(TagFilterName, deploy.AppTagKey),
 			Values: []string{"my-app"},
 		},
-		Filter{
+		{
 			Name:   fmt.Sprintf(TagFilterName, deploy.EnvTagKey),
 			Values: []string{"my-env"},
 		},
@@ -41,6 +42,64 @@ var (
 	}
 )
 
+func TestEC2_ListVpcSubnets(t *testing.T) {
+	const mockVpcID = "mockVpcID"
+	testCases := map[string]struct {
+		mockEC2Client func(m *mocks.Mockapi)
+
+		wantedError   error
+		wantedSubnets *Subnets
+	}{
+		"fail to describe subnets": {
+			mockEC2Client: func(m *mocks.Mockapi) {
+				m.EXPECT().DescribeSubnets(gomock.Any()).Return(nil, errors.New("error describing subnets"))
+			},
+			wantedError: fmt.Errorf("describe subnets: error describing subnets"),
+		},
+		"success": {
+			mockEC2Client: func(m *mocks.Mockapi) {
+				m.EXPECT().DescribeSubnets(&ec2.DescribeSubnetsInput{
+					Filters: toEC2Filter([]Filter{
+						{
+							Name:   "vpc-id",
+							Values: []string{mockVpcID},
+						},
+					}),
+				}).Return(&ec2.DescribeSubnetsOutput{
+					Subnets: []*ec2.Subnet{
+						subnet1,
+						subnet2,
+						subnet3,
+					}}, nil)
+			},
+			wantedSubnets: &Subnets{
+				PublicSubnets:  []string{"subnet-2", "subnet-3"},
+				PrivateSubnets: []string{"subnet-1"},
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+
+			mockAPI := mocks.NewMockapi(ctrl)
+			tc.mockEC2Client(mockAPI)
+
+			ec2Client := EC2{
+				client: mockAPI,
+			}
+
+			subnets, err := ec2Client.ListVpcSubnets(mockVpcID)
+			if tc.wantedError != nil {
+				require.EqualError(t, tc.wantedError, err.Error())
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.wantedSubnets, subnets)
+			}
+		})
+	}
+}
 func TestEC2_PublicSubnetIDs(t *testing.T) {
 	testCases := map[string]struct {
 		inFilter []Filter
@@ -98,6 +157,7 @@ func TestEC2_PublicSubnetIDs(t *testing.T) {
 }
 
 func TestEC2_SubnetIDs(t *testing.T) {
+	mockNextToken := aws.String("mockNextToken")
 	testCases := map[string]struct {
 		inFilter []Filter
 
@@ -127,6 +187,27 @@ func TestEC2_SubnetIDs(t *testing.T) {
 				}, nil)
 			},
 			wantedARNs: []string{"subnet-1", "subnet-2"},
+		},
+		"successfully get subnets with pagination": {
+			inFilter: inAppEnvFilters,
+			mockEC2Client: func(m *mocks.Mockapi) {
+				m.EXPECT().DescribeSubnets(&ec2.DescribeSubnetsInput{
+					Filters: toEC2Filter(inAppEnvFilters),
+				}).Return(&ec2.DescribeSubnetsOutput{
+					Subnets: []*ec2.Subnet{
+						subnet1, subnet2,
+					},
+					NextToken: mockNextToken,
+				}, nil)
+				m.EXPECT().DescribeSubnets(&ec2.DescribeSubnetsInput{
+					Filters: toEC2Filter(inAppEnvFilters),
+				}).Return(&ec2.DescribeSubnetsOutput{
+					Subnets: []*ec2.Subnet{
+						subnet3,
+					},
+				}, nil)
+			},
+			wantedARNs: []string{"subnet-1", "subnet-2", "subnet-3"},
 		},
 	}
 
@@ -178,10 +259,10 @@ func TestEC2_SecurityGroups(t *testing.T) {
 					Filters: toEC2Filter(inAppEnvFilters),
 				}).Return(&ec2.DescribeSecurityGroupsOutput{
 					SecurityGroups: []*ec2.SecurityGroup{
-						&ec2.SecurityGroup{
+						{
 							GroupId: aws.String("sg-1"),
 						},
-						&ec2.SecurityGroup{
+						{
 							GroupId: aws.String("sg-2"),
 						},
 					},

--- a/internal/pkg/aws/ec2/ec2_test.go
+++ b/internal/pkg/aws/ec2/ec2_test.go
@@ -200,7 +200,8 @@ func TestEC2_SubnetIDs(t *testing.T) {
 					NextToken: mockNextToken,
 				}, nil)
 				m.EXPECT().DescribeSubnets(&ec2.DescribeSubnetsInput{
-					Filters: toEC2Filter(inAppEnvFilters),
+					Filters:   toEC2Filter(inAppEnvFilters),
+					NextToken: mockNextToken,
 				}).Return(&ec2.DescribeSubnetsOutput{
 					Subnets: []*ec2.Subnet{
 						subnet3,


### PR DESCRIPTION
<!-- Provide summary of changes -->
Part of #1192.
1. Add `ListVpcSubnets` to list all subnets given a VPC ID.
2. Add pagination when calling `DescribeSubnets` so that we won't miss results in following pages.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
