### PR TITLE
chore(cli): enable service/job deletion outside of workspace

### DIFF
--- a/internal/pkg/cli/job_delete.go
+++ b/internal/pkg/cli/job_delete.go
@@ -69,11 +69,6 @@ func newDeleteJobOpts(vars deleteJobVars) (*deleteJobOpts, error) {
 
 // Validate returns an error if the user inputs are invalid.
 func (o *deleteJobOpts) Validate() error {
-	if o.name != "" || o.envName != "" {
-		if o.appName == "" {
-			return fmt.Errorf("--%s must be provided", appFlag)
-		}
-	}
 	if o.name != "" {
 		if _, err := o.store.GetJob(o.appName, o.name); err != nil {
 			return err
@@ -176,6 +171,9 @@ func buildJobDeleteCmd() *cobra.Command {
 
   Delete the "report-generator" job from just the prod environment.
   /code $ copilot job delete --name report-generator --env prod
+
+  Delete the "report-generator" job from the my-app application from outside of the workspace.
+  /code $ copilot job delete --name report-generator --app my-app
 
   Delete the "report-generator" job without confirmation prompt.
   /code $ copilot job delete --name report-generator --yes`,

--- a/internal/pkg/cli/job_delete_test.go
+++ b/internal/pkg/cli/job_delete_test.go
@@ -27,12 +27,12 @@ func TestDeleteJobOpts_Validate(t *testing.T) {
 
 		want error
 	}{
-		"should return error if job flag but not app flag set": {
+		"should return error if job flag set but app flag not set": {
 			inName:     "resizer",
 			setupMocks: func(m *mocks.Mockstore) {},
 			want:       errors.New("--app must be provided"),
 		},
-		"should return error if env flag but not app flag set": {
+		"should return error if env flag set but app flag not set": {
 			inEnvName:  "test",
 			setupMocks: func(m *mocks.Mockstore) {},
 			want:       errors.New("--app must be provided"),

--- a/internal/pkg/cli/job_delete_test.go
+++ b/internal/pkg/cli/job_delete_test.go
@@ -27,16 +27,6 @@ func TestDeleteJobOpts_Validate(t *testing.T) {
 
 		want error
 	}{
-		"should return error if job flag set but app flag not set": {
-			inName:     "resizer",
-			setupMocks: func(m *mocks.Mockstore) {},
-			want:       errors.New("--app must be provided"),
-		},
-		"should return error if env flag set but app flag not set": {
-			inEnvName:  "test",
-			setupMocks: func(m *mocks.Mockstore) {},
-			want:       errors.New("--app must be provided"),
-		},
 		"with no flag set": {
 			inAppName:  "phonetool",
 			setupMocks: func(m *mocks.Mockstore) {},

--- a/internal/pkg/cli/svc_delete.go
+++ b/internal/pkg/cli/svc_delete.go
@@ -235,7 +235,7 @@ func (o *deleteSvcOpts) askSvcName() error {
 		return nil
 	}
 
-	name, err := o.sel.Service("Select a service to delete", "")
+	name, err := o.sel.Service(svcDeleteNamePrompt, "")
 	if err != nil {
 		return fmt.Errorf("select service: %w", err)
 	}

--- a/internal/pkg/cli/svc_delete.go
+++ b/internal/pkg/cli/svc_delete.go
@@ -109,7 +109,7 @@ func newDeleteSvcOpts(vars deleteSvcVars) (*deleteSvcOpts, error) {
 func (o *deleteSvcOpts) Validate() error {
 	if o.name != "" || o.envName != "" {
 		if o.appName == "" {
-			return errNoAppInWorkspace
+			return fmt.Errorf("--%s must be provided", appFlag)
 		}
 	}
 	if o.name != "" {

--- a/internal/pkg/cli/svc_delete.go
+++ b/internal/pkg/cli/svc_delete.go
@@ -107,11 +107,6 @@ func newDeleteSvcOpts(vars deleteSvcVars) (*deleteSvcOpts, error) {
 
 // Validate returns an error if the user inputs are invalid.
 func (o *deleteSvcOpts) Validate() error {
-	if o.name != "" || o.envName != "" {
-		if o.appName == "" {
-			return fmt.Errorf("--%s must be provided", appFlag)
-		}
-	}
 	if o.name != "" {
 		if _, err := o.store.GetService(o.appName, o.name); err != nil {
 			return err
@@ -351,6 +346,9 @@ func buildSvcDeleteCmd() *cobra.Command {
 
   Delete the "test" service from just the prod environment.
   /code $ copilot svc delete --name test --env prod
+
+  Delete the "test" service from the "my-app" application from outside of the workspace.
+  /code $ copilot svc delete --name test --app my-app
 
   Delete the "test" service without confirmation prompt.
   /code $ copilot svc delete --name test --yes`,

--- a/internal/pkg/cli/svc_delete_test.go
+++ b/internal/pkg/cli/svc_delete_test.go
@@ -156,7 +156,7 @@ func TestDeleteSvcOpts_Ask(t *testing.T) {
 			inName:           "",
 			skipConfirmation: true,
 			mockSel: func(m *mocks.MockwsSelector) {
-				m.EXPECT().Service("Select a service to delete", "").Return(testSvcName, nil)
+				m.EXPECT().Service("Which service would you like to delete?", "").Return(testSvcName, nil)
 			},
 			mockPrompt: func(m *mocks.Mockprompter) {},
 
@@ -167,7 +167,7 @@ func TestDeleteSvcOpts_Ask(t *testing.T) {
 			inName:           "",
 			skipConfirmation: true,
 			mockSel: func(m *mocks.MockwsSelector) {
-				m.EXPECT().Service("Select a service to delete", "").Return("", mockError)
+				m.EXPECT().Service("Which service would you like to delete?", "").Return("", mockError)
 			},
 			mockPrompt: func(m *mocks.Mockprompter) {},
 
@@ -178,7 +178,7 @@ func TestDeleteSvcOpts_Ask(t *testing.T) {
 			inName:           "",
 			skipConfirmation: true,
 			mockSel: func(m *mocks.MockwsSelector) {
-				m.EXPECT().Service("Select a service to delete", "").Return("", mockError)
+				m.EXPECT().Service("Which service would you like to delete?", "").Return("", mockError)
 			},
 			mockPrompt: func(m *mocks.Mockprompter) {
 			},

--- a/internal/pkg/cli/svc_delete_test.go
+++ b/internal/pkg/cli/svc_delete_test.go
@@ -28,16 +28,6 @@ func TestDeleteSvcOpts_Validate(t *testing.T) {
 
 		want error
 	}{
-		"should return error if svc flag set but app flag not set": {
-			inName:     "api",
-			setupMocks: func(m *mocks.Mockstore) {},
-			want:       errors.New("--app must be provided"),
-		},
-		"should return error if env flag set but app flag not set": {
-			inEnvName:  "test",
-			setupMocks: func(m *mocks.Mockstore) {},
-			want:       errors.New("--app must be provided"),
-		},
 		"with no flag set": {
 			inAppName:  "phonetool",
 			setupMocks: func(m *mocks.Mockstore) {},


### PR DESCRIPTION
This change enables users to delete services from outside of the workspace using flags. Previously, `svc_delete` would error out because an app couldn't be found in the workspace.

Related: https://github.com/aws/copilot-cli/pull/1439

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
