### PR TITLE
build: update yags-parser lib version to >=18.1.2

### DIFF
--- a/cf-custom-resources/package-lock.json
+++ b/cf-custom-resources/package-lock.json
@@ -7378,18 +7378,24 @@
           "requires": {
             "ansi-regex": "^5.0.0"
           }
+        },
+        "yargs-parser": {
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
         }
       }
     },
     "yargs-parser": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.0.tgz",
-      "integrity": "sha512-o/Jr6JBOv6Yx3pL+5naWSoIA2jJ+ZkMYQG/ie9qFbukBe4uzmBatlXFOiu/tNKRWEtyf+n5w7jc/O16ufqOTdQ==",
-      "dev": true,
-      "requires": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      }
+      "version": "19.0.4",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-19.0.4.tgz",
+      "integrity": "sha512-eXeQm7yXRjPFFyf1voPkZgXQZJjYfjgQUmGPbD2TLtZeIYzvacgWX7sQ5a1HsRgVP+pfKAkRZDNtTGev4h9vhw==",
+      "dev": true
     }
   }
 }

--- a/cf-custom-resources/package.json
+++ b/cf-custom-resources/package.json
@@ -24,6 +24,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "aws-sdk": "^2.540.0",
+    "yargs-parser": ">=18.1.2",
     "aws-sdk-mock": "^4.5.0",
     "babel-minify": "^0.5.1",
     "eslint": "^6.5.1",


### PR DESCRIPTION
Resolves the GHSA-p9pc-299p-vxgp vulnerability

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
