### PR TITLE
chore(cli): environment is not always for production

### DIFF
--- a/internal/pkg/cli/env_init.go
+++ b/internal/pkg/cli/env_init.go
@@ -32,7 +32,7 @@ import (
 const (
 	envInitNamePrompt              = "What is your environment's name?"
 	envInitNameHelpPrompt          = "A unique identifier for an environment (e.g. dev, test, prod)."
-	envInitDefaultEnvConfirmPrompt = `Would you like to use the default configuration for a new production environment?
+	envInitDefaultEnvConfirmPrompt = `Would you like to use the default configuration for a new environment?
     - A new VPC with 2 AZs, 2 public subnets and 2 private subnets
     - A new ECS Cluster
     - New IAM Roles to manage services in your environment


### PR DESCRIPTION
Removing the word "production" from the `env init` console output since `environment` is not always for production and the original message could be a bit confusing sometimes.

I'm actually not sure the original intent here, so let me discuss if I'm creating a misleading PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
