### PR TITLE
docs(site): add "Scheduled Job" to --type choices in `init` 

### DIFF
--- a/site/content/docs/commands/init.md
+++ b/site/content/docs/commands/init.md
@@ -34,5 +34,5 @@ Like all commands in the copilot CLI, if you don't provide required flags, we'll
       --timeout string      Optional. The total execution time for the task, including retries.
                             Accepts valid Go duration strings. For example: "2h", "1h30m", "900s".
   -t, --type string         Type of service to create. Must be one of:
-                            "Load Balanced Web Service", "Backend Service"
+                            "Load Balanced Web Service", "Backend Service", "Scheduled Job"
 ```


### PR DESCRIPTION
For the new `--type` flag, "Scheduled Job" needs to be an option.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
