### PR TITLE
chore: early check for default cluster in `task run`

### DIFF
--- a/internal/pkg/aws/ecs/ecs.go
+++ b/internal/pkg/aws/ecs/ecs.go
@@ -5,6 +5,7 @@
 package ecs
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -198,6 +199,17 @@ func (e *ECS) DefaultCluster() (string, error) {
 	// NOTE: right now at most 1 default cluster is possible, so cluster[0] must be the default cluster
 	cluster := resp.Clusters[0]
 	return aws.StringValue(cluster.ClusterArn), nil
+}
+
+// HasDefaultCluster tries to find the default cluster and returns true if there is one.
+func (e *ECS) HasDefaultCluster() (bool, error) {
+	if _, err := e.DefaultCluster(); err != nil {
+		if errors.Is(err, ErrNoDefaultCluster) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }
 
 // RunTask runs a number of tasks with the task definition and network configurations in a cluster, and returns after

--- a/internal/pkg/aws/ecs/ecs_test.go
+++ b/internal/pkg/aws/ecs/ecs_test.go
@@ -386,6 +386,67 @@ func TestECS_DefaultCluster(t *testing.T) {
 	}
 }
 
+func TestECS_HasDefaultCluster(t *testing.T) {
+	testCases := map[string] struct{
+		mockECSClient func(m *mocks.Mockapi)
+
+		wantedHas bool
+		wantedErr error
+	}{
+		"no default cluster": {
+			mockECSClient: func(m *mocks.Mockapi) {
+				m.EXPECT().DescribeClusters(&ecs.DescribeClustersInput{}).
+					Return(&ecs.DescribeClustersOutput{
+						Clusters: []*ecs.Cluster{},
+					}, nil)
+			},
+			wantedHas: false,
+		},
+		"error getting default cluster": {
+			mockECSClient: func(m *mocks.Mockapi) {
+				m.EXPECT().DescribeClusters(&ecs.DescribeClustersInput{}).
+					Return(nil, errors.New("other error"))
+			},
+			wantedErr: fmt.Errorf("get default cluster: other error"),
+		},
+		"has default cluster": {
+			mockECSClient: func(m *mocks.Mockapi) {
+				m.EXPECT().DescribeClusters(&ecs.DescribeClustersInput{}).
+					Return(&ecs.DescribeClustersOutput{
+						Clusters: []*ecs.Cluster{
+							{ ClusterArn: aws.String("cluster") },
+						},
+					}, nil)
+			},
+			wantedHas: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockECSClient := mocks.NewMockapi(ctrl)
+			tc.mockECSClient(mockECSClient)
+
+			ecs := ECS{
+				client: mockECSClient,
+			}
+
+			has, err := ecs.HasDefaultCluster()
+			if tc.wantedErr != nil {
+				require.EqualError(t, tc.wantedErr, err.Error())
+			} else {
+				require.NoError(t, err)
+			}
+
+			require.Equal(t, tc.wantedHas, has)
+		})
+	}
+}
+
+
 func TestECS_RunTask(t *testing.T) {
 	type input struct {
 		cluster        string

--- a/internal/pkg/aws/ecs/ecs_test.go
+++ b/internal/pkg/aws/ecs/ecs_test.go
@@ -390,8 +390,8 @@ func TestECS_HasDefaultCluster(t *testing.T) {
 	testCases := map[string] struct{
 		mockECSClient func(m *mocks.Mockapi)
 
-		wantedHas bool
-		wantedErr error
+		wantedHasDefaultCluster bool
+		wantedErr               error
 	}{
 		"no default cluster": {
 			mockECSClient: func(m *mocks.Mockapi) {
@@ -400,7 +400,7 @@ func TestECS_HasDefaultCluster(t *testing.T) {
 						Clusters: []*ecs.Cluster{},
 					}, nil)
 			},
-			wantedHas: false,
+			wantedHasDefaultCluster: false,
 		},
 		"error getting default cluster": {
 			mockECSClient: func(m *mocks.Mockapi) {
@@ -418,7 +418,7 @@ func TestECS_HasDefaultCluster(t *testing.T) {
 						},
 					}, nil)
 			},
-			wantedHas: true,
+			wantedHasDefaultCluster: true,
 		},
 	}
 
@@ -434,14 +434,14 @@ func TestECS_HasDefaultCluster(t *testing.T) {
 				client: mockECSClient,
 			}
 
-			has, err := ecs.HasDefaultCluster()
+			hasDefaultCluster, err := ecs.HasDefaultCluster()
 			if tc.wantedErr != nil {
 				require.EqualError(t, tc.wantedErr, err.Error())
 			} else {
 				require.NoError(t, err)
 			}
 
-			require.Equal(t, tc.wantedHas, has)
+			require.Equal(t, tc.wantedHasDefaultCluster, hasDefaultCluster)
 		})
 	}
 }

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -308,6 +308,10 @@ type taskRunner interface {
 	Run() ([]*task.Task, error)
 }
 
