### PR TITLE
feat(templates): enable autoscaling for simple target track policies

### DIFF
--- a/internal/pkg/template/service.go
+++ b/internal/pkg/template/service.go
@@ -34,6 +34,7 @@ var (
 		"addons",
 		"sidecars",
 		"logconfig",
+		"autoscaling",
 	}
 )
 

--- a/internal/pkg/template/service_test.go
+++ b/internal/pkg/template/service_test.go
@@ -38,6 +38,7 @@ func TestTemplate_ParseSvc(t *testing.T) {
 				mockBox.AddString("workloads/common/cf/addons.yml", "addons")
 				mockBox.AddString("workloads/common/cf/sidecars.yml", "sidecars")
 				mockBox.AddString("workloads/common/cf/logconfig.yml", "logconfig")
+				mockBox.AddString("workloads/common/cf/autoscaling.yml", "autoscaling")
 
 				t.box = mockBox
 			},
@@ -51,6 +52,7 @@ func TestTemplate_ParseSvc(t *testing.T) {
   addons
   sidecars
   logconfig
+  autoscaling
 `,
 		},
 	}

--- a/templates/workloads/common/cf/autoscaling.yml
+++ b/templates/workloads/common/cf/autoscaling.yml
@@ -1,0 +1,58 @@
+{{- if .Autoscaling}}
+AutoScalingRole:
+  Type: AWS::IAM::Role
+  Properties:
+    RoleName: !Join ['', [!Ref WorkloadName, AutoScalingRole]]
+    AssumeRolePolicyDocument:
+      Statement:
+        - Effect: Allow
+          Principal:
+            Service: ecs-tasks.amazonaws.com
+          Action: 'sts:AssumeRole'
+    ManagedPolicyArns:
+      - 'arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceAutoscaleRole'
+
+AutoScalingTarget:
+  Type: AWS::ApplicationAutoScaling::ScalableTarget
+  Properties:
+    MinCapacity: {{.Autoscaling.MinCapacity}}
+    MaxCapacity: {{.Autoscaling.MaxCapacity}}
+    ResourceId:
+      Fn::Join:
+        - '/'
+        - - 'service'
+          - Fn::ImportValue:
+              !Sub '${AppName}-${EnvName}-ClusterId'
+          - !GetAtt Service.Name
+    ScalableDimension: ecs:service:DesiredCount
+    ServiceNamespace: ecs
+    RoleARN: !GetAtt AutoScalingRole.Arn
+{{if .Autoscaling.CPU}}
+AutoScalingPolicyECSServiceAverageCPUUtilization:
+  Type: AWS::ApplicationAutoScaling::ScalingPolicy
+  Properties:
+    PolicyName: !Join ['-', [!Ref WorkloadName, ECSServiceAverageCPUUtilization]]
+    PolicyType: TargetTrackingScaling
+    ScalingTargetId: !Ref AutoScalingTarget
+    TargetTrackingScalingPolicyConfiguration:
+      PredefinedMetricSpecification:
+        PredefinedMetricType: ECSServiceAverageCPUUtilization
+      ScaleInCooldown: 10
+      ScaleOutCooldown: 10
+      TargetValue: {{.Autoscaling.CPU}}
+{{- end}}
+{{if .Autoscaling.Memory}}
+AutoScalingPolicyECSServiceAverageMemoryUtilization:
+  Type: AWS::ApplicationAutoScaling::ScalingPolicy
+  Properties:
+    PolicyName: !Join ['-', [!Ref WorkloadName, ECSServiceAverageMemoryUtilization]]
+    PolicyType: TargetTrackingScaling
+    ScalingTargetId: !Ref AutoScalingTarget
+    TargetTrackingScalingPolicyConfiguration:
+      PredefinedMetricSpecification:
+        PredefinedMetricType: ECSServiceAverageMemoryUtilization
+      ScaleInCooldown: 10
+      ScaleOutCooldown: 10
+      TargetValue: {{.Autoscaling.Memory}}
+{{- end}}
+{{- end}}

--- a/templates/workloads/common/cf/autoscaling.yml
+++ b/templates/workloads/common/cf/autoscaling.yml
@@ -2,7 +2,6 @@
 AutoScalingRole:
   Type: AWS::IAM::Role
   Properties:
-    RoleName: !Join ['', [!Ref WorkloadName, AutoScalingRole]]
     AssumeRolePolicyDocument:
       Statement:
         - Effect: Allow
@@ -31,28 +30,28 @@ AutoScalingTarget:
 AutoScalingPolicyECSServiceAverageCPUUtilization:
   Type: AWS::ApplicationAutoScaling::ScalingPolicy
   Properties:
-    PolicyName: !Join ['-', [!Ref WorkloadName, ECSServiceAverageCPUUtilization]]
+    PolicyName: !Join ['-', [!Ref WorkloadName, ECSServiceAverageCPUUtilization, ScalingPolicy]]
     PolicyType: TargetTrackingScaling
     ScalingTargetId: !Ref AutoScalingTarget
     TargetTrackingScalingPolicyConfiguration:
       PredefinedMetricSpecification:
         PredefinedMetricType: ECSServiceAverageCPUUtilization
-      ScaleInCooldown: 10
-      ScaleOutCooldown: 10
+      ScaleInCooldown: 120
+      ScaleOutCooldown: 60
       TargetValue: {{.Autoscaling.CPU}}
 {{- end}}
 {{if .Autoscaling.Memory}}
 AutoScalingPolicyECSServiceAverageMemoryUtilization:
   Type: AWS::ApplicationAutoScaling::ScalingPolicy
   Properties:
-    PolicyName: !Join ['-', [!Ref WorkloadName, ECSServiceAverageMemoryUtilization]]
+    PolicyName: !Join ['-', [!Ref WorkloadName, ECSServiceAverageMemoryUtilization, ScalingPolicy]]
     PolicyType: TargetTrackingScaling
     ScalingTargetId: !Ref AutoScalingTarget
     TargetTrackingScalingPolicyConfiguration:
       PredefinedMetricSpecification:
         PredefinedMetricType: ECSServiceAverageMemoryUtilization
-      ScaleInCooldown: 10
-      ScaleOutCooldown: 10
+      ScaleInCooldown: 120
+      ScaleOutCooldown: 60
       TargetValue: {{.Autoscaling.Memory}}
 {{- end}}
 {{- end}}

--- a/templates/workloads/services/backend/cf.yml
+++ b/templates/workloads/services/backend/cf.yml
@@ -54,10 +54,9 @@ Resources:
 {{- end}}
 {{include "sidecars" . | indent 8}}
 {{include "executionrole" . | indent 2}}
-
 {{include "taskrole" . | indent 2}}
-
 {{include "servicediscovery" . | indent 2}}
+{{include "autoscaling" . | indent 2}}
 
   Service:
     Type: AWS::ECS::Service

--- a/templates/workloads/services/lb-web/cf.yml
+++ b/templates/workloads/services/lb-web/cf.yml
@@ -63,10 +63,9 @@ Resources:
 {{include "logconfig" . | indent 10}}
 {{include "sidecars" . | indent 8}}
 {{include "executionrole" . | indent 2}}
-
 {{include "taskrole" . | indent 2}}
-
 {{include "servicediscovery" . | indent 2}}
+{{include "autoscaling" . | indent 2}}
 
   Service:
     Type: AWS::ECS::Service


### PR DESCRIPTION
<!-- Provide summary of changes -->
Part of #1349. Enable Auto Scaling for simple target track policies by updating CFN template. Will add e2e test in a separate PR after this one. Also will add a custom resource to set `desiredCount` smartly so that when users update their ECS service there won't be a sudden increment/decrement to their task num.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
