### PR TITLE
chore(describe): unmarshal env template Version number

### DIFF
--- a/internal/pkg/deploy/env.go
+++ b/internal/pkg/deploy/env.go
@@ -10,6 +10,13 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/template"
 )
 
+const (
+	// LegacyEnvTemplateVersion is the version associated with the environment template before we started versioning.
+	LegacyEnvTemplateVersion = ""
+	// LatestEnvTemplateVersion is the latest version number available for environment templates.
+	LatestEnvTemplateVersion = "1.0.0"
+)
+
 // CreateEnvironmentInput holds the fields required to deploy an environment.
 type CreateEnvironmentInput struct {
 	AppName                  string            // Name of the application this environment belongs to.

--- a/internal/pkg/describe/env.go
+++ b/internal/pkg/describe/env.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/config"
 	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation/stack"
 	"github.com/aws/copilot-cli/internal/pkg/term/color"
+	"gopkg.in/yaml.v3"
 )
 
 // EnvDescription contains the information about an environment.
@@ -62,41 +63,63 @@ func NewEnvDescriber(opt NewEnvDescriberConfig) (*EnvDescriber, error) {
 
 		configStore:    opt.ConfigStore,
 		deployStore:    opt.DeployStore,
-		stackDescriber: stackAndResourcesDescriber(d),
+		stackDescriber: d,
 	}, nil
 }
 
 // Describe returns info about an application's environment.
