### PR TITLE
fix(cli): remove env init redundant prompt

### DIFF
--- a/internal/pkg/cli/env_init.go
+++ b/internal/pkg/cli/env_init.go
@@ -325,10 +325,12 @@ func (o *initEnvOpts) askCustomizedResources() error {
 	if o.NoCustomResources {
 		return nil
 	}
-	if o.selVPC == nil {
-		o.selVPC = selector.NewEC2Select(o.prompt, ec2.New(o.sess))
+	if o.ImportVPC.isSet() {
+		return o.askImportResources()
 	}
-
+	if o.AdjustVPC.isSet() {
+		return o.askAdjustResources()
+	}
 	adjustOrImport, err := o.prompt.SelectOne(
 		envInitDefaultEnvConfirmPrompt, "",
 		envInitCustomizedEnvTypes)
@@ -347,6 +349,9 @@ func (o *initEnvOpts) askCustomizedResources() error {
 }
 
 func (o *initEnvOpts) askImportResources() error {
+	if o.selVPC == nil {
+		o.selVPC = selector.NewEC2Select(o.prompt, ec2.New(o.sess))
+	}
 	if o.ImportVPC.ID == "" {
 		vpcID, err := o.selVPC.VPC(envInitVPCSelectPrompt, "")
 		if err != nil {

--- a/internal/pkg/cli/env_init_test.go
+++ b/internal/pkg/cli/env_init_test.go
@@ -150,12 +150,14 @@ func TestInitEnvOpts_Validate(t *testing.T) {
 }
 
 func TestInitEnvOpts_Ask(t *testing.T) {
-	mockEnv := "test"
-	mockProfile := "default"
+	const (
+		mockEnv         = "test"
+		mockProfile     = "default"
+		mockVPCCIDR     = "10.10.10.10/24"
+		mockSubnetCIDRs = "10.10.10.10/24,10.10.10.10/24"
+		mockRegion      = "us-west-2"
+	)
 	mockErr := errors.New("some error")
-	mockVPCCIDR := "10.10.10.10/24"
-	mockSubnetCIDRs := "10.10.10.10/24,10.10.10.10/24"
-	mockRegion := "us-west-2"
 	mockSession := &session.Session{
 		Config: &aws.Config{
 			Region: aws.String(mockRegion),
@@ -329,8 +331,7 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 			},
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(mockSession, nil)
-				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, "", envInitCustomizedEnvTypes).
-					Return(envInitImportEnvResourcesSelectOption, nil)
+				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, gomock.Any(), gomock.Any()).Times(0)
 			},
 		},
 		"fail to get VPC CIDR": {
@@ -403,8 +404,7 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 			},
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(mockSession, nil)
-				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, "", envInitCustomizedEnvTypes).
-					Return(envInitAdjustEnvResourcesSelectOption, nil)
+				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, gomock.Any(), gomock.Any()).Times(0)
 			},
 		},
 	}


### PR DESCRIPTION
<!-- Provide summary of changes -->
This PR fixes `env init` by removing redundant prompt that asks users to select if they'd like to adjust/import/use default, even if users have already specified any of import/config flag set.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
