### PR TITLE
chore(prompt): make validation optional for Get prompt

### DIFF
--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -26,6 +26,7 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/term/command"
 	"github.com/aws/copilot-cli/internal/pkg/term/log"
 	termprogress "github.com/aws/copilot-cli/internal/pkg/term/progress"
+	"github.com/aws/copilot-cli/internal/pkg/term/prompt"
 	"github.com/aws/copilot-cli/internal/pkg/term/selector"
 	"github.com/aws/copilot-cli/internal/pkg/workspace"
 	"github.com/spf13/cobra"
@@ -240,7 +241,7 @@ func (o *deploySvcOpts) askImageTag() error {
 
 	log.Warningln("Failed to default tag, are you in a git repository?")
 
-	userInputTag, err := o.prompt.Get(inputImageTagPrompt, "", nil /*no validation*/)
+	userInputTag, err := o.prompt.Get(inputImageTagPrompt, "", prompt.RequireNonEmpty)
 	if err != nil {
 		return fmt.Errorf("prompt for image tag: %w", err)
 	}

--- a/internal/pkg/cli/svc_package.go
+++ b/internal/pkg/cli/svc_package.go
@@ -18,6 +18,7 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation/stack"
 	"github.com/aws/copilot-cli/internal/pkg/manifest"
 	"github.com/aws/copilot-cli/internal/pkg/term/command"
+	"github.com/aws/copilot-cli/internal/pkg/term/prompt"
 	"github.com/aws/copilot-cli/internal/pkg/term/selector"
 	"github.com/aws/copilot-cli/internal/pkg/workspace"
 	"github.com/spf13/afero"
@@ -233,7 +234,7 @@ func (o *packageSvcOpts) askTag() error {
 	tag, err := getVersionTag(o.runner)
 	if err != nil {
 		// We're not in a Git repository, prompt the user for an explicit tag.
-		tag, err = o.prompt.Get(inputImageTagPrompt, "", nil)
+		tag, err = o.prompt.Get(inputImageTagPrompt, "", prompt.RequireNonEmpty)
 		if err != nil {
 			return fmt.Errorf("prompt get image tag: %w", err)
 		}

--- a/internal/pkg/cli/svc_package_test.go
+++ b/internal/pkg/cli/svc_package_test.go
@@ -136,7 +136,7 @@ func TestPackageSvcOpts_Ask(t *testing.T) {
 				m.EXPECT().Environment(svcPackageEnvNamePrompt, "", testAppName).Return("test", nil)
 			},
 			expectPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().Get(inputImageTagPrompt, "", nil).Return("v1.0.0", nil)
+				m.EXPECT().Get(inputImageTagPrompt, "", gomock.Any()).Return("v1.0.0", nil)
 			},
 
 			wantedSvcName: "frontend",

--- a/internal/pkg/term/prompt/prompt.go
+++ b/internal/pkg/term/prompt/prompt.go
@@ -168,8 +168,12 @@ func (p Prompt) Get(message, help string, validator ValidatorFunc, promptOpts ..
 	}
 
 	var result string
-	err := p(prompt, &result, stdio(), validators(validator), icons())
-
+	var err error
+	if validator == nil {
+		err = p(prompt, &result, stdio(), icons())
+	} else {
+		err = p(prompt, &result, stdio(), validators(validator), icons())
+	}
 	return result, err
 }
 
@@ -340,14 +344,11 @@ func icons() survey.AskOpt {
 	})
 }
 
+// RequireNonEmpty returns an error if v is a zero-value.
+func RequireNonEmpty(v interface{}) error {
+	return survey.Required(v)
+}
+
 func validators(validatorFunc ValidatorFunc) survey.AskOpt {
-	var v survey.Validator
-
-	if validatorFunc != nil {
-		v = survey.ComposeValidators(survey.Required, survey.Validator(validatorFunc))
-	} else {
-		v = survey.Required
-	}
-
-	return survey.WithValidator(v)
+	return survey.WithValidator(survey.ComposeValidators(survey.Required, survey.Validator(validatorFunc)))
 }

--- a/internal/pkg/term/selector/creds.go
+++ b/internal/pkg/term/selector/creds.go
@@ -69,15 +69,15 @@ func (s *CredsSelect) Creds(prompt, help string) (*session.Session, error) {
 func (s *CredsSelect) askTempCreds() (*session.Session, error) {
 	defaultAccessKey, defaultSecretAccessKey, defaultSessToken := defaultCreds(s.Session)
 
-	accessKeyID, err := s.askWithMaskedDefault(accessKeyIDPrompt, defaultAccessKey)
+	accessKeyID, err := s.askWithMaskedDefault(accessKeyIDPrompt, defaultAccessKey, prompt.RequireNonEmpty)
 	if err != nil {
 		return nil, fmt.Errorf("get access key id: %w", err)
 	}
-	secretAccessKey, err := s.askWithMaskedDefault(secretAccessKeyPrompt, defaultSecretAccessKey)
+	secretAccessKey, err := s.askWithMaskedDefault(secretAccessKeyPrompt, defaultSecretAccessKey, prompt.RequireNonEmpty)
 	if err != nil {
 		return nil, fmt.Errorf("get secret access key: %w", err)
 	}
-	sessionToken, err := s.askWithMaskedDefault(sessionTokenPrompt, defaultSessToken) // TODO(efekarakus): remove validation so that it can be empty.
+	sessionToken, err := s.askWithMaskedDefault(sessionTokenPrompt, defaultSessToken, nil)
 	if err != nil {
 		return nil, fmt.Errorf("get session token: %w", err)
 	}
@@ -89,8 +89,8 @@ func (s *CredsSelect) askTempCreds() (*session.Session, error) {
 	return sess, nil
 }
 
-func (s *CredsSelect) askWithMaskedDefault(msg, defaultValue string) (string, error) {
-	accessKeyId, err := s.Prompt.Get(msg, "", nil, prompt.WithDefaultInput(mask(defaultValue)))
+func (s *CredsSelect) askWithMaskedDefault(msg, defaultValue string, f prompt.ValidatorFunc) (string, error) {
+	accessKeyId, err := s.Prompt.Get(msg, "", f, prompt.WithDefaultInput(mask(defaultValue)))
 	if err != nil {
 		return "", err
 	}

--- a/internal/pkg/term/selector/creds_test.go
+++ b/internal/pkg/term/selector/creds_test.go
@@ -84,9 +84,9 @@ func TestCredsSelect_Creds(t *testing.T) {
 					},
 				}, nil)
 
-				prompter.EXPECT().Get("What's your AWS Access Key ID?", "", nil, gomock.Any()).
+				prompter.EXPECT().Get("What's your AWS Access Key ID?", "", gomock.Any(), gomock.Any()).
 					Return("****************1111", nil)
-				prompter.EXPECT().Get("What's your AWS Secret Access Key?", "", nil, gomock.Any()).
+				prompter.EXPECT().Get("What's your AWS Secret Access Key?", "", gomock.Any(), gomock.Any()).
 					Return("****************2222", nil)
 				prompter.EXPECT().Get("What's your AWS Session Token?", "", nil, gomock.Any()).
 					Return("****************3333", nil)


### PR DESCRIPTION
Previously, when the `validators` param was `nil`, the `prompt` pkg automatically added the `survey.Required` validator.
This change makes validation optional, and if we want to make a prompt's answer required we can use the new `prompt.RequireNonEmpty` function.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
