### PR TITLE
chore(cicd): fix pipeline fails to build even if location is not provided

### DIFF
--- a/templates/cicd/buildspec.yml
+++ b/templates/cicd/buildspec.yml
@@ -56,7 +56,8 @@ phases:
         for svc in $svcs; do
           manifest=$(cat $CODEBUILD_SRC_DIR/copilot/$svc/manifest.yml | ruby -ryaml -rjson -e 'puts JSON.pretty_generate(YAML.load(ARGF))')
           image_location=$(echo $manifest | jq '.image.location')
-          if [ -n "$image_location" ]; then
+          if [ ! "$image_location" = null ]; then
+            echo "skipping image building because location is provided as $image_location";
             continue
           fi
           base_dockerfile=$(echo $manifest | jq '.image.build')


### PR DESCRIPTION
<!-- Provide summary of changes -->
#1444 introduces a bug that pipeline fails to build from dockerfile even if `image.location` is not provided in the manifest. Thi is because [`$image_location`](https://github.com/aws/copilot-cli/blob/mainline/templates/cicd/buildspec.yml#L58) is actually "null" if location is not provided instead of an empty string. So the existing [condition](https://github.com/aws/copilot-cli/blob/mainline/templates/cicd/buildspec.yml#L59-L61) is always trigged no matter `image.location` is provided or not.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
