### PR TITLE
chore(job): allow no schedule to be specified in ask() and manifest

### DIFF
--- a/internal/pkg/cli/flag.go
+++ b/internal/pkg/cli/flag.go
@@ -217,7 +217,8 @@ Tasks with the same group name share the same set of resources.
 Accepts valid Go duration strings. For example: "2h", "1h30m", "900s".`
 	scheduleFlagDescription = `The schedule on which to run this job. 
 Accepts cron expressions of the format (M H DoM M DoW) and schedule definition strings. 
-For example: "0 * * * *", "@daily", "@weekly", "@every 1h30m".`
+For example: "0 * * * *", "@daily", "@weekly", "@every 1h30m".
+You may also specify "No Schedule".`
 
 	upgradeAllEnvsDescription = "Optional. Upgrade all environments."
 )

--- a/internal/pkg/cli/flag.go
+++ b/internal/pkg/cli/flag.go
@@ -218,7 +218,7 @@ Accepts valid Go duration strings. For example: "2h", "1h30m", "900s".`
 	scheduleFlagDescription = `The schedule on which to run this job. 
 Accepts cron expressions of the format (M H DoM M DoW) and schedule definition strings. 
 For example: "0 * * * *", "@daily", "@weekly", "@every 1h30m".
-You may also specify "No Schedule".`
+You may also specify "none".`
 
 	upgradeAllEnvsDescription = "Optional. Upgrade all environments."
 )

--- a/internal/pkg/cli/job_init.go
+++ b/internal/pkg/cli/job_init.go
@@ -212,7 +212,11 @@ func (o *initJobOpts) createManifest() (string, error) {
 		manifestMsgFmt = "Manifest file for job %s already exists at %s, skipping writing it.\n"
 	}
 	log.Successf(manifestMsgFmt, color.HighlightUserInput(o.name), color.HighlightResource(manifestPath))
-	log.Infoln(color.Help(fmt.Sprintf("Your manifest contains configurations like your container size and job schedule (%s).", o.schedule)))
+	scheduleText := o.schedule
+	if o.schedule == "" {
+		scheduleText = "None"
+	}
+	log.Infoln(color.Help(fmt.Sprintf("Your manifest contains configurations like your container size and job schedule (%s).", scheduleText)))
 	log.Infoln()
 
 	return manifestPath, nil
@@ -227,13 +231,17 @@ func (o *initJobOpts) newJobManifest() (*manifest.ScheduledJob, error) {
 		}
 		dfPath = path
 	}
+	schedule := o.schedule
+	if schedule == selector.NoSchedule {
+		schedule = ""
+	}
 	return manifest.NewScheduledJob(&manifest.ScheduledJobProps{
 		WorkloadProps: &manifest.WorkloadProps{
 			Name:       o.name,
 			Dockerfile: dfPath,
 			Image:      o.image,
 		},
-		Schedule: o.schedule,
+		Schedule: schedule,
 		Timeout:  o.timeout,
 		Retries:  o.retries,
 	}), nil
@@ -316,7 +324,6 @@ func (o *initJobOpts) askSchedule() error {
 	if err != nil {
 		return fmt.Errorf("get schedule: %w", err)
 	}
-
 	o.schedule = schedule
 	return nil
 }

