### PR TITLE
fix(sel): add ListJobs to ConfigLister

### DIFF
--- a/internal/pkg/term/selector/mocks/mock_selector.go
+++ b/internal/pkg/term/selector/mocks/mock_selector.go
@@ -168,31 +168,31 @@ func (mr *MockAppEnvListerMockRecorder) ListApplications() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListApplications", reflect.TypeOf((*MockAppEnvLister)(nil).ListApplications))
 }
 
-// MockConfigWlLister is a mock of ConfigWlLister interface
-type MockConfigWlLister struct {
+// MockConfigWorkloadLister is a mock of ConfigWorkloadLister interface
+type MockConfigWorkloadLister struct {
 	ctrl     *gomock.Controller
-	recorder *MockConfigWlListerMockRecorder
+	recorder *MockConfigWorkloadListerMockRecorder
 }
 
-// MockConfigWlListerMockRecorder is the mock recorder for MockConfigWlLister
-type MockConfigWlListerMockRecorder struct {
-	mock *MockConfigWlLister
+// MockConfigWorkloadListerMockRecorder is the mock recorder for MockConfigWorkloadLister
+type MockConfigWorkloadListerMockRecorder struct {
+	mock *MockConfigWorkloadLister
 }
 
-// NewMockConfigWlLister creates a new mock instance
-func NewMockConfigWlLister(ctrl *gomock.Controller) *MockConfigWlLister {
-	mock := &MockConfigWlLister{ctrl: ctrl}
-	mock.recorder = &MockConfigWlListerMockRecorder{mock}
+// NewMockConfigWorkloadLister creates a new mock instance
+func NewMockConfigWorkloadLister(ctrl *gomock.Controller) *MockConfigWorkloadLister {
+	mock := &MockConfigWorkloadLister{ctrl: ctrl}
+	mock.recorder = &MockConfigWorkloadListerMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use
-func (m *MockConfigWlLister) EXPECT() *MockConfigWlListerMockRecorder {
+func (m *MockConfigWorkloadLister) EXPECT() *MockConfigWorkloadListerMockRecorder {
 	return m.recorder
 }
 
 // ListServices mocks base method
-func (m *MockConfigWlLister) ListServices(appName string) ([]*config.Workload, error) {
+func (m *MockConfigWorkloadLister) ListServices(appName string) ([]*config.Workload, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListServices", appName)
 	ret0, _ := ret[0].([]*config.Workload)
@@ -201,13 +201,13 @@ func (m *MockConfigWlLister) ListServices(appName string) ([]*config.Workload, e
 }
 
 // ListServices indicates an expected call of ListServices
-func (mr *MockConfigWlListerMockRecorder) ListServices(appName interface{}) *gomock.Call {
+func (mr *MockConfigWorkloadListerMockRecorder) ListServices(appName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServices", reflect.TypeOf((*MockConfigWlLister)(nil).ListServices), appName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServices", reflect.TypeOf((*MockConfigWorkloadLister)(nil).ListServices), appName)
 }
 
 // ListJobs mocks base method
-func (m *MockConfigWlLister) ListJobs(appName string) ([]*config.Workload, error) {
+func (m *MockConfigWorkloadLister) ListJobs(appName string) ([]*config.Workload, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListJobs", appName)
 	ret0, _ := ret[0].([]*config.Workload)
@@ -216,9 +216,9 @@ func (m *MockConfigWlLister) ListJobs(appName string) ([]*config.Workload, error
 }
 
 // ListJobs indicates an expected call of ListJobs
-func (mr *MockConfigWlListerMockRecorder) ListJobs(appName interface{}) *gomock.Call {
+func (mr *MockConfigWorkloadListerMockRecorder) ListJobs(appName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListJobs", reflect.TypeOf((*MockConfigWlLister)(nil).ListJobs), appName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListJobs", reflect.TypeOf((*MockConfigWorkloadLister)(nil).ListJobs), appName)
 }
 
 // MockConfigLister is a mock of ConfigLister interface

--- a/internal/pkg/term/selector/mocks/mock_selector.go
+++ b/internal/pkg/term/selector/mocks/mock_selector.go
@@ -168,31 +168,31 @@ func (mr *MockAppEnvListerMockRecorder) ListApplications() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListApplications", reflect.TypeOf((*MockAppEnvLister)(nil).ListApplications))
 }
 
-// MockConfigSvcLister is a mock of ConfigSvcLister interface
-type MockConfigSvcLister struct {
+// MockConfigWlLister is a mock of ConfigWlLister interface
+type MockConfigWlLister struct {
 	ctrl     *gomock.Controller
-	recorder *MockConfigSvcListerMockRecorder
+	recorder *MockConfigWlListerMockRecorder
 }
 
-// MockConfigSvcListerMockRecorder is the mock recorder for MockConfigSvcLister
-type MockConfigSvcListerMockRecorder struct {
-	mock *MockConfigSvcLister
+// MockConfigWlListerMockRecorder is the mock recorder for MockConfigWlLister
+type MockConfigWlListerMockRecorder struct {
+	mock *MockConfigWlLister
 }
 
-// NewMockConfigSvcLister creates a new mock instance
-func NewMockConfigSvcLister(ctrl *gomock.Controller) *MockConfigSvcLister {
-	mock := &MockConfigSvcLister{ctrl: ctrl}
-	mock.recorder = &MockConfigSvcListerMockRecorder{mock}
+// NewMockConfigWlLister creates a new mock instance
+func NewMockConfigWlLister(ctrl *gomock.Controller) *MockConfigWlLister {
+	mock := &MockConfigWlLister{ctrl: ctrl}
+	mock.recorder = &MockConfigWlListerMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use
-func (m *MockConfigSvcLister) EXPECT() *MockConfigSvcListerMockRecorder {
+func (m *MockConfigWlLister) EXPECT() *MockConfigWlListerMockRecorder {
 	return m.recorder
 }
 
 // ListServices mocks base method
-func (m *MockConfigSvcLister) ListServices(appName string) ([]*config.Workload, error) {
+func (m *MockConfigWlLister) ListServices(appName string) ([]*config.Workload, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListServices", appName)
 	ret0, _ := ret[0].([]*config.Workload)
@@ -201,9 +201,24 @@ func (m *MockConfigSvcLister) ListServices(appName string) ([]*config.Workload, 
 }
 
 // ListServices indicates an expected call of ListServices
-func (mr *MockConfigSvcListerMockRecorder) ListServices(appName interface{}) *gomock.Call {
+func (mr *MockConfigWlListerMockRecorder) ListServices(appName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServices", reflect.TypeOf((*MockConfigSvcLister)(nil).ListServices), appName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServices", reflect.TypeOf((*MockConfigWlLister)(nil).ListServices), appName)
+}
+
+// ListJobs mocks base method
+func (m *MockConfigWlLister) ListJobs(appName string) ([]*config.Workload, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListJobs", appName)
+	ret0, _ := ret[0].([]*config.Workload)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListJobs indicates an expected call of ListJobs
+func (mr *MockConfigWlListerMockRecorder) ListJobs(appName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListJobs", reflect.TypeOf((*MockConfigWlLister)(nil).ListJobs), appName)
 }
 
 // MockConfigLister is a mock of ConfigLister interface
@@ -272,6 +287,21 @@ func (m *MockConfigLister) ListServices(appName string) ([]*config.Workload, err
 func (mr *MockConfigListerMockRecorder) ListServices(appName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServices", reflect.TypeOf((*MockConfigLister)(nil).ListServices), appName)
+}
+
+// ListJobs mocks base method
+func (m *MockConfigLister) ListJobs(appName string) ([]*config.Workload, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListJobs", appName)
+	ret0, _ := ret[0].([]*config.Workload)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListJobs indicates an expected call of ListJobs
+func (mr *MockConfigListerMockRecorder) ListJobs(appName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListJobs", reflect.TypeOf((*MockConfigLister)(nil).ListJobs), appName)
 }
 
 // MockWsWorkloadLister is a mock of WsWorkloadLister interface

--- a/internal/pkg/term/selector/selector.go
+++ b/internal/pkg/term/selector/selector.go
@@ -79,8 +79,8 @@ type AppEnvLister interface {
 	ListApplications() ([]*config.Application, error)
 }
 
-// ConfigWlLister wraps the method to list workloads in config store.
-type ConfigWlLister interface {
+// ConfigWorkloadLister wraps the method to list workloads in config store.
+type ConfigWorkloadLister interface {
 	ListServices(appName string) ([]*config.Workload, error)
 	ListJobs(appName string) ([]*config.Workload, error)
 }
@@ -88,7 +88,7 @@ type ConfigWlLister interface {
 // ConfigLister wraps config store listing methods.
 type ConfigLister interface {
 	AppEnvLister
-	ConfigWlLister
+	ConfigWorkloadLister
 }
 
 // WsWorkloadLister wraps the method to get workloads in current workspace.
@@ -119,7 +119,7 @@ type Select struct {
 // ConfigSelect is an application and environment selector, but can also choose a service from the config store.
 type ConfigSelect struct {
 	*Select
-	svcLister ConfigWlLister
+	svcLister ConfigWorkloadLister
 }
 
 // WorkspaceSelect  is an application and environment selector, but can also choose a service from the workspace.

--- a/internal/pkg/term/selector/selector.go
+++ b/internal/pkg/term/selector/selector.go
@@ -79,15 +79,16 @@ type AppEnvLister interface {
 	ListApplications() ([]*config.Application, error)
 }
 
-// ConfigSvcLister wraps the method to list svcs in config store.
-type ConfigSvcLister interface {
+// ConfigWlLister wraps the method to list workloads in config store.
+type ConfigWlLister interface {
 	ListServices(appName string) ([]*config.Workload, error)
+	ListJobs(appName string) ([]*config.Workload, error)
 }
 
 // ConfigLister wraps config store listing methods.
 type ConfigLister interface {
 	AppEnvLister
-	ConfigSvcLister
+	ConfigWlLister
 }
 
 // WsWorkloadLister wraps the method to get workloads in current workspace.
@@ -118,7 +119,7 @@ type Select struct {
 // ConfigSelect is an application and environment selector, but can also choose a service from the config store.
 type ConfigSelect struct {
 	*Select
-	svcLister ConfigSvcLister
+	svcLister ConfigWlLister
 }
 
 // WorkspaceSelect  is an application and environment selector, but can also choose a service from the workspace.
@@ -304,7 +305,7 @@ func (s *WorkspaceSelect) Job(msg, help string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("retrieve jobs from workspace: %w", err)
 	}
-	storeJobNames, err := s.Select.config.ListServices(summary.Application)
+	storeJobNames, err := s.Select.config.ListJobs(summary.Application)
 	if err != nil {
 		return "", fmt.Errorf("retrieve jobs from store: %w", err)
 	}

--- a/internal/pkg/term/selector/selector_test.go
+++ b/internal/pkg/term/selector/selector_test.go
@@ -504,7 +504,7 @@ func TestWorkspaceSelect_Job(t *testing.T) {
 					&workspace.Summary{
 						Application: "app-name",
 					}, nil)
-				m.configLister.EXPECT().ListServices("app-name").Return(
+				m.configLister.EXPECT().ListJobs("app-name").Return(
 					[]*config.Workload{}, nil).Times(1)
 				m.prompt.
 					EXPECT().
@@ -524,7 +524,7 @@ func TestWorkspaceSelect_Job(t *testing.T) {
 					&workspace.Summary{
 						Application: "app-name",
 					}, nil)
-				m.configLister.EXPECT().ListServices("app-name").Return(
+				m.configLister.EXPECT().ListJobs("app-name").Return(
 					[]*config.Workload{}, nil).Times(1)
 				m.prompt.
 					EXPECT().
@@ -542,7 +542,7 @@ func TestWorkspaceSelect_Job(t *testing.T) {
 					&workspace.Summary{
 						Application: "app-name",
 					}, nil)
-				m.configLister.EXPECT().ListServices("app-name").Return(
+				m.configLister.EXPECT().ListJobs("app-name").Return(
 					[]*config.Workload{
 						{
 							App:  "app-name",
@@ -569,7 +569,7 @@ func TestWorkspaceSelect_Job(t *testing.T) {
 					&workspace.Summary{
 						Application: "app-name",
 					}, nil)
-				m.configLister.EXPECT().ListServices("app-name").Return(
+				m.configLister.EXPECT().ListJobs("app-name").Return(
 					[]*config.Workload{
 						{
 							App:  "app-name",
@@ -596,7 +596,7 @@ func TestWorkspaceSelect_Job(t *testing.T) {
 					&workspace.Summary{
 						Application: "app-name",
 					}, nil)
-				m.configLister.EXPECT().ListServices("app-name").Return(
+				m.configLister.EXPECT().ListJobs("app-name").Return(
 					[]*config.Workload{
 						{
 							App:  "app-name",
@@ -620,7 +620,7 @@ func TestWorkspaceSelect_Job(t *testing.T) {
 					&workspace.Summary{
 						Application: "app-name",
 					}, nil)
-				m.configLister.EXPECT().ListServices("app-name").Return(
+				m.configLister.EXPECT().ListJobs("app-name").Return(
 					[]*config.Workload{
 						{
 							App:  "app-name",
@@ -658,7 +658,7 @@ func TestWorkspaceSelect_Job(t *testing.T) {
 					}, nil)
 				m.configLister.
 					EXPECT().
-					ListServices("app-name").
+					ListJobs("app-name").
 					Return(
 						[]*config.Workload{
 							{
@@ -713,7 +713,7 @@ func TestWorkspaceSelect_Job(t *testing.T) {
 					&workspace.Summary{
 						Application: "app-name",
 					}, nil)
-				m.configLister.EXPECT().ListServices("app-name").Return(
+				m.configLister.EXPECT().ListJobs("app-name").Return(
 					nil, errors.New("some error"))
 			},
 			wantErr: errors.New("retrieve jobs from store: some error"),
@@ -729,7 +729,7 @@ func TestWorkspaceSelect_Job(t *testing.T) {
 					&workspace.Summary{
 						Application: "app-name",
 					}, nil)
-				m.configLister.EXPECT().ListServices("app-name").Return(
+				m.configLister.EXPECT().ListJobs("app-name").Return(
 					[]*config.Workload{
 						{
 							App:  "app-name",


### PR DESCRIPTION
Added `ListJobs()` to ConfigSvcLister and renamed to ConfigWlLister.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
