### PR TITLE
chore(templates): update addons stack parameter from Workload to Name

### DIFF
--- a/templates/addons/ddb/cf.yml
+++ b/templates/addons/ddb/cf.yml
@@ -5,7 +5,7 @@ Parameters:
   Env:
     Type: String
     Description: The environment name your service, job, or workflow is being deployed to.
-  Workload:
+  Name:
     Type: String
     Description: The name of the service, job, or workflow being deployed.
 Resources:
@@ -13,7 +13,7 @@ Resources:
     Type: AWS::DynamoDB::Table
     DeletionPolicy: Retain
     Properties:
-      TableName: !Sub ${App}-${Env}-${Workload}-{{.Name}}
+      TableName: !Sub ${App}-${Env}-${Name}-{{.Name}}
       AttributeDefinitions:{{range .Attributes}}
         - AttributeName: {{.Name}}
           AttributeType: "{{.DataType}}"{{end}}

--- a/templates/addons/s3/cf.yml
+++ b/templates/addons/s3/cf.yml
@@ -5,7 +5,7 @@ Parameters:
   Env:
     Type: String
     Description: The environment name your service, job, or workflow is being deployed to.
-  Workload:
+  Name:
     Type: String
     Description: The name of the service, job, or workflow being deployed.
 Resources:
@@ -18,7 +18,7 @@ Resources:
         ServerSideEncryptionConfiguration:
         - ServerSideEncryptionByDefault:
             SSEAlgorithm: AES256
-      BucketName: !Sub '${App}-${Env}-${Workload}-{{.Name}}'
+      BucketName: !Sub '${App}-${Env}-${Name}-{{.Name}}'
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
         BlockPublicPolicy: true


### PR DESCRIPTION
<!-- Provide summary of changes -->
Fixes a bug introduced by #1340 which incorrectly renamed the storage addon stack's `Name` parameter, which was already workload-agnostic, to `Workload`. 
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