--- a/internal/pkg/cli/job_init.go
+++ b/internal/pkg/cli/job_init.go
@@ -27,7 +27,8 @@ var (
 	jobInitScheduleHelp   = `How to determine this job's schedule. "Rate" lets you define the time between 
 executions and is good for jobs which need to run frequently. "Fixed Schedule"
 lets you use a predefined or custom cron schedule and is good for less-frequent 
-jobs or those which require specific execution schedules.`
+jobs or those which require specific execution schedules. "No Schedule" does not
+create an event rule. You must instead invoke the job programmatically.`
 )
 
 const (
@@ -118,7 +119,7 @@ func (o *initJobOpts) Validate() error {
 			return err
 		}
 	}
-	if o.schedule != "" {
+	if o.schedule != "" && o.schedule != selector.None {
 		if err := validateSchedule(o.schedule); err != nil {
 			return err
 		}
@@ -232,7 +233,7 @@ func (o *initJobOpts) newJobManifest() (*manifest.ScheduledJob, error) {
 		dfPath = path
 	}
 	schedule := o.schedule
-	if schedule == selector.NoSchedule {
+	if schedule == selector.None {
 		schedule = ""
 	}
 	return manifest.NewScheduledJob(&manifest.ScheduledJobProps{

--- a/internal/pkg/deploy/cloudformation/stack/scheduled_job.go
+++ b/internal/pkg/deploy/cloudformation/stack/scheduled_job.go
@@ -158,6 +158,9 @@ func (j *ScheduledJob) Parameters() ([]*cloudformation.Parameter, error) {
 	if err != nil {
 		return nil, err
 	}
+	if schedule == "" {
+		return wkldParams, nil
+	}
 	return append(wkldParams, []*cloudformation.Parameter{
 		{
 			ParameterKey:   aws.String(ScheduledJobScheduleParamKey),
@@ -181,7 +184,7 @@ func (j *ScheduledJob) SerializedParameters() (string, error) {
 // All others become cron expressions.
 func (j *ScheduledJob) awsSchedule() (string, error) {
 	if j.manifest.Schedule == "" {
-		return "", fmt.Errorf(`missing required field "schedule" in manifest for job %s`, j.name)
+		return "", nil
 	}
 
 	// Try parsing the string as a cron expression to validate it.

--- a/internal/pkg/deploy/cloudformation/stack/scheduled_job_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/scheduled_job_test.go
@@ -174,10 +174,6 @@ func TestScheduledJob_awsSchedule(t *testing.T) {
 			inputSchedule:  "@every 1h30m",
 			wantedSchedule: "rate(90 minutes)",
 		},
-		"missing schedule": {
-			inputSchedule: "",
-			wantedError:   errors.New(`missing required field "schedule" in manifest for job mailer`),
-		},
 		"one minute rate": {
 			inputSchedule:  "@every 1m",
 			wantedSchedule: "rate(1 minute)",

--- a/internal/pkg/manifest/job_test.go
+++ b/internal/pkg/manifest/job_test.go
@@ -40,15 +40,14 @@ func TestScheduledJob_MarshalBinary(t *testing.T) {
 			},
 			wantedTestData: "scheduled-job-fully-specified.yml",
 		},
-		"with timeout and no retries": {
+		"with no schedule and no retries": {
 			inProps: ScheduledJobProps{
 				WorkloadProps: &WorkloadProps{
 					Name:       "cuteness-aggregator",
 					Dockerfile: "./cuteness-aggregator/Dockerfile",
 				},
-				Schedule: "@every 5h",
-				Retries:  0,
-				Timeout:  "3h",
+				Retries: 0,
+				Timeout: "3h",
 			},
 			wantedTestData: "scheduled-job-no-retries.yml",
 		},

--- a/internal/pkg/manifest/testdata/scheduled-job-fully-specified.yml
+++ b/internal/pkg/manifest/testdata/scheduled-job-fully-specified.yml
@@ -17,7 +17,8 @@ cpu: 256
 # Amount of memory in MiB used by the task.
 memory: 512
 
-# The trigger for your job. You can specify a cron schedule or keyword (@weekly) or a rate (2h, 1h30m, 15m)
+# The trigger for your job. You can specify a cron schedule or keyword (@weekly) or a rate (2h, 1h30m, 15m).
+# If schedule is not set, you must programmatically invoke the job or define a Cloudwatch Event Rule via Copilot addons.
 schedule: "0 */2 * * *"
 # Optional. The number of times to retry the job before failing.
 retries: 3

--- a/internal/pkg/manifest/testdata/scheduled-job-no-retries.yml
+++ b/internal/pkg/manifest/testdata/scheduled-job-no-retries.yml
@@ -17,8 +17,9 @@ cpu: 256
 # Amount of memory in MiB used by the task.
 memory: 512
 
-# The trigger for your job. You can specify a cron schedule or keyword (@weekly) or a rate (2h, 1h30m, 15m)
-schedule: "@every 5h"
+# The trigger for your job. You can specify a cron schedule or keyword (@weekly) or a rate (2h, 1h30m, 15m).
+# If schedule is not set, you must programmatically invoke the job or define a Cloudwatch Event Rule via Copilot addons.
+#schedule: "0 12 * * MON-FRI"
 # Optional. The number of times to retry the job before failing.
 #retries: 3
 # Optional. The timeout after which to stop the job if it's still running. You can use the units (h, m, s).

--- a/internal/pkg/manifest/testdata/scheduled-job-no-timeout-or-retries.yml
+++ b/internal/pkg/manifest/testdata/scheduled-job-no-timeout-or-retries.yml
@@ -17,7 +17,8 @@ cpu: 256
 # Amount of memory in MiB used by the task.
 memory: 512
 
-# The trigger for your job. You can specify a cron schedule or keyword (@weekly) or a rate (2h, 1h30m, 15m)
+# The trigger for your job. You can specify a cron schedule or keyword (@weekly) or a rate (2h, 1h30m, 15m).
+# If schedule is not set, you must programmatically invoke the job or define a Cloudwatch Event Rule via Copilot addons.
 schedule: "@weekly"
 # Optional. The number of times to retry the job before failing.
 #retries: 3

--- a/internal/pkg/manifest/testdata/scheduled-job-no-timeout.yml
+++ b/internal/pkg/manifest/testdata/scheduled-job-no-timeout.yml
@@ -17,7 +17,8 @@ cpu: 256
 # Amount of memory in MiB used by the task.
 memory: 512
 
-# The trigger for your job. You can specify a cron schedule or keyword (@weekly) or a rate (2h, 1h30m, 15m)
+# The trigger for your job. You can specify a cron schedule or keyword (@weekly) or a rate (2h, 1h30m, 15m).
+# If schedule is not set, you must programmatically invoke the job or define a Cloudwatch Event Rule via Copilot addons.
 schedule: "@every 5h"
 # Optional. The number of times to retry the job before failing.
 retries: 5

--- a/internal/pkg/term/selector/mocks/mock_selector.go
+++ b/internal/pkg/term/selector/mocks/mock_selector.go
@@ -206,6 +206,21 @@ func (mr *MockConfigSvcListerMockRecorder) ListServices(appName interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServices", reflect.TypeOf((*MockConfigSvcLister)(nil).ListServices), appName)
 }
 
+// ListJobs mocks base method
+func (m *MockConfigSvcLister) ListJobs(appName string) ([]*config.Workload, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListJobs", appName)
+	ret0, _ := ret[0].([]*config.Workload)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListJobs indicates an expected call of ListJobs
+func (mr *MockConfigSvcListerMockRecorder) ListJobs(appName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListJobs", reflect.TypeOf((*MockConfigSvcLister)(nil).ListJobs), appName)
+}
+
 // MockConfigLister is a mock of ConfigLister interface
 type MockConfigLister struct {
 	ctrl     *gomock.Controller
@@ -272,6 +287,21 @@ func (m *MockConfigLister) ListServices(appName string) ([]*config.Workload, err
 func (mr *MockConfigListerMockRecorder) ListServices(appName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServices", reflect.TypeOf((*MockConfigLister)(nil).ListServices), appName)
+}
+
+// ListJobs mocks base method
+func (m *MockConfigLister) ListJobs(appName string) ([]*config.Workload, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListJobs", appName)
+	ret0, _ := ret[0].([]*config.Workload)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListJobs indicates an expected call of ListJobs
+func (mr *MockConfigListerMockRecorder) ListJobs(appName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListJobs", reflect.TypeOf((*MockConfigLister)(nil).ListJobs), appName)
 }
 
 // MockWsWorkloadLister is a mock of WsWorkloadLister interface

--- a/internal/pkg/term/selector/selector.go
+++ b/internal/pkg/term/selector/selector.go
@@ -86,6 +86,7 @@ type AppEnvLister interface {
 // ConfigSvcLister wraps the method to list svcs in config store.
 type ConfigSvcLister interface {
 	ListServices(appName string) ([]*config.Workload, error)
+	ListJobs(appName string) ([]*config.Workload, error)
 }
 
 // ConfigLister wraps config store listing methods.
@@ -308,7 +309,7 @@ func (s *WorkspaceSelect) Job(msg, help string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("retrieve jobs from workspace: %w", err)
 	}
-	storeJobNames, err := s.Select.config.ListServices(summary.Application)
+	storeJobNames, err := s.Select.config.ListJobs(summary.Application)
 	if err != nil {
 		return "", fmt.Errorf("retrieve jobs from store: %w", err)
 	}

--- a/internal/pkg/term/selector/selector.go
+++ b/internal/pkg/term/selector/selector.go
@@ -24,7 +24,7 @@ const (
 	rate          = "Rate"
 	fixedSchedule = "Fixed Schedule"
 	// NoSchedule represents a job which only contains the state machine, retries, task definition, and other infrastructure.
-	NoSchedule = "No Schedule"
+	noSchedule = "No Schedule"
 
 	custom  = "Custom"
 	hourly  = "Hourly"
@@ -32,6 +32,8 @@ const (
 	weekly  = "Weekly"
 	monthly = "Monthly"
 	yearly  = "Yearly"
+
+	None = "none"
 )
 
 const (
@@ -57,7 +59,7 @@ For example: 0 17 ? * MON-FRI (5 pm on weekdays)
 var scheduleTypes = []string{
 	rate,
 	fixedSchedule,
-	NoSchedule,
+	noSchedule,
 }
 
 var presetSchedules = []string{
@@ -523,8 +525,8 @@ func (s *WorkspaceSelect) Schedule(scheduleTypePrompt, scheduleTypeHelp string, 
 		return s.askRate(rateValidator)
 	case fixedSchedule:
 		return s.askCron(scheduleValidator)
-	case NoSchedule:
-		return "", nil
+	case noSchedule:
+		return None, nil
 	default:
 		return "", fmt.Errorf("unrecognized schedule type %s", scheduleType)
 	}

--- a/internal/pkg/term/selector/selector.go
+++ b/internal/pkg/term/selector/selector.go
@@ -19,9 +19,12 @@ import (
 )
 
 const (
-	every         = "@every %s"
+	every = "@every %s"
+
 	rate          = "Rate"
 	fixedSchedule = "Fixed Schedule"
+	// NoSchedule represents a job which only contains the state machine, retries, task definition, and other infrastructure.
+	NoSchedule = "No Schedule"
 
 	custom  = "Custom"
 	hourly  = "Hourly"
@@ -54,6 +57,7 @@ For example: 0 17 ? * MON-FRI (5 pm on weekdays)
 var scheduleTypes = []string{
 	rate,
 	fixedSchedule,
+	NoSchedule,
 }
 
 var presetSchedules = []string{
@@ -518,6 +522,8 @@ func (s *WorkspaceSelect) Schedule(scheduleTypePrompt, scheduleTypeHelp string, 
 		return s.askRate(rateValidator)
 	case fixedSchedule:
 		return s.askCron(scheduleValidator)
+	case NoSchedule:
+		return "", nil
 	default:
 		return "", fmt.Errorf("unrecognized schedule type %s", scheduleType)
 	}

--- a/internal/pkg/term/selector/selector_test.go
+++ b/internal/pkg/term/selector/selector_test.go
@@ -504,7 +504,7 @@ func TestWorkspaceSelect_Job(t *testing.T) {
 					&workspace.Summary{
 						Application: "app-name",
 					}, nil)
-				m.configLister.EXPECT().ListServices("app-name").Return(
+				m.configLister.EXPECT().ListJobs("app-name").Return(
 					[]*config.Workload{}, nil).Times(1)
 				m.prompt.
 					EXPECT().
@@ -524,7 +524,7 @@ func TestWorkspaceSelect_Job(t *testing.T) {
 					&workspace.Summary{
 						Application: "app-name",
 					}, nil)
-				m.configLister.EXPECT().ListServices("app-name").Return(
+				m.configLister.EXPECT().ListJobs("app-name").Return(
 					[]*config.Workload{}, nil).Times(1)
 				m.prompt.
 					EXPECT().
@@ -542,7 +542,7 @@ func TestWorkspaceSelect_Job(t *testing.T) {
 					&workspace.Summary{
 						Application: "app-name",
 					}, nil)
-				m.configLister.EXPECT().ListServices("app-name").Return(
+				m.configLister.EXPECT().ListJobs("app-name").Return(
 					[]*config.Workload{
 						{
 							App:  "app-name",
@@ -569,7 +569,7 @@ func TestWorkspaceSelect_Job(t *testing.T) {
 					&workspace.Summary{
 						Application: "app-name",
 					}, nil)
-				m.configLister.EXPECT().ListServices("app-name").Return(
+				m.configLister.EXPECT().ListJobs("app-name").Return(
 					[]*config.Workload{
 						{
 							App:  "app-name",
@@ -596,7 +596,7 @@ func TestWorkspaceSelect_Job(t *testing.T) {
 					&workspace.Summary{
 						Application: "app-name",
 					}, nil)
-				m.configLister.EXPECT().ListServices("app-name").Return(
+				m.configLister.EXPECT().ListJobs("app-name").Return(
 					[]*config.Workload{
 						{
 							App:  "app-name",
@@ -620,7 +620,7 @@ func TestWorkspaceSelect_Job(t *testing.T) {
 					&workspace.Summary{
 						Application: "app-name",
 					}, nil)
-				m.configLister.EXPECT().ListServices("app-name").Return(
+				m.configLister.EXPECT().ListJobs("app-name").Return(
 					[]*config.Workload{
 						{
 							App:  "app-name",
@@ -658,7 +658,7 @@ func TestWorkspaceSelect_Job(t *testing.T) {
 					}, nil)
 				m.configLister.
 					EXPECT().
-					ListServices("app-name").
+					ListJobs("app-name").
 					Return(
 						[]*config.Workload{
 							{
@@ -713,7 +713,7 @@ func TestWorkspaceSelect_Job(t *testing.T) {
 					&workspace.Summary{
 						Application: "app-name",
 					}, nil)
-				m.configLister.EXPECT().ListServices("app-name").Return(
+				m.configLister.EXPECT().ListJobs("app-name").Return(
 					nil, errors.New("some error"))
 			},
 			wantErr: errors.New("retrieve jobs from store: some error"),
@@ -729,7 +729,7 @@ func TestWorkspaceSelect_Job(t *testing.T) {
 					&workspace.Summary{
 						Application: "app-name",
 					}, nil)
-				m.configLister.EXPECT().ListServices("app-name").Return(
+				m.configLister.EXPECT().ListJobs("app-name").Return(
 					[]*config.Workload{
 						{
 							App:  "app-name",

--- a/templates/workloads/jobs/scheduled-job/cf.yml
+++ b/templates/workloads/jobs/scheduled-job/cf.yml
@@ -9,8 +9,10 @@ Parameters:
     Type: String
   WorkloadName:
     Type: String
+  {{- if .ScheduleExpression}}
   Schedule:
     Type: String
+  {{- end}}
   ContainerImage:
     Type: String
   TaskCPU:
@@ -46,7 +48,9 @@ Resources:
 
 {{include "taskrole" . | indent 2}}
 
+{{- if .ScheduleExpression}}
 {{include "eventrule" . | indent 2}}
+{{- end}}
 
 {{include "state-machine" . | indent 2}}
 

--- a/templates/workloads/jobs/scheduled-job/manifest.yml
+++ b/templates/workloads/jobs/scheduled-job/manifest.yml
@@ -23,8 +23,13 @@ cpu: {{.CPU}}
 # Amount of memory in MiB used by the task.
 memory: {{.Memory}}
 
-# The trigger for your job. You can specify a cron schedule or keyword (@weekly) or a rate (2h, 1h30m, 15m)
+# The trigger for your job. You can specify a cron schedule or keyword (@weekly) or a rate (2h, 1h30m, 15m).
+# If schedule is not set, you must programmatically invoke the job or define a Cloudwatch Event Rule via Copilot addons.
+{{- if .Schedule}}
 schedule: "{{.Schedule}}"
+{{- else}}
+#schedule: "0 12 * * MON-FRI"
+{{- end}}
 # Optional. The number of times to retry the job before failing.
 {{- if .Retries}}
 retries: {{.Retries}}


### PR DESCRIPTION
<!-- Provide summary of changes -->
Related #1131 and #1425. 

Allows customers to specify "No Schedule" via schedule flag or selector to generate a manifest with no schedule. Schedule can also be commented out in the manifest to only create a task definition, task role, log group, and state machine. This will require that customers invoke the job programmatically or define their own event rule. 

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
