### PR TITLE
docs: Update relative path for links

### DIFF
--- a/site/content/docs/concepts/environments.md
+++ b/site/content/docs/concepts/environments.md
@@ -2,7 +2,7 @@ When you first run `copilot init` you're asked if you want to create a _test_ en
 
 While Copilot creates a test environment for you when you get started, it's common to create a new, seperate environment for production. This production environment will be completly independent from the test environment, with its own networking stack and its own copy of services. By having both a test environment and a production environment, you can deploy changes to your test environment, validate them, then promote them to the production environment.
 
-In the diagram below we have an application called _MyApp_ with two services, _API_ and _Backend_. Those two services are deployed to the two environments, _test_ and _prod_. You can see that in the _test_ environment, both services are running only one container while the _prod_ services have more containers running. Services can use different configurations depending on the environment they're deployed in. For more check out the [using environment variables](/docs/developing/environment-variables/) guide.
+In the diagram below we have an application called _MyApp_ with two services, _API_ and _Backend_. Those two services are deployed to the two environments, _test_ and _prod_. You can see that in the _test_ environment, both services are running only one container while the _prod_ services have more containers running. Services can use different configurations depending on the environment they're deployed in. For more check out the [using environment variables](../developing/environment-variables.md) guide.
 
 ![](https://user-images.githubusercontent.com/879348/85873795-7da9c480-b786-11ea-9990-9604a3cc5f01.png)
 

--- a/site/content/docs/concepts/services.md
+++ b/site/content/docs/concepts/services.md
@@ -76,7 +76,7 @@ environments:
   prod:
     count: 2               # Number of tasks to run for the "test" environment.
 ```
-To learn about the specification of manifest files, see the [manifests](/docs/manifest/overview) page.
+To learn about the specification of manifest files, see the [manifests](../manifest/overview.md) page.
 
 ## Deploying a Service
 

--- a/site/content/docs/developing/additional-aws-resources.md
+++ b/site/content/docs/developing/additional-aws-resources.md
@@ -1,12 +1,12 @@
 # Additional AWS Resources
 
-Additional AWS resources, referred as "addons" in the CLI, are any additional AWS services that a [service manifest](/docs/manifest/overview) does not integrate by default. For example, an addon can be a DynamoDB table or S3 bucket that your service needs to read or write to.
+Additional AWS resources, referred as "addons" in the CLI, are any additional AWS services that a [service manifest](../manifest/overview.md) does not integrate by default. For example, an addon can be a DynamoDB table or S3 bucket that your service needs to read or write to.
 
 ## How do I add an S3 bucket or DDB Table?
 
 Copilot provides the following commands to help you create certain kinds of addons:
 
-* [`storage init`](/docs/commands/storage-init/) will create a DynamoDB table or S3 bucket.  
+* [`storage init`](../commands/storage-init.md) will create a DynamoDB table or S3 bucket.  
 
 You can run `copilot storage init` from your workspace and be guided through some questions to help you set up these resources.
 

--- a/site/content/docs/developing/environment-variables.md
+++ b/site/content/docs/developing/environment-variables.md
@@ -27,11 +27,11 @@ By default, the AWS Copilot CLI passes in some default environment variables for
 * `COPILOT_ENVIRONMENT_NAME` - this is the name of the environment the service is running in (test vs prod, for example)
 * `COPILOT_SERVICE_NAME` - this is the name of the current service. 
 * `COPILOT_LB_DNS` - this is the DNS name of the Load Balancer (if it exists) such as _kudos-Publi-MC2WNHAIOAVS-588300247.us-west-2.elb.amazonaws.com_. One note, if you're using a custom domain name, this value will still be the Load Balancer's DNS name. 
-* `COPILOT_SERVICE_DISCOVERY_ENDPOINT` - this is the endpoint to add after a service name to talk to another service in your environment via service discovery. The value is `{app name}.local`. For more information about service discovery checkout our [service discovery guide](/docs/developing/service-discovery).
+* `COPILOT_SERVICE_DISCOVERY_ENDPOINT` - this is the endpoint to add after a service name to talk to another service in your environment via service discovery. The value is `{app name}.local`. For more information about service discovery checkout our [service discovery guide](../developing/service-discovery.md).
 
 ## How do I add my own Environment Variables?
 
-Adding your own environment variable is easy. You can add them directly to your [manifest](/docs/manifest/overview) in the `variables` section. The following snippet will pass a environment variable called `LOG_LEVEL` to your service, with the value set to `debug`. 
+Adding your own environment variable is easy. You can add them directly to your [manifest](../manifest/overview.md) in the `variables` section. The following snippet will pass a environment variable called `LOG_LEVEL` to your service, with the value set to `debug`. 
 
 ```yaml
 # in copilot/{service name}/manifest.yml 
@@ -58,4 +58,4 @@ Here's a quick guide showing you how to add environment variables to your app by
 
 ## How do I know the name of my DynamoDB table, S3 bucket, RDS database, etc?
 
-When using the Copilot CLI to provision additional AWS resources, such as DynamoDB tables, S3 buckets, Databases, etc, any output values will be passed in as environment variables to your app. For more information, check out the [additional resources guide](/docs/developing/additional-aws-resources/). 
+When using the Copilot CLI to provision additional AWS resources, such as DynamoDB tables, S3 buckets, Databases, etc, any output values will be passed in as environment variables to your app. For more information, check out the [additional resources guide](../developing/additional-aws-resources.md)

--- a/site/content/docs/developing/secrets.md
+++ b/site/content/docs/developing/secrets.md
@@ -1,10 +1,10 @@
 # Secrets
 
-Secrets are sensitive bits of information like OAuth tokens, secret keys or API keys - information that you need in your application code, but shouldn't commit to your source code. In the AWS Copilot CLI secrets are passed in as environment variables (read more about [developing with environment variables](/docs/developing/environment-variables/)) but they're treated differently, due to their sensitive nature. 
+Secrets are sensitive bits of information like OAuth tokens, secret keys or API keys - information that you need in your application code, but shouldn't commit to your source code. In the AWS Copilot CLI secrets are passed in as environment variables (read more about [developing with environment variables](../developing/environment-variables.md)) but they're treated differently, due to their sensitive nature. 
 
 ## How do I add Secrets?
 
-Adding secrets currently requires you to store your secret as a secure string in [AWS Systems Manager Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html) (SSM), then add a reference to the SSM parameter to your [manifest](/docs/manifest/overview). 
+Adding secrets currently requires you to store your secret as a secure string in [AWS Systems Manager Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html) (SSM), then add a reference to the SSM parameter to your [manifest](../manifest/overview.md). 
 
 We'll walk through an example where we want to store a secret called `GH_WEBHOOK_SECRET` with the value `secretvalue1234`. 
 

--- a/site/content/docs/developing/sidecars.md
+++ b/site/content/docs/developing/sidecars.md
@@ -76,7 +76,7 @@ logging:
     log_stream_prefix: copilot/
 ```
 
-You might need to add necessary permissions to the task role so that FireLens can forward your data. You can add permissions by specifying them in your [addons](/docs/developing/additional-aws-resources). For example:
+You might need to add necessary permissions to the task role so that FireLens can forward your data. You can add permissions by specifying them in your [addons](../developing/additional-aws-resources.md). For example:
 
 ``` yaml
 Resources:
@@ -100,7 +100,7 @@ Outputs:
 ```
 
 !!!info
-    Since Firelens log driver can route your main container's logs to various destinations, the [`svc logs`](/docs/commands/svc-logs) command can only track them when they are sent to the log group we create for Copilot service in CloudWatch. 
+    Since Firelens log driver can route your main container's logs to various destinations, the [`svc logs`](../commands/svc-logs.md) command can only track them when they are sent to the log group we create for Copilot service in CloudWatch. 
 
 !!!info
     ** We're going to make this easier and more powerful!** Currently we only support using remote images for sidecars which means users need to build and push their local sidecar image. But, we are planning to support using local image or Dockerfile. Additionally, Firelens will be able to route logs for the other sidecars (not just the main container).

--- a/site/content/docs/manifest/backend-service.md
+++ b/site/content/docs/manifest/backend-service.md
@@ -46,7 +46,7 @@ The name of your service.
 <div class="separator"></div>
 
 <a id="type" href="#type" class="field">`type`</a> <span class="type">String</span>  
-The architecture type for your service. [Backend services](/docs/concepts/services/#backend-service) is not reachable from the internet, but can be reached with [service discovery](/docs/developing/service-discovery/) from your other services.
+The architecture type for your service. [Backend services](../concepts/services.md#backend-service) is not reachable from the internet, but can be reached with [service discovery](../developing/service-discovery.md) from your other services.
 
 <div class="separator"></div>
 

--- a/site/content/docs/manifest/lb-web-service.md
+++ b/site/content/docs/manifest/lb-web-service.md
@@ -48,7 +48,7 @@ The name of your service.
 <div class="separator"></div>
 
 <a id="type" href="#type" class="field">`type`</a> <span class="type">String</span>  
-The architecture type for your service. A [Load balanced web service](/docs/concepts/services/#load-balanced-web-service) is an internet-facing service that's behind a load balancer, orchestrated by Amazon ECS on AWS Fargate.  
+The architecture type for your service. A [Load balanced web service](../concepts/services.md#load-balanced-web-service) is an internet-facing service that's behind a load balancer, orchestrated by Amazon ECS on AWS Fargate.  
 
 <div class="separator"></div>
 

--- a/site/content/docs/overview.md
+++ b/site/content/docs/overview.md
@@ -5,7 +5,7 @@ From getting started, pushing to staging and releasing to production, Copilot ca
 
 ## Installing
 
-You can install AWS Copilot through [Homebrew](https://brew.sh/) or by downloading the binaries directly. If you don't want to use Homebrew, you can install [manually](/docs/installing). 
+You can install AWS Copilot through [Homebrew](https://brew.sh/) or by downloading the binaries directly. If you don't want to use Homebrew, you can install [manually](../installing.md). 
 
 ```sh
 $ brew install aws/tap/copilot-cli


### PR DESCRIPTION
Looked for all occurrences of docs in site folder and ignored the aws docs links.
grep -ri "/docs" site/ | grep -v aws.amazon.com

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
