### PR TITLE
chore(e2e): separate bash commands to client pkg

### DIFF
--- a/e2e/customized-env/customized_env_suite_test.go
+++ b/e2e/customized-env/customized_env_suite_test.go
@@ -15,17 +15,12 @@ import (
 )
 
 var cli *client.CLI
+var aws *client.AWS
 var appName string
 var vpcStackName string
 var vpcStackTemplatePath string
 var vpcImport client.EnvInitRequestVPCImport
 var vpcConfig client.EnvInitRequestVPCConfig
-
-type vpcStackOutput struct {
-	OutputKey   string
-	OutputValue string
-	ExportName  string
-}
 
 /**
 The Customized Env Suite creates multiple environments with customized resources,
@@ -43,6 +38,7 @@ var _ = BeforeSuite(func() {
 	ecsCli, err := client.NewCLI()
 	Expect(err).NotTo(HaveOccurred())
 	cli = ecsCli
+	aws = client.NewAWS()
 	appName = fmt.Sprintf("e2e-customizedenv-%d", time.Now().Unix())
 	vpcConfig = client.EnvInitRequestVPCConfig{
 		CIDR:               "10.1.0.0/16",

--- a/e2e/customized-env/customized_env_suite_test.go
+++ b/e2e/customized-env/customized_env_suite_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/aws/copilot-cli/e2e/internal/client"
-	"github.com/aws/copilot-cli/e2e/internal/command"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -51,7 +50,7 @@ var _ = AfterSuite(func() {
 	_, err := cli.AppDelete(map[string]string{"test": "default", "prod": "default"})
 	Expect(err).NotTo(HaveOccurred())
 	// Delete VPC stack.
-	err = command.Run("aws", []string{"cloudformation", "delete-stack", "--stack-name", vpcStackName})
+	err = aws.DeleteStack(vpcStackName)
 	Expect(err).NotTo(HaveOccurred())
 })
 

--- a/e2e/customized-env/customized_env_test.go
+++ b/e2e/customized-env/customized_env_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Customized Env", func() {
 		BeforeAll(func() {
 			err := aws.CreateStack(vpcStackName, vpcStackTemplatePath)
 			Expect(err).NotTo(HaveOccurred(), "create vpc cloudformation stack")
-			err = aws.StackCreateComplete(vpcStackName)
+			err = aws.WaitStackCreateComplete(vpcStackName)
 			Expect(err).NotTo(HaveOccurred(), "vpc stack create complete")
 		})
 		It("parse vpc stack output", func() {

--- a/e2e/internal/client/aws.go
+++ b/e2e/internal/client/aws.go
@@ -42,11 +42,11 @@ func (a *AWS) CreateStack(name, templatePath string) error {
 	return a.exec(command)
 }
 
-/*StackCreateComplete runs:
+/*WaitStackCreateComplete runs:
 aws cloudformation wait stack-create-complete
 	--stack-name $name
 */
