### PR TITLE
chore: update `task run` to use manager roles and update manager permissions

### DIFF
--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -5,6 +5,7 @@ package cli
 
 import (
 	"encoding"
+	"github.com/aws/copilot-cli/internal/pkg/aws/cloudformation"
 	"github.com/aws/copilot-cli/internal/pkg/repository"
 	"github.com/aws/copilot-cli/internal/pkg/task"
 	"io"
@@ -290,7 +291,7 @@ type appResourcesGetter interface {
 }
 
 type taskDeployer interface {
-	DeployTask(input *deploy.CreateTaskResourcesInput) error
+	DeployTask(input *deploy.CreateTaskResourcesInput, opts ...cloudformation.StackOption) error
 }
 
 type taskRunner interface {

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -7,6 +7,7 @@ package mocks
 import (
 	encoding "encoding"
 	session "github.com/aws/aws-sdk-go/aws/session"
+	cloudformation "github.com/aws/copilot-cli/internal/pkg/aws/cloudformation"
 	cloudwatchlogs "github.com/aws/copilot-cli/internal/pkg/aws/cloudwatchlogs"
 	codepipeline "github.com/aws/copilot-cli/internal/pkg/aws/codepipeline"
 	ecs "github.com/aws/copilot-cli/internal/pkg/aws/ecs"
@@ -2801,17 +2802,22 @@ func (m *MocktaskDeployer) EXPECT() *MocktaskDeployerMockRecorder {
 }
 
 // DeployTask mocks base method
-func (m *MocktaskDeployer) DeployTask(input *deploy.CreateTaskResourcesInput) error {
+func (m *MocktaskDeployer) DeployTask(input *deploy.CreateTaskResourcesInput, opts ...cloudformation.StackOption) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeployTask", input)
+	varargs := []interface{}{input}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DeployTask", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeployTask indicates an expected call of DeployTask
-func (mr *MocktaskDeployerMockRecorder) DeployTask(input interface{}) *gomock.Call {
+func (mr *MocktaskDeployerMockRecorder) DeployTask(input interface{}, opts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeployTask", reflect.TypeOf((*MocktaskDeployer)(nil).DeployTask), input)
+	varargs := append([]interface{}{input}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeployTask", reflect.TypeOf((*MocktaskDeployer)(nil).DeployTask), varargs...)
 }
 
 // MocktaskRunner is a mock of taskRunner interface

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -190,10 +190,10 @@ func (o *runTaskOpts) configureRunner() taskRunner {
 func (o *runTaskOpts) configureSessAndEnv() error {
 	var sess *awssession.Session
 	var env *config.Environment
-	var err error
 
 	provider := session.NewProvider()
 	if o.env != "" {
+		var err error
 		env, err = o.targetEnv()
 		if err != nil {
 			return err
@@ -204,6 +204,7 @@ func (o *runTaskOpts) configureSessAndEnv() error {
 			return fmt.Errorf("get session from role %s and region %s: %w", env.ManagerRoleARN, env.Region, err)
 		}
 	} else {
+		var err error
 		sess, err = provider.Default()
 		if err != nil {
 			return fmt.Errorf("get default session: %w", err)

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -162,7 +162,7 @@ func (o *runTaskOpts) repositoryConfigurer(sess *awssession.Session) func() erro
 		registry := ecr.New(sess)
 		repository, err := repository.New(repoName, registry)
 		if err != nil {
-			return fmt.Errorf("initiate repository %s: %w", repoName, err)
+			return fmt.Errorf("initialize repository %s: %w", repoName, err)
 		}
 		o.repository = repository
 		return nil

--- a/internal/pkg/cli/task_run_test.go
+++ b/internal/pkg/cli/task_run_test.go
@@ -563,16 +563,22 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 
 			opts := &runTaskOpts{
 				runTaskVars: runTaskVars{
+					GlobalOpts: &GlobalOpts{},
 					groupName: inGroupName,
 					image:     tc.inImage,
 					imageTag:  tc.inTag,
 				},
 				spinner:  &mockSpinner{},
-				deployer: mockDeployer,
 			}
 			opts.configureRuntimeOpts = func() error {
-				opts.repository = mockRepo
+
 				opts.runner = mockRunner
+				opts.deployer = mockDeployer
+				opts.deploy = opts.configureDeploy()
+				opts.configureRepository = func() error {
+					opts.repository = mockRepo
+					return nil
+				}
 				return nil
 			}
 

--- a/internal/pkg/deploy/cloudformation/task.go
+++ b/internal/pkg/deploy/cloudformation/task.go
@@ -16,11 +16,14 @@ import (
 // If the task stack doesn't exist, then it creates the stack.
 // If the task stack already exists, it updates the stack.
 // If the task stack doesn't have any changes, it returns nil
-func (cf CloudFormation) DeployTask(input *deploy.CreateTaskResourcesInput) error {
+func (cf CloudFormation) DeployTask(input *deploy.CreateTaskResourcesInput, opts ...cloudformation.StackOption) error {
     conf := stack.NewTaskStackConfig(input)
     stack, err := toStack(conf)
     if err != nil {
         return err
+    }
+    for _, opt := range opts {
+        opt(stack)
     }
 
     err = cf.cfnClient.CreateAndWait(stack)

--- a/templates/environment/cf/environment-manager-role.yml
+++ b/templates/environment/cf/environment-manager-role.yml
@@ -61,7 +61,8 @@ EnvironmentManagerRole:
             "ecs:ListTaskDefinitionFamilies",
             "ecs:DescribeTaskDefinition",
             "ecs:ListTaskDefinitions",
-            "ecs:ListClusters"
+            "ecs:ListClusters",
+            "ecs:RunTask"
           ]
           Resource: "*"
         - Sid: CloudFormation
@@ -82,17 +83,22 @@ EnvironmentManagerRole:
             "cloudformation:UpdateTerminationProtection"
           ]
           Resource: "*"
-        - Sid: PipelineExecution
+        - Sid: GetAndPassCopilotRoles
           Effect: Allow
           Action: [
             "iam:GetRole",
             "iam:PassRole"
           ]
-          Resource: !GetAtt CloudformationExecutionRole.Arn
+          Resource: "*"
+          Condition:
+            StringEquals:
+              'iam:ResourceTag/copilot-application': !Sub '${AppName}'
+              'iam:ResourceTag/copilot-environment': !Sub '${EnvironmentName}'
         - Sid: ECR
           Effect: Allow
           Action: [
             "ecr:BatchGetImage",
+            "ecr:BatchCheckLayerAvailability",
             "ecr:CompleteLayerUpload",
             "ecr:DescribeImages",
             "ecr:DescribeRepositories",
@@ -101,7 +107,8 @@ EnvironmentManagerRole:
             "ecr:ListImages",
             "ecr:ListTagsForResource",
             "ecr:PutImage",
-            "ecr:UploadLayerPart"
+            "ecr:UploadLayerPart",
+            "ecr:GetAuthorizationToken"
           ]
           Resource: "*"
         - Sid: ResourceGroups
@@ -181,6 +188,13 @@ EnvironmentManagerRole:
             "s3:GetBucketLocation",
             "s3:GetObjectVersion",
             "kms:Decrypt"
+          ]
+          Resource: "*"
+        - Sid: EC2
+          Effect: Allow
+          Action: [
+            "ec2:DescribeSubnets",
+            "ec2:DescribeSecurityGroups"
           ]
           Resource: "*"
         - Sid: Tags


### PR DESCRIPTION
This PR contains the following changes:
1. Update environment manager role's permission in support of `task run`
2. Update `task run` to use environment manager

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
