### PR TITLE
fix(cli): limit image tag warning to log only conditionally

### DIFF
--- a/internal/pkg/cli/git.go
+++ b/internal/pkg/cli/git.go
@@ -9,9 +9,7 @@ import (
 	"strings"
 
 	"github.com/aws/copilot-cli/internal/pkg/term/command"
-
 	"github.com/aws/copilot-cli/internal/pkg/term/log"
-
 	"github.com/aws/copilot-cli/internal/pkg/term/prompt"
 )
 
@@ -35,8 +33,8 @@ func askImageTag(tag string, prompter prompter, cmd runner) (string, error) {
 		return tag, nil
 	}
 	tag, err := getVersionTag(cmd)
-	log.Warningln("Failed to default tag, are you in a git repository?")
 	if err != nil {
+		log.Warningln("Failed to default tag, are you in a git repository?")
 		// User is not in a Git repository, so prompt for a tag.
 		tag, err = prompter.Get(inputImageTagPrompt, "", prompt.RequireNonEmpty)
 		if err != nil {

--- a/internal/pkg/cli/git.go
+++ b/internal/pkg/cli/git.go
@@ -34,7 +34,7 @@ func askImageTag(tag string, prompter prompter, cmd runner) (string, error) {
 	}
 	tag, err := getVersionTag(cmd)
 	if err != nil {
-		log.Warningln("Failed to default tag, are you in a git repository?")
+		log.Warningln("Couldn't find a git commit sha to use as an image tag. Are you in a git repository?")
 		// User is not in a Git repository, so prompt for a tag.
 		tag, err = prompter.Get(inputImageTagPrompt, "", prompt.RequireNonEmpty)
 		if err != nil {


### PR DESCRIPTION
Fixes bug introduced in https://github.com/aws/copilot-cli/pull/1480.
Warning about not being in git repo was appearing even when user was in git repo.
This moves that warning so it's within a conditional.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
