### PR TITLE
chore(cli): extract misleading language in job manifest for rates

### DIFF
--- a/internal/pkg/manifest/testdata/scheduled-job-fully-specified.yml
+++ b/internal/pkg/manifest/testdata/scheduled-job-fully-specified.yml
@@ -18,7 +18,7 @@ cpu: 256
 memory: 512
 
 on:
-  # The scheduled trigger for your job. You can specify a cron schedule or keyword (@weekly) or a rate (2h, 1h30m, 15m)
+  # The scheduled trigger for your job. You can specify a Unix cron schedule or keyword (@weekly) or a rate (@every 1h30m)
   # AWS Schedule Expressions are also accepted: https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html
   schedule: "0 */2 * * *"
 

--- a/internal/pkg/manifest/testdata/scheduled-job-no-retries.yml
+++ b/internal/pkg/manifest/testdata/scheduled-job-no-retries.yml
@@ -18,7 +18,7 @@ cpu: 256
 memory: 512
 
 on:
-  # The scheduled trigger for your job. You can specify a cron schedule or keyword (@weekly) or a rate (2h, 1h30m, 15m)
+  # The scheduled trigger for your job. You can specify a Unix cron schedule or keyword (@weekly) or a rate (@every 1h30m)
   # AWS Schedule Expressions are also accepted: https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html
   schedule: "@every 5h"
 

--- a/internal/pkg/manifest/testdata/scheduled-job-no-timeout-or-retries.yml
+++ b/internal/pkg/manifest/testdata/scheduled-job-no-timeout-or-retries.yml
@@ -18,7 +18,7 @@ cpu: 256
 memory: 512
 
 on:
-  # The scheduled trigger for your job. You can specify a cron schedule or keyword (@weekly) or a rate (2h, 1h30m, 15m)
+  # The scheduled trigger for your job. You can specify a Unix cron schedule or keyword (@weekly) or a rate (@every 1h30m)
   # AWS Schedule Expressions are also accepted: https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html
   schedule: "@weekly"
 

--- a/internal/pkg/manifest/testdata/scheduled-job-no-timeout.yml
+++ b/internal/pkg/manifest/testdata/scheduled-job-no-timeout.yml
@@ -18,7 +18,7 @@ cpu: 256
 memory: 512
 
 on:
-  # The scheduled trigger for your job. You can specify a cron schedule or keyword (@weekly) or a rate (2h, 1h30m, 15m)
+  # The scheduled trigger for your job. You can specify a Unix cron schedule or keyword (@weekly) or a rate (@every 1h30m)
   # AWS Schedule Expressions are also accepted: https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html
   schedule: "@every 5h"
 

--- a/templates/workloads/jobs/scheduled-job/manifest.yml
+++ b/templates/workloads/jobs/scheduled-job/manifest.yml
@@ -24,7 +24,7 @@ cpu: {{.CPU}}
 memory: {{.Memory}}
 
 on:
-  # The scheduled trigger for your job. You can specify a cron schedule or keyword (@weekly) or a rate (2h, 1h30m, 15m)
+  # The scheduled trigger for your job. You can specify a Unix cron schedule or keyword (@weekly) or a rate (@every 1h30m)
   # AWS Schedule Expressions are also accepted: https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html
   schedule: "{{.On.Schedule}}"
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
At some point, we decided not to accept simple duration strings like "1h30m" in favor of the "@every 1h30m" syntax. 

This PR rewords the comment in the manifest to clarify the required syntax. 
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
