### PR TITLE
chore(stack): enable creating an environment from a specific template version

### DIFF
--- a/internal/pkg/cli/env_init.go
+++ b/internal/pkg/cli/env_init.go
@@ -470,7 +470,6 @@ func (o *initEnvOpts) deployEnv(app *config.Application) error {
 		Name:                     o.Name,
 		AppName:                  o.AppName(),
 		Prod:                     o.IsProduction,
-		PublicLoadBalancer:       true, // TODO: configure this based on user input or service Type needs?
 		ToolsAccountPrincipalARN: caller.RootUserARN,
 		AppDNSName:               app.Domain,
 		AdditionalTags:           app.Tags,

--- a/internal/pkg/cli/env_init_test.go
+++ b/internal/pkg/cli/env_init_test.go
@@ -800,7 +800,6 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 				m.EXPECT().DeployEnvironment(&deploy.CreateEnvironmentInput{
 					Name:                     "test",
 					AppName:                  "phonetool",
-					PublicLoadBalancer:       true,
 					ToolsAccountPrincipalARN: "some arn",
 				}).Return(&cloudformation.ErrStackAlreadyExists{})
 				m.EXPECT().GetEnvironment("phonetool", "test").Return(&config.Environment{

--- a/internal/pkg/deploy/cloudformation/cloudformation_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/cloudformation_integration_test.go
@@ -361,7 +361,7 @@ func Test_Environment_Deployment_Integration(t *testing.T) {
 	id, err := identity.Get()
 	require.NoError(t, err)
 
-	environmentToDeploy := deploy.CreateEnvironmentInput{Name: randStringBytes(10), AppName: randStringBytes(10), PublicLoadBalancer: true, ToolsAccountPrincipalARN: id.RootUserARN}
+	environmentToDeploy := deploy.CreateEnvironmentInput{Name: randStringBytes(10), AppName: randStringBytes(10), ToolsAccountPrincipalARN: id.RootUserARN}
 	envStackName := fmt.Sprintf("%s-%s", environmentToDeploy.AppName, environmentToDeploy.Name)
 
 	t.Run("Deploys an environment to CloudFormation", func(t *testing.T) {

--- a/internal/pkg/deploy/cloudformation/pipeline_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/pipeline_integration_test.go
@@ -64,7 +64,6 @@ func TestPipelineCreation(t *testing.T) {
 		environmentToDeploy := deploy.CreateEnvironmentInput{
 			Name:                     randStringBytes(10),
 			AppName:                  app.Name,
-			PublicLoadBalancer:       true,
 			ToolsAccountPrincipalARN: envCallerInfo.RootUserARN,
 		}
 		envStackName := fmt.Sprintf("%s-%s",

--- a/internal/pkg/deploy/cloudformation/stack/env.go
+++ b/internal/pkg/deploy/cloudformation/stack/env.go
@@ -88,6 +88,7 @@ func (e *EnvStackConfig) Template() (string, error) {
 		EnableLongARNFormatLambda: enableLongARNsLambda.String(),
 		ImportVPC:                 e.in.ImportVPCOpts(),
 		VPCConfig:                 vpcConf,
+		Version:                   e.in.Version,
 	}, template.WithFuncs(map[string]interface{}{
 		"inc": template.IncFunc,
 	}))

--- a/internal/pkg/deploy/cloudformation/stack/env.go
+++ b/internal/pkg/deploy/cloudformation/stack/env.go
@@ -5,7 +5,6 @@ package stack
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -33,8 +32,7 @@ const (
 	dnsDelegationTemplatePath  = "custom-resources/dns-delegation.js"
 	enableLongARNsTemplatePath = "custom-resources/enable-long-arns.js"
 
-	// Parameter keys.
-	envParamIncludeLBKey             = "IncludePublicLoadBalancer"
+	// Mandatory parameter keys.
 	envParamAppNameKey               = "AppName"
 	envParamEnvNameKey               = "EnvironmentName"
 	envParamToolsAccountPrincipalKey = "ToolsAccountPrincipalARN"
@@ -42,10 +40,8 @@ const (
 	envParamAppDNSDelegationRoleKey  = "AppDNSDelegationRole"
 
 	// Output keys.
-	EnvOutputCFNExecutionRoleARN       = "CFNExecutionRoleARN"
-	EnvOutputManagerRoleKey            = "EnvironmentManagerRoleARN"
-	EnvOutputPublicLoadBalancerDNSName = "PublicLoadBalancerDNSName"
-	EnvOutputSubdomain                 = "EnvironmentSubdomain"
+	envOutputCFNExecutionRoleARN = "CFNExecutionRoleARN"
+	envOutputManagerRoleKey      = "EnvironmentManagerRoleARN"
 
 	// Default parameter values
 	DefaultVPCCIDR            = "10.0.0.0/16"
@@ -105,10 +101,6 @@ func (e *EnvStackConfig) Template() (string, error) {
 // Parameters returns the parameters to be passed into a environment CloudFormation template.
 func (e *EnvStackConfig) Parameters() ([]*cloudformation.Parameter, error) {
 	return []*cloudformation.Parameter{
-		{
-			ParameterKey:   aws.String(envParamIncludeLBKey),
-			ParameterValue: aws.String(strconv.FormatBool(e.PublicLoadBalancer)),
-		},
 		{
 			ParameterKey:   aws.String(envParamAppNameKey),
 			ParameterValue: aws.String(e.AppName),
@@ -176,7 +168,7 @@ func (e *EnvStackConfig) ToEnv(stack *cloudformation.Stack) (*config.Environment
 		Prod:             e.Prod,
 		Region:           stackARN.Region,
 		AccountID:        stackARN.AccountID,
-		ManagerRoleARN:   stackOutputs[EnvOutputManagerRoleKey],
-		ExecutionRoleARN: stackOutputs[EnvOutputCFNExecutionRoleARN],
+		ManagerRoleARN:   stackOutputs[envOutputManagerRoleKey],
+		ExecutionRoleARN: stackOutputs[envOutputCFNExecutionRoleARN],
 	}, nil
 }

--- a/internal/pkg/deploy/cloudformation/stack/env_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/env_test.go
@@ -304,7 +304,6 @@ func mockDeployEnvironmentInput() *deploy.CreateEnvironmentInput {
 		Name:                     "env",
 		AppName:                  "project",
 		Prod:                     true,
-		PublicLoadBalancer:       true,
 		ToolsAccountPrincipalARN: "arn:aws:iam::000000000:root",
 	}
 }

--- a/internal/pkg/deploy/cloudformation/stack/env_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/env_test.go
@@ -63,7 +63,7 @@ func TestEnvTemplate(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			envStack := &EnvStackConfig{
-				CreateEnvironmentInput: mockDeployEnvironmentInput(),
+				in: mockDeployEnvironmentInput(),
 			}
 			tc.mockDependencies(ctrl, envStack)
 
@@ -144,7 +144,7 @@ func TestEnvParameters(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			env := &EnvStackConfig{
-				CreateEnvironmentInput: tc.input,
+				in: tc.input,
 			}
 			params, _ := env.Parameters()
 			require.ElementsMatch(t, tc.want, params)
@@ -160,7 +160,7 @@ func TestEnvDNSDelegationRole(t *testing.T) {
 		"without tools account ARN": {
 			want: "",
 			input: &EnvStackConfig{
-				CreateEnvironmentInput: &deploy.CreateEnvironmentInput{
+				in: &deploy.CreateEnvironmentInput{
 					ToolsAccountPrincipalARN: "",
 					AppDNSName:               "ecs.aws",
 				},
@@ -169,7 +169,7 @@ func TestEnvDNSDelegationRole(t *testing.T) {
 		"without DNS": {
 			want: "",
 			input: &EnvStackConfig{
-				CreateEnvironmentInput: &deploy.CreateEnvironmentInput{
+				in: &deploy.CreateEnvironmentInput{
 					ToolsAccountPrincipalARN: "arn:aws:iam::0000000:root",
 					AppDNSName:               "",
 				},
@@ -178,7 +178,7 @@ func TestEnvDNSDelegationRole(t *testing.T) {
 		"with invalid tools principal": {
 			want: "",
 			input: &EnvStackConfig{
-				CreateEnvironmentInput: &deploy.CreateEnvironmentInput{
+				in: &deploy.CreateEnvironmentInput{
 					ToolsAccountPrincipalARN: "0000000",
 					AppDNSName:               "ecs.aws",
 				},
@@ -187,7 +187,7 @@ func TestEnvDNSDelegationRole(t *testing.T) {
 		"with dns and tools principal": {
 			want: "arn:aws:iam::0000000:role/-DNSDelegationRole",
 			input: &EnvStackConfig{
-				CreateEnvironmentInput: &deploy.CreateEnvironmentInput{
+				in: &deploy.CreateEnvironmentInput{
 					ToolsAccountPrincipalARN: "arn:aws:iam::0000000:root",
 					AppDNSName:               "ecs.aws",
 				},
@@ -204,7 +204,7 @@ func TestEnvDNSDelegationRole(t *testing.T) {
 
 func TestEnvTags(t *testing.T) {
 	env := &EnvStackConfig{
-		CreateEnvironmentInput: &deploy.CreateEnvironmentInput{
+		in: &deploy.CreateEnvironmentInput{
 			Name:    "env",
 			AppName: "project",
 			AdditionalTags: map[string]string{
@@ -233,7 +233,7 @@ func TestEnvTags(t *testing.T) {
 func TestStackName(t *testing.T) {
 	deploymentInput := mockDeployEnvironmentInput()
 	env := &EnvStackConfig{
-		CreateEnvironmentInput: deploymentInput,
+		in: deploymentInput,
 	}
 	require.Equal(t, fmt.Sprintf("%s-%s", deploymentInput.AppName, deploymentInput.Name), env.StackName())
 }
@@ -269,7 +269,7 @@ func TestToEnv(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			envStack := &EnvStackConfig{
-				CreateEnvironmentInput: mockDeployInput,
+				in: mockDeployInput,
 			}
 			got, err := envStack.ToEnv(tc.mockStack)
 

--- a/internal/pkg/deploy/cloudformation/stack/env_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/env_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"strconv"
 	"strings"
 	"testing"
 
@@ -94,10 +93,6 @@ func TestEnvParameters(t *testing.T) {
 			input: deploymentInput,
 			want: []*cloudformation.Parameter{
 				{
-					ParameterKey:   aws.String(envParamIncludeLBKey),
-					ParameterValue: aws.String(strconv.FormatBool(deploymentInput.PublicLoadBalancer)),
-				},
-				{
 					ParameterKey:   aws.String(envParamAppNameKey),
 					ParameterValue: aws.String(deploymentInput.AppName),
 				},
@@ -122,10 +117,6 @@ func TestEnvParameters(t *testing.T) {
 		"with DNS": {
 			input: deploymentInputWithDNS,
 			want: []*cloudformation.Parameter{
-				{
-					ParameterKey:   aws.String(envParamIncludeLBKey),
-					ParameterValue: aws.String(strconv.FormatBool(deploymentInputWithDNS.PublicLoadBalancer)),
-				},
 				{
 					ParameterKey:   aws.String(envParamAppNameKey),
 					ParameterValue: aws.String(deploymentInputWithDNS.AppName),
@@ -297,11 +288,11 @@ func mockEnvironmentStack(stackArn, managerRoleARN, executionRoleARN string) *cl
 		StackId: aws.String(stackArn),
 		Outputs: []*cloudformation.Output{
 			{
-				OutputKey:   aws.String(EnvOutputManagerRoleKey),
+				OutputKey:   aws.String(envOutputManagerRoleKey),
 				OutputValue: aws.String(managerRoleARN),
 			},
 			{
-				OutputKey:   aws.String(EnvOutputCFNExecutionRoleARN),
+				OutputKey:   aws.String(envOutputCFNExecutionRoleARN),
 				OutputValue: aws.String(executionRoleARN),
 			},
 		},

--- a/internal/pkg/deploy/env.go
+++ b/internal/pkg/deploy/env.go
@@ -21,7 +21,8 @@ type CreateEnvironmentInput struct {
 	ImportVPCConfig          *ImportVPCConfig  // Optional configuration if users have an existing VPC.
 	AdjustVPCConfig          *AdjustVPCConfig  // Optional configuration if users want to override default VPC configuration.
 
-	Version string // The version of the environment template to use while mutating the stack.
+	// The version of the environment template to creat the stack. If empty, creates the legacy stack.
+	Version string
 }
 
 // ImportVPCOpts converts the environment's vpc importing configuration into a format parsable by the templates pkg.

--- a/internal/pkg/deploy/env.go
+++ b/internal/pkg/deploy/env.go
@@ -15,12 +15,13 @@ type CreateEnvironmentInput struct {
 	AppName                  string            // Name of the application this environment belongs to.
 	Name                     string            // Name of the environment, must be unique within an application.
 	Prod                     bool              // Whether or not this environment is a production environment.
-	PublicLoadBalancer       bool              // Whether or not this environment should contain a shared public load balancer between applications.
 	ToolsAccountPrincipalARN string            // The Principal ARN of the tools account.
 	AppDNSName               string            // The DNS name of this application, if it exists
 	AdditionalTags           map[string]string // AdditionalTags are labels applied to resources under the application.
-	ImportVPCConfig          *ImportVPCConfig
-	AdjustVPCConfig          *AdjustVPCConfig
+	ImportVPCConfig          *ImportVPCConfig  // Optional configuration if users have an existing VPC.
+	AdjustVPCConfig          *AdjustVPCConfig  // Optional configuration if users want to override default VPC configuration.
+
+	Version string // The version of the environment template to use while mutating the stack.
 }
 
 // ImportVPCOpts converts the environment's vpc importing configuration into a format parsable by the templates pkg.

--- a/internal/pkg/describe/lb_web_service.go
+++ b/internal/pkg/describe/lb_web_service.go
@@ -21,6 +21,11 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/term/color"
 )
 
+const (
+	envOutputPublicLoadBalancerDNSName = "PublicLoadBalancerDNSName"
+	envOutputSubdomain                 = "EnvironmentSubdomain"
+)
+
 // WebServiceURI represents the unique identifier to access a web service.
 type WebServiceURI struct {
 	DNSName string // The environment's subdomain if the service is served on HTTPS. Otherwise, the public load balancer's DNS.
@@ -201,12 +206,12 @@ func (d *WebServiceDescriber) URI(envName string) (string, error) {
 	d.svcParams = svcParams
 
 	uri := &WebServiceURI{
-		DNSName: envOutputs[stack.EnvOutputPublicLoadBalancerDNSName],
+		DNSName: envOutputs[envOutputPublicLoadBalancerDNSName],
 		Path:    svcParams[stack.LBWebServiceRulePathParamKey],
 	}
-	_, isHTTPS := envOutputs[stack.EnvOutputSubdomain]
+	_, isHTTPS := envOutputs[envOutputSubdomain]
 	if isHTTPS {
-		dnsName := fmt.Sprintf("%s.%s", d.svc, envOutputs[stack.EnvOutputSubdomain])
+		dnsName := fmt.Sprintf("%s.%s", d.svc, envOutputs[envOutputSubdomain])
 		uri = &WebServiceURI{
 			DNSName: dnsName,
 		}

--- a/internal/pkg/describe/lb_web_service_test.go
+++ b/internal/pkg/describe/lb_web_service_test.go
@@ -88,8 +88,8 @@ func TestWebServiceDescriber_URI(t *testing.T) {
 			setupMocks: func(m webSvcDescriberMocks) {
 				gomock.InOrder(
 					m.svcDescriber.EXPECT().EnvOutputs().Return(map[string]string{
-						stack.EnvOutputPublicLoadBalancerDNSName: testEnvLBDNSName,
-						stack.EnvOutputSubdomain:                 testEnvSubdomain,
+						envOutputPublicLoadBalancerDNSName: testEnvLBDNSName,
+						envOutputSubdomain:                 testEnvSubdomain,
 					}, nil),
 					m.svcDescriber.EXPECT().Params().Return(nil, mockErr),
 				)
@@ -100,8 +100,8 @@ func TestWebServiceDescriber_URI(t *testing.T) {
 			setupMocks: func(m webSvcDescriberMocks) {
 				gomock.InOrder(
 					m.svcDescriber.EXPECT().EnvOutputs().Return(map[string]string{
-						stack.EnvOutputPublicLoadBalancerDNSName: testEnvLBDNSName,
-						stack.EnvOutputSubdomain:                 testEnvSubdomain,
+						envOutputPublicLoadBalancerDNSName: testEnvLBDNSName,
+						envOutputSubdomain:                 testEnvSubdomain,
 					}, nil),
 					m.svcDescriber.EXPECT().Params().Return(map[string]string{
 						stack.LBWebServiceRulePathParamKey: testSvcPath,
@@ -115,7 +115,7 @@ func TestWebServiceDescriber_URI(t *testing.T) {
 			setupMocks: func(m webSvcDescriberMocks) {
 				gomock.InOrder(
 					m.svcDescriber.EXPECT().EnvOutputs().Return(map[string]string{
-						stack.EnvOutputPublicLoadBalancerDNSName: testEnvLBDNSName,
+						envOutputPublicLoadBalancerDNSName: testEnvLBDNSName,
 					}, nil),
 					m.svcDescriber.EXPECT().Params().Return(map[string]string{
 						stack.LBWebServiceRulePathParamKey: testSvcPath,
@@ -205,7 +205,7 @@ func TestWebServiceDescriber_Describe(t *testing.T) {
 				gomock.InOrder(
 					m.storeSvc.EXPECT().ListEnvironmentsDeployedTo(testApp, testSvc).Return([]string{testEnv}, nil),
 					m.svcDescriber.EXPECT().EnvOutputs().Return(map[string]string{
-						stack.EnvOutputPublicLoadBalancerDNSName: testEnvLBDNSName,
+						envOutputPublicLoadBalancerDNSName: testEnvLBDNSName,
 					}, nil),
 					m.svcDescriber.EXPECT().Params().Return(map[string]string{
 						stack.LBWebServiceContainerPortParamKey: "80",
@@ -225,7 +225,7 @@ func TestWebServiceDescriber_Describe(t *testing.T) {
 				gomock.InOrder(
 					m.storeSvc.EXPECT().ListEnvironmentsDeployedTo(testApp, testSvc).Return([]string{testEnv}, nil),
 					m.svcDescriber.EXPECT().EnvOutputs().Return(map[string]string{
-						stack.EnvOutputPublicLoadBalancerDNSName: testEnvLBDNSName,
+						envOutputPublicLoadBalancerDNSName: testEnvLBDNSName,
 					}, nil),
 					m.svcDescriber.EXPECT().Params().Return(map[string]string{
 						stack.LBWebServiceRulePathParamKey:      testSvcPath,
@@ -250,7 +250,7 @@ func TestWebServiceDescriber_Describe(t *testing.T) {
 					m.storeSvc.EXPECT().ListEnvironmentsDeployedTo(testApp, testSvc).Return([]string{testEnv, prodEnv}, nil),
 
 					m.svcDescriber.EXPECT().EnvOutputs().Return(map[string]string{
-						stack.EnvOutputPublicLoadBalancerDNSName: testEnvLBDNSName,
+						envOutputPublicLoadBalancerDNSName: testEnvLBDNSName,
 					}, nil),
 					m.svcDescriber.EXPECT().Params().Return(map[string]string{
 						stack.LBWebServiceRulePathParamKey:      testSvcPath,
@@ -265,7 +265,7 @@ func TestWebServiceDescriber_Describe(t *testing.T) {
 						}, nil),
 
 					m.svcDescriber.EXPECT().EnvOutputs().Return(map[string]string{
-						stack.EnvOutputPublicLoadBalancerDNSName: prodEnvLBDNSName,
+						envOutputPublicLoadBalancerDNSName: prodEnvLBDNSName,
 					}, nil),
 					m.svcDescriber.EXPECT().Params().Return(map[string]string{
 						stack.LBWebServiceRulePathParamKey:      prodSvcPath,


### PR DESCRIPTION
Also refactors constants to be private and removes the unused `PublicLoadBalancer` field.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
