### PR TITLE
test(e2e): fix task run test with overrides

### DIFF
--- a/e2e/task/task_test.go
+++ b/e2e/task/task_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Task", func() {
 				Dockerfile: "./backend/Dockerfile",
 
 				AppName: appName,
-				Env: envName,
+				Env:     envName,
 			})
 		})
 
@@ -66,7 +66,7 @@ var _ = Describe("Task", func() {
 				Dockerfile: "./backend/Dockerfile",
 
 				Default: true,
-				Follow: true,
+				Follow:  true,
 			})
 		})
 
@@ -101,11 +101,8 @@ var _ = Describe("Task", func() {
 				Command: "python main.py",
 				EnvVars: "STATUS=OVERRIDDEN",
 
-				AppName: appName,
-				Env: envName,
-
 				Default: true,
-				Follow: true,
+				Follow:  true,
 			})
 
 		})


### PR DESCRIPTION
The e2e tests fail now because we cannot specify both a copilot application and the default cluster while running a task.
This change runs the test only using the default cluster.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
