### PR TITLE
chore(cli): add image location option to job manifest and job deploy

### DIFF
--- a/internal/pkg/cli/job_deploy.go
+++ b/internal/pkg/cli/job_deploy.go
@@ -226,7 +226,7 @@ func (o *deployJobOpts) configureContainerImage() error {
 	if err != nil {
 		return err
 	}
-	required, err := manifest.ServiceDockerfileBuildRequired(job)
+	required, err := manifest.JobDockerfileBuildRequired(job)
 	if err != nil {
 		return err
 	}
@@ -295,6 +295,12 @@ func (o *deployJobOpts) stackConfiguration(addonsURL string) (cloudformation.Sta
 }
 
 func (o *deployJobOpts) runtimeConfig(addonsURL string) (*stack.RuntimeConfig, error) {
+	if !o.buildRequired {
+		return &stack.RuntimeConfig{
+			AddonsTemplateURL: addonsURL,
+			AdditionalTags:    tags.Merge(o.targetApp.Tags, o.resourceTags),
+		}, nil
+	}
 	resources, err := o.appCFN.GetAppResourcesByRegion(o.targetApp, o.targetEnvironment.Region)
 	if err != nil {
 		return nil, fmt.Errorf("get application %s resources from region %s: %w", o.targetApp.Name, o.targetEnvironment.Region, err)

--- a/internal/pkg/manifest/job.go
+++ b/internal/pkg/manifest/job.go
@@ -36,7 +36,7 @@ type ScheduledJob struct {
 
 // ScheduledJobConfig holds the configuration for a scheduled job
 type ScheduledJobConfig struct {
-	ImageConfig    Image `yaml:",flow"`
+	ImageConfig    Image `yaml:"image,flow"`
 	TaskConfig     `yaml:",inline"`
 	*Logging       `yaml:"logging,flow"`
 	Sidecar        `yaml:",inline"`


### PR DESCRIPTION
<!-- Provide summary of changes -->
This PR addresses the remaining work in job deploy involved in adding the image location to the manifest.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->
related #1131 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
