### PR TITLE
chore(cli): default svc logs limit to max when time filter is set

### DIFF
--- a/internal/pkg/aws/cloudwatchlogs/cloudwatchlogs.go
+++ b/internal/pkg/aws/cloudwatchlogs/cloudwatchlogs.go
@@ -90,8 +90,7 @@ func (c *CloudWatchLogs) logStreams(logGroup string, logStreams ...string) ([]st
 // LogEvents returns an array of Cloudwatch Logs events.
 func (c *CloudWatchLogs) LogEvents(opts LogEventsOpts) (*LogEventsOutput, error) {
 	var events []*Event
-	// Set default value
-	in := defaultGetLogEventsInput(opts)
+	in := initGetLogEventsInput(opts)
 	logStreams, err := c.logStreams(opts.LogGroup, opts.LogStreams...)
 	if err != nil {
 		return nil, err
@@ -148,7 +147,7 @@ func truncateEvents(limit int, events []*Event) []*Event {
 	return events[len(events)-limit:] // Only grab the last N elements where N = limit
 }
 
-func defaultGetLogEventsInput(opts LogEventsOpts) *cloudwatchlogs.GetLogEventsInput {
+func initGetLogEventsInput(opts LogEventsOpts) *cloudwatchlogs.GetLogEventsInput {
 	return &cloudwatchlogs.GetLogEventsInput{
 		LogGroupName: aws.String(opts.LogGroup),
 		StartTime:    opts.StartTime,

--- a/internal/pkg/cli/flag.go
+++ b/internal/pkg/cli/flag.go
@@ -146,7 +146,8 @@ Allows you to categorize resources.`
 	stackOutputDirFlagDescription = "Optional. Writes the stack template and template configuration to a directory."
 	prodEnvFlagDescription        = "If the environment contains production services."
 
-	limitFlagDescription  = "Optional. The maximum number of log events returned."
+	limitFlagDescription = `Optional. The maximum number of log events returned. Default is 10
+unless any time filtering flags are set.`
 	followFlagDescription = "Optional. Specifies if the logs should be streamed."
 	sinceFlagDescription  = `Optional. Only return logs newer than a relative duration like 5s, 2m, or 3h.
 Defaults to all logs. Only one of start-time / since may be used.`

--- a/internal/pkg/ecslogging/service_test.go
+++ b/internal/pkg/ecslogging/service_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/copilot-cli/internal/pkg/aws/cloudwatchlogs"
 	"github.com/aws/copilot-cli/internal/pkg/ecslogging/mocks"
 	"github.com/golang/mock/gomock"
@@ -19,7 +20,7 @@ type serviceLogsMocks struct {
 	logGetter *mocks.MocklogGetter
 }
 
-func TestServiceLogs_WriteServiceLogEvents(t *testing.T) {
+func TestServiceClient_WriteLogEvents(t *testing.T) {
 	const (
 		mockLogGroupName     = "mockLogGroup"
 		mockLogStreamPrefix  = "mockLogStreamPrefix"
@@ -52,8 +53,14 @@ firelens_log_router/fcfe4 10.0.0.00 - - [01/Jan/1970 01:01:01] "WARN some warnin
 			Message:       `10.0.0.00 - - [01/Jan/1970 01:01:01] "GET / HTTP/1.1" 404 -`,
 		},
 	}
+	mockLimit := aws.Int64(100)
+	mockDefaultLimit := aws.Int64(10)
+	var mockNilLimit *int64
+	mockStartTime := aws.Int64(123456789)
 	testCases := map[string]struct {
 		follow     bool
+		limit      *int64
+		startTime  *int64
 		jsonOutput bool
 		taskIDs    []string
 		setupMocks func(mocks serviceLogsMocks)
@@ -72,12 +79,15 @@ firelens_log_router/fcfe4 10.0.0.00 - - [01/Jan/1970 01:01:01] "WARN some warnin
 			wantedError: fmt.Errorf("get task log events for log group mockLogGroup: some error"),
 		},
 		"success with human output": {
+			limit: mockLimit,
 			setupMocks: func(m serviceLogsMocks) {
 				gomock.InOrder(
 					m.logGetter.EXPECT().LogEvents(gomock.Any()).
-						Return(&cloudwatchlogs.LogEventsOutput{
-							Events: logEvents,
-						}, nil),
+						Do(func(param cloudwatchlogs.LogEventsOpts) {
+							require.Equal(t, param.Limit, mockLimit)
+						}).Return(&cloudwatchlogs.LogEventsOutput{
+						Events: logEvents,
+					}, nil),
 				)
 			},
 
@@ -85,9 +95,13 @@ firelens_log_router/fcfe4 10.0.0.00 - - [01/Jan/1970 01:01:01] "WARN some warnin
 		},
 		"success with json output": {
 			jsonOutput: true,
+			startTime:  mockStartTime,
 			setupMocks: func(m serviceLogsMocks) {
 				gomock.InOrder(
 					m.logGetter.EXPECT().LogEvents(gomock.Any()).
+						Do(func(param cloudwatchlogs.LogEventsOpts) {
+							require.Equal(t, param.Limit, mockNilLimit)
+						}).
 						Return(&cloudwatchlogs.LogEventsOutput{
 							Events: logEvents,
 						}, nil),
@@ -101,9 +115,11 @@ firelens_log_router/fcfe4 10.0.0.00 - - [01/Jan/1970 01:01:01] "WARN some warnin
 			taskIDs: []string{"mockTaskID1", "mockTaskID2"},
 			setupMocks: func(m serviceLogsMocks) {
 				gomock.InOrder(
-					m.logGetter.EXPECT().LogEvents(gomock.Any()).Do(func(param cloudwatchlogs.LogEventsOpts) {
-						require.Equal(t, param.LogStreams, []string{"mockLogStreamPrefix/mockTaskID1", "mockLogStreamPrefix/mockTaskID2"})
-					}).
+					m.logGetter.EXPECT().LogEvents(gomock.Any()).
+						Do(func(param cloudwatchlogs.LogEventsOpts) {
+							require.Equal(t, param.LogStreams, []string{"mockLogStreamPrefix/mockTaskID1", "mockLogStreamPrefix/mockTaskID2"})
+							require.Equal(t, param.Limit, mockDefaultLimit)
+						}).
 						Return(&cloudwatchlogs.LogEventsOutput{
 							Events:              logEvents,
 							StreamLastEventTime: mockLastEventTime,
@@ -151,9 +167,11 @@ firelens_log_router/fcfe4 10.0.0.00 - - [01/Jan/1970 01:01:01] "GET / HTTP/1.1" 
 				logWriter = WriteJSONLogs
 			}
 			err := svcLogs.WriteLogEvents(WriteLogEventsOpts{
-				Follow:   tc.follow,
-				TaskIDs:  tc.taskIDs,
-				OnEvents: logWriter,
+				Follow:    tc.follow,
+				TaskIDs:   tc.taskIDs,
+				Limit:     tc.limit,
+				StartTime: tc.startTime,
+				OnEvents:  logWriter,
 			})
 
 			// THEN


### PR DESCRIPTION
<!-- Provide summary of changes -->
Currently the default value for limit is always 10. However, this doesn't make sense when users set any time filtering flags. This PR addresses this issue.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
