### PR TITLE
feat(cli): enable Job command family

### DIFF
--- a/cmd/copilot/main.go
+++ b/cmd/copilot/main.go
@@ -58,7 +58,7 @@ func buildRootCmd() *cobra.Command {
 	cmd.AddCommand(cli.BuildEnvCmd())
 	cmd.AddCommand(cli.BuildSvcCmd())
 	cmd.AddCommand(cli.BuildTaskCmd())
-	// cmd.AddCommand(cli.BuildJobCmd())
+	cmd.AddCommand(cli.BuildJobCmd())
 
 	// "Addons" command group
 	cmd.AddCommand(cli.BuildStorageCmd())


### PR DESCRIPTION
<!-- Provide summary of changes -->
Enables the `job` command family. This allows access to `job init`, `job deploy`, `job package`, `job ls`, and `job delete`, with more to come!

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->
#1131 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