-func (a *AWS) StackCreateComplete(name string) error {
+func (a *AWS) WaitStackCreateComplete(name string) error {
 	command := strings.Join([]string{
 		"cloudformation",
 		"wait",
@@ -93,11 +93,11 @@ func (a *AWS) DeleteStack(name string) error {
 	return a.exec(command)
 }
 
-/*StackDeleteComplete runs:
+/*WaitStackDeleteComplete runs:
 aws cloudformation wait stack-delete-complete
 	--stack-name $name
 */
-func (a *AWS) StackDeleteComplete(name string) error {
+func (a *AWS) WaitStackDeleteComplete(name string) error {
 	command := strings.Join([]string{
 		"cloudformation",
 		"wait",

--- a/e2e/internal/client/aws.go
+++ b/e2e/internal/client/aws.go
@@ -1,0 +1,162 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	cmd "github.com/aws/copilot-cli/e2e/internal/command"
+)
+
+// AWS is a wrapper around aws commands.
+type AWS struct{}
+
+// VPCStackOutput is the output for VPC stack.
+type VPCStackOutput struct {
+	OutputKey   string
+	OutputValue string
+	ExportName  string
+}
+
+// NewAWS returns a wrapper around AWS commands.
+func NewAWS() *AWS {
+	return &AWS{}
+}
+
+/*CreateStack runs:
+aws cloudformation create-stack
+	--stack-name $name
+	--template-body $templatePath
+*/
+func (a *AWS) CreateStack(name, templatePath string) error {
+	command := strings.Join([]string{
+		"cloudformation",
+		"create-stack",
+		"--stack-name", name,
+		"--template-body", templatePath,
+	}, " ")
+	return a.exec(command)
+}
+
+/*StackCreateComplete runs:
+aws cloudformation wait stack-create-complete
+	--stack-name $name
+*/
+func (a *AWS) StackCreateComplete(name string) error {
+	command := strings.Join([]string{
+		"cloudformation",
+		"wait",
+		"stack-create-complete",
+		"--stack-name", name,
+	}, " ")
+	return a.exec(command)
+}
+
+/*VPCStackOutput runs:
+aws cloudformation describe-stacks --stack-name $name |
+	jq -r .Stacks[0].Outputs
+*/
+func (a *AWS) VPCStackOutput(name string) ([]VPCStackOutput, error) {
+	command := strings.Join([]string{
+		"cloudformation",
+		"describe-stacks",
+		"--stack-name", name,
+		"|",
+		"jq", "-r", ".Stacks[0].Outputs",
+	}, " ")
+	var b bytes.Buffer
+	err := a.exec(command, cmd.Stdout(&b))
+	if err != nil {
+		return nil, err
+	}
+	var outputs []VPCStackOutput
+	err = json.Unmarshal(b.Bytes(), &outputs)
+	if err != nil {
+		return nil, err
+	}
+	return outputs, nil
+}
+
+/*DeleteStack runs:
+aws cloudformation delete-stack --stack-name $name
+*/
+func (a *AWS) DeleteStack(name string) error {
+	command := strings.Join([]string{
+		"cloudformation",
+		"delete-stack",
+		"--stack-name", name,
+	}, " ")
+	return a.exec(command)
+}
+
+/*StackDeleteComplete runs:
+aws cloudformation wait stack-delete-complete
+	--stack-name $name
+*/
+func (a *AWS) StackDeleteComplete(name string) error {
+	command := strings.Join([]string{
+		"cloudformation",
+		"wait",
+		"stack-delete-complete",
+		"--stack-name", name,
+	}, " ")
+	return a.exec(command)
+}
+
+/*CreateECRRepo runs:
+aws ecr create-repository --repository-name $name |
+	jq -r .repository.repositoryUri
+*/
+func (a *AWS) CreateECRRepo(name string) (string, error) {
+	command := strings.Join([]string{
+		"ecr",
+		"create-repository",
+		"--repository-name", name,
+		"|",
+		"jq", "-r", ".repository.repositoryUri",
+	}, " ")
+	var b bytes.Buffer
+	err := a.exec(command, cmd.Stdout(&b))
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(b.String()), nil
+}
+
+/*ECRLoginPassword runs:
+aws ecr get-login-password
+*/
+func (a *AWS) ECRLoginPassword() (string, error) {
+	command := strings.Join([]string{
+		"ecr",
+		"get-login-password",
+	}, " ")
+	var b bytes.Buffer
+	err := a.exec(command, cmd.Stdout(&b))
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(b.String()), nil
+}
+
+/*DeleteECRRepo runs:
+aws ecr delete-repository
+	--repository-name $name --force
+*/
+func (a *AWS) DeleteECRRepo(name string) error {
+	command := strings.Join([]string{
+		"ecr",
+		"delete-repository",
+		"--repository-name", name,
+		"--force",
+	}, " ")
+	return a.exec(command)
+}
+
+func (a *AWS) exec(command string, opts ...cmd.Option) error {
+	return BashExec(fmt.Sprintf("aws %s", command), opts...)
+}

--- a/e2e/internal/client/bash.go
+++ b/e2e/internal/client/bash.go
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	cmd "github.com/aws/copilot-cli/e2e/internal/command"
+)
+
+// BashExec execute bash commands.
+func BashExec(command string, opts ...cmd.Option) error {
+	args := []string{"-c", command}
+	err := cmd.Run("bash", args, opts...)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/e2e/internal/client/cli.go
+++ b/e2e/internal/client/cli.go
@@ -1,3 +1,6 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package client
 
 import (

--- a/e2e/internal/client/docker.go
+++ b/e2e/internal/client/docker.go
@@ -21,36 +21,36 @@ func NewDocker() *Docker {
 /*Login runs:
 docker login -u AWS --password-stdin $uri
 */
-func (a *Docker) Login(uri, password string) error {
+func (d *Docker) Login(uri, password string) error {
 	command := strings.Join([]string{
 		"login",
 		"-u", "AWS",
 		"--password-stdin", uri,
 	}, " ")
-	return a.exec(command, cmd.Stdin(strings.NewReader(password)))
+	return d.exec(command, cmd.Stdin(strings.NewReader(password)))
 }
 
 /*Build runs:
 docker build -t $uri $path
 */
-func (a *Docker) Build(uri, path string) error {
+func (d *Docker) Build(uri, path string) error {
 	command := strings.Join([]string{
 		"build",
 		"-t", uri, path,
 	}, " ")
-	return a.exec(command)
+	return d.exec(command)
 }
 
 /*Push runs:
 docker push $uri
 */
-func (a *Docker) Push(uri string) error {
+func (d *Docker) Push(uri string) error {
 	command := strings.Join([]string{
 		"push", uri,
 	}, " ")
-	return a.exec(command)
+	return d.exec(command)
 }
 
-func (a *Docker) exec(command string, opts ...cmd.Option) error {
+func (d *Docker) exec(command string, opts ...cmd.Option) error {
 	return BashExec(fmt.Sprintf("docker %s", command), opts...)
 }

--- a/e2e/internal/client/docker.go
+++ b/e2e/internal/client/docker.go
@@ -1,0 +1,56 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"fmt"
+	"strings"
+
+	cmd "github.com/aws/copilot-cli/e2e/internal/command"
+)
+
+// Docker is a wrapper around Docker commands.
+type Docker struct{}
+
+// NewDocker returns a wrapper around Docker commands.
+func NewDocker() *Docker {
+	return &Docker{}
+}
+
+/*Login runs:
+docker login -u AWS --password-stdin $uri
+*/
+func (a *Docker) Login(uri, password string) error {
+	command := strings.Join([]string{
+		"login",
+		"-u", "AWS",
+		"--password-stdin", uri,
+	}, " ")
+	return a.exec(command, cmd.Stdin(strings.NewReader(password)))
+}
+
+/*Build runs:
+docker build -t $uri $path
+*/
+func (a *Docker) Build(uri, path string) error {
+	command := strings.Join([]string{
+		"build",
+		"-t", uri, path,
+	}, " ")
+	return a.exec(command)
+}
+
+/*Push runs:
+docker push $uri
+*/
+func (a *Docker) Push(uri string) error {
+	command := strings.Join([]string{
+		"push", uri,
+	}, " ")
+	return a.exec(command)
+}
+
+func (a *Docker) exec(command string, opts ...cmd.Option) error {
+	return BashExec(fmt.Sprintf("docker %s", command), opts...)
+}

--- a/e2e/internal/client/outputs.go
+++ b/e2e/internal/client/outputs.go
@@ -1,3 +1,6 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package client
 
 import (

--- a/e2e/sidecars/sidecars_suite_test.go
+++ b/e2e/sidecars/sidecars_suite_test.go
@@ -15,6 +15,8 @@ import (
 )
 
 var cli *client.CLI
+var aws *client.AWS
+var docker *client.Docker
 var appName string
 var svcName string
 var sidecarImageURI string
@@ -30,6 +32,8 @@ var _ = BeforeSuite(func() {
 	ecsCli, err := client.NewCLI()
 	cli = ecsCli
 	Expect(err).NotTo(HaveOccurred())
+	aws = client.NewAWS()
+	docker = client.NewDocker()
 	appName = fmt.Sprintf("e2e-sidecars-%d", time.Now().Unix())
 	svcName = "hello"
 	sidecarRepoName = fmt.Sprintf("e2e-sidecars-nginx-%d", time.Now().Unix())

--- a/e2e/task/task_suite_test.go
+++ b/e2e/task/task_suite_test.go
@@ -1,3 +1,6 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package task
 
 import (
@@ -47,7 +50,7 @@ var _ = AfterSuite(func() {
 	err = aws.DeleteStack(taskStackName)
 	Expect(err).NotTo(HaveOccurred(), "start deleting task stack")
 	// Wait until task stack is removed.
-	err = aws.StackDeleteComplete(taskStackName)
+	err = aws.WaitStackDeleteComplete(taskStackName)
 	Expect(err).NotTo(HaveOccurred(), "task stack delete complete")
 	// Delete Copilot application.
 	_, err = cli.AppDelete(map[string]string{"test": "default"})

--- a/e2e/task/task_suite_test.go
+++ b/e2e/task/task_suite_test.go
@@ -6,12 +6,12 @@ import (
 	"time"
 
 	"github.com/aws/copilot-cli/e2e/internal/client"
-	"github.com/aws/copilot-cli/e2e/internal/command"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 var cli *client.CLI
+var aws *client.AWS
 var appName, envName, groupName, taskStackName, repoName string
 
 /**
@@ -26,6 +26,7 @@ var _ = BeforeSuite(func() {
 	ecsCli, err := client.NewCLI()
 	cli = ecsCli
 	Expect(err).NotTo(HaveOccurred())
+	aws = client.NewAWS()
 
 	appName = fmt.Sprintf("e2e-task-%d", time.Now().Unix())
 	envName = "test"
@@ -40,13 +41,13 @@ var _ = BeforeSuite(func() {
 
 var _ = AfterSuite(func() {
 	// Clean ECR repo before deleting the stack.
-	err := command.Run("aws", []string{"ecr", "delete-repository", "--repository-name", repoName, "--force"})
+	err := aws.DeleteECRRepo(repoName)
 	Expect(err).NotTo(HaveOccurred(), "delete ecr repo")
 	// Delete task stack.
-	err = command.Run("aws", []string{"cloudformation", "delete-stack", "--stack-name", taskStackName})
+	err = aws.DeleteStack(taskStackName)
 	Expect(err).NotTo(HaveOccurred(), "start deleting task stack")
 	// Wait until task stack is removed.
-	err = command.Run("aws", []string{"cloudformation", "wait", "stack-delete-complete", "--stack-name", taskStackName})
+	err = aws.StackDeleteComplete(taskStackName)
 	Expect(err).NotTo(HaveOccurred(), "task stack delete complete")
 	// Delete Copilot application.
 	_, err = cli.AppDelete(map[string]string{"test": "default"})

--- a/e2e/task/task_test.go
+++ b/e2e/task/task_test.go
@@ -1,3 +1,6 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package task
 
 import (


### PR DESCRIPTION
<!-- Provide summary of changes -->
Move bash commands in e2e tests to `client` pkg so as to make e2e tests more declarative. Address https://github.com/aws/copilot-cli/pull/1264#discussion_r471826422.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
