### PR TITLE
chore(cloudwatchlogs): enable retrieving logs for specific logstreams

### DIFF
--- a/internal/pkg/aws/cloudwatchlogs/cloudwatchlogs.go
+++ b/internal/pkg/aws/cloudwatchlogs/cloudwatchlogs.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 )
@@ -38,36 +37,22 @@ type CloudWatchLogs struct {
 	client api
 }
 
-// GetLogEventsOpts sets up optional parameters for LogEvents function.
-type GetLogEventsOpts func(*cloudwatchlogs.GetLogEventsInput)
-
-// WithLimit sets up limit for GetLogEventsInput
-func WithLimit(limit int) GetLogEventsOpts {
-	return func(in *cloudwatchlogs.GetLogEventsInput) {
-		in.Limit = aws.Int64(int64(limit))
-	}
-}
-
-// WithStartTime sets up startTime for GetLogEventsInput
-func WithStartTime(startTime int64) GetLogEventsOpts {
-	return func(in *cloudwatchlogs.GetLogEventsInput) {
-		in.StartTime = aws.Int64(startTime)
-	}
-}
-
-// WithEndTime sets up endTime for GetLogEventsInput
-func WithEndTime(endTime int64) GetLogEventsOpts {
-	return func(in *cloudwatchlogs.GetLogEventsInput) {
-		in.EndTime = aws.Int64(endTime)
-	}
-}
-
 // LogEventsOutput contains the output for LogEvents
 type LogEventsOutput struct {
 	// Retrieved log events.
 	Events []*Event
 	// Timestamp for the last event
 	LastEventTime map[string]int64
+}
+
+// LogEventsOpts wraps the parameters to call LogEvents.
+type LogEventsOpts struct {
+	LogGroup            string
+	LogStream           []string
+	Limit               *int64
+	StartTime           *int64
+	EndTime             *int64
+	StreamLastEventTime map[string]int64
 }
 
 // New returns a CloudWatchLogs configured against the input session.
@@ -78,56 +63,58 @@ func New(s *session.Session) *CloudWatchLogs {
 }
 
 // logStreams returns all name of the log streams in a log group.
