### PR TITLE
chore(cli): fix deploying a svc from "init" with new docker build args

### DIFF
--- a/internal/pkg/cli/init.go
+++ b/internal/pkg/cli/init.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/config"
 	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation"
 	"github.com/aws/copilot-cli/internal/pkg/docker/dockerfile"
+	"github.com/aws/copilot-cli/internal/pkg/manifest"
 	"github.com/aws/copilot-cli/internal/pkg/term/color"
 	"github.com/aws/copilot-cli/internal/pkg/term/command"
 	"github.com/aws/copilot-cli/internal/pkg/term/log"
@@ -146,6 +147,7 @@ func newInitOpts(vars initVars) (*initOpts, error) {
 
 		store:        ssm,
 		ws:           ws,
+		unmarshal:    manifest.UnmarshalService,
 		sel:          selector.NewWorkspaceSelect(prompt, ssm, ws),
 		spinner:      spin,
 		cmd:          command.New(),


### PR DESCRIPTION
The new `unmarshal` field was missing in init resulting in a segfault.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
