### PR TITLE
fix(cli): inject selector dependency to "init" cmd

### DIFF
--- a/internal/pkg/cli/init.go
+++ b/internal/pkg/cli/init.go
@@ -115,6 +115,7 @@ func newInitOpts(vars initVars) (*initOpts, error) {
 		store:       ssm,
 		appDeployer: deployer,
 		prog:        spin,
+		sel:         selector.NewWorkspaceSelect(prompt, ssm, ws),
 		prompt:      prompt,
 		setupParser: func(o *initSvcOpts) {
 			o.df = dockerfile.New(o.fs, o.dockerfilePath)


### PR DESCRIPTION
Previously, if the Dockerfile wasn't at the root or one level down
in the repo then the svcInitCmd resulted in a segfault because the
selector dependency wasn't initialized. This change fixes that.


_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