+type defaultClusterGetter interface {
+	HasDefaultCluster() (bool, error)
+}
+
 type deployer interface {
 	environmentDeployer
 	appDeployer

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -2954,6 +2954,44 @@ func (mr *MocktaskRunnerMockRecorder) Run() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Run", reflect.TypeOf((*MocktaskRunner)(nil).Run))
 }
 
+// MockdefaultClusterGetter is a mock of defaultClusterGetter interface
+type MockdefaultClusterGetter struct {
+	ctrl     *gomock.Controller
+	recorder *MockdefaultClusterGetterMockRecorder
+}
+
+// MockdefaultClusterGetterMockRecorder is the mock recorder for MockdefaultClusterGetter
+type MockdefaultClusterGetterMockRecorder struct {
+	mock *MockdefaultClusterGetter
+}
+
+// NewMockdefaultClusterGetter creates a new mock instance
+func NewMockdefaultClusterGetter(ctrl *gomock.Controller) *MockdefaultClusterGetter {
+	mock := &MockdefaultClusterGetter{ctrl: ctrl}
+	mock.recorder = &MockdefaultClusterGetterMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockdefaultClusterGetter) EXPECT() *MockdefaultClusterGetterMockRecorder {
+	return m.recorder
+}
+
+// HasDefaultCluster mocks base method
+func (m *MockdefaultClusterGetter) HasDefaultCluster() (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasDefaultCluster")
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// HasDefaultCluster indicates an expected call of HasDefaultCluster
+func (mr *MockdefaultClusterGetterMockRecorder) HasDefaultCluster() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasDefaultCluster", reflect.TypeOf((*MockdefaultClusterGetter)(nil).HasDefaultCluster))
+}
+
 // Mockdeployer is a mock of deployer interface
 type Mockdeployer struct {
 	ctrl     *gomock.Controller

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -382,7 +382,7 @@ func (o *runTaskOpts) Execute() error {
 	if o.env == "" {
 		hasDefaultCluster, err := o.defaultClusterGetter.HasDefaultCluster()
 		if err != nil {
-			return err
+			return fmt.Errorf(`find "default" cluster to deploy the task to: %v`, err)
 		}
 		if !hasDefaultCluster {
 			return errors.New("cannot find a default cluster to deploy the task to")

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -385,7 +385,7 @@ func (o *runTaskOpts) Execute() error {
 			return fmt.Errorf(`find "default" cluster to deploy the task to: %v`, err)
 		}
 		if !hasDefaultCluster {
-			return errors.New("cannot find a default cluster to deploy the task to")
+			return errors.New(`cannot find a "default" cluster to deploy the task to`)
 		}
 	}
 

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -380,11 +380,11 @@ func (o *runTaskOpts) Execute() error {
 	}
 
 	if o.env == "" {
-		has, err := o.defaultClusterGetter.HasDefaultCluster()
+		hasDefaultCluster, err := o.defaultClusterGetter.HasDefaultCluster()
 		if err != nil {
 			return err
 		}
-		if !has {
+		if !hasDefaultCluster {
 			return errors.New("cannot find a default cluster to deploy the task to")
 		}
 	}

--- a/internal/pkg/cli/task_run_test.go
+++ b/internal/pkg/cli/task_run_test.go
@@ -580,6 +580,16 @@ type runTaskMocks struct {
 	runner     *mocks.MocktaskRunner
 	store      *mocks.Mockstore
 	eventsWriter *mocks.MockeventsWriter
+	defaultClusterGetter *mocks.MockdefaultClusterGetter
+}
+
+func mockHasDefaultCluster(m runTaskMocks) {
+	m.defaultClusterGetter.EXPECT().HasDefaultCluster().Return(true, nil).AnyTimes()
+}
+
+func mockRepositoryAnytime(m runTaskMocks) {
+	m.repository.EXPECT().BuildAndPush(gomock.Any(), gomock.Any()).AnyTimes()
+	m.repository.EXPECT().URI().AnyTimes()
 }
 
 func TestTaskRunOpts_Execute(t *testing.T) {
@@ -604,6 +614,29 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 
 		wantedError error
 	}{
+		"check if default cluster exists if deploying to default cluster": {
+			setupMocks: func(m runTaskMocks) {
+				m.store.EXPECT().GetEnvironment(gomock.Any(), gomock.Any()).AnyTimes()
+				m.defaultClusterGetter.EXPECT().HasDefaultCluster().Return(true, nil)
+				m.deployer.EXPECT().DeployTask(gomock.Any()).Return(nil).AnyTimes()
+				mockRepositoryAnytime(m)
+				m.runner.EXPECT().Run().AnyTimes()
+			},
+		},
+		"do not check for default cluster if deploying to environment": {
+			inEnv: "test",
+			setupMocks: func(m runTaskMocks) {
+				m.defaultClusterGetter.EXPECT().HasDefaultCluster().Times(0)
+				m.store.EXPECT().
+					GetEnvironment(gomock.Any(), "test").
+					Return(&config.Environment{
+						ExecutionRoleARN: "env execution role",
+					}, nil)
+				m.deployer.EXPECT().DeployTask(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+				mockRepositoryAnytime(m)
+				m.runner.EXPECT().Run().AnyTimes()
+			},
+		},
 		"error deploying resources": {
 			setupMocks: func(m runTaskMocks) {
 				m.store.EXPECT().GetEnvironment(gomock.Any(), gomock.Any()).AnyTimes()
@@ -611,6 +644,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 					Name:  inGroupName,
 					Image: "",
 				}).Return(errors.New("error deploying"))
+				mockHasDefaultCluster(m)
 			},
 			wantedError: errors.New("provision resources for task my-task: error deploying"),
 		},
@@ -627,6 +661,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 					Name:  inGroupName,
 					Image: "uri/repo:latest",
 				}).Times(1).Return(errors.New("error updating"))
+				mockHasDefaultCluster(m)
 			},
 			wantedError: errors.New("update resources for task my-task: error updating"),
 		},
