### PR TITLE
chore(ecs): return container stopped reason from RunTask

### DIFF
--- a/internal/pkg/aws/ecs/ecs.go
+++ b/internal/pkg/aws/ecs/ecs.go
@@ -244,7 +244,7 @@ func (e *ECS) RunTask(input RunTaskInput) ([]*Task, error) {
 		if aerr.Code() == request.WaiterResourceNotReadyErrorCode {
 			tasks, err := e.DescribeTasks(input.Cluster, taskARNs)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("determining task failure reason: %2", err)
 			}
 
 			return nil, &ErrWaiterResourceNotReadyForTasks{tasks: tasks, awsErrResourceNotReady: aerr}

--- a/internal/pkg/aws/ecs/ecs.go
+++ b/internal/pkg/aws/ecs/ecs.go
@@ -244,7 +244,7 @@ func (e *ECS) RunTask(input RunTaskInput) ([]*Task, error) {
 		if aerr.Code() == request.WaiterResourceNotReadyErrorCode {
 			tasks, err := e.DescribeTasks(input.Cluster, taskARNs)
 			if err != nil {
-				return nil, fmt.Errorf("determining task failure reason: %2", err)
+				return nil, fmt.Errorf("determining task failure reason: %w", err)
 			}
 
 			return nil, &ErrWaiterResourceNotReadyForTasks{tasks: tasks, awsErrResourceNotReady: aerr}

--- a/internal/pkg/aws/ecs/ecs.go
+++ b/internal/pkg/aws/ecs/ecs.go
@@ -6,6 +6,8 @@ package ecs
 
 import (
 	"fmt"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"strings"
 	"time"
 
@@ -226,19 +228,29 @@ func (e *ECS) RunTask(input RunTaskInput) ([]*Task, error) {
 		taskARNs[idx] = aws.StringValue(task.TaskArn)
 	}
 
-	if err := e.client.WaitUntilTasksRunning(&ecs.DescribeTasksInput{
+	err = e.client.WaitUntilTasksRunning(&ecs.DescribeTasksInput{
 		Cluster: aws.String(input.Cluster),
 		Tasks:   aws.StringSlice(taskARNs),
-	}); err != nil {
-		return nil, fmt.Errorf("wait for tasks to be running: %w", err)
+	})
+	if err == nil {
+		tasks, err := e.DescribeTasks(input.Cluster, taskARNs)
+		if err != nil {
+			return nil, err
+		}
+		return tasks, nil
 	}
 
-	tasks, err := e.DescribeTasks(input.Cluster, taskARNs)
-	if err != nil {
-		return nil, err
-	}
+	if aerr, ok := err.(awserr.Error); ok {
+		if aerr.Code() == request.WaiterResourceNotReadyErrorCode {
+			tasks, err := e.DescribeTasks(input.Cluster, taskARNs)
+			if err != nil {
+				return nil, err
+			}
 
-	return tasks, nil
+			return nil, &ErrWaiterResourceNotReadyForTasks{tasks: tasks, awsErrResourceNotReady: aerr}
+		}
+	}
+	return nil, fmt.Errorf("wait for tasks to be running: %w", err)
 }
 
 // DescribeTasks returns the tasks with the taskARNs in the cluster.

--- a/internal/pkg/aws/ecs/errors.go
+++ b/internal/pkg/aws/ecs/errors.go
@@ -3,7 +3,39 @@
 
 package ecs
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+)
+
+const (
+	fmtErrContainerStopped = "task %s: %s"
+)
 
 // ErrNoDefaultCluster occurs when the default cluster is not found.
 var ErrNoDefaultCluster = errors.New("default cluster does not exist")
+
+// ErrResourceNotReadyForTasks contains the STOPPED reason for the container of the first task that failed to start.
+type ErrWaiterResourceNotReadyForTasks struct {
+	tasks []*Task
+	awsErrResourceNotReady error
+}
+
+func (e *ErrWaiterResourceNotReadyForTasks) Error() string {
+	for _, task := range e.tasks {
+		if aws.StringValue(task.LastStatus) != DesiredStatusStopped {
+			continue
+		}
+
+		container := task.Containers[0] // NOTE: right now we only support one container per task
+		if aws.StringValue(container.LastStatus) == DesiredStatusStopped {
+			taskID, err := task.taskID(aws.StringValue(task.TaskArn))
+			if err != nil {
+				continue
+			}
+			return fmt.Sprintf(fmtErrContainerStopped, taskID[:shortTaskIDLength], aws.StringValue(container.Reason))
+		}
+	}
+	return e.awsErrResourceNotReady.Error()
+}

--- a/internal/pkg/aws/ecs/errors.go
+++ b/internal/pkg/aws/ecs/errors.go
@@ -28,6 +28,7 @@ func (e *ErrWaiterResourceNotReadyForTasks) Error() string {
 			continue
 		}
 
+		// TODO: generalize this to be an essential container.
 		container := task.Containers[0] // NOTE: right now we only support one container per task
 		if aws.StringValue(container.LastStatus) == DesiredStatusStopped {
 			taskID, err := task.taskID(aws.StringValue(task.TaskArn))

--- a/internal/pkg/aws/ecs/errors.go
+++ b/internal/pkg/aws/ecs/errors.go
@@ -30,13 +30,15 @@ func (e *ErrWaiterResourceNotReadyForTasks) Error() string {
 
 		// TODO: generalize this to be an essential container.
 		container := task.Containers[0] // NOTE: right now we only support one container per task
-		if aws.StringValue(container.LastStatus) == DesiredStatusStopped {
-			taskID, err := task.taskID(aws.StringValue(task.TaskArn))
-			if err != nil {
-				continue
-			}
-			return fmt.Sprintf(fmtErrContainerStopped, taskID[:shortTaskIDLength], aws.StringValue(container.Reason))
+		if aws.StringValue(container.LastStatus) != DesiredStatusStopped {
+			continue
 		}
+
+		taskID, err := task.taskID(aws.StringValue(task.TaskArn))
+		if err != nil {
+			continue
+		}
+		return fmt.Sprintf(fmtErrContainerStopped, taskID[:shortTaskIDLength], aws.StringValue(container.Reason))
 	}
 	return e.awsErrResourceNotReady.Error()
 }


### PR DESCRIPTION
This PR refactors `RunTask` method from `ecs` package to return more informative error message. 

#### Why 
The error message returned from the waiter is too generic. For example, currently the error message eventually returned to the user may look like this:
```
✘ run task test: run task test: wait for tasks to be running: ResourceNotReady: failed waiting for successful resource state
```


#### How
When the waiter fails to wait for the tasks to start, if it's a `ResourceNotReady` error, we try to return the container-level failure reason, which is more informative. For example, the error message may look like this:
```
✘ run task test: run task test: task 590bc4fe: CannotStartContainerError: Error response from daemon: OCI runtime create failed: container_linux.go:348: starting container process caused "exec: \"very-random-command\": executable file not found in $PATH": unknown
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
