### PR TITLE
fix(cli): autoscaling range default value

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/backend_svc_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/backend_svc_test.go
@@ -58,9 +58,10 @@ func TestBackendService_Template(t *testing.T) {
 			Port: aws.String("80/80/80"),
 		},
 	}}
+	badRange := manifest.Range("badRange")
 	testBackendSvcManifestWithBadAutoScaling := manifest.NewBackendService(baseProps)
 	testBackendSvcManifestWithBadAutoScaling.Count.Autoscaling = manifest.Autoscaling{
-		Range: manifest.Range("badRange"),
+		Range: &badRange,
 	}
 	testCases := map[string]struct {
 		mockDependencies func(t *testing.T, ctrl *gomock.Controller, svc *BackendService)

--- a/internal/pkg/deploy/cloudformation/stack/lb_web_svc_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/lb_web_svc_test.go
@@ -259,23 +259,26 @@ func TestLoadBalancedWebService_Parameters(t *testing.T) {
 		Port: 80,
 	}
 	testLBWebServiceManifest := manifest.NewLoadBalancedWebService(baseProps)
+	testLBWebServiceManifestRange := manifest.Range("2-100")
 	testLBWebServiceManifest.Count = manifest.Count{
 		Value: aws.Int(1),
 		Autoscaling: manifest.Autoscaling{
-			Range: manifest.Range("2-100"),
+			Range: &testLBWebServiceManifestRange,
 		},
 	}
 	testLBWebServiceManifestWithBadCount := manifest.NewLoadBalancedWebService(baseProps)
+	testLBWebServiceManifestWithBadCountRange := manifest.Range("badCount")
 	testLBWebServiceManifestWithBadCount.Count = manifest.Count{
 		Autoscaling: manifest.Autoscaling{
-			Range: manifest.Range("badCount"),
+			Range: &testLBWebServiceManifestWithBadCountRange,
 		},
 	}
 	testLBWebServiceManifestWithSidecar := manifest.NewLoadBalancedWebService(baseProps)
+	testLBWebServiceManifestWithSidecarRange := manifest.Range("2-100")
 	testLBWebServiceManifestWithSidecar.Count = manifest.Count{
 		Value: aws.Int(1),
 		Autoscaling: manifest.Autoscaling{
-			Range: manifest.Range("2-100"),
+			Range: &testLBWebServiceManifestWithSidecarRange,
 		},
 	}
 	testLBWebServiceManifestWithSidecar.TargetContainer = aws.String("xray")
@@ -285,10 +288,11 @@ func TestLoadBalancedWebService_Parameters(t *testing.T) {
 		},
 	}}
 	testLBWebServiceManifestWithStickiness := manifest.NewLoadBalancedWebService(baseProps)
+	testLBWebServiceManifestWithStickinessRange := manifest.Range("2-100")
 	testLBWebServiceManifestWithStickiness.Count = manifest.Count{
 		Value: aws.Int(1),
 		Autoscaling: manifest.Autoscaling{
-			Range: manifest.Range("2-100"),
+			Range: &testLBWebServiceManifestWithStickinessRange,
 		},
 	}
 	testLBWebServiceManifestWithStickiness.Stickiness = aws.Bool(true)

