### PR TITLE
chore(docs): update homebrew installation doc

### DIFF
--- a/site/content/en/docs/Installation/_index.md
+++ b/site/content/en/docs/Installation/_index.md
@@ -9,7 +9,7 @@ You can install AWS Copilot through [Homebrew](https://brew.sh/) or by downloadi
 ## Homebrew 🍻
 
 ```sh
-brew install aws/tap/copilot-cli
+brew install copilot-cli
 ```
 
 ## Manually


### PR DESCRIPTION
Since now, copilot-cli is hosted in homebrew-core,
it would be nice to converging the efforts of the maintenance
and update the docs to reflect that.

closes #1140

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
