### PR TITLE
fix(cli): use fixed line separator when parsing github url

### DIFF
--- a/internal/pkg/cli/pipeline_init.go
+++ b/internal/pkg/cli/pipeline_init.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"os"
 	"regexp"
 	"strings"
 
@@ -464,7 +463,7 @@ func (o *initPipelineOpts) parseOwnerRepoName(url string) (string, string, error
 	regexPattern := regexp.MustCompile(`.*(github.com)(:|\/)`)
 	parsedURL := strings.TrimPrefix(url, regexPattern.FindString(url))
 	parsedURL = strings.TrimSuffix(parsedURL, ".git")
-	ownerRepo := strings.Split(parsedURL, string(os.PathSeparator))
+	ownerRepo := strings.Split(parsedURL, "/")
 	if len(ownerRepo) != 2 {
 		return "", "", fmt.Errorf("unable to parse the GitHub repository owner and name from %s: please pass the repository URL with the format `--github-url https://github.com/{owner}/{repositoryName}`", url)
 	}


### PR DESCRIPTION
Avoid using os-specific line separator to fix `pipeline init` command on **Windows**

Fixes #1325

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
