### PR TITLE
chore(describe): dash lines same length as the longest strings

### DIFF
--- a/internal/pkg/cli/env_show_test.go
+++ b/internal/pkg/cli/env_show_test.go
@@ -285,7 +285,7 @@ func TestEnvShow_Execute(t *testing.T) {
 				)
 			},
 
-			wantedContent: "About\n\n  Name              testEnv\n  Production        false\n  Region            us-west-2\n  Account ID        123456789012\n\nServices\n\n  Name              Type\n  ----              ----\n  testSvc1          load-balanced\n  testSvc2          load-balanced\n  testSvc3          load-balanced\n\nTags\n\n  Key                  Value\n  ---                  -----\n  copilot-application  testApp\n  copilot-environment  testEnv\n  key1              value1\n  key2              value2\n\nResources\n\n  AWS::IAM::Role           testApp-testEnv-CFNExecutionRole\n  testApp-testEnv-Cluster  AWS::ECS::Cluster-jI63pYBWU6BZ\n",
+			wantedContent: "About\n\n  Name              testEnv\n  Production        false\n  Region            us-west-2\n  Account ID        123456789012\n\nServices\n\n  Name              Type\n  --------          -------------\n  testSvc1          load-balanced\n  testSvc2          load-balanced\n  testSvc3          load-balanced\n\nTags\n\n  Key                  Value\n  -------------------  -------\n  copilot-application  testApp\n  copilot-environment  testEnv\n  key1              value1\n  key2              value2\n\nResources\n\n  AWS::IAM::Role           testApp-testEnv-CFNExecutionRole\n  testApp-testEnv-Cluster  AWS::ECS::Cluster-jI63pYBWU6BZ\n",
 		},
 		"success in JSON format": {
 			inputEnv:         "testEnv",

--- a/internal/pkg/describe/env.go
+++ b/internal/pkg/describe/env.go
@@ -7,7 +7,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"math"
 	"sort"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/aws/copilot-cli/internal/pkg/aws/sessions"
@@ -181,8 +183,13 @@ func (e *EnvDescription) HumanString() string {
 	fmt.Fprint(writer, color.Bold.Sprint("\nServices\n\n"))
 	writer.Flush()
 	fmt.Fprintf(writer, "  %s\t%s\n", "Name", "Type")
-	writer.Flush()
-	fmt.Fprintf(writer, "  %s\t%s\n", "----", "----")
+	nameLengthMax := len("Name")
+	typeLengthMax := len("Type")
+	for _, svc := range e.Services {
+		nameLengthMax = int(math.Max(float64(nameLengthMax), float64(len(svc.Name))))
+		typeLengthMax = int(math.Max(float64(typeLengthMax), float64(len(svc.Type))))
+	}
+	fmt.Fprintf(writer, "  %s\t%s\n", strings.Repeat("-", nameLengthMax), strings.Repeat("-", typeLengthMax))
 	writer.Flush()
 	for _, svc := range e.Services {
 		fmt.Fprintf(writer, "  %s\t%s\n", svc.Name, svc.Type)
@@ -191,8 +198,15 @@ func (e *EnvDescription) HumanString() string {
 	if len(e.Tags) != 0 {
 		fmt.Fprint(writer, color.Bold.Sprint("\nTags\n\n"))
 		writer.Flush()
+		KeyLengthMax := len("Key")
+		ValueLengthMax := len("Value")
+		for k, v := range e.Tags {
+			KeyLengthMax = int(math.Max(float64(KeyLengthMax), float64(len(k))))
+			ValueLengthMax = int(math.Max(float64(ValueLengthMax), float64(len(v))))
+		}
 		fmt.Fprintf(writer, "  %s\t%s\n", "Key", "Value")
-		fmt.Fprintf(writer, "  %s\t%s\n", "---", "-----")
+		fmt.Fprintf(writer, "  %s\t%s\n", strings.Repeat("-", KeyLengthMax), strings.Repeat("-", ValueLengthMax))
+		writer.Flush()
 		// sort Tags in alpha order by keys
 		keys := make([]string, 0, len(e.Tags))
 		for k := range e.Tags {

--- a/internal/pkg/describe/env_test.go
+++ b/internal/pkg/describe/env_test.go
@@ -377,7 +377,7 @@ func TestEnvDescription_HumanString(t *testing.T) {
 Services
 
   Name              Type
-  ----              ----
+  --------          -------------
   testSvc1          load-balanced
   testSvc2          load-balanced
   testSvc3          load-balanced
@@ -385,7 +385,7 @@ Services
 Tags
 
   Key               Value
-  ---               -----
+  ----              ------
   key1              value1
   key2              value2
 


### PR DESCRIPTION
<!-- Provide summary of changes -->

Fix https://github.com/aws/copilot-cli/issues/1562

As the linked issue mentioned, `copilot env show` was to print fixed length of dash lines.
This PR changed this by finding the longest string and print it so that the dash lines are the same length.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
