### PR TITLE
chore(storage): update unit test output to match input options

### DIFF
--- a/internal/pkg/cli/storage_init.go
+++ b/internal/pkg/cli/storage_init.go
@@ -90,14 +90,14 @@ const (
 
 const (
 	ddbStringTypeLong = "String"
-	ddbIntTypeLong = "Number"
+	ddbIntTypeLong    = "Number"
 	ddbBinaryTypeLong = "Binary"
 )
 
 var attributeTypesLong = []string{
-	"String",
-	"Number",
-	"Binary",
+	ddbStringTypeLong,
+	ddbIntTypeLong,
+	ddbBinaryTypeLong,
 }
 
 const (

--- a/internal/pkg/cli/storage_init.go
+++ b/internal/pkg/cli/storage_init.go
@@ -88,11 +88,11 @@ const (
 	ddbBinaryType = "B"
 )
 
-var attributeTypes = []string{
-	ddbStringType,
-	ddbIntType,
-	ddbBinaryType,
-}
+const (
+	ddbStringTypeLong = "String"
+	ddbIntTypeLong = "Number"
+	ddbBinaryTypeLong = "Binary"
+)
 
 var attributeTypesLong = []string{
 	"String",

--- a/internal/pkg/cli/storage_init_test.go
+++ b/internal/pkg/cli/storage_init_test.go
@@ -24,6 +24,8 @@ func TestStorageInitOpts_Validate(t *testing.T) {
 		inPartition   string
 		inSort        string
 		inLSISorts    []string
+		inNoSort      bool
+		inNoLSI       bool
 
 		mockWs    func(m *mocks.MockwsAddonManager)
 		mockStore func(m *mocks.Mockstore)
@@ -60,60 +62,103 @@ func TestStorageInitOpts_Validate(t *testing.T) {
 			inStorageName: "my-bucket",
 			wantedErr:     errors.New("retrieve local service names: wanted err"),
 		},
-		"happy path s3": {
-			mockWs: func(m *mocks.MockwsAddonManager) {
-				m.EXPECT().ServiceNames().Return([]string{"frontend"}, nil)
-			},
+		"successfully validates valid s3 bucket name": {
+			mockWs:        func(m *mocks.MockwsAddonManager) {},
 			mockStore:     func(m *mocks.Mockstore) {},
 			inAppName:     "bowie",
 			inStorageType: s3StorageType,
-			inSvcName:     "frontend",
 			inStorageName: "my-bucket.4",
 			wantedErr:     nil,
 		},
-		"happy path ddb": {
-			mockWs: func(m *mocks.MockwsAddonManager) {
-				m.EXPECT().ServiceNames().Return([]string{"frontend"}, nil)
-			},
+		"successfully validates valid DDB table name": {
+			mockWs:        func(m *mocks.MockwsAddonManager) {},
 			mockStore:     func(m *mocks.Mockstore) {},
 			inAppName:     "bowie",
 			inStorageType: dynamoDBStorageType,
-			inSvcName:     "frontend",
 			inStorageName: "my-cool_table.3",
 			wantedErr:     nil,
 		},
 		"default to ddb name validation when storage type unspecified": {
-			mockWs: func(m *mocks.MockwsAddonManager) {
-				m.EXPECT().ServiceNames().Return([]string{"frontend"}, nil)
-			},
+			mockWs:        func(m *mocks.MockwsAddonManager) {},
 			mockStore:     func(m *mocks.Mockstore) {},
 			inAppName:     "bowie",
 			inStorageType: "",
-			inSvcName:     "frontend",
 			inStorageName: "my-cool_table.3",
 			wantedErr:     nil,
 		},
 		"s3 bad character": {
-			mockWs: func(m *mocks.MockwsAddonManager) {
-				m.EXPECT().ServiceNames().Return([]string{"frontend"}, nil)
-			},
+			mockWs:        func(m *mocks.MockwsAddonManager) {},
 			mockStore:     func(m *mocks.Mockstore) {},
 			inAppName:     "bowie",
 			inStorageType: s3StorageType,
-			inSvcName:     "frontend",
 			inStorageName: "mybadbucket???",
 			wantedErr:     errValueBadFormatWithPeriod,
 		},
 		"ddb bad character": {
-			mockWs: func(m *mocks.MockwsAddonManager) {
-				m.EXPECT().ServiceNames().Return([]string{"frontend"}, nil)
-			},
+			mockWs:        func(m *mocks.MockwsAddonManager) {},
 			mockStore:     func(m *mocks.Mockstore) {},
 			inAppName:     "bowie",
 			inStorageType: dynamoDBStorageType,
-			inSvcName:     "frontend",
 			inStorageName: "badTable!!!",
 			wantedErr:     errValueBadFormatWithPeriodUnderscore,
+		},
+		"successfully validates partition key flag": {
+			mockWs:        func(m *mocks.MockwsAddonManager) {},
+			mockStore:     func(m *mocks.Mockstore) {},
+			inAppName:     "bowie",
+			inStorageType: dynamoDBStorageType,
+			inPartition:   "points:String",
+			wantedErr:     nil,
+		},
+		"successfully validates sort key flag": {
+			mockWs:        func(m *mocks.MockwsAddonManager) {},
+			mockStore:     func(m *mocks.Mockstore) {},
+			inAppName:     "bowie",
+			inStorageType: dynamoDBStorageType,
+			inSort:        "userID:Number",
+			wantedErr:     nil,
+		},
+		"successfully validates LSI": {
+			mockWs:        func(m *mocks.MockwsAddonManager) {},
+			mockStore:     func(m *mocks.Mockstore) {},
+			inAppName:     "bowie",
+			inStorageType: dynamoDBStorageType,
+			inLSISorts:    []string{"userID:Number", "data:Binary"},
+			wantedErr:     nil,
+		},
+		"success on providing --no-sort": {
+			mockWs:        func(m *mocks.MockwsAddonManager) {},
+			mockStore:     func(m *mocks.Mockstore) {},
+			inAppName:     "bowie",
+			inStorageType: dynamoDBStorageType,
+			inNoSort:      true,
+			wantedErr:     nil,
+		},
+		"success on providing --no-lsi": {
+			mockWs:        func(m *mocks.MockwsAddonManager) {},
+			mockStore:     func(m *mocks.Mockstore) {},
+			inAppName:     "bowie",
+			inStorageType: dynamoDBStorageType,
+			inNoLSI:       true,
+			wantedErr:     nil,
+		},
+		"fails when --no-lsi and --lsi are both provided": {
+			mockWs:        func(m *mocks.MockwsAddonManager) {},
+			mockStore:     func(m *mocks.Mockstore) {},
+			inAppName:     "bowie",
+			inStorageType: dynamoDBStorageType,
+			inLSISorts:    []string{"userID:Number"},
+			inNoLSI:       true,
+			wantedErr:     fmt.Errorf("validate LSI configuration: cannot specify --no-lsi and --lsi options at once"),
+		},
+		"fails when --no-sort and --lsi are both provided": {
+			mockWs:        func(m *mocks.MockwsAddonManager) {},
+			mockStore:     func(m *mocks.Mockstore) {},
+			inAppName:     "bowie",
+			inStorageType: dynamoDBStorageType,
+			inLSISorts:    []string{"userID:Number"},
+			inNoSort:      true,
+			wantedErr:     fmt.Errorf("validate LSI configuration: cannot specify --no-sort and --lsi options at once"),
 		},
 	}
 	for name, tc := range testCases {
@@ -136,6 +181,8 @@ func TestStorageInitOpts_Validate(t *testing.T) {
 					partitionKey: tc.inPartition,
 					sortKey:      tc.inSort,
 					lsiSorts:     tc.inLSISorts,
+					noLSI:        tc.inNoLSI,
+					noSort:       tc.inNoSort,
 				},
 				ws:    mockWs,
 				store: mockStore,

--- a/internal/pkg/cli/storage_init_test.go
+++ b/internal/pkg/cli/storage_init_test.go
@@ -160,8 +160,8 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 		wantedSvcName      = "frontend"
 		wantedBucketName   = "coolBucket"
 		wantedTableName    = "coolTable"
-		wantedPartitionKey = "DogName:S"
-		wantedSortKey      = "PhotoId:N"
+		wantedPartitionKey = "DogName:String"
+		wantedSortKey      = "PhotoId:Number"
 	)
 	testCases := map[string]struct {
 		inAppName     string
@@ -284,7 +284,7 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 					gomock.Any(),
 					attributeTypesLong,
 					gomock.Any(),
-				).Return(ddbStringType, nil)
+				).Return(ddbStringTypeLong, nil)
 			},
 			mockCfg: func(m *mocks.MockwsSelector) {},
 
@@ -358,7 +358,7 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 					gomock.Any(),
 					attributeTypesLong,
 					gomock.Any(),
-				).Return(ddbStringType, nil)
+				).Return(ddbStringTypeLong, nil)
 			},
 			mockCfg: func(m *mocks.MockwsSelector) {},
 
