### PR TITLE
chore(cli): enable creating environments from temporary creds

### DIFF
--- a/internal/pkg/cli/env_init.go
+++ b/internal/pkg/cli/env_init.go
@@ -96,15 +96,15 @@ type tempCredsVars struct {
 
 type initEnvVars struct {
 	*GlobalOpts
-	Name              string
-	Profile           string
-	IsProduction      bool
-	NoCustomResources bool
+	Name              string // Name for the environment.
+	Profile           string // The named profile to use for credential retrieval. Mutually exclusive with TempCreds.
+	IsProduction      bool   // True means retain resources even after deletion.
+	NoCustomResources bool   // True means no importing an existing VPC or adjusting a VPC.
 
-	ImportVPC importVPCVars
-	AdjustVPC adjustVPCVars
+	ImportVPC importVPCVars // Existing VPC resources to use instead of creating new ones.
+	AdjustVPC adjustVPCVars // Configure parameters for VPC resources generated while initializing an environment.
 
-	TempCreds tempCredsVars // Temporary credentials to initialize the environment. Mutually exclusive with the AWS profile.
+	TempCreds tempCredsVars // Temporary credentials to initialize the environment. Mutually exclusive with the Profile.
 	Region    string        // The region to create the environment in.
 }
 

--- a/internal/pkg/cli/env_init_test.go
+++ b/internal/pkg/cli/env_init_test.go
@@ -31,6 +31,11 @@ func TestInitEnvOpts_Validate(t *testing.T) {
 		inVPCCIDR           net.IPNet
 		inPublicCIDRs       []string
 
+		inProfileName     string
+		inAccessKeyID     string
+		inSecretAccessKey string
+		inSessionToken    string
+
 		wantedErrMsg string
 	}{
 		"valid environment creation": {
@@ -69,6 +74,30 @@ func TestInitEnvOpts_Validate(t *testing.T) {
 
 			wantedErrMsg: fmt.Sprintf("cannot import or configure vpc if --%s is set", noCustomResourcesFlag),
 		},
+		"should err if both profile and access key id are set": {
+			inAppName:     "phonetool",
+			inEnvName:     "test",
+			inProfileName: "default",
+			inAccessKeyID: "AKIAIOSFODNN7EXAMPLE",
+
+			wantedErrMsg: "cannot specify both --profile and --aws-access-key-id",
+		},
+		"should err if both profile and secret access key are set": {
+			inAppName:         "phonetool",
+			inEnvName:         "test",
+			inProfileName:     "default",
+			inSecretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+
+			wantedErrMsg: "cannot specify both --profile and --aws-secret-access-key",
+		},
+		"should err if both profile and session token are set": {
+			inAppName:      "phonetool",
+			inEnvName:      "test",
+			inProfileName:  "default",
+			inSessionToken: "verylongtoken",
+
+			wantedErrMsg: "cannot specify both --profile and --aws-session-token",
+		},
 	}
 
 	for name, tc := range testCases {
@@ -87,6 +116,12 @@ func TestInitEnvOpts_Validate(t *testing.T) {
 						ID:              tc.inVPCID,
 					},
 					GlobalOpts: &GlobalOpts{appName: tc.inAppName},
+					Profile:    tc.inProfileName,
+					TempCreds: tempCredsVars{
+						AccessKeyID:     tc.inAccessKeyID,
+						SecretAccessKey: tc.inSecretAccessKey,
+						SessionToken:    tc.inSessionToken,
+					},
 				},
 			}
 

--- a/internal/pkg/cli/env_init_test.go
+++ b/internal/pkg/cli/env_init_test.go
@@ -650,7 +650,7 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 				identity:    mockIdentity,
 				envIdentity: mockIdentity,
 				prog:        mockProgress,
-				initProfileClients: func(o *initEnvOpts) error {
+				configureRuntimeClients: func(o *initEnvOpts) error {
 					return nil
 				},
 			}

--- a/internal/pkg/cli/flag.go
+++ b/internal/pkg/cli/flag.go
@@ -75,6 +75,11 @@ const (
 	privateSubnetCIDRsFlag = "override-private-cidrs"
 
 	noCustomResourcesFlag = "no-custom-resources"
+
+	accessKeyIDFlag     = "aws-access-key-id"
+	secretAccessKeyFlag = "aws-secret-access-key"
+	sessionTokenFlag    = "aws-session-token"
+	regionFlag          = "region"
 )
 
 // Short flag names.
@@ -180,4 +185,9 @@ Must be of the format '<keyName>:<dataType>'.`
 	privateSubnetCIDRsFlagDescription = "Optional. CIDR to use for private subnets (default 10.0.2.0/24,10.0.3.0/24)."
 
 	noCustomResourcesFlagDescription = "Optional. Skip prompting and use default environment configuration."
+
+	accessKeyIDFlagDescription     = "Optional. An AWS access key."
+	secretAccessKeyFlagDescription = "Optional. An AWS secret access key."
+	sessionTokenFlagDescription    = "Optional. An AWS session token for temporary credentials."
+	envRegionTokenFlagDescription  = "Options. An AWS region where the environment will be created."
 )

--- a/internal/pkg/cli/init.go
+++ b/internal/pkg/cli/init.go
@@ -134,7 +134,7 @@ func newInitOpts(vars initVars) (*initOpts, error) {
 		prog:          spin,
 		identity:      id,
 
-		initProfileClients: initEnvProfileClients,
+		configureRuntimeClients: configureInitEnvClients,
 	}
 
 	deploySvcCmd := &deploySvcOpts{


### PR DESCRIPTION
- Add the struct to hold temporary credentials.
- Validate temp credentials flags.
- Create clients from temporary credentials if specified.

The PR to ask for the credentials, updating `env delete`, and `env init` will be follow-ups.

Related #1228 

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