-func (c *CloudWatchLogs) logStreams(logGroupName string) ([]*string, error) {
+func (c *CloudWatchLogs) logStreams(logGroup string, logStream ...string) ([]string, error) {
 	resp, err := c.client.DescribeLogStreams(&cloudwatchlogs.DescribeLogStreamsInput{
-		LogGroupName: aws.String(logGroupName),
+		LogGroupName: aws.String(logGroup),
 		Descending:   aws.Bool(true),
 		OrderBy:      aws.String(cloudwatchlogs.OrderByLastEventTime),
 	})
 	if err != nil {
-		return nil, fmt.Errorf("describe log streams of log group %s: %w", logGroupName, err)
+		return nil, fmt.Errorf("describe log streams of log group %s: %w", logGroup, err)
 	}
 	if len(resp.LogStreams) == 0 {
-		return nil, fmt.Errorf("no log stream found in log group %s", logGroupName)
+		return nil, fmt.Errorf("no log stream found in log group %s", logGroup)
 	}
-	logStreamNames := make([]*string, len(resp.LogStreams))
-	for ind, logStream := range resp.LogStreams {
-		logStreamNames[ind] = logStream.LogStreamName
+	var logStreamNames []string
+	for _, logStream := range resp.LogStreams {
+		name := aws.StringValue(logStream.LogStreamName)
+		if name == "" {
+			continue
+		}
+		logStreamNames = append(logStreamNames, name)
+	}
+	if len(logStream) != 0 {
+		logStreamNames = filterStringSlice(logStreamNames, logStream)
 	}
 	return logStreamNames, nil
 }
 
 // LogEvents returns an array of Cloudwatch Logs events.
-func (c *CloudWatchLogs) LogEvents(logGroupName string, streamLastEventTime map[string]int64, opts ...GetLogEventsOpts) (*LogEventsOutput, error) {
+func (c *CloudWatchLogs) LogEvents(opts *LogEventsOpts) (*LogEventsOutput, error) {
 	var events []*Event
-	var in *cloudwatchlogs.GetLogEventsInput
-	logStreamNames, err := c.logStreams(logGroupName)
+	// Set default value
+	in := defaultGetLogEventsInput(opts)
+	logStreams, err := c.logStreams(opts.LogGroup, opts.LogStream...)
 	if err != nil {
 		return nil, err
 	}
-	for _, logStreamName := range logStreamNames {
-		in = &cloudwatchlogs.GetLogEventsInput{
-			LogGroupName:  aws.String(logGroupName),
-			LogStreamName: logStreamName,
-			Limit:         aws.Int64(10), // default to be 10
-		}
-		for _, opt := range opts {
-			opt(in)
-		}
-		if streamLastEventTime[*logStreamName] != 0 {
+	for _, logStream := range logStreams {
+		// Set override value
+		in.SetLogStreamName(logStream)
+		if opts.StreamLastEventTime[logStream] != 0 {
 			// If last event for this log stream exists, increment last log event timestamp
 			// by one to get logs after the last event.
-			in.SetStartTime(streamLastEventTime[*logStreamName] + 1)
+			in.SetStartTime(opts.StreamLastEventTime[logStream] + 1)
 		}
 		// TODO: https://github.com/aws/copilot-cli/pull/628#discussion_r374291068 and https://github.com/aws/copilot-cli/pull/628#discussion_r374294362
 		resp, err := c.client.GetLogEvents(in)
 		if err != nil {
-			return nil, fmt.Errorf("get log events of %s/%s: %w", logGroupName, *logStreamName, err)
+			return nil, fmt.Errorf("get log events of %s/%s: %w", opts.LogGroup, logStream, err)
 		}
 
 		for _, event := range resp.Events {
 			log := &Event{
-				LogStreamName: trimLogStreamName(*logStreamName),
+				LogStreamName: trimLogStreamName(logStream),
 				IngestionTime: aws.Int64Value(event.IngestionTime),
 				Message:       aws.StringValue(event.Message),
 				Timestamp:     aws.Int64Value(event.Timestamp),
@@ -135,41 +122,55 @@ func (c *CloudWatchLogs) LogEvents(logGroupName string, streamLastEventTime map[
 			events = append(events, log)
 		}
 		if len(resp.Events) != 0 {
-			streamLastEventTime[*logStreamName] = *resp.Events[len(resp.Events)-1].Timestamp
+			opts.StreamLastEventTime[logStream] = *resp.Events[len(resp.Events)-1].Timestamp
 		}
 	}
 	sort.SliceStable(events, func(i, j int) bool { return events[i].Timestamp < events[j].Timestamp })
-	var truncatedEvents []*Event
-	if len(events) >= int(*in.Limit) {
-		truncatedEvents = events[len(events)-int(*in.Limit):]
-	} else {
-		truncatedEvents = events
+	limit := int(aws.Int64Value(in.Limit))
+	if limit != 0 {
+		return &LogEventsOutput{
+			Events:        truncateEvents(limit, events),
+			LastEventTime: opts.StreamLastEventTime,
+		}, nil
 	}
 	return &LogEventsOutput{
-		Events:        truncatedEvents,
-		LastEventTime: streamLastEventTime,
+		Events:        events,
+		LastEventTime: opts.StreamLastEventTime,
 	}, nil
 }
 
-// LogGroupExists returns if a log group exists.
-func (c *CloudWatchLogs) LogGroupExists(logGroupName string) (bool, error) {
-	_, err := c.client.DescribeLogStreams(&cloudwatchlogs.DescribeLogStreamsInput{
-		LogGroupName: aws.String(logGroupName),
-	})
-	if err == nil {
-		return true, nil
+func truncateEvents(limit int, events []*Event) (truncatedEvents []*Event) {
+	if len(events) >= limit {
+		truncatedEvents = events[len(events)-limit:]
+	} else {
+		truncatedEvents = events
 	}
-	aerr, ok := err.(awserr.Error)
-	if !ok {
-		return false, err
+	return
+}
+
+func defaultGetLogEventsInput(opts *LogEventsOpts) *cloudwatchlogs.GetLogEventsInput {
+	return &cloudwatchlogs.GetLogEventsInput{
+		LogGroupName: aws.String(opts.LogGroup),
+		StartTime:    opts.StartTime,
+		EndTime:      opts.EndTime,
+		Limit:        opts.Limit,
 	}
-	if aerr.Code() != cloudwatchlogs.ErrCodeResourceNotFoundException {
-		return false, err
-	}
-	return false, nil
 }
 
 func trimLogStreamName(logStreamName string) string {
 	// logStreamName example: copilot/{name}/1cc0685ad01d4d0f8e4e2c00d1775c56
 	return strings.TrimPrefix(logStreamName, logStreamNamePrefix)
+}
+
+func filterStringSlice(all, filter []string) (res []string) {
+	mask := make(map[string]bool)
+	for _, s := range filter {
+		mask[s] = true
+	}
+	for _, s := range all {
+		if mask[s] {
+			res = append(res, s)
+		}
+	}
+	return
 }

--- a/internal/pkg/aws/cloudwatchlogs/cloudwatchlogs_test.go
+++ b/internal/pkg/aws/cloudwatchlogs/cloudwatchlogs_test.go
@@ -31,12 +31,8 @@ func TestLogEvents(t *testing.T) {
 		wantErr           error
 	}{
 		"should get log stream name and return log events": {
-			logGroupName:  "mockLogGroup",
-			logStream:     []string{"copilot/mockLogGroup/mockLogStream1", "copilot/mockLogGroup/mockLogStream2"},
-			startTime:     aws.Int64(1234567),
-			endTime:       aws.Int64(1234568),
-			limit:         aws.Int64(10),
-			lastEventTime: make(map[string]int64),
+			logGroupName: "mockLogGroup",
+			logStream:    []string{"copilot/mockLogGroup/mockLogStream1", "copilot/mockLogGroup/mockLogStream2"},
 			mockcloudwatchlogsClient: func(m *mocks.Mockapi) {
 				m.EXPECT().DescribeLogStreams(&cloudwatchlogs.DescribeLogStreamsInput{
 					LogGroupName: aws.String("mockLogGroup"),
@@ -57,9 +53,6 @@ func TestLogEvents(t *testing.T) {
 				}, nil)
 
 				m.EXPECT().GetLogEvents(&cloudwatchlogs.GetLogEventsInput{
-					StartTime:     aws.Int64(1234567),
-					EndTime:       aws.Int64(1234568),
-					Limit:         aws.Int64(10),
 					LogGroupName:  aws.String("mockLogGroup"),
 					LogStreamName: aws.String("copilot/mockLogGroup/mockLogStream1"),
 				}).Return(&cloudwatchlogs.GetLogEventsOutput{
@@ -72,9 +65,6 @@ func TestLogEvents(t *testing.T) {
 				}, nil)
 
 				m.EXPECT().GetLogEvents(&cloudwatchlogs.GetLogEventsInput{
-					StartTime:     aws.Int64(1234567),
-					EndTime:       aws.Int64(1234568),
-					Limit:         aws.Int64(10),
 					LogGroupName:  aws.String("mockLogGroup"),
 					LogStreamName: aws.String("copilot/mockLogGroup/mockLogStream2"),
 				}).Return(&cloudwatchlogs.GetLogEventsOutput{
@@ -89,12 +79,12 @@ func TestLogEvents(t *testing.T) {
 
 			wantLogEvents: []*Event{
 				{
-					LogStreamName: "mockLogGroup/mockLogStream2",
+					LogStreamName: "copilot/mockLogGroup/mockLogStream2",
 					Message:       "other log",
 					Timestamp:     0,
 				},
 				{
-					LogStreamName: "mockLogGroup/mockLogStream1",
+					LogStreamName: "copilot/mockLogGroup/mockLogStream1",
 					Message:       "some log",
 					Timestamp:     1,
 				},
@@ -108,8 +98,6 @@ func TestLogEvents(t *testing.T) {
 		"should override startTime to be last event time when follow mode": {
 			logGroupName: "mockLogGroup",
 			startTime:    aws.Int64(1234567),
-			endTime:      aws.Int64(1234999),
-			limit:        aws.Int64(10),
 			lastEventTime: map[string]int64{
 				"copilot/mockLogGroup/mockLogStream": 1234890,
 			},
@@ -128,8 +116,6 @@ func TestLogEvents(t *testing.T) {
 
 				m.EXPECT().GetLogEvents(&cloudwatchlogs.GetLogEventsInput{
 					StartTime:     aws.Int64(1234891),
-					Limit:         aws.Int64(10),
-					EndTime:       aws.Int64(1234999),
 					LogGroupName:  aws.String("mockLogGroup"),
 					LogStreamName: aws.String("copilot/mockLogGroup/mockLogStream"),
 				}).Return(&cloudwatchlogs.GetLogEventsOutput{
@@ -144,7 +130,7 @@ func TestLogEvents(t *testing.T) {
 
 			wantLogEvents: []*Event{
 				{
-					LogStreamName: "mockLogGroup/mockLogStream",
+					LogStreamName: "copilot/mockLogGroup/mockLogStream",
 					Message:       "some log",
 					Timestamp:     1234892,
 				},
@@ -155,11 +141,8 @@ func TestLogEvents(t *testing.T) {
 			wantErr: nil,
 		},
 		"should return limited number of log events": {
-			logGroupName:  "mockLogGroup",
-			startTime:     aws.Int64(1234567),
-			endTime:       aws.Int64(1234568),
-			limit:         aws.Int64(1),
-			lastEventTime: make(map[string]int64),
+			logGroupName: "mockLogGroup",
+			limit:        aws.Int64(1),
 			mockcloudwatchlogsClient: func(m *mocks.Mockapi) {
 				m.EXPECT().DescribeLogStreams(&cloudwatchlogs.DescribeLogStreamsInput{
 					LogGroupName: aws.String("mockLogGroup"),
@@ -174,8 +157,6 @@ func TestLogEvents(t *testing.T) {
 				}, nil)
 
 				m.EXPECT().GetLogEvents(&cloudwatchlogs.GetLogEventsInput{
-					StartTime:     aws.Int64(1234567),
-					EndTime:       aws.Int64(1234568),
 					Limit:         aws.Int64(1),
 					LogGroupName:  aws.String("mockLogGroup"),
 					LogStreamName: aws.String("copilot/mockLogGroup/mockLogStream"),
@@ -195,7 +176,7 @@ func TestLogEvents(t *testing.T) {
 
 			wantLogEvents: []*Event{
 				{
-					LogStreamName: "mockLogGroup/mockLogStream",
+					LogStreamName: "copilot/mockLogGroup/mockLogStream",
 					Message:       "other log",
 					Timestamp:     1,
 				},
@@ -206,11 +187,7 @@ func TestLogEvents(t *testing.T) {
 			wantErr: nil,
 		},
 		"returns error if fail to describe log streams": {
-			logGroupName:  "mockLogGroup",
-			startTime:     aws.Int64(1234567),
-			endTime:       aws.Int64(1234568),
-			limit:         aws.Int64(10),
-			lastEventTime: make(map[string]int64),
+			logGroupName: "mockLogGroup",
 			mockcloudwatchlogsClient: func(m *mocks.Mockapi) {
 				m.EXPECT().DescribeLogStreams(&cloudwatchlogs.DescribeLogStreamsInput{
 					LogGroupName: aws.String("mockLogGroup"),
@@ -223,11 +200,7 @@ func TestLogEvents(t *testing.T) {
 			wantErr:       fmt.Errorf("describe log streams of log group %s: %w", "mockLogGroup", mockError),
 		},
 		"returns error if no log stream found": {
-			logGroupName:  "mockLogGroup",
-			startTime:     aws.Int64(1234567),
-			endTime:       aws.Int64(1234568),
-			limit:         aws.Int64(10),
-			lastEventTime: make(map[string]int64),
+			logGroupName: "mockLogGroup",
 			mockcloudwatchlogsClient: func(m *mocks.Mockapi) {
 				m.EXPECT().DescribeLogStreams(&cloudwatchlogs.DescribeLogStreamsInput{
 					LogGroupName: aws.String("mockLogGroup"),
@@ -242,11 +215,7 @@ func TestLogEvents(t *testing.T) {
 			wantErr:       fmt.Errorf("no log stream found in log group %s", "mockLogGroup"),
 		},
 		"returns error if fail to get log events": {
-			logGroupName:  "mockLogGroup",
-			startTime:     aws.Int64(1234567),
-			endTime:       aws.Int64(1234568),
-			limit:         aws.Int64(10),
-			lastEventTime: make(map[string]int64),
+			logGroupName: "mockLogGroup",
 			mockcloudwatchlogsClient: func(m *mocks.Mockapi) {
 				m.EXPECT().DescribeLogStreams(&cloudwatchlogs.DescribeLogStreamsInput{
 					LogGroupName: aws.String("mockLogGroup"),
@@ -260,9 +229,6 @@ func TestLogEvents(t *testing.T) {
 					},
 				}, nil)
 				m.EXPECT().GetLogEvents(&cloudwatchlogs.GetLogEventsInput{
-					StartTime:     aws.Int64(1234567),
-					EndTime:       aws.Int64(1234568),
-					Limit:         aws.Int64(10),
 					LogGroupName:  aws.String("mockLogGroup"),
 					LogStreamName: aws.String("mockLogStream"),
 				}).Return(nil, mockError)

--- a/internal/pkg/aws/cloudwatchlogs/cloudwatchlogs_test.go
+++ b/internal/pkg/aws/cloudwatchlogs/cloudwatchlogs_test.go
@@ -251,7 +251,7 @@ func TestLogEvents(t *testing.T) {
 			service := CloudWatchLogs{
 				client: mockcloudwatchlogsClient,
 			}
-			gotLogEventsOutput, gotErr := service.LogEvents(&LogEventsOpts{
+			gotLogEventsOutput, gotErr := service.LogEvents(LogEventsOpts{
 				LogGroup:            tc.logGroupName,
 				EndTime:             tc.endTime,
 				Limit:               tc.limit,
@@ -264,7 +264,7 @@ func TestLogEvents(t *testing.T) {
 				require.Equal(t, tc.wantErr, gotErr)
 			} else {
 				require.ElementsMatch(t, tc.wantLogEvents, gotLogEventsOutput.Events)
-				require.Equal(t, tc.wantLastEventTime, gotLogEventsOutput.LastEventTime)
+				require.Equal(t, tc.wantLastEventTime, gotLogEventsOutput.StreamLastEventTime)
 			}
 		})
 	}

--- a/internal/pkg/aws/ecs/ecs.go
+++ b/internal/pkg/aws/ecs/ecs.go
@@ -289,7 +289,7 @@ func (e *ECS) DescribeTasks(cluster string, taskARNs []string) ([]*Task, error) 
 
 // TaskStatus returns the status of the running task.
 func (t *Task) TaskStatus() (*TaskStatus, error) {
-	taskID, err := t.taskID(aws.StringValue(t.TaskArn))
+	taskID, err := TaskID(aws.StringValue(t.TaskArn))
 	if err != nil {
 		return nil, err
 	}
@@ -321,19 +321,6 @@ func (t *Task) TaskStatus() (*TaskStatus, error) {
 		StoppedAt:     stoppedAt,
 		StoppedReason: stoppedReason,
 	}, nil
-}
-
-// taskID parses the task ARN and returns the task ID.
-// For example: arn:aws:ecs:us-west-2:123456789:task/my-project-test-Cluster-9F7Y0RLP60R7/4082490ee6c245e09d2145010aa1ba8d
-// becomes 4082490ee6c245e09d2145010aa1ba8d.
-func (t *Task) taskID(taskArn string) (string, error) {
-	parsedArn, err := arn.Parse(taskArn)
-	if err != nil {
-		return "", err
-	}
-	resources := strings.Split(parsedArn.Resource, "/")
-	taskID := resources[len(resources)-1]
-	return taskID, nil
 }
 
 // imageDigest returns the short image digest.
@@ -396,4 +383,17 @@ func (s *ServiceArn) ServiceName() (string, error) {
 		return "", fmt.Errorf("cannot parse resource for ARN %s", serviceArn)
 	}
 	return resources[2], nil
+}
+
+// TaskID parses the task ARN and returns the task ID.
+// For example: arn:aws:ecs:us-west-2:123456789:task/my-project-test-Cluster-9F7Y0RLP60R7/4082490ee6c245e09d2145010aa1ba8d
+// becomes 4082490ee6c245e09d2145010aa1ba8d.
+func TaskID(taskArn string) (string, error) {
+	parsedArn, err := arn.Parse(taskArn)
+	if err != nil {
+		return "", err
+	}
+	resources := strings.Split(parsedArn.Resource, "/")
+	taskID := resources[len(resources)-1]
+	return taskID, nil
 }

--- a/internal/pkg/aws/ecs/ecs.go
+++ b/internal/pkg/aws/ecs/ecs.go
@@ -386,14 +386,15 @@ func (s *ServiceArn) ServiceName() (string, error) {
 }
 
 // TaskID parses the task ARN and returns the task ID.
-// For example: arn:aws:ecs:us-west-2:123456789:task/my-project-test-Cluster-9F7Y0RLP60R7/4082490ee6c245e09d2145010aa1ba8d
-// becomes 4082490ee6c245e09d2145010aa1ba8d.
-func TaskID(taskArn string) (string, error) {
-	parsedArn, err := arn.Parse(taskArn)
+// For example: arn:aws:ecs:us-west-2:123456789:task/my-project-test-Cluster-9F7Y0RLP60R7/4082490ee6c245e09d2145010aa1ba8d,
+// arn:aws:ecs:us-west-2:123456789:task/4082490ee6c245e09d2145010aa1ba8d
+// return 4082490ee6c245e09d2145010aa1ba8d.
+func TaskID(taskARN string) (string, error) {
+	parsedARN, err := arn.Parse(taskARN)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("parse ECS task ARN: %w", err)
 	}
-	resources := strings.Split(parsedArn.Resource, "/")
+	resources := strings.Split(parsedARN.Resource, "/")
 	taskID := resources[len(resources)-1]
 	return taskID, nil
 }

--- a/internal/pkg/aws/ecs/ecs_test.go
+++ b/internal/pkg/aws/ecs/ecs_test.go
@@ -730,7 +730,7 @@ func TestTask_TaskStatus(t *testing.T) {
 	}{
 		"errors if failed to parse task ID": {
 			taskArn: aws.String("badTaskArn"),
-			wantErr: fmt.Errorf("arn: invalid prefix"),
+			wantErr: fmt.Errorf("parse ECS task ARN: arn: invalid prefix"),
 		},
 		"success with a provisioning task": {
 			taskArn: aws.String("arn:aws:ecs:us-west-2:123456789:task/my-project-test-Cluster-9F7Y0RLP60R7/4082490ee6c245e09d2145010aa1ba8d"),
@@ -893,6 +893,35 @@ func TestTaskStatus_HumanString(t *testing.T) {
 			gotTaskStatus := task.HumanString()
 
 			require.Equal(t, tc.wantTaskStatus, gotTaskStatus)
+		})
+
+	}
+}
+func Test_TaskID(t *testing.T) {
+	testCases := map[string]struct {
+		taskARN string
+
+		wantErr error
+		wantID  string
+	}{
+		"bad unparsable task ARN": {
+			taskARN: "mockBadTaskARN",
+			wantErr: fmt.Errorf("parse ECS task ARN: arn: invalid prefix"),
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// WHEN
+			gotID, gotErr := TaskID(tc.taskARN)
+
+			// THEN
+			if gotErr != nil {
+				require.EqualError(t, gotErr, tc.wantErr.Error())
+			} else {
+				require.NoError(t, gotErr)
+				require.Equal(t, tc.wantID, gotID)
+			}
 		})
 
 	}

--- a/internal/pkg/aws/ecs/ecs_test.go
+++ b/internal/pkg/aws/ecs/ecs_test.go
@@ -341,11 +341,11 @@ func TestECS_DefaultCluster(t *testing.T) {
 					DescribeClusters(&ecs.DescribeClustersInput{}).
 					Return(&ecs.DescribeClustersOutput{
 						Clusters: []*ecs.Cluster{
-							&ecs.Cluster{
+							{
 								ClusterArn:  aws.String("arn:aws:ecs:us-east-1:0123456:cluster/cluster1"),
 								ClusterName: aws.String("cluster1"),
 							},
-							&ecs.Cluster{
+							{
 								ClusterArn:  aws.String("arn:aws:ecs:us-east-1:0123456:cluster/cluster2"),
 								ClusterName: aws.String("cluster2"),
 							},
@@ -492,13 +492,13 @@ func TestECS_RunTask(t *testing.T) {
 				}).
 					Return(&ecs.RunTaskOutput{
 						Tasks: []*ecs.Task{
-							&ecs.Task{
+							{
 								TaskArn: aws.String("task-1"),
 							},
-							&ecs.Task{
+							{
 								TaskArn: aws.String("task-2"),
 							},
-							&ecs.Task{
+							{
 								TaskArn: aws.String("task-3"),
 							},
 						},
@@ -616,26 +616,26 @@ func TestECS_DescribeTasks(t *testing.T) {
 					Tasks:   aws.StringSlice(inTaskARNs),
 				}).Return(&ecs.DescribeTasksOutput{
 					Tasks: []*ecs.Task{
-						&ecs.Task{
+						{
 							TaskArn: aws.String("task-1"),
 						},
-						&ecs.Task{
+						{
 							TaskArn: aws.String("task-2"),
 						},
-						&ecs.Task{
+						{
 							TaskArn: aws.String("task-3"),
 						},
 					},
 				}, nil)
 			},
 			wantedTasks: []*Task{
-				&Task{
+				{
 					TaskArn: aws.String("task-1"),
 				},
-				&Task{
+				{
 					TaskArn: aws.String("task-2"),
 				},
-				&Task{
+				{
 					TaskArn: aws.String("task-3"),
 				},
 			},

--- a/internal/pkg/aws/ecs/errors.go
+++ b/internal/pkg/aws/ecs/errors.go
@@ -17,7 +17,7 @@ const (
 // ErrNoDefaultCluster occurs when the default cluster is not found.
 var ErrNoDefaultCluster = errors.New("default cluster does not exist")
 
-// ErrResourceNotReadyForTasks contains the STOPPED reason for the container of the first task that failed to start.
+// ErrWaiterResourceNotReadyForTasks contains the STOPPED reason for the container of the first task that failed to start.
 type ErrWaiterResourceNotReadyForTasks struct {
 	tasks                  []*Task
 	awsErrResourceNotReady error
@@ -35,7 +35,7 @@ func (e *ErrWaiterResourceNotReadyForTasks) Error() string {
 			continue
 		}
 
-		taskID, err := task.taskID(aws.StringValue(task.TaskArn))
+		taskID, err := TaskID(aws.StringValue(task.TaskArn))
 		if err != nil {
 			continue
 		}

--- a/internal/pkg/cli/svc_logs.go
+++ b/internal/pkg/cli/svc_logs.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/copilot-cli/internal/pkg/aws/sessions"
 	"github.com/aws/copilot-cli/internal/pkg/config"
 	"github.com/aws/copilot-cli/internal/pkg/deploy"
@@ -44,8 +45,8 @@ type svcLogsOpts struct {
 	svcLogsVars
 
 	// internal states
-	startTime int64
-	endTime   int64
+	startTime *int64
+	endTime   *int64
 
 	w           io.Writer
 	configStore store
@@ -120,7 +121,7 @@ func (o *svcLogsOpts) Validate() error {
 		if err != nil {
 			return fmt.Errorf(`invalid argument %s for "--start-time" flag: %w`, o.humanStartTime, err)
 		}
-		o.startTime = startTime
+		o.startTime = aws.Int64(startTime)
 	}
 
 	if o.humanEndTime != "" {
@@ -128,7 +129,7 @@ func (o *svcLogsOpts) Validate() error {
 		if err != nil {
 			return fmt.Errorf(`invalid argument %s for "--end-time" flag: %w`, o.humanEndTime, err)
 		}
-		o.endTime = endTime
+		o.endTime = aws.Int64(endTime)
 	}
 
 	if o.limit < cwGetLogEventsLimitMin || o.limit > cwGetLogEventsLimitMax {
@@ -190,10 +191,10 @@ func (o *svcLogsOpts) askSvcEnvName() error {
 	return nil
 }
 
-func (o *svcLogsOpts) parseSince() int64 {
+func (o *svcLogsOpts) parseSince() *int64 {
 	sinceSec := int64(o.since.Round(time.Second).Seconds())
 	timeNow := time.Now().Add(time.Duration(-sinceSec) * time.Second)
-	return timeNow.Unix() * 1000
+	return aws.Int64(timeNow.Unix() * 1000)
 }
 
 func (o *svcLogsOpts) parseRFC3339(timeStr string) (int64, error) {

--- a/internal/pkg/describe/status_test.go
+++ b/internal/pkg/describe/status_test.go
@@ -115,7 +115,7 @@ func TestServiceStatus_Describe(t *testing.T) {
 				)
 			},
 
-			wantedError: fmt.Errorf("get status for task badMockTaskArn: arn: invalid prefix"),
+			wantedError: fmt.Errorf("get status for task badMockTaskArn: parse ECS task ARN: arn: invalid prefix"),
 		},
 		"errors if failed to get CloudWatch alarms": {
 			setupMocks: func(m serviceStatusMocks) {

--- a/internal/pkg/ecslogging/mocks/mock_service.go
+++ b/internal/pkg/ecslogging/mocks/mock_service.go
@@ -34,7 +34,7 @@ func (m *MocklogGetter) EXPECT() *MocklogGetterMockRecorder {
 }
 
 // LogEvents mocks base method
-func (m *MocklogGetter) LogEvents(opts *cloudwatchlogs.LogEventsOpts) (*cloudwatchlogs.LogEventsOutput, error) {
+func (m *MocklogGetter) LogEvents(opts cloudwatchlogs.LogEventsOpts) (*cloudwatchlogs.LogEventsOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LogEvents", opts)
 	ret0, _ := ret[0].(*cloudwatchlogs.LogEventsOutput)

--- a/internal/pkg/ecslogging/mocks/mock_service.go
+++ b/internal/pkg/ecslogging/mocks/mock_service.go
@@ -34,21 +34,16 @@ func (m *MocklogGetter) EXPECT() *MocklogGetterMockRecorder {
 }
 
 // LogEvents mocks base method
-func (m *MocklogGetter) LogEvents(logGroupName string, streamLastEventTime map[string]int64, opts ...cloudwatchlogs.GetLogEventsOpts) (*cloudwatchlogs.LogEventsOutput, error) {
+func (m *MocklogGetter) LogEvents(opts *cloudwatchlogs.LogEventsOpts) (*cloudwatchlogs.LogEventsOutput, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{logGroupName, streamLastEventTime}
-	for _, a := range opts {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "LogEvents", varargs...)
+	ret := m.ctrl.Call(m, "LogEvents", opts)
 	ret0, _ := ret[0].(*cloudwatchlogs.LogEventsOutput)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // LogEvents indicates an expected call of LogEvents
-func (mr *MocklogGetterMockRecorder) LogEvents(logGroupName, streamLastEventTime interface{}, opts ...interface{}) *gomock.Call {
+func (mr *MocklogGetterMockRecorder) LogEvents(opts interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{logGroupName, streamLastEventTime}, opts...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogEvents", reflect.TypeOf((*MocklogGetter)(nil).LogEvents), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogEvents", reflect.TypeOf((*MocklogGetter)(nil).LogEvents), opts)
 }

--- a/internal/pkg/ecslogging/service.go
+++ b/internal/pkg/ecslogging/service.go
@@ -20,7 +20,7 @@ const (
 )
 
 type logGetter interface {
-	LogEvents(opts *cloudwatchlogs.LogEventsOpts) (*cloudwatchlogs.LogEventsOutput, error)
+	LogEvents(opts cloudwatchlogs.LogEventsOpts) (*cloudwatchlogs.LogEventsOutput, error)
 }
 
 // ServiceClient retrieves the logs of an Amazon ECS service.
@@ -52,7 +52,7 @@ func NewServiceClient(sess *session.Session, app, env, svc string) *ServiceClien
 
 // WriteLogEvents writes service logs.
 func (s *ServiceClient) WriteLogEvents(opts WriteLogEventsOpts) error {
-	logEventsOpts := &cloudwatchlogs.LogEventsOpts{
+	logEventsOpts := cloudwatchlogs.LogEventsOpts{
 		LogGroup:  s.logGroupName,
 		Limit:     aws.Int64(int64(opts.Limit)),
 		EndTime:   opts.EndTime,
@@ -71,10 +71,10 @@ func (s *ServiceClient) WriteLogEvents(opts WriteLogEventsOpts) error {
 			return nil
 		}
 		// for unit test.
-		if logEventsOutput.LastEventTime == nil {
+		if logEventsOutput.StreamLastEventTime == nil {
 			return nil
 		}
-		logEventsOpts.StreamLastEventTime = logEventsOutput.LastEventTime
+		logEventsOpts.StreamLastEventTime = logEventsOutput.StreamLastEventTime
 		time.Sleep(cloudwatchlogs.SleepDuration)
 	}
 }

--- a/internal/pkg/ecslogging/service.go
+++ b/internal/pkg/ecslogging/service.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/copilot-cli/internal/pkg/aws/cloudwatchlogs"
 	"github.com/aws/copilot-cli/internal/pkg/term/log"
@@ -19,9 +20,7 @@ const (
 )
 
 type logGetter interface {
-	LogEvents(logGroupName string,
-		streamLastEventTime map[string]int64,
-		opts ...cloudwatchlogs.GetLogEventsOpts) (*cloudwatchlogs.LogEventsOutput, error)
+	LogEvents(opts *cloudwatchlogs.LogEventsOpts) (*cloudwatchlogs.LogEventsOutput, error)
 }
 
 // ServiceClient retrieves the logs of an Amazon ECS service.
@@ -35,8 +34,8 @@ type ServiceClient struct {
 type WriteLogEventsOpts struct {
 	Follow    bool
 	Limit     int
-	StartTime int64
-	EndTime   int64
+	StartTime *int64
+	EndTime   *int64
 	// OnEvents is a handler that's invoked when logs are retrieved from the service.
 	OnEvents func(w io.Writer, logs []HumanJSONStringer) error
 }
@@ -56,9 +55,17 @@ func (s *ServiceClient) WriteLogEvents(opts WriteLogEventsOpts) error {
 	logEventsOutput := &cloudwatchlogs.LogEventsOutput{
 		LastEventTime: make(map[string]int64),
 	}
+	logEventsOpts := &cloudwatchlogs.LogEventsOpts{
+		LogGroup:  s.logGroupName,
+		Limit:     aws.Int64(int64(opts.Limit)),
+		EndTime:   opts.EndTime,
+		StartTime: opts.StartTime,
+		// TODO: Add log filtering by task ID.
+	}
 	var err error
 	for {
-		logEventsOutput, err = s.eventsGetter.LogEvents(s.logGroupName, logEventsOutput.LastEventTime, opts.generateGetLogEventOpts()...)
+		logEventsOpts.StreamLastEventTime = logEventsOutput.LastEventTime
+		logEventsOutput, err = s.eventsGetter.LogEvents(logEventsOpts)
 		if err != nil {
 			return fmt.Errorf("get task log events for log group %s: %w", s.logGroupName, err)
 		}
@@ -74,17 +81,4 @@ func (s *ServiceClient) WriteLogEvents(opts WriteLogEventsOpts) error {
 		}
 		time.Sleep(cloudwatchlogs.SleepDuration)
 	}
-}
-
-func (w *WriteLogEventsOpts) generateGetLogEventOpts() []cloudwatchlogs.GetLogEventsOpts {
-	opts := []cloudwatchlogs.GetLogEventsOpts{
-		cloudwatchlogs.WithLimit(w.Limit),
-	}
-	if w.StartTime != 0 {
-		opts = append(opts, cloudwatchlogs.WithStartTime(w.StartTime))
-	}
-	if w.EndTime != 0 {
-		opts = append(opts, cloudwatchlogs.WithEndTime(w.EndTime))
-	}
-	return opts
 }

--- a/internal/pkg/ecslogging/service_test.go
+++ b/internal/pkg/ecslogging/service_test.go
@@ -62,7 +62,7 @@ firelens_log_router/fcfe4 10.0.0.00 - - [01/Jan/1970 01:01:01] "WARN some warnin
 		"failed to get task log events": {
 			setupMocks: func(m serviceLogsMocks) {
 				gomock.InOrder(
-					m.logGetter.EXPECT().LogEvents(mockLogGroupName, make(map[string]int64), gomock.Any()).
+					m.logGetter.EXPECT().LogEvents(gomock.Any()).
 						Return(nil, errors.New("some error")),
 				)
 			},
@@ -72,7 +72,7 @@ firelens_log_router/fcfe4 10.0.0.00 - - [01/Jan/1970 01:01:01] "WARN some warnin
 		"success with human output": {
 			setupMocks: func(m serviceLogsMocks) {
 				gomock.InOrder(
-					m.logGetter.EXPECT().LogEvents(mockLogGroupName, make(map[string]int64), gomock.Any()).
+					m.logGetter.EXPECT().LogEvents(gomock.Any()).
 						Return(&cloudwatchlogs.LogEventsOutput{
 							Events: logEvents,
 						}, nil),
@@ -85,7 +85,7 @@ firelens_log_router/fcfe4 10.0.0.00 - - [01/Jan/1970 01:01:01] "WARN some warnin
 			jsonOutput: true,
 			setupMocks: func(m serviceLogsMocks) {
 				gomock.InOrder(
-					m.logGetter.EXPECT().LogEvents(mockLogGroupName, make(map[string]int64), gomock.Any()).
+					m.logGetter.EXPECT().LogEvents(gomock.Any()).
 						Return(&cloudwatchlogs.LogEventsOutput{
 							Events: logEvents,
 						}, nil),
@@ -98,12 +98,12 @@ firelens_log_router/fcfe4 10.0.0.00 - - [01/Jan/1970 01:01:01] "WARN some warnin
 			follow: true,
 			setupMocks: func(m serviceLogsMocks) {
 				gomock.InOrder(
-					m.logGetter.EXPECT().LogEvents(mockLogGroupName, make(map[string]int64), gomock.Any()).
+					m.logGetter.EXPECT().LogEvents(gomock.Any()).
 						Return(&cloudwatchlogs.LogEventsOutput{
 							Events:        logEvents,
 							LastEventTime: mockLastEventTime,
 						}, nil),
-					m.logGetter.EXPECT().LogEvents(mockLogGroupName, mockLastEventTime, gomock.Any()).
+					m.logGetter.EXPECT().LogEvents(gomock.Any()).
 						Return(&cloudwatchlogs.LogEventsOutput{
 							Events:        moreLogEvents,
 							LastEventTime: nil,

--- a/internal/pkg/ecslogging/service_test.go
+++ b/internal/pkg/ecslogging/service_test.go
@@ -100,13 +100,13 @@ firelens_log_router/fcfe4 10.0.0.00 - - [01/Jan/1970 01:01:01] "WARN some warnin
 				gomock.InOrder(
 					m.logGetter.EXPECT().LogEvents(gomock.Any()).
 						Return(&cloudwatchlogs.LogEventsOutput{
-							Events:        logEvents,
-							LastEventTime: mockLastEventTime,
+							Events:              logEvents,
+							StreamLastEventTime: mockLastEventTime,
 						}, nil),
 					m.logGetter.EXPECT().LogEvents(gomock.Any()).
 						Return(&cloudwatchlogs.LogEventsOutput{
-							Events:        moreLogEvents,
-							LastEventTime: nil,
+							Events:              moreLogEvents,
+							StreamLastEventTime: nil,
 						}, nil),
 				)
 			},

--- a/internal/pkg/ecslogging/task.go
+++ b/internal/pkg/ecslogging/task.go
@@ -116,7 +116,8 @@ func (t *TaskClient) allTasksStopped() (bool, error) {
 	return stopped, nil
 }
 
-func (t *TaskClient) logStreamNamesFromTasks(tasks []*task.Task) (logStreamNames []string, err error) {
+func (t *TaskClient) logStreamNamesFromTasks(tasks []*task.Task) ([]string, error) {
+	var logStreamNames []string
 	for _, task := range tasks {
 		id, err := ecs.TaskID(task.TaskARN)
 		if err != nil {
@@ -124,5 +125,5 @@ func (t *TaskClient) logStreamNamesFromTasks(tasks []*task.Task) (logStreamNames
 		}
 		logStreamNames = append(logStreamNames, fmt.Sprintf(fmtLogStreamName, t.GroupName, id))
 	}
-	return
+	return logStreamNames, nil
 }

--- a/internal/pkg/ecslogging/task_test.go
+++ b/internal/pkg/ecslogging/task_test.go
@@ -27,48 +27,93 @@ type mockWriter struct{}
 func (mockWriter) Write(p []byte) (int, error) { return 0, nil }
 
 func TestEventsWriter_WriteEventsUntilStopped(t *testing.T) {
-	groupName := "my-log-group"
+	const (
+		groupName = "my-log-group"
+		taskARN1  = "arn:aws:ecs:us-west-2:123456789:task/cluster/task1"
+		taskARN2  = "arn:aws:ecs:us-west-2:123456789:task/cluster/task2"
+		taskARN3  = "arn:aws:ecs:us-west-2:123456789:task/cluster/task3"
+		taskARN4  = "task4"
+	)
+	now := time.Now()
+	tomorrow := now.AddDate(0, 0, 1)
+	theDayAfter := now.AddDate(0, 0, 2)
+	goodTasks := []*task.Task{
+		{
+			TaskARN:    taskARN1,
+			ClusterARN: "cluster",
+			StartedAt:  &now,
+		},
+		{
+			TaskARN:    taskARN2,
+			ClusterARN: "cluster",
+			StartedAt:  &tomorrow,
+		},
+		{
+			TaskARN:    taskARN3,
+			ClusterARN: "cluster",
+			StartedAt:  &theDayAfter,
+		},
+	}
+	badTasks := []*task.Task{
+		{
+			TaskARN:    taskARN4,
+			ClusterARN: "cluster",
+			StartedAt:  &now,
+		},
+	}
 	testCases := map[string]struct {
+		tasks      []*task.Task
 		setUpMocks func(m writeEventMocks)
 
 		wantedError error
 	}{
+		"error parsing task ID": {
+			tasks:       badTasks,
+			setUpMocks:  func(m writeEventMocks) {},
+			wantedError: errors.New("parse task ID from ARN task4"),
+		},
 		"error getting log events": {
+			tasks: goodTasks,
 			setUpMocks: func(m writeEventMocks) {
-				m.logGetter.EXPECT().LogEvents(groupName, gomock.Any(), gomock.Any()).
+				m.logGetter.EXPECT().LogEvents(gomock.Any()).
 					Return(&cloudwatchlogs.LogEventsOutput{}, errors.New("error getting log events"))
 			},
 			wantedError: errors.New("get task log events: error getting log events"),
 		},
 		"error describing tasks": {
+			tasks: goodTasks,
 			setUpMocks: func(m writeEventMocks) {
-				m.logGetter.EXPECT().LogEvents(gomock.Any(), gomock.Any(), gomock.Any()).
+				m.logGetter.EXPECT().LogEvents(gomock.Any()).
 					Return(&cloudwatchlogs.LogEventsOutput{
 						Events: []*cloudwatchlogs.Event{},
 					}, nil).AnyTimes()
-				m.describer.EXPECT().DescribeTasks("cluster", []string{"task-1", "task-2", "task-3"}).
+				m.describer.EXPECT().DescribeTasks("cluster", []string{taskARN1, taskARN2, taskARN3}).
 					Return(nil, errors.New("error describing tasks"))
 			},
 			wantedError: errors.New("describe tasks: error describing tasks"),
 		},
 		"success": {
+			tasks: goodTasks,
 			setUpMocks: func(m writeEventMocks) {
-				m.logGetter.EXPECT().LogEvents(gomock.Any(), gomock.Any(), gomock.Any()).
+				m.logGetter.EXPECT().LogEvents(gomock.Any()).Do(func(param *cloudwatchlogs.LogEventsOpts) {
+					require.Equal(t, param.LogGroup, "/copilot/my-log-group")
+					require.Equal(t, param.LogStream, []string{"copilot-task/my-log-group/task1", "copilot-task/my-log-group/task2", "copilot-task/my-log-group/task3"})
+				}).
 					Return(&cloudwatchlogs.LogEventsOutput{
 						Events: []*cloudwatchlogs.Event{},
-					}, nil).AnyTimes()
-				m.describer.EXPECT().DescribeTasks("cluster", []string{"task-1", "task-2", "task-3"}).
+					}, nil).Times(numCWLogsCallsPerRound)
+				m.describer.EXPECT().DescribeTasks("cluster", []string{taskARN1, taskARN2, taskARN3}).
 					Return([]*ecs.Task{
 						{
-							TaskArn:    aws.String("task-1"),
+							TaskArn:    aws.String(taskARN1),
 							LastStatus: aws.String(ecs.DesiredStatusStopped),
 						},
 						{
-							TaskArn:    aws.String("task-2"),
+							TaskArn:    aws.String(taskARN2),
 							LastStatus: aws.String(ecs.DesiredStatusStopped),
 						},
 						{
-							TaskArn:    aws.String("task-3"),
+							TaskArn:    aws.String(taskARN3),
 							LastStatus: aws.String(ecs.DesiredStatusStopped),
 						},
 					}, nil)
@@ -76,32 +121,10 @@ func TestEventsWriter_WriteEventsUntilStopped(t *testing.T) {
 		},
 	}
 
-	now := time.Now()
-	tomorrow := now.AddDate(0, 0, 1)
-	theDayAfter := now.AddDate(0, 0, 2)
-
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
-
-			tasks := []*task.Task{
-				{
-					TaskARN:    "task-1",
-					ClusterARN: "cluster",
-					StartedAt:  &now,
-				},
-				{
-					TaskARN:    "task-2",
-					ClusterARN: "cluster",
-					StartedAt:  &tomorrow,
-				},
-				{
-					TaskARN:    "task-3",
-					ClusterARN: "cluster",
-					StartedAt:  &theDayAfter,
-				},
-			}
 
 			mocks := writeEventMocks{
 				logGetter: mocks.NewMocklogGetter(ctrl),
@@ -111,7 +134,7 @@ func TestEventsWriter_WriteEventsUntilStopped(t *testing.T) {
 
 			ew := &TaskClient{
 				GroupName: groupName,
-				Tasks:     tasks,
+				Tasks:     tc.tasks,
 
 				Writer:       mockWriter{},
 				EventsLogger: mocks.logGetter,

--- a/internal/pkg/ecslogging/task_test.go
+++ b/internal/pkg/ecslogging/task_test.go
@@ -95,7 +95,7 @@ func TestEventsWriter_WriteEventsUntilStopped(t *testing.T) {
 		"success": {
 			tasks: goodTasks,
 			setUpMocks: func(m writeEventMocks) {
-				m.logGetter.EXPECT().LogEvents(gomock.Any()).Do(func(param *cloudwatchlogs.LogEventsOpts) {
+				m.logGetter.EXPECT().LogEvents(gomock.Any()).Do(func(param cloudwatchlogs.LogEventsOpts) {
 					require.Equal(t, param.LogGroup, "/copilot/my-log-group")
 					require.Equal(t, param.LogStream, []string{"copilot-task/my-log-group/task1", "copilot-task/my-log-group/task2", "copilot-task/my-log-group/task3"})
 				}).


### PR DESCRIPTION
<!-- Provide summary of changes -->
This PR enables retrieving logs for specific logstreams in a log group. Also fixes #1301.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
