### PR TITLE
test(e2e): wrap "app ls" tests with eventually

### DIFF
--- a/e2e/addons/addons_test.go
+++ b/e2e/addons/addons_test.go
@@ -37,9 +37,7 @@ var _ = Describe("addons flow", func() {
 		})
 
 		It("app ls includes new app", func() {
-			apps, err := cli.AppList()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(apps).To(ContainSubstring(appName))
+			Eventually(cli.AppList, "30s", "5s").Should(ContainSubstring(appName))
 		})
 
 		It("app show includes app name", func() {

--- a/e2e/customized-env/customized_env_test.go
+++ b/e2e/customized-env/customized_env_test.go
@@ -35,9 +35,7 @@ var _ = Describe("Customized Env", func() {
 		})
 
 		It("app ls includes new app", func() {
-			apps, err := cli.AppList()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(apps).To(ContainSubstring(appName))
+			Eventually(cli.AppList, "30s", "5s").Should(ContainSubstring(appName))
 		})
 
 		It("app show includes app name", func() {

--- a/e2e/multi-env-app/multi_env_test.go
+++ b/e2e/multi-env-app/multi_env_test.go
@@ -37,9 +37,7 @@ var _ = Describe("Multiple Env App", func() {
 		})
 
 		It("app ls includes new app", func() {
-			apps, err := cli.AppList()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(apps).To(ContainSubstring(appName))
+			Eventually(cli.AppList, "30s", "5s").Should(ContainSubstring(appName))
 		})
 
 		It("app show includes app name", func() {

--- a/e2e/multi-svc-app/multi_svc_app_test.go
+++ b/e2e/multi-svc-app/multi_svc_app_test.go
@@ -35,9 +35,7 @@ var _ = Describe("Multiple Service App", func() {
 		})
 
 		It("app ls includes new application", func() {
-			apps, err := cli.AppList()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(apps).To(ContainSubstring(appName))
+			Eventually(cli.AppList, "30s", "5s").Should(ContainSubstring(appName))
 		})
 
 		It("app show includes app name", func() {

--- a/e2e/sidecars/sidecars_test.go
+++ b/e2e/sidecars/sidecars_test.go
@@ -77,9 +77,7 @@ var _ = Describe("sidecars flow", func() {
 		})
 
 		It("app ls includes new app", func() {
-			apps, err := cli.AppList()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(apps).To(ContainSubstring(appName))
+			Eventually(cli.AppList, "30s", "5s").Should(ContainSubstring(appName))
 		})
 
 		It("app show includes app name", func() {


### PR DESCRIPTION
We see transient failures with "app ls" where the application does not
get listed immediately after creation. Wrap the calls in a loop so that
we fail the test only if after 30 secs we cannot find the application
name.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
