### PR TITLE
feat(cli): add init no-deploy flag

### DIFF
--- a/docs/docs/commands/init/index.html
+++ b/docs/docs/commands/init/index.html
@@ -1255,7 +1255,8 @@
 <h2 id="what-are-the-flags">What are the flags?</h2>
 <p>Like all commands in the copilot CLI, if you don't provide required flags, we'll prompt you for all the information we need to get you going. You can skip the prompts by providing information via flags:</p>
 <div class="highlight"><pre><span></span><code>  -a, --app string          Name of the application.
-      --deploy              Deploy your service to a <span class="s2">&quot;test&quot;</span> environment.
+      --deploy              Optional. Deploy your service to a <span class="s2">&quot;test&quot;</span> environment.
+      --no-deploy           Optional. Do not prompt if the application must be deployed.
   -d, --dockerfile string   Path to the Dockerfile.
   -h, --help                <span class="nb">help</span> <span class="k">for</span> init
       --port uint16         Optional. The port on which your service listens.

--- a/internal/pkg/cli/flag.go
+++ b/internal/pkg/cli/flag.go
@@ -39,6 +39,7 @@ const (
 	tasksFlag             = "tasks"
 	prodEnvFlag           = "prod"
 	deployFlag            = "deploy"
+	noDeployFlag          = "no-deploy"
 	resourcesFlag         = "resources"
 	githubURLFlag         = "github-url"
 	githubAccessTokenFlag = "github-access-token"
@@ -163,7 +164,8 @@ Defaults to all logs. Only one of start-time / since may be used.`
 Defaults to all logs. Only one of end-time / follow may be used.`
 	tasksLogsFlagDescription = "Optional. Only return logs from specific task IDs."
 
-	deployTestFlagDescription        = `Deploy your service to a "test" environment.`
+	deployTestFlagDescription        = `Optional. Deploy your service to a "test" environment.`
+	noDeployTestFlagDescription      = `Optional. Do not prompt if the application must be deployed.`
 	githubURLFlagDescription         = "GitHub repository URL for your service."
 	githubAccessTokenFlagDescription = "GitHub personal access token for your repository."
 	gitBranchFlagDescription         = "Branch used to trigger your pipeline."

--- a/internal/pkg/cli/init.go
+++ b/internal/pkg/cli/init.go
@@ -40,13 +40,14 @@ const (
 
 type initVars struct {
 	// Flags unique to "init" that's not provided by other sub-commands.
-	shouldDeploy   bool
-	appName        string
-	wkldType       string
-	svcName        string
-	dockerfilePath string
-	image          string
-	imageTag       string
+	shouldDeploy    bool
+	shouldNotDeploy bool
+	appName         string
+	wkldType        string
+	svcName         string
+	dockerfilePath  string
+	image           string
+	imageTag        string
 
 	// Service specific flags
 	port uint16
@@ -61,7 +62,7 @@ type initOpts struct {
 	initVars
 
 	ShouldDeploy          bool // true means we should create a test environment and deploy the service to it. Defaults to false.
-	promptForShouldDeploy bool // true means that the user set the ShouldDeploy flag explicitly.
+	promptForShouldDeploy bool // true means that the user set the ShouldDeploy or the ShouldNotDeploy flag explicitly.
 
 	// Sub-commands to execute.
 	initAppCmd   actionCommand
@@ -165,7 +166,7 @@ func newInitOpts(vars initVars) (*initOpts, error) {
 
 	return &initOpts{
 		initVars:     vars,
-		ShouldDeploy: vars.shouldDeploy,
+		ShouldDeploy: vars.shouldDeploy && !vars.shouldNotDeploy,
 
 		initAppCmd:   initAppCmd,
 		initEnvCmd:   initEnvCmd,
@@ -417,7 +418,7 @@ func BuildInitCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			opts.promptForShouldDeploy = !cmd.Flags().Changed(deployFlag)
+			opts.promptForShouldDeploy = !cmd.Flags().Changed(deployFlag) && !cmd.Flags().Changed(noDeployFlag)
 			if err := opts.Run(); err != nil {
 				return err
 			}
@@ -438,6 +439,7 @@ func BuildInitCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&vars.dockerfilePath, dockerFileFlag, dockerFileFlagShort, "", dockerFileFlagDescription)
 	cmd.Flags().StringVarP(&vars.image, imageFlag, imageFlagShort, "", imageFlagDescription)
 	cmd.Flags().BoolVar(&vars.shouldDeploy, deployFlag, false, deployTestFlagDescription)
+	cmd.Flags().BoolVar(&vars.shouldNotDeploy, noDeployFlag, false, noDeployTestFlagDescription)
 	cmd.Flags().StringVar(&vars.imageTag, imageTagFlag, "", imageTagFlagDescription)
 	cmd.Flags().Uint16Var(&vars.port, svcPortFlag, 0, svcPortFlagDescription)
 	cmd.Flags().StringVar(&vars.schedule, scheduleFlag, "", scheduleFlagDescription)

--- a/site/content/docs/commands/app-delete.md
+++ b/site/content/docs/commands/app-delete.md
@@ -11,6 +11,7 @@ $ copilot app delete [flags]
 
 ```bash
 -h, --help                          help for delete
+-n, --name string                   Name of the application. 
     --yes                           Skips confirmation prompt.
 ```
 

--- a/site/content/docs/commands/init.md
+++ b/site/content/docs/commands/init.md
@@ -16,7 +16,8 @@ Like all commands in the copilot CLI, if you don't provide required flags, we'll
 
 ```sh
   -a, --app string          Name of the application.
-      --deploy              Deploy your service to a "test" environment.
+      --deploy              Optional. Deploy your service to a "test" environment.
+      --no-deploy           Optional. Do not prompt if the application must be deployed.
   -d, --dockerfile string   Path to the Dockerfile.
   -h, --help                help for init
       --port uint16         Optional. The port on which your service listens.


### PR DESCRIPTION
There is currently no way to avoid the deploy prompt when running `copilot init` if I don't want to deploy the app in a `test` env. This is quite painful if I want to run the command in a bash script or in a CI, as I need to run:

```bash
copilot init --app foo --svc bar --svc-type "Backend Service" -d "./Dockerfile" < /dev/null || true
```

This PR adds a `--no-deploy` flag allowing to bypass the prompt:

```bash
copilot init --app foo --svc bar --svc-type "Backend Service" -d "./Dockerfile" --no-deploy
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
