### PR TITLE
test(e2e): clean redundant task stack for task e2e test

### DIFF
--- a/e2e/task/task_suite_test.go
+++ b/e2e/task/task_suite_test.go
@@ -2,15 +2,17 @@ package task
 
 import (
 	"fmt"
-	"github.com/aws/copilot-cli/e2e/internal/client"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	"testing"
 	"time"
+
+	"github.com/aws/copilot-cli/e2e/internal/client"
+	"github.com/aws/copilot-cli/e2e/internal/command"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
 var cli *client.CLI
-var appName, envName, groupName string
+var appName, envName, groupName, taskStackName, repoName string
 
 /**
 The task suite runs through several tests focusing on running one-off tasks with different configurations.
@@ -27,16 +29,28 @@ var _ = BeforeSuite(func() {
 
 	appName = fmt.Sprintf("e2e-task-%d", time.Now().Unix())
 	envName = "test"
-	// NOTE: cfn stack for task isn't deleted automatically, and `task delete` isn't implemented yet
-	// so we deploy all tasks to the same group, so that it doesn't create a lot of stacks.
 	groupName = fmt.Sprintf("e2e-task-%d", time.Now().Unix())
+	// We name task stack in format of "task-${groupName}".
+	// See https://github.com/aws/copilot-cli/blob/e9e3114561e740c367fb83b5e075750f232ad639/internal/pkg/deploy/cloudformation/stack/name.go#L26.
+	taskStackName = fmt.Sprintf("task-%s", groupName)
+	// We name ECR repo name in format of "copilot-${groupName}".
+	// See https://github.com/aws/copilot-cli/blob/e9e3114561e740c367fb83b5e075750f232ad639/templates/task/cf.yml#L75.
+	repoName = fmt.Sprintf("copilot-%s", groupName)
 })
 
 var _ = AfterSuite(func() {
-	_, err := cli.AppDelete(map[string]string{"test": "default"})
-	Expect(err).NotTo(HaveOccurred())
-
-	// TODO: cli.TaskDelete()
+	// Clean ECR repo before deleting the stack.
+	err := command.Run("aws", []string{"ecr", "delete-repository", "--repository-name", repoName, "--force"})
+	Expect(err).NotTo(HaveOccurred(), "delete ecr repo")
+	// Delete task stack.
+	err = command.Run("aws", []string{"cloudformation", "delete-stack", "--stack-name", taskStackName})
+	Expect(err).NotTo(HaveOccurred(), "start deleting task stack")
+	// Wait until task stack is removed.
+	err = command.Run("aws", []string{"cloudformation", "wait", "stack-delete-complete", "--stack-name", taskStackName})
+	Expect(err).NotTo(HaveOccurred(), "task stack delete complete")
+	// Delete Copilot application.
+	_, err = cli.AppDelete(map[string]string{"test": "default"})
+	Expect(err).NotTo(HaveOccurred(), "delete Copilot application")
 })
 
 func BeforeAll(fn func()) {


### PR DESCRIPTION
<!-- Provide summary of changes -->
Currently our task e2e test doesn't delete the task stack after running the task e2e test. And the task stack is very difficult to remove because the CFN Execution Role that used to manage the task stack is deleted when we delete copilot environment.  Also, the remaining task stacks piles up in our Copilot pipeline account.

This PR fixes this issue by removing task stack before we delete copilot app/env.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
