### PR TITLE
chore(cli): add jobs to copilot deploy cmd

### DIFF
--- a/internal/pkg/cli/deploy.go
+++ b/internal/pkg/cli/deploy.go
@@ -89,7 +89,6 @@ func newDeployOpts(vars deployWkldVars) (*deployOpts, error) {
 				cmd:          command.New(),
 				sessProvider: sessions.NewProvider(),
 			}
-			return
 		},
 	}, nil
 }

--- a/internal/pkg/cli/deploy.go
+++ b/internal/pkg/cli/deploy.go
@@ -158,6 +158,11 @@ func BuildDeployCmd() *cobra.Command {
 		Use:   "deploy",
 		Short: "Deploy a Copilot job or service.",
 		Long:  "Deploy a Copilot job or service.",
+		Example: `
+  Deploys a service named "frontend" to a "test" environment.
+  /code $ copilot deploy --name frontend --env test
+  Deploys a job named "mailer" with additional resource tags to a "prod" environment.
+  /code $ copilot deploy -n mailer -e prod --resource-tags source/revision=bb133e7,deployment/initiator=manual`,
 		RunE: runCmdE(func(cmd *cobra.Command, args []string) error {
 			opts, err := newDeployOpts(vars)
 			if err != nil {
@@ -170,7 +175,7 @@ func BuildDeployCmd() *cobra.Command {
 		}),
 	}
 	cmd.Flags().StringVarP(&vars.appName, appFlag, appFlagShort, tryReadingAppName(), appFlagDescription)
-	cmd.Flags().StringVarP(&vars.name, nameFlag, nameFlagShort, "", svcFlagDescription)
+	cmd.Flags().StringVarP(&vars.name, nameFlag, nameFlagShort, "", workloadFlagDescription)
 	cmd.Flags().StringVarP(&vars.envName, envFlag, envFlagShort, "", envFlagDescription)
 	cmd.Flags().StringVar(&vars.imageTag, imageTagFlag, "", imageTagFlagDescription)
 	cmd.Flags().StringToStringVar(&vars.resourceTags, resourceTagsFlag, nil, resourceTagsFlagDescription)

--- a/internal/pkg/cli/deploy_test.go
+++ b/internal/pkg/cli/deploy_test.go
@@ -1,0 +1,164 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/copilot-cli/internal/pkg/cli/mocks"
+	"github.com/aws/copilot-cli/internal/pkg/config"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeployOpts_Run(t *testing.T) {
+	mockWl := config.Workload{
+		App:  "app",
+		Name: "fe",
+		Type: "Load Balanced Web Service",
+	}
+	mockJob := config.Workload{
+		App:  "app",
+		Name: "mailer",
+		Type: "Scheduled Job",
+	}
+	testCases := map[string]struct {
+		inAppName string
+		inName    string
+
+		wantedErr string
+
+		mockSel           func(m *mocks.MockwsSelector)
+		mockActionCommand func(m *mocks.MockactionCommand)
+		mockStore         func(m *mocks.Mockstore)
+	}{
+		"prompts for workload": {
+			inAppName: "app",
+			mockSel: func(m *mocks.MockwsSelector) {
+				m.EXPECT().Workload("Select a service or job in your workspace", "").Return("fe", nil)
+			},
+			mockActionCommand: func(m *mocks.MockactionCommand) {
+				m.EXPECT().Ask()
+				m.EXPECT().Validate()
+				m.EXPECT().Execute()
+			},
+			mockStore: func(m *mocks.Mockstore) {
+				m.EXPECT().GetWorkload("app", "fe").Return(&mockWl, nil)
+			},
+		},
+		"errors correctly if job returned": {
+			inAppName: "app",
+			wantedErr: "ask job deploy: some error",
+			mockSel: func(m *mocks.MockwsSelector) {
+				m.EXPECT().Workload("Select a service or job in your workspace", "").Return("mailer", nil)
+			},
+			mockActionCommand: func(m *mocks.MockactionCommand) {
+				m.EXPECT().Ask().Return(errors.New("some error"))
+			},
+			mockStore: func(m *mocks.Mockstore) {
+				m.EXPECT().GetWorkload("app", "mailer").Return(&mockJob, nil)
+			},
+		},
+		"doesn't prompt if name is specified": {
+			inAppName: "app",
+			inName:    "fe",
+
+			mockSel: func(m *mocks.MockwsSelector) {},
+			mockActionCommand: func(m *mocks.MockactionCommand) {
+				m.EXPECT().Ask()
+				m.EXPECT().Validate()
+				m.EXPECT().Execute()
+			},
+			mockStore: func(m *mocks.Mockstore) {
+				m.EXPECT().GetWorkload("app", "fe").Return(&mockWl, nil)
+			},
+		},
+		"get name error": {
+			inAppName: "app",
+			wantedErr: "select service or job: some error",
+			mockSel: func(m *mocks.MockwsSelector) {
+				m.EXPECT().Workload(gomock.Any(), gomock.Any()).Return("", errors.New("some error"))
+			},
+			mockActionCommand: func(m *mocks.MockactionCommand) {},
+			mockStore:         func(m *mocks.Mockstore) {},
+		},
+		"ask error": {
+			inAppName: "app",
+			inName:    "fe",
+			wantedErr: "ask svc deploy: some error",
+
+			mockSel: func(m *mocks.MockwsSelector) {},
+			mockActionCommand: func(m *mocks.MockactionCommand) {
+				m.EXPECT().Ask().Return(errors.New("some error"))
+			},
+			mockStore: func(m *mocks.Mockstore) {
+				m.EXPECT().GetWorkload("app", "fe").Return(&mockWl, nil)
+			},
+		},
+		"validate error": {
+			inAppName: "app",
+			inName:    "fe",
+			wantedErr: "validate svc deploy: some error",
+
+			mockSel: func(m *mocks.MockwsSelector) {},
+			mockActionCommand: func(m *mocks.MockactionCommand) {
+				m.EXPECT().Ask()
+				m.EXPECT().Validate().Return(errors.New("some error"))
+			},
+			mockStore: func(m *mocks.Mockstore) {
+				m.EXPECT().GetWorkload("app", "fe").Return(&mockWl, nil)
+			},
+		},
+		"execute error": {
+			inAppName: "app",
+			inName:    "fe",
+			wantedErr: "execute svc deploy: some error",
+
+			mockSel: func(m *mocks.MockwsSelector) {},
+			mockActionCommand: func(m *mocks.MockactionCommand) {
+				m.EXPECT().Ask()
+				m.EXPECT().Validate()
+				m.EXPECT().Execute().Return(errors.New("some error"))
+			},
+			mockStore: func(m *mocks.Mockstore) {
+				m.EXPECT().GetWorkload("app", "fe").Return(&mockWl, nil)
+			},
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// GIVEN
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockSel := mocks.NewMockwsSelector(ctrl)
+			mockCmd := mocks.NewMockactionCommand(ctrl)
+			mockStore := mocks.NewMockstore(ctrl)
+			tc.mockStore(mockStore)
+			tc.mockSel(mockSel)
+			tc.mockActionCommand(mockCmd)
+			opts := &deployOpts{
+				deployWkldVars: deployWkldVars{
+					appName: tc.inAppName,
+					name:    tc.inName,
+					envName: "test",
+				},
+				deployWkld: mockCmd,
+				sel:        mockSel,
+				store:      mockStore,
+
+				setupDeployCmd: func(o *deployOpts, isJob bool) {},
+			}
+
+			// WHEN
+			err := opts.Run()
+
+			// THEN
+			if tc.wantedErr != "" {
+				require.EqualError(t, err, tc.wantedErr)
+			}
+		})
+	}
+}

--- a/internal/pkg/cli/deploy_test.go
+++ b/internal/pkg/cli/deploy_test.go
@@ -149,7 +149,7 @@ func TestDeployOpts_Run(t *testing.T) {
 				sel:        mockSel,
 				store:      mockStore,
 
-				setupDeployCmd: func(o *deployOpts, isJob bool) {},
+				setupDeployCmd: func(o *deployOpts, wlType string) {},
 			}
 
 			// WHEN

--- a/internal/pkg/cli/init.go
+++ b/internal/pkg/cli/init.go
@@ -80,7 +80,7 @@ type initOpts struct {
 
 	prompt prompter
 
-	setupWorkoadInit func(*initOpts, string) error
+	setupWorkloadInit func(*initOpts, string) error
 }
 
 func newInitOpts(vars initVars) (*initOpts, error) {
@@ -176,7 +176,7 @@ func newInitOpts(vars initVars) (*initOpts, error) {
 
 		prompt: prompt,
 
-		setupWorkoadInit: func(o *initOpts, wkldType string) error {
+		setupWorkloadInit: func(o *initOpts, wkldType string) error {
 			wlInitializer := &initialize.WorkloadInitializer{Store: ssm, Ws: ws, Prog: spin, Deployer: deployer}
 			wkldVars := initWkldVars{
 				appName:        *o.appName,
@@ -315,7 +315,7 @@ func (o *initOpts) loadWkldCmd() error {
 	if err != nil {
 		return err
 	}
-	if err := o.setupWorkoadInit(o, wkldType); err != nil {
+	if err := o.setupWorkloadInit(o, wkldType); err != nil {
 		return err
 	}
 

--- a/internal/pkg/cli/init.go
+++ b/internal/pkg/cli/init.go
@@ -132,7 +132,7 @@ func newInitOpts(vars initVars) (*initOpts, error) {
 	}
 
 	deploySvcCmd := &deploySvcOpts{
-		deploySvcVars: deploySvcVars{
+		deployWkldVars: deployWkldVars{
 			envName:  defaultEnvironmentName,
 			imageTag: vars.imageTag,
 			appName:  vars.appName,
@@ -148,7 +148,7 @@ func newInitOpts(vars initVars) (*initOpts, error) {
 		sessProvider: sessProvider,
 	}
 	deployJobCmd := &deployJobOpts{
-		deployJobVars: deployJobVars{
+		deployWkldVars: deployWkldVars{
 			envName:  defaultEnvironmentName,
 			imageTag: vars.imageTag,
 			appName:  vars.appName,

--- a/internal/pkg/cli/init_test.go
+++ b/internal/pkg/cli/init_test.go
@@ -162,11 +162,11 @@ func TestInitOpts_Run(t *testing.T) {
 				prompt: climocks.NewMockprompter(ctrl),
 
 				// These fields are used for logging, the values are not important for tests.
-				appName:          &mockAppName,
-				initWkldVars:     &initWkldVars{},
-				schedule:         &mockSchedule,
-				port:             &mockPort,
-				setupWorkoadInit: func(*initOpts, string) error { return nil },
+				appName:           &mockAppName,
+				initWkldVars:      &initWkldVars{},
+				schedule:          &mockSchedule,
+				port:              &mockPort,
+				setupWorkloadInit: func(*initOpts, string) error { return nil },
 			}
 			tc.expect(opts)
 

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -57,6 +57,10 @@ type jobStore interface {
 	DeleteJob(appName, jobName string) error
 }
 
+type wlLister interface {
+	ListWorkloads(appName string) ([]*config.Workload, error)
+}
+
 type workloadListWriter interface {
 	Write(appName string) error
 }
@@ -112,6 +116,7 @@ type store interface {
 	environmentStore
 	serviceStore
 	jobStore
+	wlLister
 }
 
 type deployedEnvironmentLister interface {
@@ -249,9 +254,22 @@ type wsJobReader interface {
 	wsJobLister
 }
 
+type wsWlReader interface {
+	WorkloadNames() ([]string, error)
+}
+
 type wsJobDirReader interface {
 	wsJobReader
-	CopilotDirPath() (string, error)
+	copilotDirGetter
+}
+
+type wsWlDirReader interface {
+	wsJobReader
+	wsSvcReader
+	copilotDirGetter
+	wsWlReader
+	ListDockerfiles() ([]string, error)
+	Summary() (*workspace.Summary, error)
 }
 
 type wsPipelineReader interface {
@@ -408,6 +426,7 @@ type wsSelector interface {
 	appEnvSelector
 	Service(prompt, help string) (string, error)
 	Job(prompt, help string) (string, error)
+	Workload(msg, help string) (string, error)
 }
 
 type initJobSelector interface {

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -57,8 +57,9 @@ type jobStore interface {
 	DeleteJob(appName, jobName string) error
 }
 
-type wlLister interface {
+type wlStore interface {
 	ListWorkloads(appName string) ([]*config.Workload, error)
+	GetWorkload(appName, name string) (*config.Workload, error)
 }
 
 type workloadListWriter interface {
@@ -116,7 +117,7 @@ type store interface {
 	environmentStore
 	serviceStore
 	jobStore
-	wlLister
+	wlStore
 }
 
 type deployedEnvironmentLister interface {

--- a/internal/pkg/cli/job_deploy.go
+++ b/internal/pkg/cli/job_deploy.go
@@ -33,16 +33,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type deployJobVars struct {
-	appName      string
-	name         string
-	envName      string
-	imageTag     string
-	resourceTags map[string]string
-}
-
 type deployJobOpts struct {
-	deployJobVars
+	deployWkldVars
 
 	store              store
 	ws                 wsJobDirReader
@@ -65,7 +57,7 @@ type deployJobOpts struct {
 	buildRequired     bool
 }
 
-func newJobDeployOpts(vars deployJobVars) (*deployJobOpts, error) {
+func newJobDeployOpts(vars deployWkldVars) (*deployJobOpts, error) {
 	store, err := config.NewStore()
 	if err != nil {
 		return nil, fmt.Errorf("new config store: %w", err)
@@ -80,7 +72,7 @@ func newJobDeployOpts(vars deployJobVars) (*deployJobOpts, error) {
 		return nil, err
 	}
 	return &deployJobOpts{
-		deployJobVars: vars,
+		deployWkldVars: vars,
 
 		store:        store,
 		ws:           ws,
@@ -396,7 +388,7 @@ func (o *deployJobOpts) askEnvName() error {
 
 // buildJobDeployCmd builds the `job deploy` subcommand.
 func buildJobDeployCmd() *cobra.Command {
-	vars := deployJobVars{}
+	vars := deployWkldVars{}
 	cmd := &cobra.Command{
 		Use:   "deploy",
 		Short: "Deploys a job to an environment.",

--- a/internal/pkg/cli/job_deploy_test.go
+++ b/internal/pkg/cli/job_deploy_test.go
@@ -95,7 +95,7 @@ func TestJobDeployOpts_Validate(t *testing.T) {
 			tc.mockWs(mockWs)
 			tc.mockStore(mockStore)
 			opts := deployJobOpts{
-				deployJobVars: deployJobVars{
+				deployWkldVars: deployWkldVars{
 					appName: tc.inAppName,
 					name:    tc.inJobName,
 					envName: tc.inEnvName,
@@ -168,7 +168,7 @@ func TestJobDeployOpts_Ask(t *testing.T) {
 
 			tc.wantedCalls(mockSel)
 			opts := deployJobOpts{
-				deployJobVars: deployJobVars{
+				deployWkldVars: deployWkldVars{
 					appName:  tc.inAppName,
 					name:     tc.inJobName,
 					envName:  tc.inEnvName,
@@ -318,7 +318,7 @@ image:
 			}
 			test.setupMocks(mocks)
 			opts := deployJobOpts{
-				deployJobVars: deployJobVars{
+				deployWkldVars: deployWkldVars{
 					name: test.inputSvc,
 				},
 				unmarshal:          manifest.UnmarshalWorkload,

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -269,6 +269,44 @@ func (mr *MockjobStoreMockRecorder) DeleteJob(appName, jobName interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteJob", reflect.TypeOf((*MockjobStore)(nil).DeleteJob), appName, jobName)
 }
 
+// MockwlLister is a mock of wlLister interface
+type MockwlLister struct {
+	ctrl     *gomock.Controller
+	recorder *MockwlListerMockRecorder
+}
+
+// MockwlListerMockRecorder is the mock recorder for MockwlLister
+type MockwlListerMockRecorder struct {
+	mock *MockwlLister
+}
+
+// NewMockwlLister creates a new mock instance
+func NewMockwlLister(ctrl *gomock.Controller) *MockwlLister {
+	mock := &MockwlLister{ctrl: ctrl}
+	mock.recorder = &MockwlListerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockwlLister) EXPECT() *MockwlListerMockRecorder {
+	return m.recorder
+}
+
+// ListWorkloads mocks base method
+func (m *MockwlLister) ListWorkloads(appName string) ([]*config.Workload, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListWorkloads", appName)
+	ret0, _ := ret[0].([]*config.Workload)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListWorkloads indicates an expected call of ListWorkloads
+func (mr *MockwlListerMockRecorder) ListWorkloads(appName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListWorkloads", reflect.TypeOf((*MockwlLister)(nil).ListWorkloads), appName)
+}
+
 // MockworkloadListWriter is a mock of workloadListWriter interface
 type MockworkloadListWriter struct {
 	ctrl     *gomock.Controller
@@ -1021,6 +1059,21 @@ func (m *Mockstore) DeleteJob(appName, jobName string) error {
 func (mr *MockstoreMockRecorder) DeleteJob(appName, jobName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteJob", reflect.TypeOf((*Mockstore)(nil).DeleteJob), appName, jobName)
+}
+
+// ListWorkloads mocks base method
+func (m *Mockstore) ListWorkloads(appName string) ([]*config.Workload, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListWorkloads", appName)
+	ret0, _ := ret[0].([]*config.Workload)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListWorkloads indicates an expected call of ListWorkloads
+func (mr *MockstoreMockRecorder) ListWorkloads(appName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListWorkloads", reflect.TypeOf((*Mockstore)(nil).ListWorkloads), appName)
 }
 
 // MockdeployedEnvironmentLister is a mock of deployedEnvironmentLister interface
@@ -2368,6 +2421,44 @@ func (mr *MockwsJobReaderMockRecorder) JobNames() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JobNames", reflect.TypeOf((*MockwsJobReader)(nil).JobNames))
 }
 
+// MockwsWlReader is a mock of wsWlReader interface
+type MockwsWlReader struct {
+	ctrl     *gomock.Controller
+	recorder *MockwsWlReaderMockRecorder
+}
+
+// MockwsWlReaderMockRecorder is the mock recorder for MockwsWlReader
+type MockwsWlReaderMockRecorder struct {
+	mock *MockwsWlReader
+}
+
+// NewMockwsWlReader creates a new mock instance
+func NewMockwsWlReader(ctrl *gomock.Controller) *MockwsWlReader {
+	mock := &MockwsWlReader{ctrl: ctrl}
+	mock.recorder = &MockwsWlReaderMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockwsWlReader) EXPECT() *MockwsWlReaderMockRecorder {
+	return m.recorder
+}
+
+// WorkloadNames mocks base method
+func (m *MockwsWlReader) WorkloadNames() ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WorkloadNames")
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WorkloadNames indicates an expected call of WorkloadNames
+func (mr *MockwsWlReaderMockRecorder) WorkloadNames() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadNames", reflect.TypeOf((*MockwsWlReader)(nil).WorkloadNames))
+}
+
 // MockwsJobDirReader is a mock of wsJobDirReader interface
 type MockwsJobDirReader struct {
 	ctrl     *gomock.Controller
@@ -2434,6 +2525,149 @@ func (m *MockwsJobDirReader) CopilotDirPath() (string, error) {
 func (mr *MockwsJobDirReaderMockRecorder) CopilotDirPath() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopilotDirPath", reflect.TypeOf((*MockwsJobDirReader)(nil).CopilotDirPath))
+}
+
+// MockwsWlDirReader is a mock of wsWlDirReader interface
+type MockwsWlDirReader struct {
+	ctrl     *gomock.Controller
+	recorder *MockwsWlDirReaderMockRecorder
+}
+
+// MockwsWlDirReaderMockRecorder is the mock recorder for MockwsWlDirReader
+type MockwsWlDirReaderMockRecorder struct {
+	mock *MockwsWlDirReader
+}
+
+// NewMockwsWlDirReader creates a new mock instance
+func NewMockwsWlDirReader(ctrl *gomock.Controller) *MockwsWlDirReader {
+	mock := &MockwsWlDirReader{ctrl: ctrl}
+	mock.recorder = &MockwsWlDirReaderMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockwsWlDirReader) EXPECT() *MockwsWlDirReaderMockRecorder {
+	return m.recorder
+}
+
+// ReadJobManifest mocks base method
+func (m *MockwsWlDirReader) ReadJobManifest(jobName string) ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReadJobManifest", jobName)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReadJobManifest indicates an expected call of ReadJobManifest
+func (mr *MockwsWlDirReaderMockRecorder) ReadJobManifest(jobName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadJobManifest", reflect.TypeOf((*MockwsWlDirReader)(nil).ReadJobManifest), jobName)
+}
+
+// JobNames mocks base method
+func (m *MockwsWlDirReader) JobNames() ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "JobNames")
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// JobNames indicates an expected call of JobNames
+func (mr *MockwsWlDirReaderMockRecorder) JobNames() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JobNames", reflect.TypeOf((*MockwsWlDirReader)(nil).JobNames))
+}
+
+// ServiceNames mocks base method
+func (m *MockwsWlDirReader) ServiceNames() ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ServiceNames")
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ServiceNames indicates an expected call of ServiceNames
+func (mr *MockwsWlDirReaderMockRecorder) ServiceNames() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceNames", reflect.TypeOf((*MockwsWlDirReader)(nil).ServiceNames))
+}
+
+// ReadServiceManifest mocks base method
+func (m *MockwsWlDirReader) ReadServiceManifest(svcName string) ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReadServiceManifest", svcName)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReadServiceManifest indicates an expected call of ReadServiceManifest
+func (mr *MockwsWlDirReaderMockRecorder) ReadServiceManifest(svcName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadServiceManifest", reflect.TypeOf((*MockwsWlDirReader)(nil).ReadServiceManifest), svcName)
+}
+
+// CopilotDirPath mocks base method
+func (m *MockwsWlDirReader) CopilotDirPath() (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CopilotDirPath")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CopilotDirPath indicates an expected call of CopilotDirPath
+func (mr *MockwsWlDirReaderMockRecorder) CopilotDirPath() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopilotDirPath", reflect.TypeOf((*MockwsWlDirReader)(nil).CopilotDirPath))
+}
+
+// WorkloadNames mocks base method
+func (m *MockwsWlDirReader) WorkloadNames() ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WorkloadNames")
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WorkloadNames indicates an expected call of WorkloadNames
+func (mr *MockwsWlDirReaderMockRecorder) WorkloadNames() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadNames", reflect.TypeOf((*MockwsWlDirReader)(nil).WorkloadNames))
+}
+
+// ListDockerfiles mocks base method
+func (m *MockwsWlDirReader) ListDockerfiles() ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListDockerfiles")
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListDockerfiles indicates an expected call of ListDockerfiles
+func (mr *MockwsWlDirReaderMockRecorder) ListDockerfiles() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDockerfiles", reflect.TypeOf((*MockwsWlDirReader)(nil).ListDockerfiles))
+}
+
+// Summary mocks base method
+func (m *MockwsWlDirReader) Summary() (*workspace.Summary, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Summary")
+	ret0, _ := ret[0].(*workspace.Summary)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Summary indicates an expected call of Summary
+func (mr *MockwsWlDirReaderMockRecorder) Summary() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Summary", reflect.TypeOf((*MockwsWlDirReader)(nil).Summary))
 }
 
 // MockwsPipelineReader is a mock of wsPipelineReader interface
@@ -4375,6 +4609,21 @@ func (m *MockwsSelector) Job(prompt, help string) (string, error) {
 func (mr *MockwsSelectorMockRecorder) Job(prompt, help interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Job", reflect.TypeOf((*MockwsSelector)(nil).Job), prompt, help)
+}
+
+// Workload mocks base method
+func (m *MockwsSelector) Workload(msg, help string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Workload", msg, help)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Workload indicates an expected call of Workload
+func (mr *MockwsSelectorMockRecorder) Workload(msg, help interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Workload", reflect.TypeOf((*MockwsSelector)(nil).Workload), msg, help)
 }
 
 // MockinitJobSelector is a mock of initJobSelector interface

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -269,31 +269,31 @@ func (mr *MockjobStoreMockRecorder) DeleteJob(appName, jobName interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteJob", reflect.TypeOf((*MockjobStore)(nil).DeleteJob), appName, jobName)
 }
 
-// MockwlLister is a mock of wlLister interface
-type MockwlLister struct {
+// MockwlStore is a mock of wlStore interface
+type MockwlStore struct {
 	ctrl     *gomock.Controller
-	recorder *MockwlListerMockRecorder
+	recorder *MockwlStoreMockRecorder
 }
 
-// MockwlListerMockRecorder is the mock recorder for MockwlLister
-type MockwlListerMockRecorder struct {
-	mock *MockwlLister
+// MockwlStoreMockRecorder is the mock recorder for MockwlStore
+type MockwlStoreMockRecorder struct {
+	mock *MockwlStore
 }
 
-// NewMockwlLister creates a new mock instance
-func NewMockwlLister(ctrl *gomock.Controller) *MockwlLister {
-	mock := &MockwlLister{ctrl: ctrl}
-	mock.recorder = &MockwlListerMockRecorder{mock}
+// NewMockwlStore creates a new mock instance
+func NewMockwlStore(ctrl *gomock.Controller) *MockwlStore {
+	mock := &MockwlStore{ctrl: ctrl}
+	mock.recorder = &MockwlStoreMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use
-func (m *MockwlLister) EXPECT() *MockwlListerMockRecorder {
+func (m *MockwlStore) EXPECT() *MockwlStoreMockRecorder {
 	return m.recorder
 }
 
 // ListWorkloads mocks base method
-func (m *MockwlLister) ListWorkloads(appName string) ([]*config.Workload, error) {
+func (m *MockwlStore) ListWorkloads(appName string) ([]*config.Workload, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListWorkloads", appName)
 	ret0, _ := ret[0].([]*config.Workload)
@@ -302,9 +302,24 @@ func (m *MockwlLister) ListWorkloads(appName string) ([]*config.Workload, error)
 }
 
 // ListWorkloads indicates an expected call of ListWorkloads
-func (mr *MockwlListerMockRecorder) ListWorkloads(appName interface{}) *gomock.Call {
+func (mr *MockwlStoreMockRecorder) ListWorkloads(appName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListWorkloads", reflect.TypeOf((*MockwlLister)(nil).ListWorkloads), appName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListWorkloads", reflect.TypeOf((*MockwlStore)(nil).ListWorkloads), appName)
+}
+
+// GetWorkload mocks base method
+func (m *MockwlStore) GetWorkload(appName, name string) (*config.Workload, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetWorkload", appName, name)
+	ret0, _ := ret[0].(*config.Workload)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetWorkload indicates an expected call of GetWorkload
+func (mr *MockwlStoreMockRecorder) GetWorkload(appName, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkload", reflect.TypeOf((*MockwlStore)(nil).GetWorkload), appName, name)
 }
 
 // MockworkloadListWriter is a mock of workloadListWriter interface
@@ -1074,6 +1089,21 @@ func (m *Mockstore) ListWorkloads(appName string) ([]*config.Workload, error) {
 func (mr *MockstoreMockRecorder) ListWorkloads(appName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListWorkloads", reflect.TypeOf((*Mockstore)(nil).ListWorkloads), appName)
+}
+
+// GetWorkload mocks base method
+func (m *Mockstore) GetWorkload(appName, name string) (*config.Workload, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetWorkload", appName, name)
+	ret0, _ := ret[0].(*config.Workload)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetWorkload indicates an expected call of GetWorkload
+func (mr *MockstoreMockRecorder) GetWorkload(appName, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkload", reflect.TypeOf((*Mockstore)(nil).GetWorkload), appName, name)
 }
 
 // MockdeployedEnvironmentLister is a mock of deployedEnvironmentLister interface

--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -36,7 +36,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type deploySvcVars struct {
+type deployWkldVars struct {
 	appName      string
 	name         string
 	envName      string
@@ -45,7 +45,7 @@ type deploySvcVars struct {
 }
 
 type deploySvcOpts struct {
-	deploySvcVars
+	deployWkldVars
 
 	store              store
 	ws                 wsSvcDirReader
@@ -69,7 +69,7 @@ type deploySvcOpts struct {
 	buildRequired     bool
 }
 
-func newSvcDeployOpts(vars deploySvcVars) (*deploySvcOpts, error) {
+func newSvcDeployOpts(vars deployWkldVars) (*deploySvcOpts, error) {
 	store, err := config.NewStore()
 	if err != nil {
 		return nil, fmt.Errorf("new config store: %w", err)
@@ -81,7 +81,7 @@ func newSvcDeployOpts(vars deploySvcVars) (*deploySvcOpts, error) {
 	}
 	prompter := prompt.New()
 	return &deploySvcOpts{
-		deploySvcVars: vars,
+		deployWkldVars: vars,
 
 		store:        store,
 		ws:           ws,
@@ -482,7 +482,7 @@ func (o *deploySvcOpts) showSvcURI() error {
 
 // buildSvcDeployCmd builds the `svc deploy` subcommand.
 func buildSvcDeployCmd() *cobra.Command {
-	vars := deploySvcVars{}
+	vars := deployWkldVars{}
 	cmd := &cobra.Command{
 		Use:   "deploy",
 		Short: "Deploys a service to an environment.",

--- a/internal/pkg/cli/svc_deploy_test.go
+++ b/internal/pkg/cli/svc_deploy_test.go
@@ -98,7 +98,7 @@ func TestSvcDeployOpts_Validate(t *testing.T) {
 			tc.mockWs(mockWs)
 			tc.mockStore(mockStore)
 			opts := deploySvcOpts{
-				deploySvcVars: deploySvcVars{
+				deployWkldVars: deployWkldVars{
 					appName: tc.inAppName,
 					name:    tc.inSvcName,
 					envName: tc.inEnvName,
@@ -171,7 +171,7 @@ func TestSvcDeployOpts_Ask(t *testing.T) {
 
 			tc.wantedCalls(mockSel)
 			opts := deploySvcOpts{
-				deploySvcVars: deploySvcVars{
+				deployWkldVars: deployWkldVars{
 					appName:  tc.inAppName,
 					name:     tc.inSvcName,
 					envName:  tc.inEnvName,
@@ -321,7 +321,7 @@ image:
 			}
 			test.setupMocks(mocks)
 			opts := deploySvcOpts{
-				deploySvcVars: deploySvcVars{
+				deployWkldVars: deployWkldVars{
 					name: test.inputSvc,
 				},
 				unmarshal:          manifest.UnmarshalWorkload,
@@ -471,7 +471,7 @@ func TestSvcDeployOpts_pushAddonsTemplateToS3Bucket(t *testing.T) {
 			tc.mockAddons(mockAddons)
 
 			opts := deploySvcOpts{
-				deploySvcVars: deploySvcVars{
+				deployWkldVars: deployWkldVars{
 					name: tc.inputSvc,
 				},
 				store:             mockProjectSvc,

--- a/internal/pkg/config/errors.go
+++ b/internal/pkg/config/errors.go
@@ -90,3 +90,23 @@ func (e *ErrNoSuchJob) Error() string {
 	return fmt.Sprintf("couldn't find job %s in the application %s",
 		e.Name, e.App)
 }
+
+// ErrNoSuchWorkload means a workload couldn't be found in a specific application.
+type ErrNoSuchWorkload struct {
+	App  string
+	Name string
+}
+
+// Is returns whether the provided error equals this error
+func (e *ErrNoSuchWorkload) Is(target error) bool {
+	t, ok := target.(*ErrNoSuchWorkload)
+	if !ok {
+		return false
+	}
+	return e.App == t.App &&
+		e.Name == t.Name
+}
+
+func (e *ErrNoSuchWorkload) Error() string {
+	return fmt.Sprintf("couldn't find %s in the application %s", e.Name, e.App)
+}

--- a/internal/pkg/config/workload.go
+++ b/internal/pkg/config/workload.go
@@ -142,30 +142,6 @@ func (s *Store) GetJob(appName, jobName string) (*Workload, error) {
 	return &job, nil
 }
 
-func (s *Store) getWorkload(appName, wlName, wlType string, match func(string) bool) (*Workload, error) {
-	wlPath := fmt.Sprintf(fmtWkldParamPath, appName, wlName)
-	wlParam, err := s.ssmClient.GetParameter(&ssm.GetParameterInput{
-		Name: aws.String(wlPath),
-	})
-
-	if err != nil {
-		if aerr, ok := err.(awserr.Error); ok {
-			switch aerr.Code() {
-			case ssm.ErrCodeParameterNotFound:
-				return nil, fmt.Errorf("job or service %s not found in application %s", wlName, appName)
-			}
-		}
-		return nil, fmt.Errorf("get job or svc %s in application %s: %w", wlName, appName, err)
-	}
-
-	var wl Workload
-	err = json.Unmarshal([]byte(*wlParam.Parameter.Value), &wl)
-	if err != nil {
-		return nil, fmt.Errorf("read configuration for job or service %s in application %s: %w", wlName, appName, err)
-	}
-	return &wl, nil
-}
-
 // ListServices returns all services belonging to a particular application.
 func (s *Store) ListServices(appName string) ([]*Workload, error) {
 	wklds, err := s.listWorkloads(appName)

--- a/internal/pkg/config/workload.go
+++ b/internal/pkg/config/workload.go
@@ -116,11 +116,11 @@ func (s *Store) GetJob(appName, jobName string) (*Workload, error) {
 	return &job, nil
 }
 
-// GetWorkload gets a job or service belonging to an application by name.
+// GetWorkload gets a workload belonging to an application by name.
 func (s *Store) GetWorkload(appName, name string) (*Workload, error) {
 	param, err := s.getWorkloadParam(appName, name)
 	if err != nil {
-		return nil, fmt.Errorf("get job or service: %w", err)
+		return nil, fmt.Errorf("get workload: %w", err)
 	}
 	var wl Workload
 	err = json.Unmarshal(param, &wl)
@@ -188,7 +188,7 @@ func (s *Store) ListJobs(appName string) ([]*Workload, error) {
 func (s *Store) ListWorkloads(appName string) ([]*Workload, error) {
 	wklds, err := s.listWorkloads(appName)
 	if err != nil {
-		return nil, fmt.Errorf("read job & service configuration for application %s: %w", appName, err)
+		return nil, fmt.Errorf("read workload configuration for application %s: %w", appName, err)
 	}
 
 	return wklds, nil

--- a/internal/pkg/config/workload_test.go
+++ b/internal/pkg/config/workload_test.go
@@ -333,10 +333,7 @@ func TestStore_GetService(t *testing.T) {
 				require.Equal(t, testServicePath, *param.Name)
 				return nil, awserr.New(ssm.ErrCodeParameterNotFound, "bloop", nil)
 			},
-			wantedErr: &ErrNoSuchService{
-				App:  testService.App,
-				Name: testService.Name,
-			},
+			wantedErr: errors.New("get service: couldn't find api in the application chicken"),
 		},
 		"with malformed json": {
 			mockGetParameter: func(t *testing.T, param *ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {
@@ -354,7 +351,7 @@ func TestStore_GetService(t *testing.T) {
 			mockGetParameter: func(t *testing.T, param *ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {
 				return nil, fmt.Errorf("broken")
 			},
-			wantedErr: fmt.Errorf("get service api in application chicken: broken"),
+			wantedErr: fmt.Errorf("get service: broken"),
 		},
 	}
 
@@ -415,10 +412,7 @@ func TestStore_GetJob(t *testing.T) {
 				require.Equal(t, mailerJobPath, *param.Name)
 				return nil, awserr.New(ssm.ErrCodeParameterNotFound, "bloop", nil)
 			},
-			wantedErr: &ErrNoSuchJob{
-				App:  mailerJob.App,
-				Name: mailerJob.Name,
-			},
+			wantedErr: errors.New("get job: couldn't find mailer in the application chicken"),
 		},
 		"with existing service": {
 			mockGetParameter: func(t *testing.T, param *ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {

--- a/internal/pkg/term/selector/mocks/mock_selector.go
+++ b/internal/pkg/term/selector/mocks/mock_selector.go
@@ -221,6 +221,21 @@ func (mr *MockConfigWorkloadListerMockRecorder) ListJobs(appName interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListJobs", reflect.TypeOf((*MockConfigWorkloadLister)(nil).ListJobs), appName)
 }
 
+// ListWorkloads mocks base method
+func (m *MockConfigWorkloadLister) ListWorkloads(appName string) ([]*config.Workload, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListWorkloads", appName)
+	ret0, _ := ret[0].([]*config.Workload)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListWorkloads indicates an expected call of ListWorkloads
+func (mr *MockConfigWorkloadListerMockRecorder) ListWorkloads(appName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListWorkloads", reflect.TypeOf((*MockConfigWorkloadLister)(nil).ListWorkloads), appName)
+}
+
 // MockConfigLister is a mock of ConfigLister interface
 type MockConfigLister struct {
 	ctrl     *gomock.Controller
@@ -304,6 +319,21 @@ func (mr *MockConfigListerMockRecorder) ListJobs(appName interface{}) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListJobs", reflect.TypeOf((*MockConfigLister)(nil).ListJobs), appName)
 }
 
+// ListWorkloads mocks base method
+func (m *MockConfigLister) ListWorkloads(appName string) ([]*config.Workload, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListWorkloads", appName)
+	ret0, _ := ret[0].([]*config.Workload)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListWorkloads indicates an expected call of ListWorkloads
+func (mr *MockConfigListerMockRecorder) ListWorkloads(appName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListWorkloads", reflect.TypeOf((*MockConfigLister)(nil).ListWorkloads), appName)
+}
+
 // MockWsWorkloadLister is a mock of WsWorkloadLister interface
 type MockWsWorkloadLister struct {
 	ctrl     *gomock.Controller
@@ -357,6 +387,21 @@ func (mr *MockWsWorkloadListerMockRecorder) JobNames() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JobNames", reflect.TypeOf((*MockWsWorkloadLister)(nil).JobNames))
 }
 
+// WorkloadNames mocks base method
+func (m *MockWsWorkloadLister) WorkloadNames() ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WorkloadNames")
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WorkloadNames indicates an expected call of WorkloadNames
+func (mr *MockWsWorkloadListerMockRecorder) WorkloadNames() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadNames", reflect.TypeOf((*MockWsWorkloadLister)(nil).WorkloadNames))
+}
+
 // MockWorkspaceRetriever is a mock of WorkspaceRetriever interface
 type MockWorkspaceRetriever struct {
 	ctrl     *gomock.Controller
@@ -408,6 +453,21 @@ func (m *MockWorkspaceRetriever) JobNames() ([]string, error) {
 func (mr *MockWorkspaceRetrieverMockRecorder) JobNames() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JobNames", reflect.TypeOf((*MockWorkspaceRetriever)(nil).JobNames))
+}
+
+// WorkloadNames mocks base method
+func (m *MockWorkspaceRetriever) WorkloadNames() ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WorkloadNames")
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WorkloadNames indicates an expected call of WorkloadNames
+func (mr *MockWorkspaceRetrieverMockRecorder) WorkloadNames() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadNames", reflect.TypeOf((*MockWorkspaceRetriever)(nil).WorkloadNames))
 }
 
 // Summary mocks base method

--- a/internal/pkg/term/selector/selector.go
+++ b/internal/pkg/term/selector/selector.go
@@ -29,6 +29,9 @@ const (
 	weekly  = "Weekly"
 	monthly = "Monthly"
 	yearly  = "Yearly"
+
+	jobWlType = "job"
+	svcWlType = "service"
 )
 
 const (
@@ -83,6 +86,7 @@ type AppEnvLister interface {
 type ConfigWorkloadLister interface {
 	ListServices(appName string) ([]*config.Workload, error)
 	ListJobs(appName string) ([]*config.Workload, error)
+	ListWorkloads(appName string) ([]*config.Workload, error)
 }
 
 // ConfigLister wraps config store listing methods.
@@ -95,6 +99,7 @@ type ConfigLister interface {
 type WsWorkloadLister interface {
 	ServiceNames() ([]string, error)
 	JobNames() ([]string, error)
+	WorkloadNames() ([]string, error)
 }
 
 // WorkspaceRetriever wraps methods to get workload names, app names, and Dockerfiles from the workspace.
@@ -325,6 +330,44 @@ func (s *WorkspaceSelect) Job(msg, help string) (string, error) {
 	return selectedJobName, nil
 }
 
+// Workload fetches all jobs and services in an app and prompts the user to select one.
+func (s *WorkspaceSelect) Workload(msg, help string) (wl string, err error) {
+	summary, err := s.ws.Summary()
+	if err != nil {
+		return "", fmt.Errorf("read workspace summary: %w", err)
+	}
+	wsWlNames, err := s.retrieveWorkspaceWorkloads()
+	if err != nil {
+		return "", fmt.Errorf("retrieve jobs and services from workspace: %w", err)
+	}
+	storeWls, err := s.Select.config.ListWorkloads(summary.Application)
+	if err != nil {
+		return "", fmt.Errorf("retrieve jobs and services from store: %w", err)
+	}
+	wlNames := filterWlsByName(storeWls, wsWlNames)
+	if len(wlNames) == 0 {
+		return "", errors.New("no jobs or services found")
+	}
+	if len(wlNames) == 1 {
+		log.Infof("Only found one job or service, defaulting to: %s\n", color.HighlightUserInput(wlNames[0]))
+		return wlNames[0], nil
+	}
+	selectedWlName, err := s.prompt.SelectOne(msg, help, wlNames, prompt.WithFinalMessage("Name: "))
+	if err != nil {
+		return "", fmt.Errorf("select job or service: %w", err)
+	}
+	return selectedWlName, nil
+}
+
+func isJob(name string, workloads []*config.Workload) bool {
+	for _, w := range workloads {
+		if w.Name == name && strings.Contains(strings.ToLower(w.Type), jobWlType) {
+			return true
+		}
+	}
+	return false
+}
+
 func filterWlsByName(wls []*config.Workload, wantedNames []string) []string {
 	isWanted := make(map[string]bool)
 	for _, name := range wantedNames {
@@ -465,6 +508,14 @@ func (s *WorkspaceSelect) retrieveWorkspaceJobs() ([]string, error) {
 		return nil, err
 	}
 	return localJobNames, nil
+}
+
+func (s *WorkspaceSelect) retrieveWorkspaceWorkloads() ([]string, error) {
+	localWlNames, err := s.ws.WorkloadNames()
+	if err != nil {
+		return nil, err
+	}
+	return localWlNames, nil
 }
 
 // Dockerfile asks the user to select from a list of Dockerfiles in the current

--- a/internal/pkg/term/selector/selector.go
+++ b/internal/pkg/term/selector/selector.go
@@ -346,12 +346,12 @@ func (s *WorkspaceSelect) Workload(msg, help string) (wl string, err error) {
 		return "", errors.New("no jobs or services found")
 	}
 	if len(wlNames) == 1 {
-		log.Infof("Only found one job or service, defaulting to: %s\n", color.HighlightUserInput(wlNames[0]))
+		log.Infof("Only found one workload, defaulting to: %s\n", color.HighlightUserInput(wlNames[0]))
 		return wlNames[0], nil
 	}
 	selectedWlName, err := s.prompt.SelectOne(msg, help, wlNames, prompt.WithFinalMessage("Name: "))
 	if err != nil {
-		return "", fmt.Errorf("select job or service: %w", err)
+		return "", fmt.Errorf("select workload: %w", err)
 	}
 	return selectedWlName, nil
 }

--- a/internal/pkg/term/selector/selector.go
+++ b/internal/pkg/term/selector/selector.go
@@ -29,9 +29,6 @@ const (
 	weekly  = "Weekly"
 	monthly = "Monthly"
 	yearly  = "Yearly"
-
-	jobWlType = "job"
-	svcWlType = "service"
 )
 
 const (
@@ -357,15 +354,6 @@ func (s *WorkspaceSelect) Workload(msg, help string) (wl string, err error) {
 		return "", fmt.Errorf("select job or service: %w", err)
 	}
 	return selectedWlName, nil
-}
-
-func isJob(name string, workloads []*config.Workload) bool {
-	for _, w := range workloads {
-		if w.Name == name && strings.Contains(strings.ToLower(w.Type), jobWlType) {
-			return true
-		}
-	}
-	return false
 }
 
 func filterWlsByName(wls []*config.Workload, wantedNames []string) []string {

--- a/site/content/docs/commands/deploy.md
+++ b/site/content/docs/commands/deploy.md
@@ -3,4 +3,36 @@
 $ copilot deploy
 ```
 
-This command is an alias for [`copilot svc deploy`](../commands/svc-deploy.md).
+## What does it do? 
+
+This command is used to run either [`copilot svc deploy`](../commands/svc-deploy.md) or [`copilot job deploy`](../commands/job-deploy.md) under the hood. The steps involved in `copilot deploy` are the same as those involved in `copilot svc deploy` and `copilot job deploy`:
+
+1. Build your local Dockerfile into an image
+2. Tag it with the value from `--tag` or the latest git sha (if you're in a git directory)
+3. Push the image to ECR
+4. Package your manifest file and addons into CloudFormation
+5. Create / update your ECS task definition and job or service.
+
+## What are the flags?
+
+```bash
+  -a, --app string                     Name of the application.
+  -e, --env string                     Name of the environment.
+  -h, --help                           help for deploy
+  -n, --name string                    Name of the service or job.
+      --resource-tags stringToString   Optional. Labels with a key and value separated with commas.
+                                       Allows you to categorize resources. (default [])
+      --tag string                     Optional. The container image tag.
+```
+
+## Examples
+
+Deploys a service named "frontend" to a "test" environment.
+```bash
+ $ copilot deploy --name frontend --env test
+```
+
+Deploys a job named "mailer" with additional resource tags to a "prod" environment.
+```bash
+$ copilot deploy -n mailer -e prod --resource-tags source/revision=bb133e7,deployment/initiator=manual
+```


### PR DESCRIPTION
<!-- Provide summary of changes -->
Adds the ability to deploy jobs as well as services from `copilot deploy`. All deploy flags are accepted. 
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->
#1131 related
Resolves #1544 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