@@ -501,7 +501,7 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 					gomock.Eq(lsiTypeHelp),
 					gomock.Eq(attributeTypesLong),
 					gomock.Any(),
-				).Return(ddbStringType, nil)
+				).Return(ddbStringTypeLong, nil)
 				m.EXPECT().Confirm(
 					gomock.Eq(storageInitDDBMoreLSIPrompt),
 					gomock.Eq(storageInitDDBLSIHelp),
@@ -521,7 +521,7 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 				partitionKey: wantedPartitionKey,
 				sortKey:      wantedSortKey,
 				noLSI:        false,
-				lsiSorts:     []string{"Email:S"},
+				lsiSorts:     []string{"Email:String"},
 			},
 		},
 		"noLSI is set correctly if no lsis specified": {
@@ -663,7 +663,7 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 			inStorageName: wantedTableName,
 			inPartition:   wantedPartitionKey,
 			inSort:        wantedSortKey,
-			inLSISorts:    []string{"email:S"},
+			inLSISorts:    []string{"email:String"},
 
 			mockPrompt: func(m *mocks.Mockprompter) {},
 			mockCfg:    func(m *mocks.MockwsSelector) {},
@@ -721,8 +721,8 @@ func TestStorageInitOpts_Execute(t *testing.T) {
 		wantedSvcName      = "frontend"
 		wantedBucketName   = "coolBucket"
 		wantedTableName    = "coolTable"
-		wantedPartitionKey = "DogName:S"
-		wantedSortKey      = "PhotoId:N"
+		wantedPartitionKey = "DogName:String"
+		wantedSortKey      = "PhotoId:Number"
 	)
 	fileExistsError := &workspace.ErrFileExists{FileName: "my-file"}
 	testCases := map[string]struct {
@@ -774,7 +774,7 @@ func TestStorageInitOpts_Execute(t *testing.T) {
 			inStorageName: "my-table",
 			inPartition:   wantedPartitionKey,
 			inSort:        wantedSortKey,
-			inLSISorts:    []string{"goodness:N"},
+			inLSISorts:    []string{"goodness:Number"},
 
 			mockWs: func(m *mocks.MockwsAddonManager) {
 				m.EXPECT().WriteAddon(gomock.Any(), wantedSvcName, "my-table").Return("/frontend/addons/my-table.yml", nil)


### PR DESCRIPTION
<!-- Provide summary of changes -->
Previously, unit test mocks for `Ask()` returned values like "KeyName:S" when prompting for a partition key, sort key, or alternate sort key. This unit test updates the tests to match the actual behavior of the CLI. 

It also expands unit test coverage of the validate() method to ensure errors are correctly caught. 

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
