### PR TITLE
test(integ): fix pipeline template generation integ tests

### DIFF
--- a/templates/cicd/pipeline_cfn.yml
+++ b/templates/cicd/pipeline_cfn.yml
@@ -283,8 +283,8 @@ Resources:
                 ActionMode: CREATE_UPDATE
                 StackName: {{$.AppName}}-{{$stage.Name}}-{{$svc}}
                 Capabilities: CAPABILITY_NAMED_IAM
-                TemplatePath: BuildOutput::infrastructure/{{$stage.ServiceTemplatePath $svc}}
-                TemplateConfiguration: BuildOutput::infrastructure/{{$stage.ServiceTemplateConfigurationPath $svc}}
+                TemplatePath: BuildOutput::infrastructure/{{$stage.WorkloadTemplatePath $svc}}
+                TemplateConfiguration: BuildOutput::infrastructure/{{$stage.WorkloadTemplateConfigurationPath $svc}}
                 # The ARN of the IAM role (in the env account) that
                 # AWS CloudFormation assumes when it operates on resources
                 # in a stack in an environment account.


### PR DESCRIPTION
In #1512 we renamed the methods of `*PipelineStage` to
`WorkloadTemplatePath` and `WorkloadTemplateConfigurationPath` instead
of `ServiceTemplatePath` and `ServiceTemplateConfigurationPath`.

This resulted in an error while generating the cfn template for the pipeline
since we are depending on the old names.

This change fixes that.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
