### PR TITLE
chore(cli): use default input when asking for rates

### DIFF
--- a/internal/pkg/term/selector/selector.go
+++ b/internal/pkg/term/selector/selector.go
@@ -529,6 +529,7 @@ func (s *WorkspaceSelect) askRate(rateValidator prompt.ValidatorFunc) (string, e
 		ratePrompt,
 		rateHelp,
 		rateValidator,
+		prompt.WithDefaultInput("1h30m"),
 		prompt.WithFinalMessage("Rate:"),
 	)
 	if err != nil {


### PR DESCRIPTION
<!-- Provide summary of changes -->
Previously, when we asked customers to specify a rate they were met with a blank prompt. 
```
  How long would you like to wait between executions? [? for help] 
```
Now, we add a default input to give folks a hint for how to format their response.
```
  How long would you like to wait between executions? [? for help] (1h30m) 
```

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
