### PR TITLE
fix(cli): remove requirement for Dockerfile to be within workspace

### DIFF
--- a/internal/pkg/cli/cli.go
+++ b/internal/pkg/cli/cli.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/copilot-cli/internal/pkg/term/color"
@@ -101,9 +100,6 @@ func relativeDockerfilePath(ws copilotDirGetter, dockerfilePath string) (string,
 	absDfPath, err := filepath.Abs(dockerfilePath)
 	if err != nil {
 		return "", fmt.Errorf("get absolute path: %v", err)
-	}
-	if !strings.Contains(absDfPath, wsRoot) {
-		return "", fmt.Errorf("Dockerfile %s not within workspace %s", absDfPath, wsRoot)
 	}
 	relDfPath, err := filepath.Rel(wsRoot, absDfPath)
 	if err != nil {


### PR DESCRIPTION
Removes the check that a user-provided path to their Dockerfile is within the workspace directory. Enables users to have more flexibility in the organization of their files.

Fixes https://github.com/aws/copilot-cli/issues/1422.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
