### PR TITLE
feat(cli): add image flag to svc/job init

### DIFF
--- a/internal/pkg/cli/flag.go
+++ b/internal/pkg/cli/flag.go
@@ -90,7 +90,7 @@ const (
 )
 
 // Short flag names.
-// A short flag only exists if the flag is mandatory by the command.
+// A short flag only exists if the flag or flag set is mandatory by the command.
 const (
 	nameFlagShort    = "n"
 	appFlagShort     = "a"
@@ -100,6 +100,7 @@ const (
 	jobTypeFlagShort = "t"
 
 	dockerFileFlagShort        = "d"
+	imageFlagShort             = "i"
 	githubURLFlagShort         = "u"
 	githubAccessTokenFlagShort = "t"
 	gitBranchFlagShort         = "b"
@@ -185,7 +186,7 @@ Must be of the format '<keyName>:<dataType>'.`
 	countFlagDescription         = "Optional. The number of tasks to set up."
 	cpuFlagDescription           = "Optional. The number of CPU units to reserve for each task."
 	memoryFlagDescription        = "Optional. The amount of memory to reserve in MiB for each task."
-	imageFlagDescription         = "Optional. The image to run instead of building a Dockerfile."
+	imageFlagDescription         = "Optional. The docker image to use instead of building from a Dockerfile."
 	taskRoleFlagDescription      = "Optional. The ARN of the role for the task to use."
 	executionRoleFlagDescription = "Optional. The ARN of the role that grants the container agent permission to make AWS API calls."
 	envVarsFlagDescription       = "Optional. Environment variables specified by key=value separated with commas."

--- a/internal/pkg/cli/flag.go
+++ b/internal/pkg/cli/flag.go
@@ -113,6 +113,10 @@ const (
 var (
 	svcTypeFlagDescription = fmt.Sprintf(`Type of service to create. Must be one of:
 %s`, strings.Join(template.QuoteSliceFunc(manifest.ServiceTypes), ", "))
+	imageFlagDescription = fmt.Sprintf(`The location of an existing Docker image.
+Mutually exclusive with -%s, --%s`, dockerFileFlagShort, dockerFileFlag)
+	dockerFileFlagDescription = fmt.Sprintf(`Path to the Dockerfile.
+Mutually exclusive with -%s, --%s`, imageFlagShort, imageFlag)
 	storageTypeFlagDescription = fmt.Sprintf(`Type of storage to add. Must be one of:
 %s`, strings.Join(template.QuoteSliceFunc(storageTypes), ", "))
 	jobTypeFlagDescription = fmt.Sprintf(`Type of job to create. Must be one of:
@@ -140,7 +144,6 @@ const (
 	yesFlagDescription      = "Skips confirmation prompt."
 	jsonFlagDescription     = "Optional. Outputs in JSON format."
 
-	dockerFileFlagDescription   = "Path to the Dockerfile."
 	imageTagFlagDescription     = `Optional. The container image tag.`
 	resourceTagsFlagDescription = `Optional. Labels with a key and value separated with commas.
 Allows you to categorize resources.`
@@ -186,7 +189,6 @@ Must be of the format '<keyName>:<dataType>'.`
 	countFlagDescription         = "Optional. The number of tasks to set up."
 	cpuFlagDescription           = "Optional. The number of CPU units to reserve for each task."
 	memoryFlagDescription        = "Optional. The amount of memory to reserve in MiB for each task."
-	imageFlagDescription         = "Optional. The docker image to use instead of building from a Dockerfile."
 	taskRoleFlagDescription      = "Optional. The ARN of the role for the task to use."
 	executionRoleFlagDescription = "Optional. The ARN of the role that grants the container agent permission to make AWS API calls."
 	envVarsFlagDescription       = "Optional. Environment variables specified by key=value separated with commas."

--- a/internal/pkg/cli/job_init.go
+++ b/internal/pkg/cli/job_init.go
@@ -142,11 +142,11 @@ func (o *initJobOpts) Ask() error {
 	if err := o.askJobName(); err != nil {
 		return err
 	}
-	useImage, err := o.askDockerfile()
+	dfSelected, err := o.askDockerfile()
 	if err != nil {
 		return err
 	}
-	if useImage {
+	if !dfSelected {
 		if err := o.askImage(); err != nil {
 			return err
 		}
@@ -279,9 +279,10 @@ func (o *initJobOpts) askImage() error {
 	return nil
 }
 
-func (o *initJobOpts) askDockerfile() (useImage bool, err error) {
+// isDfSelected indicates if any Dockerfile is in use.
+func (o *initJobOpts) askDockerfile() (isDfSelected bool, err error) {
 	if o.dockerfilePath != "" || o.image != "" {
-		return false, nil
+		return true, nil
 	}
 	df, err := o.sel.Dockerfile(
 		fmt.Sprintf(fmtWkldInitDockerfilePrompt, color.HighlightUserInput(o.name)),
@@ -296,10 +297,10 @@ func (o *initJobOpts) askDockerfile() (useImage bool, err error) {
 		return false, fmt.Errorf("select Dockerfile: %w", err)
 	}
 	if df == selector.DockerfilePromptUseImage {
-		return true, nil
+		return false, nil
 	}
 	o.dockerfilePath = df
-	return false, nil
+	return true, nil
 }
 
 func (o *initJobOpts) askSchedule() error {

--- a/internal/pkg/cli/svc_init.go
+++ b/internal/pkg/cli/svc_init.go
@@ -53,7 +53,7 @@ const (
 	fmtAddSvcToAppComplete = "Created ECR repositories for service %s.\n"
 
 	wkldInitImagePrompt     = `What's the location of the image to use?`
-	wkldInitImagePromptHelp = `The location of an existing Docker image. Docker Hub registry are available by default.
+	wkldInitImagePromptHelp = `The name of an existing Docker image. Images in the Docker Hub registry are available by default.
 Other repositories are specified with either repository-url/image:tag or repository-url/image@digest`
 )
 
@@ -165,11 +165,11 @@ func (o *initSvcOpts) Ask() error {
 	if err := o.askSvcName(); err != nil {
 		return err
 	}
-	useImage, err := o.askDockerfile()
+	dfSelected, err := o.askDockerfile()
 	if err != nil {
 		return err
 	}
-	if useImage {
+	if !dfSelected {
 		if err := o.askImage(); err != nil {
 			return err
 		}
@@ -350,10 +350,10 @@ func (o *initSvcOpts) askImage() error {
 	return nil
 }
 
-// askDockerfile prompts for the Dockerfile by looking at sub-directories with a Dockerfile.
-func (o *initSvcOpts) askDockerfile() (useImage bool, err error) {
+// isDfSelected indicates if any Dockerfile is in use.
+func (o *initSvcOpts) askDockerfile() (isDfSelected bool, err error) {
 	if o.dockerfilePath != "" || o.image != "" {
-		return false, nil
+		return true, nil
 	}
 	df, err := o.sel.Dockerfile(
 		fmt.Sprintf(fmtWkldInitDockerfilePrompt, color.HighlightUserInput(o.name)),
@@ -368,10 +368,10 @@ func (o *initSvcOpts) askDockerfile() (useImage bool, err error) {
 		return false, fmt.Errorf("select Dockerfile: %w", err)
 	}
 	if df == selector.DockerfilePromptUseImage {
-		return true, nil
+		return false, nil
 	}
 	o.dockerfilePath = df
-	return false, nil
+	return true, nil
 }
 
 func (o *initSvcOpts) askSvcPort() error {

--- a/internal/pkg/cli/svc_init.go
+++ b/internal/pkg/cli/svc_init.go
@@ -138,7 +138,7 @@ func (o *initSvcOpts) Validate() error {
 		}
 	}
 	if o.dockerfilePath != "" && o.image != "" {
-		return fmt.Errorf("--%s and --%s cannot be specified at the same time", dockerFileFlag, imageFlag)
+		return fmt.Errorf("--%s and --%s cannot be specified together", dockerFileFlag, imageFlag)
 	}
 	if o.dockerfilePath != "" {
 		if _, err := o.fs.Stat(o.dockerfilePath); err != nil {

--- a/internal/pkg/cli/svc_init_test.go
+++ b/internal/pkg/cli/svc_init_test.go
@@ -106,6 +106,7 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 		wantedSvcName        = "frontend"
 		wantedDockerfilePath = "frontend/Dockerfile"
 		wantedSvcPort        = 80
+		wantedImage          = "mockImage"
 	)
 	testCases := map[string]struct {
 		inSvcType        string
@@ -333,6 +334,12 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, wantedSvcType, opts.serviceType)
 				require.Equal(t, wantedSvcName, opts.name)
+				if opts.dockerfilePath != "" {
+					require.Equal(t, wantedDockerfilePath, opts.dockerfilePath)
+				}
+				if opts.image != "" {
+					require.Equal(t, wantedImage, opts.image)
+				}
 			}
 		})
 	}

--- a/internal/pkg/cli/svc_init_test.go
+++ b/internal/pkg/cli/svc_init_test.go
@@ -189,6 +189,50 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 			mockDockerfile: func(m *mocks.MockdockerfileParser) {},
 			wantedErr:      nil,
 		},
+		"returns an error if fail to get image location": {
+			inSvcType:        wantedSvcType,
+			inSvcName:        wantedSvcName,
+			inSvcPort:        wantedSvcPort,
+			inDockerfilePath: "",
+
+			mockPrompt: func(m *mocks.Mockprompter) {
+				m.EXPECT().Get(wkldInitImagePrompt, wkldInitImagePromptHelp, nil, gomock.Any()).
+					Return("", mockError)
+			},
+			mockSel: func(m *mocks.MockdockerfileSelector) {
+				m.EXPECT().Dockerfile(
+					gomock.Eq(fmt.Sprintf(fmtWkldInitDockerfilePrompt, wantedSvcName)),
+					gomock.Eq(fmt.Sprintf(fmtWkldInitDockerfilePathPrompt, wantedSvcName)),
+					gomock.Eq(wkldInitDockerfileHelpPrompt),
+					gomock.Eq(wkldInitDockerfilePathHelpPrompt),
+					gomock.Any(),
+				).Return("Use an existing image instead", nil)
+			},
+			mockDockerfile: func(m *mocks.MockdockerfileParser) {},
+			wantedErr:      fmt.Errorf("get image location: mock error"),
+		},
+		"using existing image": {
+			inSvcType:        wantedSvcType,
+			inSvcName:        wantedSvcName,
+			inDockerfilePath: "",
+
+			mockPrompt: func(m *mocks.Mockprompter) {
+				m.EXPECT().Get(wkldInitImagePrompt, wkldInitImagePromptHelp, nil, gomock.Any()).
+					Return("mockImage", nil)
+				m.EXPECT().Get(gomock.Eq(fmt.Sprintf(svcInitSvcPortPrompt, "port")), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(defaultSvcPortString, nil)
+			},
+			mockSel: func(m *mocks.MockdockerfileSelector) {
+				m.EXPECT().Dockerfile(
+					gomock.Eq(fmt.Sprintf(fmtWkldInitDockerfilePrompt, wantedSvcName)),
+					gomock.Eq(fmt.Sprintf(fmtWkldInitDockerfilePathPrompt, wantedSvcName)),
+					gomock.Eq(wkldInitDockerfileHelpPrompt),
+					gomock.Eq(wkldInitDockerfilePathHelpPrompt),
+					gomock.Any(),
+				).Return("Use an existing image instead", nil)
+			},
+			mockDockerfile: func(m *mocks.MockdockerfileParser) {},
+		},
 		"select Dockerfile": {
 			inSvcType:        wantedSvcType,
 			inSvcName:        wantedSvcName,
@@ -221,7 +265,7 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 			},
 			mockPrompt:     func(m *mocks.Mockprompter) {},
 			mockDockerfile: func(m *mocks.MockdockerfileParser) {},
-			wantedErr:      fmt.Errorf("some error"),
+			wantedErr:      fmt.Errorf("select Dockerfile: some error"),
 		},
 		"asks for port if not specified": {
 			inSvcType:        wantedSvcType,

--- a/internal/pkg/cli/svc_init_test.go
+++ b/internal/pkg/cli/svc_init_test.go
@@ -46,7 +46,7 @@ func TestSvcInitOpts_Validate(t *testing.T) {
 			inAppName:        "phonetool",
 			inDockerfilePath: "mockDockerfile",
 			inImage:          "mockImage",
-			wantedErr:        fmt.Errorf("--dockerfile and --image cannot be specified at the same time"),
+			wantedErr:        fmt.Errorf("--dockerfile and --image cannot be specified together"),
 		},
 		"invalid dockerfile directory path": {
 			inAppName:        "phonetool",

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -627,7 +627,7 @@ Run a task with a command.
 
 	cmd.Flags().StringVarP(&vars.groupName, taskGroupNameFlag, nameFlagShort, "", taskGroupFlagDescription)
 
-	cmd.Flags().StringVar(&vars.image, imageFlag, "", imageFlagDescription)
+	cmd.Flags().StringVarP(&vars.image, imageFlag, imageFlagShort, "", imageFlagDescription)
 	cmd.Flags().StringVar(&vars.dockerfilePath, dockerFileFlag, defaultDockerfilePath, dockerFileFlagDescription)
 	cmd.Flags().StringVar(&vars.imageTag, imageTagFlag, "", taskImageTagFlagDescription)
 

--- a/internal/pkg/manifest/backend_svc.go
+++ b/internal/pkg/manifest/backend_svc.go
@@ -76,12 +76,8 @@ func NewBackendService(props BackendServiceProps) *BackendService {
 	}
 	// Apply overrides.
 	svc.Name = aws.String(props.Name)
-	if props.Image != "" {
-		svc.BackendServiceConfig.ImageConfig.Image.Location = aws.String(props.Image)
-	}
-	if props.Dockerfile != "" {
-		svc.BackendServiceConfig.ImageConfig.Build.BuildArgs.Dockerfile = aws.String(props.Dockerfile)
-	}
+	svc.BackendServiceConfig.ImageConfig.Image.Location = stringP(props.Image)
+	svc.BackendServiceConfig.ImageConfig.Build.BuildArgs.Dockerfile = stringP(props.Dockerfile)
 	svc.BackendServiceConfig.ImageConfig.Port = aws.Uint16(props.Port)
 	svc.BackendServiceConfig.ImageConfig.HealthCheck = healthCheck
 	svc.parser = template.New()

--- a/internal/pkg/manifest/backend_svc.go
+++ b/internal/pkg/manifest/backend_svc.go
@@ -76,7 +76,12 @@ func NewBackendService(props BackendServiceProps) *BackendService {
 	}
 	// Apply overrides.
 	svc.Name = aws.String(props.Name)
-	svc.BackendServiceConfig.ImageConfig.Build.BuildArgs.Dockerfile = aws.String(props.Dockerfile)
+	if props.Image != "" {
+		svc.BackendServiceConfig.ImageConfig.Image.Location = aws.String(props.Image)
+	}
+	if props.Dockerfile != "" {
+		svc.BackendServiceConfig.ImageConfig.Build.BuildArgs.Dockerfile = aws.String(props.Dockerfile)
+	}
 	svc.BackendServiceConfig.ImageConfig.Port = aws.Uint16(props.Port)
 	svc.BackendServiceConfig.ImageConfig.HealthCheck = healthCheck
 	svc.parser = template.New()

--- a/internal/pkg/manifest/backend_svc_test.go
+++ b/internal/pkg/manifest/backend_svc_test.go
@@ -59,8 +59,8 @@ func TestNewBackendSvc(t *testing.T) {
 		"with custom healthcheck command": {
 			inProps: BackendServiceProps{
 				WorkloadProps: WorkloadProps{
-					Name:       "subscribers",
-					Dockerfile: "./subscribers/Dockerfile",
+					Name:  "subscribers",
+					Image: "mockImage",
 				},
 				HealthCheck: &ContainerHealthCheck{
 					Command: []string{"CMD", "curl -f http://localhost:8080 || exit 1"},
@@ -76,11 +76,7 @@ func TestNewBackendSvc(t *testing.T) {
 					ImageConfig: imageWithPortAndHealthcheck{
 						ServiceImageWithPort: ServiceImageWithPort{
 							Image: Image{
-								Build: BuildArgsOrString{
-									BuildArgs: DockerBuildArgs{
-										Dockerfile: aws.String("./subscribers/Dockerfile"),
-									},
-								},
+								Location: aws.String("mockImage"),
 							},
 							Port: aws.Uint16(8080),
 						},
@@ -138,8 +134,8 @@ func TestBackendSvc_MarshalBinary(t *testing.T) {
 		"with custom healthcheck command": {
 			inProps: BackendServiceProps{
 				WorkloadProps: WorkloadProps{
-					Name:       "subscribers",
-					Dockerfile: "./subscribers/Dockerfile",
+					Name:  "subscribers",
+					Image: "flask-sample",
 				},
 				HealthCheck: &ContainerHealthCheck{
 					Command:     []string{"CMD-SHELL", "curl -f http://localhost:8080 || exit 1"},

--- a/internal/pkg/manifest/job.go
+++ b/internal/pkg/manifest/job.go
@@ -90,7 +90,12 @@ func NewScheduledJob(props *ScheduledJobProps) *ScheduledJob {
 	job := newDefaultScheduledJob()
 	// Apply overrides.
 	job.Name = aws.String(props.Name)
-	job.ScheduledJobConfig.ImageConfig.Build.BuildArgs.Dockerfile = aws.String(props.Dockerfile)
+	if props.Dockerfile != "" {
+		job.ScheduledJobConfig.ImageConfig.Build.BuildArgs.Dockerfile = aws.String(props.Dockerfile)
+	}
+	if props.Image != "" {
+		job.ScheduledJobConfig.ImageConfig.Location = aws.String(props.Image)
+	}
 	job.Schedule = props.Schedule
 	job.Retries = props.Retries
 	job.Timeout = props.Timeout

--- a/internal/pkg/manifest/job.go
+++ b/internal/pkg/manifest/job.go
@@ -90,12 +90,8 @@ func NewScheduledJob(props *ScheduledJobProps) *ScheduledJob {
 	job := newDefaultScheduledJob()
 	// Apply overrides.
 	job.Name = aws.String(props.Name)
-	if props.Dockerfile != "" {
-		job.ScheduledJobConfig.ImageConfig.Build.BuildArgs.Dockerfile = aws.String(props.Dockerfile)
-	}
-	if props.Image != "" {
-		job.ScheduledJobConfig.ImageConfig.Location = aws.String(props.Image)
-	}
+	job.ScheduledJobConfig.ImageConfig.Build.BuildArgs.Dockerfile = stringP(props.Dockerfile)
+	job.ScheduledJobConfig.ImageConfig.Location = stringP(props.Image)
 	job.Schedule = props.Schedule
 	job.Retries = props.Retries
 	job.Timeout = props.Timeout

--- a/internal/pkg/manifest/job_test.go
+++ b/internal/pkg/manifest/job_test.go
@@ -21,8 +21,8 @@ func TestScheduledJob_MarshalBinary(t *testing.T) {
 		"without timeout or retries": {
 			inProps: ScheduledJobProps{
 				WorkloadProps: &WorkloadProps{
-					Name:       "cuteness-aggregator",
-					Dockerfile: "./cuteness-aggregator/Dockerfile",
+					Name:  "cuteness-aggregator",
+					Image: "copilot/cuteness-aggregator",
 				},
 				Schedule: "@weekly",
 			},

--- a/internal/pkg/manifest/lb_web_svc.go
+++ b/internal/pkg/manifest/lb_web_svc.go
@@ -68,7 +68,12 @@ func NewLoadBalancedWebService(props *LoadBalancedWebServiceProps) *LoadBalanced
 	svc := newDefaultLoadBalancedWebService()
 	// Apply overrides.
 	svc.Name = aws.String(props.Name)
-	svc.LoadBalancedWebServiceConfig.ImageConfig.Build.BuildArgs.Dockerfile = aws.String(props.Dockerfile)
+	if props.Image != "" {
+		svc.LoadBalancedWebServiceConfig.ImageConfig.Image.Location = aws.String(props.Image)
+	}
+	if props.Dockerfile != "" {
+		svc.LoadBalancedWebServiceConfig.ImageConfig.Build.BuildArgs.Dockerfile = aws.String(props.Dockerfile)
+	}
 	svc.LoadBalancedWebServiceConfig.ImageConfig.Port = aws.Uint16(props.Port)
 	svc.RoutingRule.Path = aws.String(props.Path)
 	svc.parser = template.New()

--- a/internal/pkg/manifest/lb_web_svc.go
+++ b/internal/pkg/manifest/lb_web_svc.go
@@ -68,12 +68,8 @@ func NewLoadBalancedWebService(props *LoadBalancedWebServiceProps) *LoadBalanced
 	svc := newDefaultLoadBalancedWebService()
 	// Apply overrides.
 	svc.Name = aws.String(props.Name)
-	if props.Image != "" {
-		svc.LoadBalancedWebServiceConfig.ImageConfig.Image.Location = aws.String(props.Image)
-	}
-	if props.Dockerfile != "" {
-		svc.LoadBalancedWebServiceConfig.ImageConfig.Build.BuildArgs.Dockerfile = aws.String(props.Dockerfile)
-	}
+	svc.LoadBalancedWebServiceConfig.ImageConfig.Image.Location = stringP(props.Image)
+	svc.LoadBalancedWebServiceConfig.ImageConfig.Build.BuildArgs.Dockerfile = stringP(props.Dockerfile)
 	svc.LoadBalancedWebServiceConfig.ImageConfig.Port = aws.Uint16(props.Port)
 	svc.RoutingRule.Path = aws.String(props.Path)
 	svc.parser = template.New()

--- a/internal/pkg/manifest/testdata/backend-svc-customhealthcheck.yml
+++ b/internal/pkg/manifest/testdata/backend-svc-customhealthcheck.yml
@@ -9,8 +9,8 @@ name: subscribers
 type: Backend Service
 
 image:
-  # Docker build arguments. You can specify additional overrides here. Supported: dockerfile, context, args
-  build: ./subscribers/Dockerfile
+  # The Docker image used for your service.
+  location: flask-sample
   # Port exposed through your container to route traffic to it.
   port: 8080
   healthcheck:

--- a/internal/pkg/manifest/testdata/backend-svc-customhealthcheck.yml
+++ b/internal/pkg/manifest/testdata/backend-svc-customhealthcheck.yml
@@ -9,7 +9,7 @@ name: subscribers
 type: Backend Service
 
 image:
-  # The Docker image used for your service.
+  # The name of the Docker image.
   location: flask-sample
   # Port exposed through your container to route traffic to it.
   port: 8080

--- a/internal/pkg/manifest/testdata/backend-svc-nohealthcheck.yml
+++ b/internal/pkg/manifest/testdata/backend-svc-nohealthcheck.yml
@@ -9,7 +9,7 @@ name: subscribers
 type: Backend Service
 
 image:
-  # Docker build arguments. You can specify additional overrides here. Supported: dockerfile, context, args
+  # Docker build arguments. You can specify additional overrides here. Supported: dockerfile, context, args.
   build: ./subscribers/Dockerfile
   # Port exposed through your container to route traffic to it.
   port: 8080

--- a/internal/pkg/manifest/testdata/scheduled-job-fully-specified.yml
+++ b/internal/pkg/manifest/testdata/scheduled-job-fully-specified.yml
@@ -9,7 +9,7 @@ name: cuteness-aggregator
 type: Scheduled Job
 
 image:
-  # Docker build arguments. You can specify additional overrides here. Supported: dockerfile, context, args
+  # Docker build arguments. You can specify additional overrides here. Supported: dockerfile, context, args.
   build: ./cuteness-aggregator/Dockerfile
 
 # Number of CPU units for the task.

--- a/internal/pkg/manifest/testdata/scheduled-job-no-retries.yml
+++ b/internal/pkg/manifest/testdata/scheduled-job-no-retries.yml
@@ -9,7 +9,7 @@ name: cuteness-aggregator
 type: Scheduled Job
 
 image:
-  # Docker build arguments. You can specify additional overrides here. Supported: dockerfile, context, args
+  # Docker build arguments. You can specify additional overrides here. Supported: dockerfile, context, args.
   build: ./cuteness-aggregator/Dockerfile
 
 # Number of CPU units for the task.

--- a/internal/pkg/manifest/testdata/scheduled-job-no-timeout-or-retries.yml
+++ b/internal/pkg/manifest/testdata/scheduled-job-no-timeout-or-retries.yml
@@ -9,7 +9,7 @@ name: cuteness-aggregator
 type: Scheduled Job
 
 image:
-  # The Docker image used for your service.
+  # The name of the Docker image.
   location: copilot/cuteness-aggregator
 
 # Number of CPU units for the task.

--- a/internal/pkg/manifest/testdata/scheduled-job-no-timeout-or-retries.yml
+++ b/internal/pkg/manifest/testdata/scheduled-job-no-timeout-or-retries.yml
@@ -9,8 +9,8 @@ name: cuteness-aggregator
 type: Scheduled Job
 
 image:
-  # Docker build arguments. You can specify additional overrides here. Supported: dockerfile, context, args
-  build: ./cuteness-aggregator/Dockerfile
+  # The Docker image used for your service.
+  location: copilot/cuteness-aggregator
 
 # Number of CPU units for the task.
 cpu: 256

--- a/internal/pkg/manifest/testdata/scheduled-job-no-timeout.yml
+++ b/internal/pkg/manifest/testdata/scheduled-job-no-timeout.yml
@@ -9,7 +9,7 @@ name: cuteness-aggregator
 type: Scheduled Job
 
 image:
-  # Docker build arguments. You can specify additional overrides here. Supported: dockerfile, context, args
+  # Docker build arguments. You can specify additional overrides here. Supported: dockerfile, context, args.
   build: ./cuteness-aggregator/Dockerfile
 
 # Number of CPU units for the task.

--- a/internal/pkg/manifest/workload.go
+++ b/internal/pkg/manifest/workload.go
@@ -263,6 +263,7 @@ type TaskConfig struct {
 type WorkloadProps struct {
 	Name       string
 	Dockerfile string
+	Image      string
 }
 
 // UnmarshalWorkload deserializes the YAML input stream into a workload manifest object.

--- a/internal/pkg/manifest/workload.go
+++ b/internal/pkg/manifest/workload.go
@@ -306,6 +306,7 @@ func UnmarshalWorkload(in []byte) (interface{}, error) {
 
 func requiresBuild(image Image) (bool, error) {
 	noBuild, noURL := image.Build.isEmpty(), image.Location == nil
+	// Error if both of them are specified or neither is specified.
 	if noBuild == noURL {
 		return false, fmt.Errorf(`either "image.build" or "image.location" needs to be specified in the manifest`)
 	}

--- a/internal/pkg/manifest/workload.go
+++ b/internal/pkg/manifest/workload.go
@@ -305,8 +305,8 @@ func UnmarshalWorkload(in []byte) (interface{}, error) {
 }
 
 func requiresBuild(image Image) (bool, error) {
-	hasBuild, hasURL := image.Build.isEmpty(), image.Location == nil
-	if hasBuild == hasURL {
+	noBuild, noURL := image.Build.isEmpty(), image.Location == nil
+	if noBuild == noURL {
 		return false, fmt.Errorf(`either "image.build" or "image.location" needs to be specified in the manifest`)
 	}
 	if image.Location == nil {

--- a/internal/pkg/manifest/workload.go
+++ b/internal/pkg/manifest/workload.go
@@ -329,3 +329,10 @@ func dockerfileBuildRequired(workloadType string, svc interface{}) (bool, error)
 	}
 	return required, nil
 }
+
+func stringP(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}

--- a/internal/pkg/term/selector/selector.go
+++ b/internal/pkg/term/selector/selector.go
@@ -31,21 +31,10 @@ const (
 	yearly  = "Yearly"
 )
 
-var scheduleTypes = []string{
-	rate,
-	fixedSchedule,
-}
+const (
+	// DockerfilePromptUseImage is the option for using existing image instead of Dockerfile.
+	DockerfilePromptUseImage = "Use an existing image instead"
 
-var presetSchedules = []string{
-	custom,
-	hourly,
-	daily,
-	weekly,
-	monthly,
-	yearly,
-}
-
-var (
 	ratePrompt = "How long would you like to wait between executions?"
 	rateHelp   = `You can specify the time as a duration string. (For example, 2m, 1h30m, 24h)`
 
@@ -61,6 +50,20 @@ For example: 0 17 ? * MON-FRI (5 pm on weekdays)
 	humanReadableCronConfirmHelp   = `Confirm whether the schedule looks right to you.
 (Y)es will continue execution. (N)o will allow you to input a different schedule.`
 )
+
+var scheduleTypes = []string{
+	rate,
+	fixedSchedule,
+}
+
+var presetSchedules = []string{
+	custom,
+	hourly,
+	daily,
+	weekly,
+	monthly,
+	yearly,
+}
 
 // Prompter wraps the methods to ask for inputs from the terminal.
 type Prompter interface {
@@ -436,6 +439,7 @@ func (s *WorkspaceSelect) Dockerfile(selPrompt, notFoundPrompt, selHelp, notFoun
 	// If Dockerfiles are found in the current directory or subdirectory one level down, ask the user to select one.
 	var sel string
 	if err == nil {
+		dockerfiles = append(dockerfiles, DockerfilePromptUseImage)
 		sel, err = s.prompt.SelectOne(
 			selPrompt,
 			selHelp,

--- a/internal/pkg/term/selector/selector_test.go
+++ b/internal/pkg/term/selector/selector_test.go
@@ -884,7 +884,12 @@ func TestWorkspaceSelect_Dockerfile(t *testing.T) {
 			mockPrompt: func(m *mocks.MockPrompter) {
 				m.EXPECT().SelectOne(
 					gomock.Any(), gomock.Any(),
-					gomock.Eq(dockerfiles),
+					gomock.Eq([]string{
+						"./Dockerfile",
+						"backend/Dockerfile",
+						"frontend/Dockerfile",
+						"Use an existing image instead",
+					}),
 					gomock.Any(),
 				).Return("frontend/Dockerfile", nil)
 			},

--- a/templates/workloads/jobs/scheduled-job/manifest.yml
+++ b/templates/workloads/jobs/scheduled-job/manifest.yml
@@ -14,7 +14,7 @@ image:
   build: {{.ImageConfig.Build.BuildArgs.Dockerfile}}
 {{- end}}
 {{- if .ImageConfig.Location}}
-  # The Docker image used for your service.
+  # The name of the Docker image.
   location: {{.ImageConfig.Location}}
 {{- end}}
 

--- a/templates/workloads/jobs/scheduled-job/manifest.yml
+++ b/templates/workloads/jobs/scheduled-job/manifest.yml
@@ -9,8 +9,14 @@ name: {{.Name}}
 type: {{.Type}}
 
 image:
-  # Docker build arguments. You can specify additional overrides here. Supported: dockerfile, context, args
+{{- if .ImageConfig.Build.BuildArgs.Dockerfile}}
+  # Docker build arguments. You can specify additional overrides here. Supported: dockerfile, context, args.
   build: {{.ImageConfig.Build.BuildArgs.Dockerfile}}
+{{- end}}
+{{- if .ImageConfig.Location}}
+  # The Docker image used for your service.
+  location: {{.ImageConfig.Location}}
+{{- end}}
 
 # Number of CPU units for the task.
 cpu: {{.CPU}}

--- a/templates/workloads/services/backend/manifest.yml
+++ b/templates/workloads/services/backend/manifest.yml
@@ -14,7 +14,7 @@ image:
   build: {{.ImageConfig.Build.BuildArgs.Dockerfile}}
 {{- end}}
 {{- if .ImageConfig.Image.Location}}
-  # The Docker image used for your service.
+  # The name of the Docker image.
   location: {{.ImageConfig.Image.Location}}
 {{- end}}
   # Port exposed through your container to route traffic to it.

--- a/templates/workloads/services/backend/manifest.yml
+++ b/templates/workloads/services/backend/manifest.yml
@@ -9,17 +9,25 @@ name: {{.Name}}
 type: {{.Type}}
 
 image:
-  # Docker build arguments. You can specify additional overrides here. Supported: dockerfile, context, args
+{{- if .ImageConfig.Build.BuildArgs.Dockerfile}}
+  # Docker build arguments. You can specify additional overrides here. Supported: dockerfile, context, args.
   build: {{.ImageConfig.Build.BuildArgs.Dockerfile}}
+{{- end}}
+{{- if .ImageConfig.Image.Location}}
+  # The Docker image used for your service.
+  location: {{.ImageConfig.Image.Location}}
+{{- end}}
   # Port exposed through your container to route traffic to it.
-  port: {{.ImageConfig.Port}}{{if .ImageConfig.HealthCheck}}
+  port: {{.ImageConfig.Port}}
+{{- if .ImageConfig.HealthCheck}}
   healthcheck:
     # The command the container runs to determine if it's healthy.
     command: {{fmtSlice (quoteSlice .ImageConfig.HealthCheck.Command)}}
     interval: {{.ImageConfig.HealthCheck.Interval}}  # Time period between healthchecks. Default is 10s.
     retries: {{.ImageConfig.HealthCheck.Retries}}      # Number of times to retry before container is deemed unhealthy. Default is 2.
     timeout: {{.ImageConfig.HealthCheck.Timeout}}     # How long to wait before considering the healthcheck failed. Default is 5s.
-    start_period: {{.ImageConfig.HealthCheck.StartPeriod}} # Grace period within which to provide containers time to bootstrap before failed health checks count towards the maximum number of retries. Default is 0s.{{end}}
+    start_period: {{.ImageConfig.HealthCheck.StartPeriod}} # Grace period within which to provide containers time to bootstrap before failed health checks count towards the maximum number of retries. Default is 0s.
+{{- end}}
 
 # Number of CPU units for the task.
 cpu: {{.CPU}}

--- a/templates/workloads/services/lb-web/manifest.yml
+++ b/templates/workloads/services/lb-web/manifest.yml
@@ -8,8 +8,14 @@ name: {{.Name}}
 type: {{.Type}}
 
 image:
-  # Docker build arguments. You can specify additional overrides here. Supported: dockerfile, context, args
+{{- if .ImageConfig.Build.BuildArgs.Dockerfile}}
+  # Docker build arguments. You can specify additional overrides here. Supported: dockerfile, context, args.
   build: {{.ImageConfig.Build.BuildArgs.Dockerfile}}
+{{- end}}
+{{- if .ImageConfig.Image.Location}}
+  # The Docker image used for your service.
+  location: {{.ImageConfig.Image.Location}}
+{{- end}}
   # Port exposed through your container to route traffic to it.
   port: {{.ImageConfig.Port}}
 

--- a/templates/workloads/services/lb-web/manifest.yml
+++ b/templates/workloads/services/lb-web/manifest.yml
@@ -13,7 +13,7 @@ image:
   build: {{.ImageConfig.Build.BuildArgs.Dockerfile}}
 {{- end}}
 {{- if .ImageConfig.Image.Location}}
-  # The Docker image used for your service.
+  # The name of the Docker image.
   location: {{.ImageConfig.Image.Location}}
 {{- end}}
   # Port exposed through your container to route traffic to it.


### PR DESCRIPTION
<!-- Provide summary of changes -->
Add image flag to `svc init` and `job init` so that users can opt-in using existing docker image instead of building from local Dockerfile, and write to the manifest.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
