### PR TITLE
feat(autoscaling): override desired count to autoscaling count during deployments

### DIFF
--- a/cf-custom-resources/lib/desired-count-delegation.js
+++ b/cf-custom-resources/lib/desired-count-delegation.js
@@ -1,0 +1,131 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+'use strict';
+
+const aws = require('aws-sdk');
+
+// These are used for test purposes only
+let defaultResponseURL;
+
+/**
+ * Upload a CloudFormation response object to S3.
+ *
+ * @param {object} event the Lambda event payload received by the handler function
+ * @param {object} context the Lambda context received by the handler function
+ * @param {string} responseStatus the response status, either 'SUCCESS' or 'FAILED'
+ * @param {string} physicalResourceId CloudFormation physical resource ID
+ * @param {object} [responseData] arbitrary response data object
+ * @param {string} [reason] reason for failure, if any, to convey to the user
+ * @returns {Promise} Promise that is resolved on success, or rejected on connection error or HTTP error response
+ */
+let report = function (event, context, responseStatus, physicalResourceId, responseData, reason) {
+    return new Promise((resolve, reject) => {
+        const https = require('https');
+        const {
+            URL
+        } = require('url');
+
+        var responseBody = JSON.stringify({
+            Status: responseStatus,
+            Reason: reason,
+            PhysicalResourceId: physicalResourceId || context.logStreamName,
+            StackId: event.StackId,
+            RequestId: event.RequestId,
+            LogicalResourceId: event.LogicalResourceId,
+            Data: responseData
+        });
+
+        const parsedUrl = new URL(event.ResponseURL || defaultResponseURL);
+        const options = {
+            hostname: parsedUrl.hostname,
+            port: 443,
+            path: parsedUrl.pathname + parsedUrl.search,
+            method: 'PUT',
+            headers: {
+                'Content-Type': '',
+                'Content-Length': responseBody.length
+            }
+        };
+
+        https.request(options)
+            .on('error', reject)
+            .on('response', res => {
+                res.resume();
+                if (res.statusCode >= 400) {
+                    reject(new Error(`Error ${res.statusCode}: ${res.statusMessage}`));
+                } else {
+                    resolve();
+                }
+            })
+            .end(responseBody, 'utf8');
+    });
+};
+
+/**
+ * Get the current running task number for a specific task definition.
+ *
+ * @param {string} cluster Name of the ECS cluster.
+ * @param {string} family Name of the task definition family.
+
+ * @returns {number} The running task number.
+ */
+const getRunningTaskCount = async function (cluster, family) {
+  var ecs = new aws.ECS();
+
+  var taskNum = 0
+  var nextToken;
+  do {
+    const resp = await ecs.listTasks({
+      cluster: cluster,
+      family: family,
+      nextToken: nextToken
+    }).promise();
+    taskNum += resp.taskArns.length;
+    nextToken = resp.nextToken;
+  } while (nextToken)
+
+  return taskNum;
+};
+
+/**
+ * Correct desired count handler, invoked by Lambda.
+ */
+exports.desiredCountHandler = async function(event, context) {
+  var responseData = {};
+  var physicalResourceId;
+
+  try {
+    switch (event.RequestType) {
+      case 'Create':
+        responseData.DesiredCount = event.ResourceProperties.DesiredCount;
+        physicalResourceId = event.PhysicalResourceId;
+        console.log(`Successfully set desired count to ${responseData.DesiredCount}.`);
+        break;
+      case 'Update':
+        responseData.DesiredCount = await getRunningTaskCount(event.ResourceProperties.Cluster, event.ResourceProperties.Family);
+        physicalResourceId = event.PhysicalResourceId;
+        console.log(`Successfully update desired count to ${responseData.DesiredCount}.`);
+        break;
+      case 'Delete':
+        physicalResourceId = event.PhysicalResourceId;
+        break;
+      default:
+        throw new Error(`Unsupported request type ${event.RequestType}`);
+    }
+
+    await report(event, context, 'SUCCESS', physicalResourceId, responseData);
+  } catch (err) {
+    // If it fails, just set to be desired count and return.
+    responseData.DesiredCount = event.ResourceProperties.DesiredCount;
+    console.log(`Caught error ${err}. Set back desired count to ${responseData.DesiredCount}`);
+    await report(event, context, 'SUCCESS', physicalResourceId, responseData);
+  }
+};
+
+
+/**
+ * @private
+ */
+exports.withDefaultResponseURL = function(url) {
+  defaultResponseURL = url;
+};

--- a/cf-custom-resources/lib/desired-count-delegation.js
+++ b/cf-custom-resources/lib/desired-count-delegation.js
@@ -113,21 +113,16 @@ const getRunningTaskCount = async function (
   const serviceARN = resources[0].ResourceARN;
 
   var ecs = new aws.ECS();
-  var taskNum = 0;
-  var nextToken;
-  do {
-    const resp = await ecs
-      .listTasks({
-        cluster: cluster,
-        serviceName: serviceARN,
-        nextToken: nextToken,
-      })
-      .promise();
-    taskNum += resp.taskArns.length;
-    nextToken = resp.nextToken;
-  } while (nextToken);
-
-  return taskNum;
+  const resp = await ecs
+    .describeServices({
+      cluster: cluster,
+      services: [serviceARN],
+    })
+    .promise();
+  if (resp.services.length !== 1) {
+    return defaultDesiredCount;
+  }
+  return resp.services[0].desiredCount;
 };
 
 /**

--- a/cf-custom-resources/lib/desired-count-delegation.js
+++ b/cf-custom-resources/lib/desired-count-delegation.js
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-'use strict';
+"use strict";
 
-const aws = require('aws-sdk');
+const aws = require("aws-sdk");
 
 // These are used for test purposes only
 let defaultResponseURL;
@@ -18,71 +18,114 @@ let defaultResponseURL;
  * @param {string} [reason] reason for failure, if any, to convey to the user
  * @returns {Promise} Promise that is resolved on success, or rejected on connection error or HTTP error response
  */
