### PR TITLE
chore: lower Service Discovery DNS TTL

### DIFF
--- a/templates/services/common/cf/servicediscovery.yml
+++ b/templates/services/common/cf/servicediscovery.yml
@@ -5,9 +5,9 @@ DiscoveryService:
     DnsConfig:
       RoutingPolicy: MULTIVALUE
       DnsRecords:
-        - TTL: 60
+        - TTL: 10
           Type: A
-        - TTL: 60
+        - TTL: 10
           Type: SRV
     HealthCheckCustomConfig:
       FailureThreshold: 1


### PR DESCRIPTION
This lowers the service discovery down from 1min to 10s. This value is how long a IP address is cached. While we wait for https://github.com/aws/containers-roadmap/issues/343 to be resolved, we can lower the value to 10seconds. The longer this value is, the longer a service might fail to call another service due to a bad cache value.

fixes #1173

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