-func (e *EnvDescriber) Describe() (*EnvDescription, error) {
-	svcs, err := e.filterDeployedSvcs()
+func (d *EnvDescriber) Describe() (*EnvDescription, error) {
+	svcs, err := d.filterDeployedSvcs()
 	if err != nil {
 		return nil, err
 	}
 
-	tags, err := e.stackTags()
+	tags, err := d.stackTags()
 	if err != nil {
 		return nil, fmt.Errorf("retrieve environment tags: %w", err)
 	}
 
 	var stackResources []*CfnResource
-	if e.enableResources {
-		stackResources, err = e.envOutputs()
+	if d.enableResources {
+		stackResources, err = d.envOutputs()
 		if err != nil {
 			return nil, fmt.Errorf("retrieve environment resources: %w", err)
 		}
 	}
 
 	return &EnvDescription{
-		Environment: e.env,
+		Environment: d.env,
 		Services:    svcs,
 		Tags:        tags,
 		Resources:   stackResources,
 	}, nil
 }
 
-func (e *EnvDescriber) stackTags() (map[string]string, error) {
+// Version returns the CloudFormation template version associated with
+// the environment by reading the Metadata.Version field from the template.
+//
+// If the Version field does not exist, then it's a legacy template and it returns an empty string and nil error.
+func (d *EnvDescriber) Version() (string, error) {
+	body, err := d.stackDescriber.Template(stack.NameForEnv(d.app, d.env.Name))
+	if err != nil {
+		return "", err
+	}
+
+	type metadata struct {
+		Version string `yaml:"Version"`
+	}
+	tpl := struct {
+		Metadata metadata `yaml:"Metadata"`
+	}{}
+	if err := yaml.Unmarshal([]byte(body), &tpl); err != nil {
+		return "", fmt.Errorf("unmarshal CloudFormation template to read Version: %w", err)
+	}
+	return tpl.Metadata.Version, nil
+}
+
+func (d *EnvDescriber) stackTags() (map[string]string, error) {
 	tags := make(map[string]string)
-	envStack, err := e.stackDescriber.Stack(stack.NameForEnv(e.app, e.env.Name))
+	envStack, err := d.stackDescriber.Stack(stack.NameForEnv(d.app, d.env.Name))
 	if err != nil {
 		return nil, err
 	}
@@ -106,18 +129,18 @@ func (e *EnvDescriber) stackTags() (map[string]string, error) {
 	return tags, nil
 }
 
-func (e *EnvDescriber) filterDeployedSvcs() ([]*config.Workload, error) {
-	allSvcs, err := e.configStore.ListServices(e.app)
+func (d *EnvDescriber) filterDeployedSvcs() ([]*config.Workload, error) {
+	allSvcs, err := d.configStore.ListServices(d.app)
 	if err != nil {
-		return nil, fmt.Errorf("list services for app %s: %w", e.app, err)
+		return nil, fmt.Errorf("list services for app %s: %w", d.app, err)
 	}
 	svcs := make(map[string]*config.Workload)
 	for _, svc := range allSvcs {
 		svcs[svc.Name] = svc
 	}
-	deployedSvcNames, err := e.deployStore.ListDeployedServices(e.app, e.env.Name)
+	deployedSvcNames, err := d.deployStore.ListDeployedServices(d.app, d.env.Name)
 	if err != nil {
-		return nil, fmt.Errorf("list deployed services in env %s: %w", e.env.Name, err)
+		return nil, fmt.Errorf("list deployed services in env %s: %w", d.env.Name, err)
 	}
 	var deployedSvcs []*config.Workload
 	for _, deployedSvcName := range deployedSvcNames {
@@ -126,8 +149,8 @@ func (e *EnvDescriber) filterDeployedSvcs() ([]*config.Workload, error) {
 	return deployedSvcs, nil
 }
 
-func (e *EnvDescriber) envOutputs() ([]*CfnResource, error) {
-	envStack, err := e.stackDescriber.StackResources(stack.NameForEnv(e.app, e.env.Name))
+func (d *EnvDescriber) envOutputs() ([]*CfnResource, error) {
+	envStack, err := d.stackDescriber.StackResources(stack.NameForEnv(d.app, d.env.Name))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/describe/env.go
+++ b/internal/pkg/describe/env.go
@@ -100,21 +100,18 @@ func (d *EnvDescriber) Describe() (*EnvDescription, error) {
 //
 // If the Version field does not exist, then it's a legacy template and it returns an empty string and nil error.
 func (d *EnvDescriber) Version() (string, error) {
-	body, err := d.stackDescriber.Template(stack.NameForEnv(d.app, d.env.Name))
+	raw, err := d.stackDescriber.Metadata(stack.NameForEnv(d.app, d.env.Name))
 	if err != nil {
 		return "", err
 	}
 
-	type metadata struct {
+	metadata := struct {
 		Version string `yaml:"Version"`
-	}
-	tpl := struct {
-		Metadata metadata `yaml:"Metadata"`
 	}{}
-	if err := yaml.Unmarshal([]byte(body), &tpl); err != nil {
-		return "", fmt.Errorf("unmarshal CloudFormation template to read Version: %w", err)
+	if err := yaml.Unmarshal([]byte(raw), &metadata); err != nil {
+		return "", fmt.Errorf("unmarshal Metadata property to read Version: %w", err)
 	}
-	return tpl.Metadata.Version, nil
+	return metadata.Version, nil
 }
 
 func (d *EnvDescriber) stackTags() (map[string]string, error) {

--- a/internal/pkg/describe/env.go
+++ b/internal/pkg/describe/env.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/aws/copilot-cli/internal/pkg/aws/sessions"
 	"github.com/aws/copilot-cli/internal/pkg/config"
+	"github.com/aws/copilot-cli/internal/pkg/deploy"
 	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation/stack"
 	"github.com/aws/copilot-cli/internal/pkg/term/color"
 	"gopkg.in/yaml.v3"
@@ -98,7 +99,7 @@ func (d *EnvDescriber) Describe() (*EnvDescription, error) {
 // Version returns the CloudFormation template version associated with
 // the environment by reading the Metadata.Version field from the template.
 //
-// If the Version field does not exist, then it's a legacy template and it returns an empty string and nil error.
+// If the Version field does not exist, then it's a legacy template and it returns an deploy.LegacyEnvTemplateVersion and nil error.
 func (d *EnvDescriber) Version() (string, error) {
 	raw, err := d.stackDescriber.Metadata(stack.NameForEnv(d.app, d.env.Name))
 	if err != nil {
@@ -110,6 +111,9 @@ func (d *EnvDescriber) Version() (string, error) {
 	}{}
 	if err := yaml.Unmarshal([]byte(raw), &metadata); err != nil {
 		return "", fmt.Errorf("unmarshal Metadata property to read Version: %w", err)
+	}
+	if metadata.Version == "" {
+		return deploy.LegacyEnvTemplateVersion, nil
 	}
 	return metadata.Version, nil
 }

--- a/internal/pkg/describe/env_test.go
+++ b/internal/pkg/describe/env_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/copilot-cli/internal/pkg/config"
+	"github.com/aws/copilot-cli/internal/pkg/deploy"
 	"github.com/aws/copilot-cli/internal/pkg/describe/mocks"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
@@ -234,7 +235,7 @@ func TestEnvDescriber_Version(t *testing.T) {
 		wantedVersion string
 		wantedErr     error
 	}{
-		"should return empty version if legacy template": {
+		"should return deploy.LegacyEnvTemplateVersion version if legacy template": {
 			given: func(ctrl *gomock.Controller) *EnvDescriber {
 				m := mocks.NewMockstackAndResourcesDescriber(ctrl)
 				m.EXPECT().Metadata(gomock.Any()).Return("", nil)
@@ -244,6 +245,7 @@ func TestEnvDescriber_Version(t *testing.T) {
 					stackDescriber: m,
 				}
 			},
+			wantedVersion: deploy.LegacyEnvTemplateVersion,
 		},
 		"should read the version from the Metadata field": {
 			given: func(ctrl *gomock.Controller) *EnvDescriber {

--- a/internal/pkg/describe/env_test.go
+++ b/internal/pkg/describe/env_test.go
@@ -237,17 +237,7 @@ func TestEnvDescriber_Version(t *testing.T) {
 		"should return empty version if legacy template": {
 			given: func(ctrl *gomock.Controller) *EnvDescriber {
 				m := mocks.NewMockstackAndResourcesDescriber(ctrl)
-				m.EXPECT().Template(gomock.Any()).Return(`
-Resources:
-  Service:
-    Type: AWS::ECS::Service
-    DependsOn: LoadBalancerRule
-    Properties:
-      ServiceName: !Ref 'ServiceName'
-      Cluster:
-        Fn::ImportValue:
-          !Join [':', [!Ref 'StackName', 'ClusterName']]
-`, nil)
+				m.EXPECT().Metadata(gomock.Any()).Return("", nil)
 				return &EnvDescriber{
 					app:            "phonetool",
 					env:            &config.Environment{Name: "test"},
@@ -258,10 +248,7 @@ Resources:
 		"should read the version from the Metadata field": {
 			given: func(ctrl *gomock.Controller) *EnvDescriber {
 				m := mocks.NewMockstackAndResourcesDescriber(ctrl)
-				m.EXPECT().Template("phonetool-test").Return(`
-Metadata:
-  Version: 1.0.0
-`, nil)
+				m.EXPECT().Metadata("phonetool-test").Return(`{"Version":"1.0.0"}`, nil)
 				return &EnvDescriber{
 					app:            "phonetool",
 					env:            &config.Environment{Name: "test"},

--- a/internal/pkg/describe/mocks/mock_service.go
+++ b/internal/pkg/describe/mocks/mock_service.go
@@ -65,6 +65,21 @@ func (mr *MockstackAndResourcesDescriberMockRecorder) StackResources(stackName i
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StackResources", reflect.TypeOf((*MockstackAndResourcesDescriber)(nil).StackResources), stackName)
 }
 
+// Template mocks base method
+func (m *MockstackAndResourcesDescriber) Template(stackName string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Template", stackName)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Template indicates an expected call of Template
+func (mr *MockstackAndResourcesDescriberMockRecorder) Template(stackName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Template", reflect.TypeOf((*MockstackAndResourcesDescriber)(nil).Template), stackName)
+}
+
 // MockecsClient is a mock of ecsClient interface
 type MockecsClient struct {
 	ctrl     *gomock.Controller

--- a/internal/pkg/describe/mocks/mock_service.go
+++ b/internal/pkg/describe/mocks/mock_service.go
@@ -65,19 +65,19 @@ func (mr *MockstackAndResourcesDescriberMockRecorder) StackResources(stackName i
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StackResources", reflect.TypeOf((*MockstackAndResourcesDescriber)(nil).StackResources), stackName)
 }
 
-// Template mocks base method
-func (m *MockstackAndResourcesDescriber) Template(stackName string) (string, error) {
+// Metadata mocks base method
+func (m *MockstackAndResourcesDescriber) Metadata(stackName string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Template", stackName)
+	ret := m.ctrl.Call(m, "Metadata", stackName)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// Template indicates an expected call of Template
-func (mr *MockstackAndResourcesDescriberMockRecorder) Template(stackName interface{}) *gomock.Call {
+// Metadata indicates an expected call of Metadata
+func (mr *MockstackAndResourcesDescriberMockRecorder) Metadata(stackName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Template", reflect.TypeOf((*MockstackAndResourcesDescriber)(nil).Template), stackName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Metadata", reflect.TypeOf((*MockstackAndResourcesDescriber)(nil).Metadata), stackName)
 }
 
 // MockecsClient is a mock of ecsClient interface

--- a/internal/pkg/describe/mocks/mock_stack.go
+++ b/internal/pkg/describe/mocks/mock_stack.go
@@ -62,3 +62,18 @@ func (mr *MockcfnStackDescriberMockRecorder) DescribeStackResources(input interf
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeStackResources", reflect.TypeOf((*MockcfnStackDescriber)(nil).DescribeStackResources), input)
 }
+
+// GetTemplate mocks base method
+func (m *MockcfnStackDescriber) GetTemplate(in *cloudformation.GetTemplateInput) (*cloudformation.GetTemplateOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTemplate", in)
+	ret0, _ := ret[0].(*cloudformation.GetTemplateOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTemplate indicates an expected call of GetTemplate
+func (mr *MockcfnStackDescriberMockRecorder) GetTemplate(in interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTemplate", reflect.TypeOf((*MockcfnStackDescriber)(nil).GetTemplate), in)
+}

--- a/internal/pkg/describe/mocks/mock_stack.go
+++ b/internal/pkg/describe/mocks/mock_stack.go
@@ -63,17 +63,17 @@ func (mr *MockcfnStackDescriberMockRecorder) DescribeStackResources(input interf
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeStackResources", reflect.TypeOf((*MockcfnStackDescriber)(nil).DescribeStackResources), input)
 }
 
-// GetTemplate mocks base method
-func (m *MockcfnStackDescriber) GetTemplate(in *cloudformation.GetTemplateInput) (*cloudformation.GetTemplateOutput, error) {
+// GetTemplateSummary mocks base method
+func (m *MockcfnStackDescriber) GetTemplateSummary(in *cloudformation.GetTemplateSummaryInput) (*cloudformation.GetTemplateSummaryOutput, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTemplate", in)
-	ret0, _ := ret[0].(*cloudformation.GetTemplateOutput)
+	ret := m.ctrl.Call(m, "GetTemplateSummary", in)
+	ret0, _ := ret[0].(*cloudformation.GetTemplateSummaryOutput)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetTemplate indicates an expected call of GetTemplate
-func (mr *MockcfnStackDescriberMockRecorder) GetTemplate(in interface{}) *gomock.Call {
+// GetTemplateSummary indicates an expected call of GetTemplateSummary
+func (mr *MockcfnStackDescriberMockRecorder) GetTemplateSummary(in interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTemplate", reflect.TypeOf((*MockcfnStackDescriber)(nil).GetTemplate), in)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTemplateSummary", reflect.TypeOf((*MockcfnStackDescriber)(nil).GetTemplateSummary), in)
 }

--- a/internal/pkg/describe/service.go
+++ b/internal/pkg/describe/service.go
@@ -25,7 +25,7 @@ const (
 type stackAndResourcesDescriber interface {
 	Stack(stackName string) (*cloudformation.Stack, error)
 	StackResources(stackName string) ([]*cloudformation.StackResource, error)
-	Template(stackName string) (string, error)
+	Metadata(stackName string) (string, error)
 }
 
 type ecsClient interface {

--- a/internal/pkg/describe/service.go
+++ b/internal/pkg/describe/service.go
@@ -25,6 +25,7 @@ const (
 type stackAndResourcesDescriber interface {
 	Stack(stackName string) (*cloudformation.Stack, error)
 	StackResources(stackName string) ([]*cloudformation.StackResource, error)
+	Template(stackName string) (string, error)
 }
 
 type ecsClient interface {

--- a/internal/pkg/describe/stack.go
+++ b/internal/pkg/describe/stack.go
@@ -14,7 +14,7 @@ import (
 type cfnStackDescriber interface {
 	DescribeStacks(input *cloudformation.DescribeStacksInput) (*cloudformation.DescribeStacksOutput, error)
 	DescribeStackResources(input *cloudformation.DescribeStackResourcesInput) (*cloudformation.DescribeStackResourcesOutput, error)
-	GetTemplate(in *cloudformation.GetTemplateInput) (*cloudformation.GetTemplateOutput, error)
+	GetTemplateSummary(in *cloudformation.GetTemplateSummaryInput) (*cloudformation.GetTemplateSummaryOutput, error)
 }
 
 // stackDescriber retrieves information of a CloudFormation Stack.
@@ -54,13 +54,13 @@ func (d *stackDescriber) StackResources(stackName string) ([]*cloudformation.Sta
 	return out.StackResources, nil
 }
 
-// Template returns the CloudFormation template of the stack.
-func (d *stackDescriber) Template(stackName string) (string, error) {
-	out, err := d.stackDescribers.GetTemplate(&cloudformation.GetTemplateInput{
+// Metadata returns the Metadata property of the CloudFormation stack's template.
+func (d *stackDescriber) Metadata(stackName string) (string, error) {
+	out, err := d.stackDescribers.GetTemplateSummary(&cloudformation.GetTemplateSummaryInput{
 		StackName: aws.String(stackName),
 	})
 	if err != nil {
-		return "", fmt.Errorf("get template for stack %s: %w", stackName, err)
+		return "", fmt.Errorf("get template summary for stack %s: %w", stackName, err)
 	}
-	return aws.StringValue(out.TemplateBody), nil
+	return aws.StringValue(out.Metadata), nil
 }

--- a/internal/pkg/describe/stack.go
+++ b/internal/pkg/describe/stack.go
@@ -14,6 +14,7 @@ import (
 type cfnStackDescriber interface {
 	DescribeStacks(input *cloudformation.DescribeStacksInput) (*cloudformation.DescribeStacksOutput, error)
 	DescribeStackResources(input *cloudformation.DescribeStackResourcesInput) (*cloudformation.DescribeStackResourcesOutput, error)
+	GetTemplate(in *cloudformation.GetTemplateInput) (*cloudformation.GetTemplateOutput, error)
 }
 
 // stackDescriber retrieves information of a CloudFormation Stack.
@@ -51,4 +52,15 @@ func (d *stackDescriber) StackResources(stackName string) ([]*cloudformation.Sta
 		return nil, fmt.Errorf("describe resources for stack %s: %w", stackName, err)
 	}
 	return out.StackResources, nil
+}
+
+// Template returns the CloudFormation template of the stack.
+func (d *stackDescriber) Template(stackName string) (string, error) {
+	out, err := d.stackDescribers.GetTemplate(&cloudformation.GetTemplateInput{
+		StackName: aws.String(stackName),
+	})
+	if err != nil {
+		return "", fmt.Errorf("get template for stack %s: %w", stackName, err)
+	}
+	return aws.StringValue(out.TemplateBody), nil
 }

--- a/internal/pkg/describe/stack_test.go
+++ b/internal/pkg/describe/stack_test.go
@@ -189,7 +189,7 @@ func TestStackDescriber_Metadata(t *testing.T) {
 				return m
 			},
 
-			wantedErr: errors.New("get template for stack phonetool-test: some error"),
+			wantedErr: errors.New("get template summary for stack phonetool-test: some error"),
 		},
 		"should retrieve metadata on successful call": {
 			stackName: "phonetool-test",

--- a/internal/pkg/describe/stack_test.go
+++ b/internal/pkg/describe/stack_test.go
@@ -173,37 +173,37 @@ func TestStackDescriber_StackResources(t *testing.T) {
 	}
 }
 
-func TestStackDescriber_Template(t *testing.T) {
+func TestStackDescriber_Metadata(t *testing.T) {
 	testCases := map[string]struct {
 		stackName string
 		mockCFN   func(ctrl *gomock.Controller) cfnStackDescriber
 
-		wantedTemplate string
+		wantedMetadata string
 		wantedErr      error
 	}{
 		"should wrap cfn error": {
 			stackName: "phonetool-test",
 			mockCFN: func(ctrl *gomock.Controller) cfnStackDescriber {
 				m := mocks.NewMockcfnStackDescriber(ctrl)
-				m.EXPECT().GetTemplate(gomock.Any()).Return(nil, errors.New("some error"))
+				m.EXPECT().GetTemplateSummary(gomock.Any()).Return(nil, errors.New("some error"))
 				return m
 			},
 
 			wantedErr: errors.New("get template for stack phonetool-test: some error"),
 		},
-		"should retrieve template body on successful call": {
+		"should retrieve metadata on successful call": {
 			stackName: "phonetool-test",
 			mockCFN: func(ctrl *gomock.Controller) cfnStackDescriber {
 				m := mocks.NewMockcfnStackDescriber(ctrl)
-				m.EXPECT().GetTemplate(&cloudformation.GetTemplateInput{
+				m.EXPECT().GetTemplateSummary(&cloudformation.GetTemplateSummaryInput{
 					StackName: aws.String("phonetool-test"),
-				}).Return(&cloudformation.GetTemplateOutput{
-					TemplateBody: aws.String("hello"),
+				}).Return(&cloudformation.GetTemplateSummaryOutput{
+					Metadata: aws.String("hello"),
 				}, nil)
 				return m
 			},
 
-			wantedTemplate: "hello",
+			wantedMetadata: "hello",
 		},
 	}
 
@@ -217,14 +217,14 @@ func TestStackDescriber_Template(t *testing.T) {
 			}
 
 			// WHEN
-			actual, err := d.Template(tc.stackName)
+			actual, err := d.Metadata(tc.stackName)
 
 			// THEN
 			if tc.wantedErr != nil {
 				require.EqualError(t, err, tc.wantedErr.Error())
 			} else {
 				require.NoError(t, err)
-				require.Equal(t, tc.wantedTemplate, actual)
+				require.Equal(t, tc.wantedMetadata, actual)
 			}
 		})
 	}


### PR DESCRIPTION
Add `Version` method to `*EnvDescriber` to read the version of an environment's cloudformation template.
The "env upgrade" command needs this functionality to determine if it needs to upgrade the template or not.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