-let report = function (event, context, responseStatus, physicalResourceId, responseData, reason) {
-    return new Promise((resolve, reject) => {
-        const https = require('https');
-        const {
-            URL
-        } = require('url');
+let report = function (
+  event,
+  context,
+  responseStatus,
+  physicalResourceId,
+  responseData,
+  reason
+) {
+  return new Promise((resolve, reject) => {
+    const https = require("https");
+    const { URL } = require("url");
 
-        var responseBody = JSON.stringify({
-            Status: responseStatus,
-            Reason: reason,
-            PhysicalResourceId: physicalResourceId || context.logStreamName,
-            StackId: event.StackId,
-            RequestId: event.RequestId,
-            LogicalResourceId: event.LogicalResourceId,
-            Data: responseData
-        });
-
-        const parsedUrl = new URL(event.ResponseURL || defaultResponseURL);
-        const options = {
-            hostname: parsedUrl.hostname,
-            port: 443,
-            path: parsedUrl.pathname + parsedUrl.search,
-            method: 'PUT',
-            headers: {
-                'Content-Type': '',
-                'Content-Length': responseBody.length
-            }
-        };
-
-        https.request(options)
-            .on('error', reject)
-            .on('response', res => {
-                res.resume();
-                if (res.statusCode >= 400) {
-                    reject(new Error(`Error ${res.statusCode}: ${res.statusMessage}`));
-                } else {
-                    resolve();
-                }
-            })
-            .end(responseBody, 'utf8');
+    var responseBody = JSON.stringify({
+      Status: responseStatus,
+      Reason: reason,
+      PhysicalResourceId: physicalResourceId || context.logStreamName,
+      StackId: event.StackId,
+      RequestId: event.RequestId,
+      LogicalResourceId: event.LogicalResourceId,
+      Data: responseData,
     });
+
+    const parsedUrl = new URL(event.ResponseURL || defaultResponseURL);
+    const options = {
+      hostname: parsedUrl.hostname,
+      port: 443,
+      path: parsedUrl.pathname + parsedUrl.search,
+      method: "PUT",
+      headers: {
+        "Content-Type": "",
+        "Content-Length": responseBody.length,
+      },
+    };
+
+    https
+      .request(options)
+      .on("error", reject)
+      .on("response", (res) => {
+        res.resume();
+        if (res.statusCode >= 400) {
+          reject(new Error(`Error ${res.statusCode}: ${res.statusMessage}`));
+        } else {
+          resolve();
+        }
+      })
+      .end(responseBody, "utf8");
+  });
 };
 
 /**
  * Get the current running task number for a specific task definition.
  *
+ * @param {string} defaultDesiredCount Default desired count number.
  * @param {string} cluster Name of the ECS cluster.
- * @param {string} family Name of the task definition family.
-
+ * @param {string} app Name of the copilot application.
+ * @param {string} env Name of the copilot environment.
+ * @param {string} svc Name of the copilot service.
+ *
  * @returns {number} The running task number.
  */
-const getRunningTaskCount = async function (cluster, family) {
-  var ecs = new aws.ECS();
+const getRunningTaskCount = async function (
+  defaultDesiredCount,
+  cluster,
+  app,
+  env,
+  svc
+) {
+  var resourcegroupstaggingapi = new aws.ResourceGroupsTaggingAPI();
+  const rgResp = await resourcegroupstaggingapi
+    .getResources({
+      ResourceTypeFilters: ["ecs:service"],
+      TagFilters: [
+        {
+          Key: "copilot-application",
+          Values: [app],
+        },
+        {
+          Key: "copilot-environment",
+          Values: [env],
+        },
+        {
+          Key: "copilot-service",
+          Values: [svc],
+        },
+      ],
+    })
+    .promise();
 
-  var taskNum = 0
+  const resources = rgResp.ResourceTagMappingList;
+  if (resources.length !== 1) {
+    return defaultDesiredCount;
+  }
+  const serviceARN = resources[0].ResourceARN;
+
+  var ecs = new aws.ECS();
+  var taskNum = 0;
   var nextToken;
   do {
-    const resp = await ecs.listTasks({
-      cluster: cluster,
-      family: family,
-      nextToken: nextToken
-    }).promise();
+    const resp = await ecs
+      .listTasks({
+        cluster: cluster,
+        serviceName: serviceARN,
+        nextToken: nextToken,
+      })
+      .promise();
     taskNum += resp.taskArns.length;
     nextToken = resp.nextToken;
-  } while (nextToken)
+  } while (nextToken);
 
   return taskNum;
 };
@@ -90,42 +133,53 @@ const getRunningTaskCount = async function (cluster, family) {
 /**
  * Correct desired count handler, invoked by Lambda.
  */
-exports.desiredCountHandler = async function(event, context) {
+exports.handler = async function (event, context) {
   var responseData = {};
   var physicalResourceId;
+  const props = event.ResourceProperties;
 
   try {
     switch (event.RequestType) {
-      case 'Create':
-        responseData.DesiredCount = event.ResourceProperties.DesiredCount;
-        physicalResourceId = event.PhysicalResourceId;
-        console.log(`Successfully set desired count to ${responseData.DesiredCount}.`);
+      case "Create":
+        responseData.DesiredCount = await getRunningTaskCount(
+          props.DefaultDesiredCount,
+          props.Cluster,
+          props.App,
+          props.Env,
+          props.Svc
+        );
+        physicalResourceId = `copilot/apps/${props.App}/envs/${props.Env}/services/${props.Svc}/autoscaling`;
         break;
-      case 'Update':
-        responseData.DesiredCount = await getRunningTaskCount(event.ResourceProperties.Cluster, event.ResourceProperties.Family);
+      case "Update":
+        responseData.DesiredCount = await getRunningTaskCount(
+          props.DefaultDesiredCount,
+          props.Cluster,
+          props.App,
+          props.Env,
+          props.Svc
+        );
         physicalResourceId = event.PhysicalResourceId;
-        console.log(`Successfully update desired count to ${responseData.DesiredCount}.`);
         break;
-      case 'Delete':
+      case "Delete":
         physicalResourceId = event.PhysicalResourceId;
         break;
       default:
         throw new Error(`Unsupported request type ${event.RequestType}`);
     }
-
-    await report(event, context, 'SUCCESS', physicalResourceId, responseData);
+    await report(event, context, "SUCCESS", physicalResourceId, responseData);
   } catch (err) {
     // If it fails, just set to be desired count and return.
-    responseData.DesiredCount = event.ResourceProperties.DesiredCount;
-    console.log(`Caught error ${err}. Set back desired count to ${responseData.DesiredCount}`);
-    await report(event, context, 'SUCCESS', physicalResourceId, responseData);
+    responseData.DesiredCount = props.DefaultDesiredCount;
+    console.log(
+      `Caught error ${err}. Set back desired count to ${responseData.DesiredCount}`
+    );
+    await report(event, context, "SUCCESS", physicalResourceId, responseData);
   }
 };
-
 
 /**
  * @private
  */
-exports.withDefaultResponseURL = function(url) {
+exports.withDefaultResponseURL = function (url) {
   defaultResponseURL = url;
 };

--- a/cf-custom-resources/lib/dns-delegation.js
+++ b/cf-custom-resources/lib/dns-delegation.js
@@ -4,13 +4,8 @@
 
 const aws = require("aws-sdk");
 
-const defaultSleep = function (ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-};
-
 // These are used for test purposes only
 let defaultResponseURL;
-let waiter;
 
 /**
  * Upload a CloudFormation response object to S3.

--- a/cf-custom-resources/test/desired-count-delegation-test.js
+++ b/cf-custom-resources/test/desired-count-delegation-test.js
@@ -1,0 +1,146 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+'use strict';
+
+describe('Desired count delegation Handler', () => {
+  const AWS = require('aws-sdk-mock');
+  const sinon = require('sinon');
+  const DesiredCountDelegation = require('../lib/desired-count-delegation');
+  const LambdaTester = require('lambda-tester').noVersionCheck();
+  const nock = require('nock');
+  const responseURL = 'https://cloudwatch-response-mock.example.com/';
+  const testRequestId = 'f4ef1b10-c39a-44e3-99c0-fbf7e53c3943';
+  let origLog = console.log;
+
+  const testCluster = 'mockClusterName';
+  const testFamily = 'mockFamilyName';
+  const testNextToken = 'mockNextToken';
+
+  beforeEach(() => {
+    DesiredCountDelegation.withDefaultResponseURL(responseURL);
+    // Prevent logging.
+    console.log = function() { };
+  });
+  afterEach(() => {
+    // Restore logger
+    AWS.restore();
+    console.log = origLog;
+  });
+
+  test('update operation', () => {
+    const listTasksFake = sinon.fake.resolves({
+      taskArns: [
+        "mockTask1",
+        "mockTask2",
+      ]
+    });
+    AWS.mock('ECS', 'listTasks', listTasksFake);
+    const request = nock(responseURL).put('/', body => {
+      return body.Status === 'SUCCESS' && body.Data.DesiredCount == 2;
+    }).reply(200);
+
+    return LambdaTester(DesiredCountDelegation.desiredCountHandler)
+      .event({
+        RequestType: 'Update',
+        RequestId: testRequestId,
+        ResponseURL: responseURL,
+        ResourceProperties: {
+          Cluster: testCluster,
+          Family: testFamily,
+          DesiredCount: 3,
+        }
+      }).expectResolve(() => {
+      sinon.assert.calledWith(listTasksFake, sinon.match({
+        cluster: testCluster,
+        family: testFamily
+      }));
+      expect(request.isDone()).toBe(true);
+    });
+  });
+
+  test('update operation with pagination', () => {
+    const listTasksFake = sinon.stub();
+    listTasksFake.onCall(0).resolves({
+      taskArns: [
+        "mockTask1",
+        "mockTask2",
+      ],
+      nextToken: testNextToken
+    });
+    listTasksFake.onCall(1).resolves({
+      taskArns: [
+        "mockTask3",
+        "mockTask4",
+      ],
+    });
+    AWS.mock('ECS', 'listTasks', listTasksFake);
+    const request = nock(responseURL).put('/', body => {
+      return body.Status === 'SUCCESS' && body.Data.DesiredCount == 4;
+    }).reply(200);
+
+    return LambdaTester(DesiredCountDelegation.desiredCountHandler)
+      .event({
+        RequestType: 'Update',
+        RequestId: testRequestId,
+        ResponseURL: responseURL,
+        ResourceProperties: {
+          Cluster: testCluster,
+          Family: testFamily,
+          DesiredCount: 3,
+        }
+      }).expectResolve(() => {
+      sinon.assert.calledWith(listTasksFake.firstCall, sinon.match({
+        cluster: testCluster,
+        family: testFamily
+      }));
+      sinon.assert.calledWith(listTasksFake.secondCall, sinon.match({
+        cluster: testCluster,
+        family: testFamily,
+        nextToken: testNextToken
+      }));
+      expect(request.isDone()).toBe(true);
+    });
+  });
+
+  test('create operation', () => {
+      const mockListTasks = sinon.stub();
+
+      AWS.mock('ECS', 'listTasks', mockListTasks)
+      const request = nock(responseURL).put('/', body => {
+          return body.Status === 'SUCCESS' && body.Data.DesiredCount == 3;
+      }).reply(200);
+
+      return LambdaTester(DesiredCountDelegation.desiredCountHandler)
+          .event({
+              RequestType: 'Create',
+              RequestId: testRequestId,
+              ResponseURL: responseURL,
+              ResourceProperties: {
+                Cluster: testCluster,
+                Family: testFamily,
+                DesiredCount: 3,
+              }
+          }).expectResolve(() => {
+          sinon.assert.notCalled(mockListTasks);
+          expect(request.isDone()).toBe(true);
+      });
+  });
+
+  test('delete operation should do nothing', () => {
+      const mockListTasks = sinon.stub();
+
+      AWS.mock('ECS', 'listTasks', mockListTasks)
+      const request = nock(responseURL).put('/', body => {
+          return body.Status === 'SUCCESS';
+      }).reply(200);
+
+      return LambdaTester(DesiredCountDelegation.desiredCountHandler)
+          .event({
+              RequestType: 'Delete',
+              ResponseURL: responseURL,
+          }).expectResolve(() => {
+          sinon.assert.notCalled(mockListTasks);
+          expect(request.isDone()).toBe(true);
+      });
+  });
+});

--- a/cf-custom-resources/test/desired-count-delegation-test.js
+++ b/cf-custom-resources/test/desired-count-delegation-test.js
@@ -1,25 +1,28 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-'use strict';
+"use strict";
 
-describe('Desired count delegation Handler', () => {
-  const AWS = require('aws-sdk-mock');
-  const sinon = require('sinon');
-  const DesiredCountDelegation = require('../lib/desired-count-delegation');
-  const LambdaTester = require('lambda-tester').noVersionCheck();
-  const nock = require('nock');
-  const responseURL = 'https://cloudwatch-response-mock.example.com/';
-  const testRequestId = 'f4ef1b10-c39a-44e3-99c0-fbf7e53c3943';
+describe("Desired count delegation Handler", () => {
+  const AWS = require("aws-sdk-mock");
+  const sinon = require("sinon");
+  const DesiredCountDelegation = require("../lib/desired-count-delegation");
+  const LambdaTester = require("lambda-tester").noVersionCheck();
+  const nock = require("nock");
+  const responseURL = "https://cloudwatch-response-mock.example.com/";
+  const testRequestId = "f4ef1b10-c39a-44e3-99c0-fbf7e53c3943";
   let origLog = console.log;
 
-  const testCluster = 'mockClusterName';
-  const testFamily = 'mockFamilyName';
-  const testNextToken = 'mockNextToken';
+  const testCluster = "mockClusterName";
+  const testApp = "mockApp";
+  const testEnv = "testEnv";
+  const testSvc = "testSvc";
+  const testECSService = "testECSService";
+  const testNextToken = "mockNextToken";
 
   beforeEach(() => {
     DesiredCountDelegation.withDefaultResponseURL(responseURL);
     // Prevent logging.
-    console.log = function() { };
+    console.log = function () {};
   });
   afterEach(() => {
     // Restore logger
@@ -27,120 +30,233 @@ describe('Desired count delegation Handler', () => {
     console.log = origLog;
   });
 
-  test('update operation', () => {
-    const listTasksFake = sinon.fake.resolves({
-      taskArns: [
-        "mockTask1",
-        "mockTask2",
-      ]
-    });
-    AWS.mock('ECS', 'listTasks', listTasksFake);
-    const request = nock(responseURL).put('/', body => {
-      return body.Status === 'SUCCESS' && body.Data.DesiredCount == 2;
-    }).reply(200);
+  test("invalid operation should return default desired count", () => {
+    const request = nock(responseURL)
+      .put("/", (body) => {
+        return body.Status === "SUCCESS" && body.Data.DesiredCount == 3;
+      })
+      .reply(200);
 
-    return LambdaTester(DesiredCountDelegation.desiredCountHandler)
+    return LambdaTester(DesiredCountDelegation.handler)
       .event({
-        RequestType: 'Update',
-        RequestId: testRequestId,
+        RequestType: "OOPS",
         ResponseURL: responseURL,
         ResourceProperties: {
-          Cluster: testCluster,
-          Family: testFamily,
-          DesiredCount: 3,
-        }
-      }).expectResolve(() => {
-      sinon.assert.calledWith(listTasksFake, sinon.match({
-        cluster: testCluster,
-        family: testFamily
-      }));
-      expect(request.isDone()).toBe(true);
-    });
-  });
-
-  test('update operation with pagination', () => {
-    const listTasksFake = sinon.stub();
-    listTasksFake.onCall(0).resolves({
-      taskArns: [
-        "mockTask1",
-        "mockTask2",
-      ],
-      nextToken: testNextToken
-    });
-    listTasksFake.onCall(1).resolves({
-      taskArns: [
-        "mockTask3",
-        "mockTask4",
-      ],
-    });
-    AWS.mock('ECS', 'listTasks', listTasksFake);
-    const request = nock(responseURL).put('/', body => {
-      return body.Status === 'SUCCESS' && body.Data.DesiredCount == 4;
-    }).reply(200);
-
-    return LambdaTester(DesiredCountDelegation.desiredCountHandler)
-      .event({
-        RequestType: 'Update',
-        RequestId: testRequestId,
-        ResponseURL: responseURL,
-        ResourceProperties: {
-          Cluster: testCluster,
-          Family: testFamily,
-          DesiredCount: 3,
-        }
-      }).expectResolve(() => {
-      sinon.assert.calledWith(listTasksFake.firstCall, sinon.match({
-        cluster: testCluster,
-        family: testFamily
-      }));
-      sinon.assert.calledWith(listTasksFake.secondCall, sinon.match({
-        cluster: testCluster,
-        family: testFamily,
-        nextToken: testNextToken
-      }));
-      expect(request.isDone()).toBe(true);
-    });
-  });
-
-  test('create operation', () => {
-      const mockListTasks = sinon.stub();
-
-      AWS.mock('ECS', 'listTasks', mockListTasks)
-      const request = nock(responseURL).put('/', body => {
-          return body.Status === 'SUCCESS' && body.Data.DesiredCount == 3;
-      }).reply(200);
-
-      return LambdaTester(DesiredCountDelegation.desiredCountHandler)
-          .event({
-              RequestType: 'Create',
-              RequestId: testRequestId,
-              ResponseURL: responseURL,
-              ResourceProperties: {
-                Cluster: testCluster,
-                Family: testFamily,
-                DesiredCount: 3,
-              }
-          }).expectResolve(() => {
-          sinon.assert.notCalled(mockListTasks);
-          expect(request.isDone()).toBe(true);
+          DefaultDesiredCount: 3,
+        },
+      })
+      .expectResolve(() => {
+        expect(request.isDone()).toBe(true);
       });
   });
 
-  test('delete operation should do nothing', () => {
-      const mockListTasks = sinon.stub();
+  test("create operation", () => {
+    const getResourcesFake = sinon.fake.resolves({
+      ResourceTagMappingList: [],
+    });
+    const listTasksFake = sinon.stub();
+    AWS.mock("ResourceGroupsTaggingAPI", "getResources", getResourcesFake);
+    AWS.mock("ECS", "listTasks", listTasksFake);
+    const request = nock(responseURL)
+      .put("/", (body) => {
+        return body.Status === "SUCCESS" && body.Data.DesiredCount == 3;
+      })
+      .reply(200);
 
-      AWS.mock('ECS', 'listTasks', mockListTasks)
-      const request = nock(responseURL).put('/', body => {
-          return body.Status === 'SUCCESS';
-      }).reply(200);
+    return LambdaTester(DesiredCountDelegation.handler)
+      .event({
+        RequestType: "Create",
+        RequestId: testRequestId,
+        ResponseURL: responseURL,
+        ResourceProperties: {
+          Cluster: testCluster,
+          App: testApp,
+          Env: testEnv,
+          Svc: testSvc,
+          DefaultDesiredCount: 3,
+        },
+      })
+      .expectResolve(() => {
+        sinon.assert.calledWith(
+          getResourcesFake,
+          sinon.match({
+            ResourceTypeFilters: ["ecs:service"],
+            TagFilters: [
+              {
+                Key: "copilot-application",
+                Values: [testApp],
+              },
+              {
+                Key: "copilot-environment",
+                Values: [testEnv],
+              },
+              {
+                Key: "copilot-service",
+                Values: [testSvc],
+              },
+            ],
+          })
+        );
+        sinon.assert.notCalled(listTasksFake);
+        expect(request.isDone()).toBe(true);
+      });
+  });
 
-      return LambdaTester(DesiredCountDelegation.desiredCountHandler)
-          .event({
-              RequestType: 'Delete',
-              ResponseURL: responseURL,
-          }).expectResolve(() => {
-          sinon.assert.notCalled(mockListTasks);
-          expect(request.isDone()).toBe(true);
+  test("update operation", () => {
+    const getResourcesFake = sinon.fake.resolves({
+      ResourceTagMappingList: [
+        {
+          ResourceARN: testECSService,
+        },
+      ],
+    });
+    const listTasksFake = sinon.fake.resolves({
+      taskArns: ["mockTask1", "mockTask2"],
+    });
+    AWS.mock("ResourceGroupsTaggingAPI", "getResources", getResourcesFake);
+    AWS.mock("ECS", "listTasks", listTasksFake);
+    const request = nock(responseURL)
+      .put("/", (body) => {
+        return body.Status === "SUCCESS" && body.Data.DesiredCount == 2;
+      })
+      .reply(200);
+
+    return LambdaTester(DesiredCountDelegation.handler)
+      .event({
+        RequestType: "Update",
+        RequestId: testRequestId,
+        ResponseURL: responseURL,
+        ResourceProperties: {
+          Cluster: testCluster,
+          App: testApp,
+          Env: testEnv,
+          Svc: testSvc,
+          DefaultDesiredCount: 3,
+        },
+      })
+      .expectResolve(() => {
+        sinon.assert.calledWith(
+          getResourcesFake,
+          sinon.match({
+            ResourceTypeFilters: ["ecs:service"],
+            TagFilters: [
+              {
+                Key: "copilot-application",
+                Values: [testApp],
+              },
+              {
+                Key: "copilot-environment",
+                Values: [testEnv],
+              },
+              {
+                Key: "copilot-service",
+                Values: [testSvc],
+              },
+            ],
+          })
+        );
+        sinon.assert.calledWith(
+          listTasksFake,
+          sinon.match({
+            cluster: testCluster,
+            serviceName: testECSService,
+          })
+        );
+        expect(request.isDone()).toBe(true);
+      });
+  });
+
+  test("update operation with pagination", () => {
+    const getResourcesFake = sinon.fake.resolves({
+      ResourceTagMappingList: [
+        {
+          ResourceARN: testECSService,
+        },
+      ],
+    });
+    const listTasksFake = sinon.stub();
+    listTasksFake.onCall(0).resolves({
+      taskArns: ["mockTask1", "mockTask2"],
+      nextToken: testNextToken,
+    });
+    listTasksFake.onCall(1).resolves({
+      taskArns: ["mockTask3", "mockTask4"],
+    });
+    AWS.mock("ResourceGroupsTaggingAPI", "getResources", getResourcesFake);
+    AWS.mock("ECS", "listTasks", listTasksFake);
+    const request = nock(responseURL)
+      .put("/", (body) => {
+        return body.Status === "SUCCESS" && body.Data.DesiredCount == 4;
+      })
+      .reply(200);
+
+    return LambdaTester(DesiredCountDelegation.handler)
+      .event({
+        RequestType: "Update",
+        RequestId: testRequestId,
+        ResponseURL: responseURL,
+        ResourceProperties: {
+          Cluster: testCluster,
+          App: testApp,
+          Env: testEnv,
+          Svc: testSvc,
+          DefaultDesiredCount: 3,
+        },
+      })
+      .expectResolve(() => {
+        sinon.assert.calledWith(
+          getResourcesFake,
+          sinon.match({
+            ResourceTypeFilters: ["ecs:service"],
+            TagFilters: [
+              {
+                Key: "copilot-application",
+                Values: [testApp],
+              },
+              {
+                Key: "copilot-environment",
+                Values: [testEnv],
+              },
+              {
+                Key: "copilot-service",
+                Values: [testSvc],
+              },
+            ],
+          })
+        );
+        sinon.assert.calledWith(
+          listTasksFake.firstCall,
+          sinon.match({
+            cluster: testCluster,
+            serviceName: testECSService,
+          })
+        );
+        sinon.assert.calledWith(
+          listTasksFake.secondCall,
+          sinon.match({
+            cluster: testCluster,
+            serviceName: testECSService,
+            nextToken: testNextToken,
+          })
+        );
+        expect(request.isDone()).toBe(true);
+      });
+  });
+
+  test("delete operation should do nothing", () => {
+    const request = nock(responseURL)
+      .put("/", (body) => {
+        return body.Status === "SUCCESS";
+      })
+      .reply(200);
+
+    return LambdaTester(DesiredCountDelegation.handler)
+      .event({
+        RequestType: "Delete",
+        ResponseURL: responseURL,
+      })
+      .expectResolve(() => {
+        expect(request.isDone()).toBe(true);
       });
   });
 });

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,6 @@ github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/aws/aws-sdk-go v1.15.11/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
-github.com/aws/aws-sdk-go v1.34.18 h1:Mo/Clq3u1dQFzpg8YQqBii8m+Vl3fWIfHi6kXs5wpuM=
-github.com/aws/aws-sdk-go v1.34.18/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.34.22 h1:7V2sKilVVgHqdjbW+O/xaVWYfnmuLwZdF/+6JuUh6Cw=
 github.com/aws/aws-sdk-go v1.34.22/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/awslabs/goformation/v4 v4.15.0 h1:yZM85dzEKrRIPpMZIdsUV+EWbvhWsfoqC81Fv/aFPck=
@@ -144,7 +142,6 @@ github.com/gobuffalo/logger v1.0.3 h1:YaXOTHNPCvkqqA7w05A4v0k2tCdpr+sgFlgINbQ6gq
 github.com/gobuffalo/logger v1.0.3/go.mod h1:SoeejUwldiS7ZsyCBphOGURmWdwUFXs0J7TCjEhjKxM=
 github.com/gobuffalo/packd v1.0.0 h1:6ERZvJHfe24rfFmA9OaoKBdC7+c9sydrytMg8SdFGBM=
 github.com/gobuffalo/packd v1.0.0/go.mod h1:6VTc4htmJRFB7u1m/4LeMTWjFoYrUiBkU9Fdec9hrhI=
-github.com/gobuffalo/packr v1.30.1 h1:hu1fuVR3fXEZR7rXNW3h8rqSML8EVAf6KNm0NKO/wKg=
 github.com/gobuffalo/packr/v2 v2.8.0 h1:IULGd15bQL59ijXLxEvA5wlMxsmx/ZkQv9T282zNVIY=
 github.com/gobuffalo/packr/v2 v2.8.0/go.mod h1:PDk2k3vGevNE3SwVyVRgQCCXETC9SaONCNSXT1Q8M1g=
 github.com/godbus/dbus v0.0.0-20190422162347-ade71ed3457e/go.mod h1:bBOAhwG1umN6/6ZUMtDFBMQR8jRg9O75tm9K00oMsK4=

--- a/go.sum
+++ b/go.sum
@@ -144,6 +144,7 @@ github.com/gobuffalo/logger v1.0.3 h1:YaXOTHNPCvkqqA7w05A4v0k2tCdpr+sgFlgINbQ6gq
 github.com/gobuffalo/logger v1.0.3/go.mod h1:SoeejUwldiS7ZsyCBphOGURmWdwUFXs0J7TCjEhjKxM=
 github.com/gobuffalo/packd v1.0.0 h1:6ERZvJHfe24rfFmA9OaoKBdC7+c9sydrytMg8SdFGBM=
 github.com/gobuffalo/packd v1.0.0/go.mod h1:6VTc4htmJRFB7u1m/4LeMTWjFoYrUiBkU9Fdec9hrhI=
+github.com/gobuffalo/packr v1.30.1 h1:hu1fuVR3fXEZR7rXNW3h8rqSML8EVAf6KNm0NKO/wKg=
 github.com/gobuffalo/packr/v2 v2.8.0 h1:IULGd15bQL59ijXLxEvA5wlMxsmx/ZkQv9T282zNVIY=
 github.com/gobuffalo/packr/v2 v2.8.0/go.mod h1:PDk2k3vGevNE3SwVyVRgQCCXETC9SaONCNSXT1Q8M1g=
 github.com/godbus/dbus v0.0.0-20190422162347-ade71ed3457e/go.mod h1:bBOAhwG1umN6/6ZUMtDFBMQR8jRg9O75tm9K00oMsK4=

--- a/internal/pkg/deploy/cloudformation/stack/backend_svc.go
+++ b/internal/pkg/deploy/cloudformation/stack/backend_svc.go
@@ -28,6 +28,7 @@ type backendSvcReadParser interface {
 type BackendService struct {
 	*wkld
 	manifest *manifest.BackendService
+	updateID string
 
 	parser backendSvcReadParser
 }
@@ -61,6 +62,17 @@ func NewBackendService(mft *manifest.BackendService, env, app string, rc Runtime
 
 // Template returns the CloudFormation template for the backend service.
 func (s *BackendService) Template() (string, error) {
+	desiredCountLambda, err := s.parser.Read(desiredCountGeneratorPath)
+	if err != nil {
+		return "", fmt.Errorf("read desired count lambda: %w", err)
+	}
+	if s.updateID == "" {
+		id, err := randomUpdateID()
+		if err != nil {
+			return "", err
+		}
+		s.updateID = id
+	}
 	outputs, err := s.addonsOutputs()
 	if err != nil {
 		return "", err
@@ -74,13 +86,15 @@ func (s *BackendService) Template() (string, error) {
 		return "", fmt.Errorf("convert the Auto Scaling configuration for service %s: %w", s.name, err)
 	}
 	content, err := s.parser.ParseBackendService(template.ServiceOpts{
-		Variables:   s.manifest.BackendServiceConfig.Variables,
-		Secrets:     s.manifest.BackendServiceConfig.Secrets,
-		NestedStack: outputs,
-		Sidecars:    sidecars,
-		Autoscaling: autoscaling,
-		HealthCheck: s.manifest.BackendServiceConfig.Image.HealthCheckOpts(),
-		LogConfig:   s.manifest.LogConfigOpts(),
+		Variables:                  s.manifest.BackendServiceConfig.Variables,
+		Secrets:                    s.manifest.BackendServiceConfig.Secrets,
+		NestedStack:                outputs,
+		Sidecars:                   sidecars,
+		Autoscaling:                autoscaling,
+		HealthCheck:                s.manifest.BackendServiceConfig.Image.HealthCheckOpts(),
+		LogConfig:                  s.manifest.LogConfigOpts(),
+		DesiredCountLambda:         desiredCountLambda.String(),
+		DesiredCountLambdaUpdateID: s.updateID,
 	})
 	if err != nil {
 		return "", fmt.Errorf("parse backend service template: %w", err)

--- a/internal/pkg/deploy/cloudformation/stack/backend_svc.go
+++ b/internal/pkg/deploy/cloudformation/stack/backend_svc.go
@@ -28,7 +28,6 @@ type backendSvcReadParser interface {
 type BackendService struct {
 	*wkld
 	manifest *manifest.BackendService
-	updateID string
 
 	parser backendSvcReadParser
 }
@@ -66,13 +65,6 @@ func (s *BackendService) Template() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("read desired count lambda: %w", err)
 	}
-	if s.updateID == "" {
-		id, err := randomUpdateID()
-		if err != nil {
-			return "", err
-		}
-		s.updateID = id
-	}
 	outputs, err := s.addonsOutputs()
 	if err != nil {
 		return "", err
@@ -86,15 +78,14 @@ func (s *BackendService) Template() (string, error) {
 		return "", fmt.Errorf("convert the Auto Scaling configuration for service %s: %w", s.name, err)
 	}
 	content, err := s.parser.ParseBackendService(template.ServiceOpts{
-		Variables:                  s.manifest.BackendServiceConfig.Variables,
-		Secrets:                    s.manifest.BackendServiceConfig.Secrets,
-		NestedStack:                outputs,
-		Sidecars:                   sidecars,
-		Autoscaling:                autoscaling,
-		HealthCheck:                s.manifest.BackendServiceConfig.Image.HealthCheckOpts(),
-		LogConfig:                  s.manifest.LogConfigOpts(),
-		DesiredCountLambda:         desiredCountLambda.String(),
-		DesiredCountLambdaUpdateID: s.updateID,
+		Variables:          s.manifest.BackendServiceConfig.Variables,
+		Secrets:            s.manifest.BackendServiceConfig.Secrets,
+		NestedStack:        outputs,
+		Sidecars:           sidecars,
+		Autoscaling:        autoscaling,
+		HealthCheck:        s.manifest.BackendServiceConfig.Image.HealthCheckOpts(),
+		LogConfig:          s.manifest.LogConfigOpts(),
+		DesiredCountLambda: desiredCountLambda.String(),
 	})
 	if err != nil {
 		return "", fmt.Errorf("parse backend service template: %w", err)

--- a/internal/pkg/deploy/cloudformation/stack/backend_svc_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/backend_svc_test.go
@@ -45,7 +45,6 @@ var testBackendSvcManifest = manifest.NewBackendService(manifest.BackendServiceP
 })
 
 func TestBackendService_Template(t *testing.T) {
-	const mockUpdateID = "mockUpdateID"
 	baseProps := manifest.BackendServiceProps{
 		ServiceProps: manifest.ServiceProps{
 			Name:       "frontend",
@@ -144,8 +143,7 @@ func TestBackendService_Template(t *testing.T) {
 						StartPeriod: aws.Int64(0),
 						Timeout:     aws.Int64(10),
 					},
-					DesiredCountLambda:         "something",
-					DesiredCountLambdaUpdateID: mockUpdateID,
+					DesiredCountLambda: "something",
 					NestedStack: &template.ServiceNestedStackOpts{
 						StackName:       addon.StackName,
 						VariableOutputs: []string{"Hello"},
@@ -178,7 +176,6 @@ func TestBackendService_Template(t *testing.T) {
 					},
 				},
 				manifest: tc.manifest,
-				updateID: mockUpdateID,
 			}
 			tc.mockDependencies(t, ctrl, conf)
 

--- a/internal/pkg/deploy/cloudformation/stack/lb_web_svc_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/lb_web_svc_test.go
@@ -93,7 +93,6 @@ func TestLoadBalancedWebService_StackName(t *testing.T) {
 }
 
 func TestLoadBalancedWebService_Template(t *testing.T) {
-	const mockUpdateID = "mockUpdateID"
 	testCases := map[string]struct {
 		mockDependencies func(t *testing.T, ctrl *gomock.Controller, c *LoadBalancedWebService)
 
@@ -155,9 +154,8 @@ func TestLoadBalancedWebService_Template(t *testing.T) {
 				m.EXPECT().Read(lbWebSvcRulePriorityGeneratorPath).Return(&template.Content{Buffer: bytes.NewBufferString("lambda")}, nil)
 				m.EXPECT().Read(desiredCountGeneratorPath).Return(&template.Content{Buffer: bytes.NewBufferString("something")}, nil)
 				m.EXPECT().ParseLoadBalancedWebService(template.ServiceOpts{
-					RulePriorityLambda:         "lambda",
-					DesiredCountLambda:         "something",
-					DesiredCountLambdaUpdateID: mockUpdateID,
+					RulePriorityLambda: "lambda",
+					DesiredCountLambda: "something",
 				}).Return(&template.Content{Buffer: bytes.NewBufferString("template")}, nil)
 
 				addons := mockTemplater{err: &addon.ErrDirNotExist{}}
@@ -179,9 +177,8 @@ func TestLoadBalancedWebService_Template(t *testing.T) {
 						SecretOutputs:   []string{"MySecretArn"},
 						PolicyOutputs:   []string{"AdditionalResourcesPolicyArn"},
 					},
-					RulePriorityLambda:         "lambda",
-					DesiredCountLambda:         "something",
-					DesiredCountLambdaUpdateID: mockUpdateID,
+					RulePriorityLambda: "lambda",
+					DesiredCountLambda: "something",
 				}).Return(&template.Content{Buffer: bytes.NewBufferString("template")}, nil)
 				addons := mockTemplater{
 					tpl: `Resources:
@@ -233,7 +230,6 @@ Outputs:
 					},
 				},
 				manifest: testLBWebServiceManifest,
-				updateID: mockUpdateID,
 			}
 			tc.mockDependencies(t, ctrl, conf)
 

--- a/internal/pkg/template/service.go
+++ b/internal/pkg/template/service.go
@@ -9,6 +9,7 @@ import (
 	"text/template"
 
 	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/google/uuid"
 )
 
 // Paths of workload cloudformation templates under templates/workloads/.
@@ -93,10 +94,9 @@ type ServiceOpts struct {
 	Autoscaling *AutoscalingOpts
 
 	// Additional options that're not shared across all service templates.
-	HealthCheck                *ecs.HealthCheck
-	RulePriorityLambda         string
-	DesiredCountLambda         string
-	DesiredCountLambdaUpdateID string
+	HealthCheck        *ecs.HealthCheck
+	RulePriorityLambda string
+	DesiredCountLambda string
 }
 
 // ParseLoadBalancedWebService parses a load balanced web service's CloudFormation template
@@ -140,6 +140,7 @@ func withSvcParsingFuncs() ParseOption {
 			"hasSecrets":  hasSecrets,
 			"fmtSlice":    FmtSliceFunc,
 			"quoteSlice":  QuotePSliceFunc,
+			"randomUUID":  randomUUIDFunc,
 		})
 	}
 }
@@ -152,4 +153,12 @@ func hasSecrets(opts ServiceOpts) bool {
 		return true
 	}
 	return false
+}
+
+func randomUUIDFunc() (string, error) {
+	id, err := uuid.NewRandom()
+	if err != nil {
+		return "", fmt.Errorf("generate random uuid: %w", err)
+	}
+	return id.String(), err
 }

--- a/internal/pkg/template/service.go
+++ b/internal/pkg/template/service.go
@@ -93,8 +93,10 @@ type ServiceOpts struct {
 	Autoscaling *AutoscalingOpts
 
 	// Additional options that're not shared across all service templates.
-	HealthCheck        *ecs.HealthCheck
-	RulePriorityLambda string
+	HealthCheck                *ecs.HealthCheck
+	RulePriorityLambda         string
+	DesiredCountLambda         string
+	DesiredCountLambdaUpdateID string
 }
 
 // ParseLoadBalancedWebService parses a load balanced web service's CloudFormation template

--- a/templates/workloads/common/cf/autoscaling.yml
+++ b/templates/workloads/common/cf/autoscaling.yml
@@ -54,7 +54,6 @@ AutoScalingPolicyECSServiceAverageMemoryUtilization:
       ScaleOutCooldown: 60
       TargetValue: {{.Autoscaling.Memory}}
 {{- end}}
-{{- end}}
 
 DynamicDesiredCountAction:
   Type: Custom::DynamicDesiredCountFunction
@@ -63,9 +62,12 @@ DynamicDesiredCountAction:
     Cluster:
       Fn::ImportValue:
         !Sub '${AppName}-${EnvName}-ClusterId'
-    Family: !Join ['', [!Ref AppName, '-', !Ref EnvName, '-', !Ref WorkloadName]]
-    DesiredCount: !Ref TaskCount
-    UpdateID: {{.DesiredCountLambdaUpdateID}}
+    App: !Ref AppName
+    Env: !Ref EnvName
+    Svc: !Ref WorkloadName
+    DefaultDesiredCount: !Ref TaskCount
+    # We need to force trigger this lambda function on all deployments, so we give it a random ID as input on all event types.
+    UpdateID: {{ randomUUID }}
 
 DynamicDesiredCountFunction:
   Type: AWS::Lambda::Function
@@ -73,8 +75,9 @@ DynamicDesiredCountFunction:
     Code:
       ZipFile: |
         {{.DesiredCountLambda}}
-    Handler: "index.desiredCountHandler"
+    Handler: "index.handler"
     Timeout: 600
     MemorySize: 512
     Role: !GetAtt 'CustomResourceRole.Arn'
-    Runtime: nodejs10.x
+    Runtime: nodejs12.x
+{{- end}}

--- a/templates/workloads/common/cf/autoscaling.yml
+++ b/templates/workloads/common/cf/autoscaling.yml
@@ -55,3 +55,26 @@ AutoScalingPolicyECSServiceAverageMemoryUtilization:
       TargetValue: {{.Autoscaling.Memory}}
 {{- end}}
 {{- end}}
+
+DynamicDesiredCountAction:
+  Type: Custom::DynamicDesiredCountFunction
+  Properties:
+    ServiceToken: !GetAtt DynamicDesiredCountFunction.Arn
+    Cluster:
+      Fn::ImportValue:
+        !Sub '${AppName}-${EnvName}-ClusterId'
+    Family: !Join ['', [!Ref AppName, '-', !Ref EnvName, '-', !Ref WorkloadName]]
+    DesiredCount: !Ref TaskCount
+    UpdateID: {{.DesiredCountLambdaUpdateID}}
+
+DynamicDesiredCountFunction:
+  Type: AWS::Lambda::Function
+  Properties:
+    Code:
+      ZipFile: |
+        {{.DesiredCountLambda}}
+    Handler: "index.desiredCountHandler"
+    Timeout: 600
+    MemorySize: 512
+    Role: !GetAtt 'CustomResourceRole.Arn'
+    Runtime: nodejs10.x

--- a/templates/workloads/common/cf/service-base-properties.yml
+++ b/templates/workloads/common/cf/service-base-properties.yml
@@ -2,7 +2,7 @@ Cluster:
   Fn::ImportValue:
     !Sub '${AppName}-${EnvName}-ClusterId'
 TaskDefinition: !Ref TaskDefinition
-DesiredCount: !Ref TaskCount
+DesiredCount: !GetAtt DynamicDesiredCountAction.DesiredCount
 PropagateTags: SERVICE
 LaunchType: FARGATE
 NetworkConfiguration:

--- a/templates/workloads/common/cf/service-base-properties.yml
+++ b/templates/workloads/common/cf/service-base-properties.yml
@@ -2,7 +2,11 @@ Cluster:
   Fn::ImportValue:
     !Sub '${AppName}-${EnvName}-ClusterId'
 TaskDefinition: !Ref TaskDefinition
+{{- if .Autoscaling }}
 DesiredCount: !GetAtt DynamicDesiredCountAction.DesiredCount
+{{- else }}
+DesiredCount: !Ref TaskCount
+{{- end}}
 PropagateTags: SERVICE
 LaunchType: FARGATE
 NetworkConfiguration:

--- a/templates/workloads/services/backend/cf.yml
+++ b/templates/workloads/services/backend/cf.yml
@@ -80,7 +80,7 @@ Resources:
             - Sid: ECS
               Effect: Allow
               Action:
-                - ecs:ListTasks
+                - ecs:DescribeServices
               Resource: "*"
               Condition: 
                 ArnEquals: 

--- a/templates/workloads/services/backend/cf.yml
+++ b/templates/workloads/services/backend/cf.yml
@@ -57,7 +57,52 @@ Resources:
 {{include "taskrole" . | indent 2}}
 {{include "servicediscovery" . | indent 2}}
 {{include "autoscaling" . | indent 2}}
-
+{{- if .Autoscaling }}
+  CustomResourceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          -
+            Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Path: /
+      Policies:
+        - PolicyName: "DelegateDesiredCountAccess"
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+            - Sid: ECS
+              Effect: Allow
+              Action:
+                - ecs:ListTasks
+              Resource: "*"
+              Condition: 
+                ArnEquals: 
+                  'ecs:cluster':
+                    Fn::Sub:
+                      - arn:${AWS::Partition}:ecs:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}
+                      - ClusterName:
+                          Fn::ImportValue:
+                            !Sub '${AppName}-${EnvName}-ClusterId'
+            - Sid: ResourceGroups
+              Effect: Allow
+              Action:
+                - resource-groups:GetResources
+              Resource: "*"
+            - Sid: Tags
+              Effect: Allow
+              Action:
+                - "tag:GetResources"
+              Resource: "*"
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+{{- end }}
   Service:
     Type: AWS::ECS::Service
     Properties:

--- a/templates/workloads/services/lb-web/cf.yml
+++ b/templates/workloads/services/lb-web/cf.yml
@@ -168,6 +168,14 @@ Resources:
               Action:
                 - elasticloadbalancing:DescribeRules
               Resource: "*"
+        - PolicyName: "ECSAccess"
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+            - Effect: Allow
+              Action:
+                - ecs:ListTasks
+              Resource: "*"
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
 

--- a/templates/workloads/services/lb-web/cf.yml
+++ b/templates/workloads/services/lb-web/cf.yml
@@ -168,14 +168,35 @@ Resources:
               Action:
                 - elasticloadbalancing:DescribeRules
               Resource: "*"
-        - PolicyName: "ECSAccess"
+{{- if .Autoscaling }}
+        - PolicyName: "DelegateDesiredCountAccess"
           PolicyDocument:
             Version: '2012-10-17'
             Statement:
-            - Effect: Allow
+            - Sid: ECS
+              Effect: Allow
               Action:
                 - ecs:ListTasks
               Resource: "*"
+              Condition: 
+                ArnEquals: 
+                  'ecs:cluster':
+                    Fn::Sub:
+                      - arn:${AWS::Partition}:ecs:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}
+                      - ClusterName:
+                          Fn::ImportValue:
+                            !Sub '${AppName}-${EnvName}-ClusterId'
+            - Sid: ResourceGroups
+              Effect: Allow
+              Action:
+                - resource-groups:GetResources
+              Resource: "*"
+            - Sid: Tags
+              Effect: Allow
+              Action:
+                - "tag:GetResources"
+              Resource: "*"
+{{- end}}
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
 

--- a/templates/workloads/services/lb-web/cf.yml
+++ b/templates/workloads/services/lb-web/cf.yml
@@ -176,7 +176,7 @@ Resources:
             - Sid: ECS
               Effect: Allow
               Action:
-                - ecs:ListTasks
+                - ecs:DescribeServices
               Resource: "*"
               Condition: 
                 ArnEquals: 


### PR DESCRIPTION
Part of #1349. Add custom resource lambda function so that we can delegate desired count smartly. By default when a service is deployed for the first time, we take either the desired count specify by the user or the minimum value of their auto scaling range (if exists) as the ECS service desired count. When they update their service, we detect their current running copies and set the ECS service desired count to remain the same, so as to avoid users having this issue https://github.com/aws/containers-roadmap/issues/493.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