--- a/internal/pkg/deploy/cloudformation/stack/workload.go
+++ b/internal/pkg/deploy/cloudformation/stack/workload.go
@@ -88,7 +88,7 @@ func (w *wkld) Parameters() ([]*cloudformation.Parameter, error) {
 	if !w.tc.Count.Autoscaling.IsEmpty() {
 		min, _, err := w.tc.Count.Autoscaling.Range.Parse()
 		if err != nil {
-			return nil, fmt.Errorf("parse task count value %s: %w", string(w.tc.Count.Autoscaling.Range), err)
+			return nil, fmt.Errorf("parse task count value %s: %w", aws.StringValue((*string)(w.tc.Count.Autoscaling.Range)), err)
 		}
 		desiredCount = aws.Int(min)
 	}

--- a/internal/pkg/manifest/lb_web_svc_test.go
+++ b/internal/pkg/manifest/lb_web_svc_test.go
@@ -63,6 +63,7 @@ func TestLoadBalancedWebService_MarshalBinary(t *testing.T) {
 }
 
 func TestLoadBalancedWebService_ApplyEnv(t *testing.T) {
+	mockRange := Range("1-10")
 	testCases := map[string]struct {
 		in         *LoadBalancedWebService
 		envToApply string
@@ -270,6 +271,38 @@ func TestLoadBalancedWebService_ApplyEnv(t *testing.T) {
 						ConfigFile: aws.String("mockConfigFile"),
 						SecretOptions: map[string]string{
 							"FOO": "BAR",
+						},
+					},
+				},
+			},
+		},
+		"with range override": {
+			in: &LoadBalancedWebService{
+				LoadBalancedWebServiceConfig: LoadBalancedWebServiceConfig{
+					TaskConfig: TaskConfig{
+						Count: Count{
+							Autoscaling: Autoscaling{
+								Range: &mockRange,
+								CPU:   aws.Int(80),
+							},
+						},
+					},
+				},
+				Environments: map[string]*LoadBalancedWebServiceConfig{
+					"prod-iad": {},
+				},
+			},
+			envToApply: "prod-iad",
+
+			wanted: &LoadBalancedWebService{
+				LoadBalancedWebServiceConfig: LoadBalancedWebServiceConfig{
+					TaskConfig: TaskConfig{
+						Count: Count{
+							Value: nil,
+							Autoscaling: Autoscaling{
+								Range: &mockRange,
+								CPU:   aws.Int(80),
+							},
 						},
 					},
 				},

--- a/internal/pkg/manifest/svc.go
+++ b/internal/pkg/manifest/svc.go
@@ -87,7 +87,7 @@ func (a *Count) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 // Autoscaling represents the configurable options for Auto Scaling.
 type Autoscaling struct {
-	Range        Range          `yaml:"range"`
+	Range        *Range         `yaml:"range"`
 	CPU          *int           `yaml:"cpu_percentage"`
 	Memory       *int           `yaml:"memory_percentage"`
 	Requests     *int           `yaml:"requests"`
@@ -126,7 +126,7 @@ func (a *Autoscaling) Options() (*template.AutoscalingOpts, error) {
 
 // IsEmpty returns whether Autoscaling is empty.
 func (a *Autoscaling) IsEmpty() bool {
-	return a.Range == "" && a.CPU == nil && a.Memory == nil &&
+	return a.Range == nil && a.CPU == nil && a.Memory == nil &&
 		a.Requests == nil && a.ResponseTime == nil
 }
 

--- a/internal/pkg/manifest/svc_test.go
+++ b/internal/pkg/manifest/svc_test.go
@@ -62,6 +62,7 @@ environments:
       cpu_percentage: 70
 `,
 			requireCorrectValues: func(t *testing.T, i interface{}) {
+				mockRange := Range("1-10")
 				actualManifest, ok := i.(*LoadBalancedWebService)
 				require.True(t, ok)
 				wantedManifest := &LoadBalancedWebService{
@@ -122,7 +123,7 @@ environments:
 							TaskConfig: TaskConfig{
 								Count: Count{
 									Autoscaling: Autoscaling{
-										Range: Range("1-10"),
+										Range: &mockRange,
 										CPU:   aws.Int(70),
 									},
 								},
@@ -211,6 +212,7 @@ type: 'OH NO'
 
 func TestCount_UnmarshalYAML(t *testing.T) {
 	mockResponseTime := 500 * time.Millisecond
+	mockRange := Range("1-10")
 	testCases := map[string]struct {
 		inContent []byte
 
@@ -234,7 +236,7 @@ func TestCount_UnmarshalYAML(t *testing.T) {
 `),
 			wantedStruct: Count{
 				Autoscaling: Autoscaling{
-					Range:        Range("1-10"),
+					Range:        &mockRange,
 					CPU:          aws.Int(70),
 					Memory:       aws.Int(80),
 					Requests:     aws.Int(1000),
@@ -321,7 +323,7 @@ func TestAutoscaling_Options(t *testing.T) {
 	)
 	mockResponseTime := 512 * time.Millisecond
 	testCases := map[string]struct {
-		inRange        string
+		inRange        Range
 		inCPU          int
 		inMemory       int
 		inRequests     int
@@ -355,7 +357,7 @@ func TestAutoscaling_Options(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			a := Autoscaling{
-				Range:        Range(tc.inRange),
+				Range:        &tc.inRange,
 				CPU:          aws.Int(tc.inCPU),
 				Memory:       aws.Int(tc.inMemory),
 				Requests:     aws.Int(tc.inRequests),


### PR DESCRIPTION
<!-- Provide summary of changes -->

When using the following manifest file and deploying on `production` env, the `range` value is set to an empty string :

```yaml
name: foobar
type: Load Balanced Web Service

image:
  build: Dockerfile
  port: 80

count:
  range: 2-6
  cpu_percentage: 70
  memory_percentage: 80

environments:
  production:
    variables:
      MODE: production
```

After running the command:
```
# copilot svc package -n foobar -e production --output-dir /tmp/out

✘ generate stack template: convert the Auto Scaling configuration for service adminapi: invalid range value . Should be in format of ${min}-${max}
```

This bug comes from this code:

```go
// internal/pkg/manifest/lb_web_svc.go

func (s LoadBalancedWebService) ApplyEnv(envName string) (*LoadBalancedWebService, error) {
	// ...
	err := mergo.Merge(&s, LoadBalancedWebService{
		LoadBalancedWebServiceConfig: *overrideConfig,
	}, mergo.WithOverride, mergo.WithOverwriteWithEmptyValue)
```

As the `mergo.WithOverwriteWithEmptyValue` option is used, the `Autoscaling.Range` value is overrided by the default one, which is an empty string.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
