### PR TITLE
chore(cloudformation): rename prefix for change set name

### DIFF
--- a/internal/pkg/aws/cloudformation/changeset.go
+++ b/internal/pkg/aws/cloudformation/changeset.go
@@ -15,7 +15,7 @@ import (
 const (
 	// The change set name must match the regex [a-zA-Z][-a-zA-Z0-9]*. The generated UUID can start with a number,
 	// by prefixing the uuid with a word we guarantee that we start with a letter.
-	fmtChangeSetName = "ecscli-%s"
+	fmtChangeSetName = "copilot-%s"
 
 	// Status reasons that can occur if the change set execution status is "FAILED".
 	noChangesReason = "NO_CHANGES_REASON"

--- a/internal/pkg/aws/cloudformation/cloudformation_test.go
+++ b/internal/pkg/aws/cloudformation/cloudformation_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const mockChangeSetName = "ecscli-31323334-3536-4738-b930-313233333435"
+const mockChangeSetName = "copilot-31323334-3536-4738-b930-313233333435"
 
 var (
 	mockStack = NewStack("id", "template")


### PR DESCRIPTION
related #362

Current prefix for ChangeSetName is "ecscli-". ECS CLI v2 was former name, so I think "copilot-" is better.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
