### PR TITLE
chore: handle parallel env upgrade requests

### DIFF
--- a/internal/pkg/aws/cloudformation/changeset.go
+++ b/internal/pkg/aws/cloudformation/changeset.go
@@ -85,9 +85,9 @@ func (cs *changeSet) String() string {
 	return fmt.Sprintf("change set %s for stack %s", cs.name, cs.stackName)
 }
 
-// create creates a Change Set and waits until it's created.
+// create creates a ChangeSet, waits until it's created, and returns the ChangeSet ID on success.
 func (cs *changeSet) create(conf *stackConfig) error {
-	_, err := cs.client.CreateChangeSet(&cloudformation.CreateChangeSetInput{
+	out, err := cs.client.CreateChangeSet(&cloudformation.CreateChangeSetInput{
 		ChangeSetName: aws.String(cs.name),
 		StackName:     aws.String(cs.stackName),
 		ChangeSetType: aws.String(cs.csType.String()),
@@ -105,12 +105,17 @@ func (cs *changeSet) create(conf *stackConfig) error {
 		return fmt.Errorf("create %s: %w", cs, err)
 	}
 	err = cs.client.WaitUntilChangeSetCreateCompleteWithContext(context.Background(), &cloudformation.DescribeChangeSetInput{
-		ChangeSetName: aws.String(cs.name),
-		StackName:     aws.String(cs.stackName),
+		ChangeSetName: out.Id,
 	}, waiters...)
 	if err != nil {
 		return fmt.Errorf("wait for creation of %s: %w", cs, err)
 	}
+
+	// Since the ChangeSet creation succeeded, use the full ARN instead of the name.
+	// Using the full ID is essential in case the ChangeSet execution status is obsolete.
+	// If we call DescribeChangeSet using the ChangeSet name and Stack name on an obsolete changeset, the results is empty.
+	// On the other hand, if you DescribeChangeSet using the full ID then the ChangeSet summary is retrieved correctly.
+	cs.name = aws.StringValue(out.Id)
 	return nil
 }
 
@@ -158,7 +163,7 @@ func (cs *changeSet) execute() error {
 		if descr.statusReason == noUpdatesReason {
 			return nil
 		}
-		return &errChangeSetNotExecutable{
+		return &ErrChangeSetNotExecutable{
 			cs:    cs,
 			descr: descr,
 		}

--- a/internal/pkg/aws/cloudformation/cloudformation.go
+++ b/internal/pkg/aws/cloudformation/cloudformation.go
@@ -45,7 +45,7 @@ func (c *CloudFormation) Create(stack *Stack) error {
 		// If the stack does not exist, create it.
 		return c.create(stack)
 	}
-	status := stackStatus(aws.StringValue(descr.StackStatus))
+	status := StackStatus(aws.StringValue(descr.StackStatus))
 	if status.requiresCleanup() {
 		// If the stack exists, but failed to create, we'll clean it up and then re-create it.
 		if err := c.Delete(stack.Name); err != nil {
@@ -53,7 +53,7 @@ func (c *CloudFormation) Create(stack *Stack) error {
 		}
 		return c.create(stack)
 	}
-	if status.inProgress() {
+	if status.InProgress() {
 		return &ErrStackUpdateInProgress{
 			Name: stack.Name,
 		}
@@ -90,8 +90,8 @@ func (c *CloudFormation) Update(stack *Stack) error {
 	if err != nil {
 		return err
 	}
-	status := stackStatus(aws.StringValue(descr.StackStatus))
-	if status.inProgress() {
+	status := StackStatus(aws.StringValue(descr.StackStatus))
+	if status.InProgress() {
 		return &ErrStackUpdateInProgress{
 			Name: stack.Name,
 		}

--- a/internal/pkg/aws/cloudformation/cloudformation_test.go
+++ b/internal/pkg/aws/cloudformation/cloudformation_test.go
@@ -18,7 +18,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const mockChangeSetName = "copilot-31323334-3536-4738-b930-313233333435"
+const (
+	mockChangeSetName = "copilot-31323334-3536-4738-b930-313233333435"
+	mockChangeSetID   = "arn:aws:cloudformation:us-west-2:111:changeSet/copilot-31323334-3536-4738-b930-313233333435/9edc39b0-ee18-440d-823e-3dda74646b2"
+)
 
 var (
 	mockStack = NewStack("id", "template")
@@ -584,13 +587,15 @@ func addDeployCalls(m *mocks.Mockapi, changeSetType string) {
 			cloudformation.CapabilityCapabilityNamedIam,
 			cloudformation.CapabilityCapabilityAutoExpand,
 		}),
-	}).Return(nil, nil)
+	}).Return(&cloudformation.CreateChangeSetOutput{
+		Id:      aws.String(mockChangeSetID),
+		StackId: aws.String(mockStack.Name),
+	}, nil)
 	m.EXPECT().WaitUntilChangeSetCreateCompleteWithContext(gomock.Any(), &cloudformation.DescribeChangeSetInput{
-		ChangeSetName: aws.String(mockChangeSetName),
-		StackName:     aws.String(mockStack.Name),
+		ChangeSetName: aws.String(mockChangeSetID),
 	}, gomock.Any())
 	m.EXPECT().DescribeChangeSet(&cloudformation.DescribeChangeSetInput{
-		ChangeSetName: aws.String(mockChangeSetName),
+		ChangeSetName: aws.String(mockChangeSetID),
 		StackName:     aws.String(mockStack.Name),
 	}).Return(&cloudformation.DescribeChangeSetOutput{
 		Changes: []*cloudformation.Change{
@@ -605,7 +610,7 @@ func addDeployCalls(m *mocks.Mockapi, changeSetType string) {
 		StatusReason:    aws.String("some reason"),
 	}, nil)
 	m.EXPECT().ExecuteChangeSet(&cloudformation.ExecuteChangeSetInput{
-		ChangeSetName: aws.String(mockChangeSetName),
+		ChangeSetName: aws.String(mockChangeSetID),
 		StackName:     aws.String(mockStack.Name),
 	})
 }

--- a/internal/pkg/aws/cloudformation/errors.go
+++ b/internal/pkg/aws/cloudformation/errors.go
@@ -38,13 +38,13 @@ func (e *ErrStackNotFound) Error() string {
 	return fmt.Sprintf("stack named %s cannot be found", e.name)
 }
 
-// errChangeSetNotExecutable occurs when the change set cannot be executed.
-type errChangeSetNotExecutable struct {
+// ErrChangeSetNotExecutable occurs when the change set cannot be executed.
+type ErrChangeSetNotExecutable struct {
 	cs    *changeSet
 	descr *changeSetDescription
 }
 
-func (e *errChangeSetNotExecutable) Error() string {
+func (e *ErrChangeSetNotExecutable) Error() string {
 	return fmt.Sprintf("execute change set %s for stack %s because status is %s with reason %s", e.cs.name, e.cs.stackName, e.descr.executionStatus, e.descr.statusReason)
 }
 

--- a/internal/pkg/aws/cloudformation/stackstatus.go
+++ b/internal/pkg/aws/cloudformation/stackstatus.go
@@ -9,14 +9,15 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 )
 
-type stackStatus string
+// StackStatus represents the status of a stack.
+type StackStatus string
 
 // requiresCleanup returns true if the stack was created, but failed and should be deleted.
-func (s stackStatus) requiresCleanup() bool {
+func (s StackStatus) requiresCleanup() bool {
 	return cloudformation.StackStatusRollbackComplete == string(s) || cloudformation.StackStatusRollbackFailed == string(s)
 }
 
-// inProgress returns true if the stack is currently being updated.
-func (s stackStatus) inProgress() bool {
+// InProgress returns true if the stack is currently being updated.
+func (s StackStatus) InProgress() bool {
 	return strings.HasSuffix(string(s), "IN_PROGRESS")
 }

--- a/internal/pkg/aws/cloudformation/stackstatus_test.go
+++ b/internal/pkg/aws/cloudformation/stackstatus_test.go
@@ -1,0 +1,47 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudformation
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStackStatus_InProgress(t *testing.T) {
+	testCases := map[string]struct {
+		status string
+
+		wanted bool
+	}{
+		"should be false if stack is created succesfully": {
+			status: cloudformation.StackStatusCreateComplete,
+			wanted: false,
+		},
+		"should be false if stack creation failed": {
+			status: cloudformation.StackStatusCreateFailed,
+			wanted: false,
+		},
+		"should be true if stack creation is in progress": {
+			status: cloudformation.StackStatusCreateInProgress,
+			wanted: true,
+		},
+		"should be true if stack update is in progress": {
+			status: cloudformation.StackStatusUpdateInProgress,
+			wanted: true,
+		},
+		"should be true if stack deletion is in progress": {
+			status: cloudformation.StackStatusDeleteInProgress,
+			wanted: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			actual := StackStatus(tc.status).InProgress()
+			require.Equal(t, tc.wanted, actual)
+		})
+	}
+}

--- a/internal/pkg/cli/env_upgrade.go
+++ b/internal/pkg/cli/env_upgrade.go
@@ -75,6 +75,9 @@ func (o *envUpgradeOpts) Validate() error {
 	if o.all && o.name != "" {
 		return fmt.Errorf("cannot specify both --%s and --%s flags", allFlag, nameFlag)
 	}
+	if o.all {
+		return nil
+	}
 	if o.name != "" {
 		if _, err := o.store.GetEnvironment(o.appName, o.name); err != nil {
 			var errEnvDoesNotExist *config.ErrNoSuchEnvironment
@@ -170,6 +173,9 @@ func (o *envUpgradeOpts) shouldUpgrade(env string) (bool, error) {
 
 	msg := fmt.Sprintf("Environment %s is already on the latest version %s, skip upgrade.", env, deploy.LatestEnvTemplateVersion)
 	if diff > 0 {
+		// It's possible that a teammate used a different version of the CLI to upgrade the environment
+		// to a newer version. And the current user is on an older version of the CLI.
+		// In this situation we notify them they should update the CLI.
 		msg = fmt.Sprintf(`Skip upgrading environment %s to version %s since it's on version %s. 
 Are you using the latest version of AWS Copilot?`, env, deploy.LatestEnvTemplateVersion, version)
 	}

--- a/internal/pkg/cli/env_upgrade_test.go
+++ b/internal/pkg/cli/env_upgrade_test.go
@@ -81,6 +81,17 @@ func TestEnvUpgradeOpts_Validate(t *testing.T) {
 			},
 			wantedErr: errors.New("cannot specify both --all and --name flags"),
 		},
+		"should shorcircuit if only --all is provided": {
+			given: func(ctrl *gomock.Controller) *envUpgradeOpts {
+				return &envUpgradeOpts{
+					envUpgradeVars: envUpgradeVars{
+						appName: "phonetool",
+						all:     true,
+					},
+				}
+			},
+			wantedErr: nil,
+		},
 	}
 
 	for name, tc := range testCases {

--- a/internal/pkg/deploy/env.go
+++ b/internal/pkg/deploy/env.go
@@ -18,6 +18,9 @@ const (
 
 // CreateEnvironmentInput holds the fields required to deploy an environment.
 type CreateEnvironmentInput struct {
+	// The version of the environment template to create the stack. If empty, creates the legacy stack.
+	Version string
+
 	AppName                  string            // Name of the application this environment belongs to.
 	Name                     string            // Name of the environment, must be unique within an application.
 	Prod                     bool              // Whether or not this environment is a production environment.
@@ -27,8 +30,7 @@ type CreateEnvironmentInput struct {
 	ImportVPCConfig          *config.ImportVPC // Optional configuration if users have an existing VPC.
 	AdjustVPCConfig          *config.AdjustVPC // Optional configuration if users want to override default VPC configuration.
 
-	// The version of the environment template to creat the stack. If empty, creates the legacy stack.
-	Version string
+	CFNServiceRoleARN string // Optional. A service role ARN that CloudFormation should use to make calls to resources in the stack.
 }
 
 // CreateEnvironmentResponse holds the created environment on successful deployment.


### PR DESCRIPTION
If multiple `env upgrade` is run in parallel for the same environment, then only one of the requests will go through successfully while the other will return an `ErrChangeSetNotExecutable` error because the changeset has an execution status of `"OBSOLETE"`.

This PR handles that scenario. In case the request is obsolete, then we retry updating the environment stack until the changeset is empty.


_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
