### PR TITLE
docs(site): adding a section on workshops in the community guide

### DIFF
--- a/site/content/community/guides.md
+++ b/site/content/community/guides.md
@@ -26,3 +26,9 @@ Share your applications, videos, and blog posts with fellow Copilots!
 | Repository      | Description                          | Key features |
 | ----------- | ------------------------------------ | ------------ |
 [**github.com/copilot-example-voting-app**](https://github.com/copilot-example-voting-app) | A voting application distributed over three ECS services created with AWS Copilot. | Amazon Aurora PostgreSQL database, service discovery, autoscaling |
+
+
+## Workshops
+| Title      | Description                          |
+| ----------- | ------------------------------------ |
+[**ECS Workshop Using copilot-cli**](https://ecsworkshop.com/microservices/) | In this workshop, we deploy a three tier microservices application using the copilot-cli |

--- a/site/content/community/guides.md
+++ b/site/content/community/guides.md
@@ -31,4 +31,4 @@ Share your applications, videos, and blog posts with fellow Copilots!
 ## Workshops
 | Title      | Description                          |
 | ----------- | ------------------------------------ |
-[**ECS Workshop Using copilot-cli**](https://ecsworkshop.com/microservices/) | In this workshop, we deploy a three tier microservices application using the copilot-cli |
+[**ECS Workshop**](https://ecsworkshop.com/microservices/) | In this workshop, we deploy a three tier microservices application using the copilot-cli |


### PR DESCRIPTION
Adding ecsworkshop.com to the community guide

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
