### PR TITLE
fix(stack): render test commands with quotes in pipeline cfn template

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/pipeline_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/pipeline_integration_test.go
@@ -1,0 +1,57 @@
+// +build integration
+
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package stack_test
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/aws/copilot-cli/internal/pkg/deploy"
+	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation/stack"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPipeline_Template ensures that the CloudFormation template generated for a pipeline matches our pre-defined template.
+func TestPipeline_Template(t *testing.T) {
+	ps := stack.NewPipelineStackConfig(&deploy.CreatePipelineInput{
+		AppName: "phonetool",
+		Name:    "phonetool-pipeline",
+		Source: &deploy.Source{
+			ProviderName: "GitHub",
+			Properties: map[string]interface{}{
+				"repository":          "https://github.com/aws/phonetool",
+				"branch":              "mainline",
+				"access_token_secret": "mysecret",
+			},
+		},
+		Stages: []deploy.PipelineStage{
+			{
+				AssociatedEnvironment: &deploy.AssociatedEnvironment{
+					Name:      "test",
+					Region:    "us-west-2",
+					AccountID: "1111",
+				},
+				LocalServices:    []string{"api"},
+				RequiresApproval: false,
+				TestCommands:     []string{`echo "test"`},
+			},
+		},
+		ArtifactBuckets: []deploy.ArtifactBucket{
+			{
+				BucketName: "fancy-bucket",
+				KeyArn:     "arn:aws:kms:us-west-2:1111:key/abcd",
+			},
+		},
+		AdditionalTags: nil,
+	})
+
+	actual, err := ps.Template()
+	require.NoError(t, err, "template should have rendered successfully")
+	expected, err := ioutil.ReadFile(filepath.Join("testdata", "pipeline", "template.yaml"))
+	require.NoError(t, err, "should be able to read expected template file")
+	require.Equal(t, string(expected), actual)
+}

--- a/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/template.yaml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/template.yaml
@@ -6,13 +6,13 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 AWSTemplateFormatVersion: '2010-09-09'
-Description: CodePipeline for {{$.AppName}}
+Description: CodePipeline for phonetool
 Parameters:
   # TODO: #273 make this source-provider-agnostic
   GitHubAccessTokenSecretId:
     Description: The secretId of the GitHub Personal Access token stored in the Secrets Manager
     Type: String
-    Default: {{$.Source.GitHubPersonalAccessTokenSecretID}}
+    Default: mysecret
 Resources:
   BuildProjectRole:
     Type: AWS::IAM::Role
@@ -46,9 +46,9 @@ Resources:
             # TODO: This might not be necessary. We may only need the bucket
             # that is in the same region as the pipeline.
             # Loop through all the artifact buckets created in the stackset
-            Resource:{{range .ArtifactBuckets}}
-              - !Join ['', ['arn:aws:s3:::', '{{.BucketName}}']]
-              - !Join ['', ['arn:aws:s3:::', '{{.BucketName}}', '/*']]{{end}}
+            Resource:
+              - !Join ['', ['arn:aws:s3:::', 'fancy-bucket']]
+              - !Join ['', ['arn:aws:s3:::', 'fancy-bucket', '/*']]
           - Effect: Allow
             Action:
               # TODO: scope this down if possible
@@ -58,8 +58,8 @@ Resources:
             # Loop through all the KMS keys used to en/decrypt artifacts
             # across (cross-regional) pipeline stages, with each stage
             # backed by a (regional) S3 bucket.
-            Resource:{{range .ArtifactBuckets}}
-              - {{.KeyArn}}{{end}}
+            Resource:
+              - arn:aws:kms:us-west-2:1111:key/abcd
           - Effect: Allow
             Action:
               - logs:CreateLogGroup
@@ -86,7 +86,7 @@ Resources:
               - ecr:UploadLayerPart
               - ecr:CompleteLayerUpload
             Resource: '*'
-            Condition: {StringEquals: {'ecr:ResourceTag/copilot-application': {{$.AppName}}}}
+            Condition: {StringEquals: {'ecr:ResourceTag/copilot-application': phonetool}}
       Roles:
         - !Ref BuildProjectRole
   BuildProject:
@@ -96,7 +96,7 @@ Resources:
       Description: !Sub Build for ${AWS::StackName}
       # ArtifactKey is the KMS key ID or ARN that is used with the artifact bucket
       # created in the same region as this pipeline.
-      EncryptionKey: !ImportValue {{$.AppName}}-ArtifactKey
+      EncryptionKey: !ImportValue phonetool-ArtifactKey
       ServiceRole: !GetAtt BuildProjectRole.Arn
       Artifacts:
         Type: CODEPIPELINE
@@ -161,31 +161,29 @@ Resources:
               - kms:Decrypt
               - kms:Encrypt
               - kms:GenerateDataKey
-            Resource:{{range .ArtifactBuckets}}
-              - {{.KeyArn}}{{end}}
+            Resource:
+              - arn:aws:kms:us-west-2:1111:key/abcd
           - Effect: Allow
             Action:
               - s3:PutObject
               - s3:GetBucketPolicy
               - s3:GetObject
               - s3:ListBucket
-            Resource:{{range .ArtifactBuckets}}
-              - !Join ['', ['arn:aws:s3:::', '{{.BucketName}}']]
-              - !Join ['', ['arn:aws:s3:::', '{{.BucketName}}', '/*']]{{end}}
+            Resource:
+              - !Join ['', ['arn:aws:s3:::', 'fancy-bucket']]
+              - !Join ['', ['arn:aws:s3:::', 'fancy-bucket', '/*']]
           - Effect: Allow
             Action:
               - sts:AssumeRole
-            Resource:{{range $stage := .Stages}}
-              - arn:aws:iam::{{$stage.AccountID}}:role/{{$.AppName}}-{{$stage.Name}}-EnvManagerRole{{end}}
+            Resource:
+              - arn:aws:iam::1111:role/phonetool-test-EnvManagerRole
       Roles:
         - !Ref PipelineRole
-{{- range $index, $stage := .Stages}}
-  {{- if $stage.TestCommands}}
-  BuildTestCommands{{$stage.Name}}:
+  BuildTestCommandstest:
     Type: AWS::CodeBuild::Project
     Properties:
-      Name: BuildTestCommands-{{$.AppName}}-{{$stage.Name}}
-      EncryptionKey: !ImportValue {{$.AppName}}-ArtifactKey
+      Name: BuildTestCommands-phonetool-test
+      EncryptionKey: !ImportValue phonetool-ArtifactKey
       ServiceRole: !GetAtt BuildProjectRole.Arn
       Artifacts:
         Type: NO_ARTIFACTS
@@ -200,47 +198,43 @@ Resources:
           phases:
             build:
               commands:
-              {{- range $index, $command := $stage.TestCommands}}
-                - {{$command}}
-              {{- end}}
-  {{- end}}
-{{- end}}
+                - echo "test"
   Pipeline:
     Type: AWS::CodePipeline::Pipeline
     DependsOn:
       - PipelineRole
       - PipelineRolePolicy
     Properties:
-      ArtifactStores:{{range .ArtifactBuckets}}
-        - Region: {{.Region}}
+      ArtifactStores:
+        - Region: us-west-2
           ArtifactStore:
             Type: S3
-            Location: {{.BucketName}}
+            Location: fancy-bucket
             EncryptionKey:
-              Id: {{.KeyArn}}
-              Type: KMS{{end}}
+              Id: arn:aws:kms:us-west-2:1111:key/abcd
+              Type: KMS
       RoleArn: !GetAtt PipelineRole.Arn
       Name: !Ref AWS::StackName
       Stages:
         - Name: Source
           Actions:
-            - Name: SourceCodeFor-{{$.AppName}}
+            - Name: SourceCodeFor-phonetool
               ActionTypeId:
                 Category: Source
                 # TODO: #273 For CodeCommit, this needs to be AWS. Let's do that later
                 Owner: ThirdParty
                 Version: 1
-                Provider: {{.Source.ProviderName}}
+                Provider: GitHub
               Configuration:
                 # TODO: #273 For now this set of configurations is GitHub-specific,
                 # change it to be more generic
