### PR TITLE
chore(workspace): do not wrap the error when writing the manifest

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,6 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/apache/thrift v0.0.0-20161221203622-b2a4d4ae21c7/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/aws/aws-sdk-go v1.15.11/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
-github.com/aws/aws-sdk-go v1.34.27 h1:qBqccUrlz43Zermh0U1O502bHYZsgMlBm+LUVabzBPA=
-github.com/aws/aws-sdk-go v1.34.27/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.34.32 h1:EHjowHEGXyLHWhcO7M7AVA+oA2c8aLE9WfRvqHwxd3A=
 github.com/aws/aws-sdk-go v1.34.32/go.mod h1:H7NKnBqNVzoTJpGfLrQkkD+ytBA93eiDYi/+8rV9s48=
 github.com/awslabs/goformation/v4 v4.15.0 h1:yZM85dzEKrRIPpMZIdsUV+EWbvhWsfoqC81Fv/aFPck=
@@ -194,10 +192,9 @@ github.com/ishidawataru/sctp v0.0.0-20191218070446-00ab2ac2db07/go.mod h1:co9pwD
 github.com/jaguilar/vt100 v0.0.0-20150826170717-2703a27b14ea/go.mod h1:QMdK4dGB3YhEW2BmA1wgGpPYI3HZy/5gD705PXKUVSg=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
-github.com/jmespath/go-jmespath v0.3.0 h1:OS12ieG61fsCg5+qLJ+SsW9NicxNkg3b25OyT2yCeUc=
-github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=

--- a/internal/pkg/workspace/workspace.go
+++ b/internal/pkg/workspace/workspace.go
@@ -218,26 +218,18 @@ func (ws *Workspace) ReadPipelineManifest() ([]byte, error) {
 
 // WriteServiceManifest writes the service's manifest under the copilot/{name}/ directory.
 func (ws *Workspace) WriteServiceManifest(marshaler encoding.BinaryMarshaler, name string) (string, error) {
-	mfPath, err := ws.writeWorkloadManifest(marshaler, name)
+	data, err := marshaler.MarshalBinary()
 	if err != nil {
 		return "", fmt.Errorf("marshal service %s manifest to binary: %w", name, err)
 	}
-	return mfPath, nil
+	return ws.write(data, name, manifestFileName)
 }
 
 // WriteJobManifest writes the job's manifest under the copilot/{name}/ directory.
 func (ws *Workspace) WriteJobManifest(marshaler encoding.BinaryMarshaler, name string) (string, error) {
-	mfPath, err := ws.writeWorkloadManifest(marshaler, name)
-	if err != nil {
-		return "", fmt.Errorf("marshal job %s manifest to binary: %w", name, err)
-	}
-	return mfPath, nil
-}
-
-func (ws *Workspace) writeWorkloadManifest(marshaler encoding.BinaryMarshaler, name string) (string, error) {
 	data, err := marshaler.MarshalBinary()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("marshal job %s manifest to binary: %w", name, err)
 	}
 	return ws.write(data, name, manifestFileName)
 }


### PR DESCRIPTION
<!-- Provide summary of changes -->
This PR fixes a bug in the `workspace` pkg that breaks the e2e test:
previously the error return by [this](https://github.com/aws/copilot-cli/blob/b6958f65c48a73dca9cfc2afa03e681cf173a4bc/internal/pkg/workspace/workspace.go#L242) is not wrapped up so [here](https://github.com/aws/copilot-cli/blob/b6958f65c48a73dca9cfc2afa03e681cf173a4bc/internal/pkg/cli/svc_init.go#L208) we can determine if the error type is ErrFileExists. However, now since we have another [layer](https://github.com/aws/copilot-cli/blob/b6958f65c48a73dca9cfc2afa03e681cf173a4bc/internal/pkg/workspace/workspace.go#L220-L226), the error is wrapped and causing
```
marshal service test manifest to binary: file /Users/penghaoh/Desktop/python/flask-app/copilot/test/manifest.yml already exists
```
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