@@ -634,9 +669,9 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 			setupMocks: func(m runTaskMocks) {
 				m.store.EXPECT().GetEnvironment(gomock.Any(), gomock.Any()).AnyTimes()
 				m.deployer.EXPECT().DeployTask(gomock.Any()).Return(nil).Times(2)
-				m.repository.EXPECT().BuildAndPush(gomock.Any(), gomock.Eq(&defaultBuildArguments))
-				m.repository.EXPECT().URI().Return(mockRepoURI)
+				mockRepositoryAnytime(m)
 				m.runner.EXPECT().Run().Return(nil, errors.New("error running"))
+				mockHasDefaultCluster(m)
 			},
 			wantedError: errors.New("run task my-task: error running"),
 		},
@@ -648,18 +683,18 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 						ExecutionRoleARN: "env execution role",
 					}, nil)
 				m.deployer.EXPECT().DeployTask(gomock.Any(), gomock.Len(1)).AnyTimes() // NOTE: matching length because gomock is unable to match function arguments.
-				m.repository.EXPECT().BuildAndPush(gomock.Any(), gomock.Any()).AnyTimes()
-				m.repository.EXPECT().URI().AnyTimes()
+				mockRepositoryAnytime(m)
 				m.runner.EXPECT().Run().AnyTimes()
+				m.defaultClusterGetter.EXPECT().HasDefaultCluster().Times(0)
 			},
 		},
 		"deploy without execution role option if env is empty": {
 			setupMocks: func(m runTaskMocks) {
 				m.store.EXPECT().GetEnvironment(gomock.Any(), gomock.Any()).Times(0)
 				m.deployer.EXPECT().DeployTask(gomock.Any(), gomock.Len(0)).AnyTimes() // NOTE: matching length because gomock is unable to match function arguments.
-				m.repository.EXPECT().BuildAndPush(gomock.Any(), gomock.Any()).AnyTimes()
-				m.repository.EXPECT().URI().AnyTimes()
+				mockRepositoryAnytime(m)
 				m.runner.EXPECT().Run().AnyTimes()
+				mockHasDefaultCluster(m)
 			},
 		},
 		"append 'latest' to image tag": {
@@ -676,6 +711,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 				)
 				m.repository.EXPECT().URI().AnyTimes()
 				m.runner.EXPECT().Run().AnyTimes()
+				mockHasDefaultCluster(m)
 			},
 		},
 		"update image to task resource if image is not provided": {
@@ -692,6 +728,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 					Image: "uri/repo:latest",
 				}).Times(1).Return(nil)
 				m.runner.EXPECT().Run().AnyTimes()
+				mockHasDefaultCluster(m)
 			},
 		},
 		"fail to write events": {
@@ -712,6 +749,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 				}, nil)
 				m.eventsWriter.EXPECT().WriteEventsUntilStopped().Times(1).
 					Return(errors.New("error writing events"))
+				mockHasDefaultCluster(m)
 			},
 			wantedError: errors.New("write events: error writing events"),
 		},
@@ -728,6 +766,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 				runner:     mocks.NewMocktaskRunner(ctrl),
 				store:      mocks.NewMockstore(ctrl),
 				eventsWriter: mocks.NewMockeventsWriter(ctrl),
+				defaultClusterGetter: mocks.NewMockdefaultClusterGetter(ctrl),
 			}
 			tc.setupMocks(mocks)
 
@@ -747,6 +786,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 			opts.configureRuntimeOpts = func() error {
 				opts.runner = mocks.runner
 				opts.deployer = mocks.deployer
+				opts.defaultClusterGetter = mocks.defaultClusterGetter
 				return nil
 			}
 			opts.configureRepository = func() error {


### PR DESCRIPTION
This PR contains the following changes:
1. implement `HasDefaultCluster` in `ecs` package
2. early check for default cluster in `task run`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