-                Owner: {{$.Source.Owner}}
-                Repo: {{$.Source.Repository}}
-                Branch: {{index $.Source.Properties "branch"}}
+                Owner: aws
+                Repo: phonetool
+                Branch: mainline
                 # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/dynamic-references.html#dynamic-references-secretsmanager
                 # Use the *entire* SecretString with version AWSCURRENT
                 OAuthToken: !Sub
-                    - '{{"{{"}}resolve:secretsmanager:${SecretId}{{"}}"}}'
+                    - '{{resolve:secretsmanager:${SecretId}}}'
                     - { SecretId: !Ref GitHubAccessTokenSecretId }
               OutputArtifacts:
                 - Name: SCCheckoutArtifact
@@ -260,18 +254,10 @@ Resources:
               - Name: SCCheckoutArtifact
             OutputArtifacts:
               - Name: BuildOutput
-        {{- $length := len .Stages}}{{if gt $length 0}}{{range $stage := .Stages}}{{$svcNum := len $stage.LocalServices}}{{if gt $svcNum 0}}
-        - Name: DeployTo-{{$stage.Name}}
-          Actions:{{if $stage.RequiresApproval }}
-            - Name: ApprovePromotionTo-{{$stage.Name}}
-              ActionTypeId:
-                Category: Approval
-                Owner: AWS
-                Version: 1
-                Provider: Manual
-              RunOrder: 1{{end}}{{range $svc := $stage.LocalServices}}
-            - Name: CreateOrUpdate-{{$svc}}-{{$stage.Name}}
-              Region: {{$stage.Region}}
+        - Name: DeployTo-test
+          Actions:
+            - Name: CreateOrUpdate-api-test
+              Region: us-west-2
               ActionTypeId:
                 Category: Deploy
                 Owner: AWS
@@ -279,23 +265,23 @@ Resources:
                 Provider: CloudFormation
               Configuration:
                 # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/continuous-delivery-codepipeline-action-reference.html
-                ChangeSetName: {{$.AppName}}-{{$stage.Name}}-{{$svc}}
+                ChangeSetName: phonetool-test-api
                 ActionMode: CREATE_UPDATE
-                StackName: {{$.AppName}}-{{$stage.Name}}-{{$svc}}
+                StackName: phonetool-test-api
                 Capabilities: CAPABILITY_NAMED_IAM
-                TemplatePath: BuildOutput::infrastructure/{{$stage.ServiceTemplatePath $svc}}
-                TemplateConfiguration: BuildOutput::infrastructure/{{$stage.ServiceTemplateConfigurationPath $svc}}
+                TemplatePath: BuildOutput::infrastructure/api.stack.yml
+                TemplateConfiguration: BuildOutput::infrastructure/api-test.params.json
                 # The ARN of the IAM role (in the env account) that
                 # AWS CloudFormation assumes when it operates on resources
                 # in a stack in an environment account.
-                RoleArn: arn:aws:iam::{{$stage.AccountID}}:role/{{$.AppName}}-{{$stage.Name}}-CFNExecutionRole
+                RoleArn: arn:aws:iam::1111:role/phonetool-test-CFNExecutionRole
               InputArtifacts:
                 - Name: BuildOutput
               RunOrder: 2
               # The ARN of the environment manager IAM role (in the env
               # account) that performs the declared action. This is assumed
               # through the roleArn for the pipeline.
-              RoleArn: arn:aws:iam::{{$stage.AccountID}}:role/{{$.AppName}}-{{$stage.Name}}-EnvManagerRole{{end}}{{if $stage.TestCommands}}
+              RoleArn: arn:aws:iam::1111:role/phonetool-test-EnvManagerRole
             - Name: TestCommands
               ActionTypeId:
                 Category: Test
@@ -303,7 +289,7 @@ Resources:
                 Version: 1
                 Provider: CodeBuild
               Configuration:
-                ProjectName: !Ref BuildTestCommands{{$stage.Name}}
+                ProjectName: !Ref BuildTestCommandstest
               RunOrder: 3
               InputArtifacts:
-                - Name: SCCheckoutArtifact{{end}}{{end}}{{end}}{{end}}
+                - Name: SCCheckoutArtifact


### PR DESCRIPTION
By using the literal block scalar syntax for the buildspec, we
remove the double quotes from our inlined buildspec which means that
users can now use them in their commands. This has also the additional
benefit of increasing readability.

Fixes #1279

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
