### PR TITLE
chore(task): delete tasks created with a CFNExecutionRole during app delete.

### DIFF
--- a/e2e/task/task_suite_test.go
+++ b/e2e/task/task_suite_test.go
@@ -43,18 +43,12 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	// Clean ECR repo before deleting the stack.
-	err := aws.DeleteECRRepo(repoName)
-	Expect(err).NotTo(HaveOccurred(), "delete ecr repo")
-	// Delete task stack.
-	err = aws.DeleteStack(taskStackName)
-	Expect(err).NotTo(HaveOccurred(), "start deleting task stack")
-	// Wait until task stack is removed.
-	err = aws.WaitStackDeleteComplete(taskStackName)
-	Expect(err).NotTo(HaveOccurred(), "task stack delete complete")
 	// Delete Copilot application.
-	_, err = cli.AppDelete()
+	_, err := cli.AppDelete()
 	Expect(err).NotTo(HaveOccurred(), "delete Copilot application")
+	// Check that task stack is deleted.
+	err = aws.DeleteStack(taskStackName)
+	Expect(err).NotTo(HaveOccurred(), "try deleting task stack")
 })
 
 func BeforeAll(fn func()) {

--- a/internal/pkg/aws/cloudformation/cloudformation.go
+++ b/internal/pkg/aws/cloudformation/cloudformation.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -227,6 +228,11 @@ func (c *CloudFormation) events(stackName string, match eventMatcher) ([]StackEv
 	return events, nil
 }
 
+// ListStacksWithPrefix returns all the stacks in the current AWS account.
+func (c *CloudFormation) ListStacksWithPrefix(prefix string) ([]StackDescription, error) {
+	return c.listStacks(prefix)
+}
+
 // ErrorEvents returns the list of events with "failed" status in **chronological order**
 func (c *CloudFormation) ErrorEvents(stackName string) ([]StackEvent, error) {
 	return c.events(stackName, func(in *cloudformation.StackEvent) bool {
@@ -237,6 +243,11 @@ func (c *CloudFormation) ErrorEvents(stackName string) ([]StackEvent, error) {
 		}
 		return false
 	})
+}
+
+// ListStacksWithPrefix returns all the stacks in the current AWS account.
+func (c *CloudFormation) ListStacksWithPrefix(prefix string) ([]StackSummary, error) {
+	return c.listStacks(prefix, []*string{})
 }
 
 func (c *CloudFormation) create(stack *Stack) error {
@@ -271,4 +282,28 @@ func (c *CloudFormation) deleteAndWait(in *cloudformation.DeleteStackInput) erro
 		return fmt.Errorf("wait until stack %s delete is complete: %w", aws.StringValue(in.StackName), err)
 	}
 	return nil
+}
+
+func (c *CloudFormation) listStacks(prefix string) ([]StackDescription, error) {
+	var nextToken *string
+	var summaries []StackDescription
+	for {
+		out, err := c.client.DescribeStacks(&cloudformation.DescribeStacksInput{
+			NextToken: nextToken,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("list stacks: %w", err)
+		}
+
+		for _, summary := range out.Stacks {
+			if strings.HasPrefix(*summary.StackName, prefix) {
+				summaries = append(summaries, StackDescription(*summary))
+			}
+		}
+		nextToken = out.NextToken
+		if nextToken == nil {
+			break
+		}
+	}
+	return summaries, nil
 }

--- a/internal/pkg/aws/cloudformation/interfaces.go
+++ b/internal/pkg/aws/cloudformation/interfaces.go
@@ -25,6 +25,8 @@ type api interface {
 	GetTemplate(input *cloudformation.GetTemplateInput) (*cloudformation.GetTemplateOutput, error)
 	DeleteStack(*cloudformation.DeleteStackInput) (*cloudformation.DeleteStackOutput, error)
 
+	ListStacks(*cloudformation.ListStacksInput) (*cloudformation.ListStacksOutput, error)
+
 	WaitUntilStackCreateCompleteWithContext(aws.Context, *cloudformation.DescribeStacksInput, ...request.WaiterOption) error
 	WaitUntilStackUpdateCompleteWithContext(aws.Context, *cloudformation.DescribeStacksInput, ...request.WaiterOption) error
 	WaitUntilStackDeleteCompleteWithContext(aws.Context, *cloudformation.DescribeStacksInput, ...request.WaiterOption) error

--- a/internal/pkg/aws/cloudformation/mocks/mock_cloudformation.go
+++ b/internal/pkg/aws/cloudformation/mocks/mock_cloudformation.go
@@ -276,6 +276,21 @@ func (mr *MockapiMockRecorder) DeleteStack(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteStack", reflect.TypeOf((*Mockapi)(nil).DeleteStack), arg0)
 }
 
+// ListStacks mocks base method
+func (m *Mockapi) ListStacks(arg0 *cloudformation.ListStacksInput) (*cloudformation.ListStacksOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListStacks", arg0)
+	ret0, _ := ret[0].(*cloudformation.ListStacksOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListStacks indicates an expected call of ListStacks
+func (mr *MockapiMockRecorder) ListStacks(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListStacks", reflect.TypeOf((*Mockapi)(nil).ListStacks), arg0)
+}
+
 // WaitUntilStackCreateCompleteWithContext mocks base method
 func (m *Mockapi) WaitUntilStackCreateCompleteWithContext(arg0 aws.Context, arg1 *cloudformation.DescribeStacksInput, arg2 ...request.WaiterOption) error {
 	m.ctrl.T.Helper()

--- a/internal/pkg/aws/cloudformation/stack.go
+++ b/internal/pkg/aws/cloudformation/stack.go
@@ -79,6 +79,9 @@ type StackEvent cloudformation.StackEvent
 // StackDescription represents an existing AWS CloudFormation stack.
 type StackDescription cloudformation.Stack
 
+// StackSummary represents a summary of an existing AWS CloudFormation stack.
+type StackSummary cloudformation.StackSummary
+
 // SDK returns the underlying struct from the AWS SDK.
 func (d *StackDescription) SDK() *cloudformation.Stack {
 	raw := cloudformation.Stack(*d)

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -348,6 +348,9 @@ type appResourcesGetter interface {
 
 type taskDeployer interface {
 	DeployTask(input *deploy.CreateTaskResourcesInput, opts ...cloudformation.StackOption) error
+	GetDefaultTaskStackInfo() ([]deploy.TaskStackInfo, error)
+	GetTaskStackInfo(appName, envName string) ([]deploy.TaskStackInfo, error)
+	DeleteTask(deploy.TaskStackInfo) error
 }
 
 type taskRunner interface {
@@ -362,6 +365,7 @@ type deployer interface {
 	environmentDeployer
 	appDeployer
 	pipelineDeployer
+	taskDeployer
 }
 
 type domainValidator interface {

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -3517,6 +3517,50 @@ func (mr *MocktaskDeployerMockRecorder) DeployTask(input interface{}, opts ...in
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeployTask", reflect.TypeOf((*MocktaskDeployer)(nil).DeployTask), varargs...)
 }
 
+// GetDefaultTaskStackInfo mocks base method
+func (m *MocktaskDeployer) GetDefaultTaskStackInfo() ([]deploy.TaskStackInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDefaultTaskStackInfo")
+	ret0, _ := ret[0].([]deploy.TaskStackInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDefaultTaskStackInfo indicates an expected call of GetDefaultTaskStackInfo
+func (mr *MocktaskDeployerMockRecorder) GetDefaultTaskStackInfo() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDefaultTaskStackInfo", reflect.TypeOf((*MocktaskDeployer)(nil).GetDefaultTaskStackInfo))
+}
+
+// GetTaskStackInfo mocks base method
+func (m *MocktaskDeployer) GetTaskStackInfo(appName, envName string) ([]deploy.TaskStackInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTaskStackInfo", appName, envName)
+	ret0, _ := ret[0].([]deploy.TaskStackInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTaskStackInfo indicates an expected call of GetTaskStackInfo
+func (mr *MocktaskDeployerMockRecorder) GetTaskStackInfo(appName, envName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTaskStackInfo", reflect.TypeOf((*MocktaskDeployer)(nil).GetTaskStackInfo), appName, envName)
+}
+
+// DeleteTask mocks base method
+func (m *MocktaskDeployer) DeleteTask(arg0 deploy.TaskStackInfo) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteTask", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteTask indicates an expected call of DeleteTask
+func (mr *MocktaskDeployerMockRecorder) DeleteTask(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTask", reflect.TypeOf((*MocktaskDeployer)(nil).DeleteTask), arg0)
+}
+
 // MocktaskRunner is a mock of taskRunner interface
 type MocktaskRunner struct {
 	ctrl     *gomock.Controller
@@ -3886,6 +3930,69 @@ func (m *Mockdeployer) GetRegionalAppResources(app *config.Application) ([]*stac
 func (mr *MockdeployerMockRecorder) GetRegionalAppResources(app interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegionalAppResources", reflect.TypeOf((*Mockdeployer)(nil).GetRegionalAppResources), app)
+}
+
+// DeployTask mocks base method
+func (m *Mockdeployer) DeployTask(input *deploy.CreateTaskResourcesInput, opts ...cloudformation.StackOption) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{input}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DeployTask", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeployTask indicates an expected call of DeployTask
+func (mr *MockdeployerMockRecorder) DeployTask(input interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{input}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeployTask", reflect.TypeOf((*Mockdeployer)(nil).DeployTask), varargs...)
+}
+
+// GetDefaultTaskStackInfo mocks base method
+func (m *Mockdeployer) GetDefaultTaskStackInfo() ([]deploy.TaskStackInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDefaultTaskStackInfo")
+	ret0, _ := ret[0].([]deploy.TaskStackInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDefaultTaskStackInfo indicates an expected call of GetDefaultTaskStackInfo
+func (mr *MockdeployerMockRecorder) GetDefaultTaskStackInfo() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDefaultTaskStackInfo", reflect.TypeOf((*Mockdeployer)(nil).GetDefaultTaskStackInfo))
+}
+
+// GetTaskStackInfo mocks base method
+func (m *Mockdeployer) GetTaskStackInfo(appName, envName string) ([]deploy.TaskStackInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTaskStackInfo", appName, envName)
+	ret0, _ := ret[0].([]deploy.TaskStackInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTaskStackInfo indicates an expected call of GetTaskStackInfo
+func (mr *MockdeployerMockRecorder) GetTaskStackInfo(appName, envName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTaskStackInfo", reflect.TypeOf((*Mockdeployer)(nil).GetTaskStackInfo), appName, envName)
+}
+
+// DeleteTask mocks base method
+func (m *Mockdeployer) DeleteTask(arg0 deploy.TaskStackInfo) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteTask", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteTask indicates an expected call of DeleteTask
+func (mr *MockdeployerMockRecorder) DeleteTask(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTask", reflect.TypeOf((*Mockdeployer)(nil).DeleteTask), arg0)
 }
 
 // MockdomainValidator is a mock of domainValidator interface

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -45,7 +45,6 @@ const (
 )
 
 const (
-	fmtRepoName = "copilot-%s"
 	fmtImageURI = "%s:%s"
 )
 
@@ -142,7 +141,7 @@ func newTaskRunOpts(vars runTaskVars) (*runTaskOpts, error) {
 	}
 
 	opts.configureRepository = func() error {
-		repoName := fmt.Sprintf(fmtRepoName, opts.groupName)
+		repoName := fmt.Sprintf(deploy.FmtTaskECRRepoName, opts.groupName)
 		registry := ecr.New(opts.sess)
 		repository, err := repository.New(repoName, registry)
 		if err != nil {

--- a/internal/pkg/deploy/cloudformation/cloudformation.go
+++ b/internal/pkg/deploy/cloudformation/cloudformation.go
@@ -39,6 +39,7 @@ type cfnClient interface {
 	Describe(stackName string) (*cloudformation.StackDescription, error)
 	TemplateBody(stackName string) (string, error)
 	Events(stackName string) ([]cloudformation.StackEvent, error)
+	ListStacksWithPrefix(prefix string) ([]cloudformation.StackDescription, error)
 	ErrorEvents(stackName string) ([]cloudformation.StackEvent, error)
 }
 

--- a/internal/pkg/deploy/cloudformation/mocks/mock_cloudformation.go
+++ b/internal/pkg/deploy/cloudformation/mocks/mock_cloudformation.go
@@ -287,6 +287,21 @@ func (mr *MockcfnClientMockRecorder) Events(stackName interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Events", reflect.TypeOf((*MockcfnClient)(nil).Events), stackName)
 }
 
+// ListStacksWithPrefix mocks base method
+func (m *MockcfnClient) ListStacksWithPrefix(prefix string) ([]cloudformation0.StackDescription, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListStacksWithPrefix", prefix)
+	ret0, _ := ret[0].([]cloudformation0.StackDescription)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListStacksWithPrefix indicates an expected call of ListStacksWithPrefix
+func (mr *MockcfnClientMockRecorder) ListStacksWithPrefix(prefix interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListStacksWithPrefix", reflect.TypeOf((*MockcfnClient)(nil).ListStacksWithPrefix), prefix)
+}
+
 // ErrorEvents mocks base method
 func (m *MockcfnClient) ErrorEvents(stackName string) ([]cloudformation0.StackEvent, error) {
 	m.ctrl.T.Helper()

--- a/internal/pkg/deploy/cloudformation/stack/name.go
+++ b/internal/pkg/deploy/cloudformation/stack/name.go
@@ -3,7 +3,20 @@
 
 package stack
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
+
+const fmtTaskStackName = "task-%s"
+
+// TaskStackName holds the name of a Copilot one-off task stack.
+type TaskStackName string
+
+// TaskName returns the name of the task family, generated from the stack name
+func (t TaskStackName) TaskName() string {
+	return strings.SplitN(string(t), "-", 2)[1]
+}
 
 // NameForService returns the stack name for a service.
 func NameForService(app, env, svc string) string {
@@ -23,6 +36,6 @@ func NameForEnv(app, env string) string {
 }
 
 // NameForTask returns the stack name for a task.
-func NameForTask(task string) string {
-	return fmt.Sprintf("task-%s", task)
+func NameForTask(task string) TaskStackName {
+	return TaskStackName(fmt.Sprintf(fmtTaskStackName, task))
 }

--- a/internal/pkg/deploy/cloudformation/stack/task.go
+++ b/internal/pkg/deploy/cloudformation/stack/task.go
@@ -47,7 +47,7 @@ func NewTaskStackConfig(taskOpts *deploy.CreateTaskResourcesInput) *taskStackCon
 
 // StackName returns the name of the CloudFormation stack for the task.
 func (t *taskStackConfig) StackName() string {
-	return NameForTask(t.Name)
+	return string(NameForTask(t.Name))
 }
 
 // Template returns the task CloudFormation template.

--- a/internal/pkg/deploy/cloudformation/stack/task_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/task_test.go
@@ -137,7 +137,7 @@ func TestTaskStackConfig_StackName(t *testing.T) {
 		CreateTaskResourcesInput: &taskInput,
 	}
 	got := task.StackName()
-	require.Equal(t, got, fmt.Sprintf("task-%s", testTaskName))
+	require.Equal(t, got, fmt.Sprintf(fmtTaskStackName, testTaskName))
 }
 
 func TestTaskStackConfig_Tags(t *testing.T) {

--- a/internal/pkg/deploy/cloudformation/task.go
+++ b/internal/pkg/deploy/cloudformation/task.go
@@ -7,10 +7,14 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/copilot-cli/internal/pkg/aws/cloudformation"
 	"github.com/aws/copilot-cli/internal/pkg/deploy"
+
 	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation/stack"
 )
+
+const taskStackPrefix = "task-"
 
 // DeployTask deploys a task stack and waits until the deployment is done.
 // If the task stack doesn't exist, then it creates the stack.
@@ -47,4 +51,83 @@ func (cf CloudFormation) DeployTask(input *deploy.CreateTaskResourcesInput, opts
 	}
 
 	return nil
+}
+
+// GetTaskStackInfo returns all the CF stacks which represent one-off copilot tasks in a given application's environments
+func (cf CloudFormation) GetTaskStackInfo(appName, envName string) ([]deploy.TaskStackInfo, error) {
+	tasks, err := cf.cfnClient.ListStacksWithPrefix(taskStackPrefix)
+	if err != nil {
+		return nil, err
+	}
+	var outputTaskStacks []deploy.TaskStackInfo
+	for _, task := range tasks {
+		var hasTaskTag, hasAppTag, hasEnvTag bool
+		for _, tag := range task.Tags {
+			if aws.StringValue(tag.Key) == deploy.TaskTagKey {
+				hasTaskTag = true
+			}
+
+			if aws.StringValue(tag.Key) == deploy.AppTagKey && aws.StringValue(tag.Value) == appName {
+				hasAppTag = true
+			}
+
+			if aws.StringValue(tag.Key) == deploy.EnvTagKey && aws.StringValue(tag.Value) == envName {
+				hasEnvTag = true
+			}
+		}
+
+		if !hasTaskTag || !hasAppTag || !hasEnvTag {
+			continue
+		}
+
+		outputTaskStacks = append(outputTaskStacks, deploy.TaskStackInfo{
+			StackName: aws.StringValue(task.StackName),
+			App:       appName,
+			Env:       envName,
+
+			RoleARN: aws.StringValue(task.RoleARN),
+		})
+	}
+	return outputTaskStacks, nil
+}
+
+// GetDefaultTaskStackInfo returns all the CF stacks created by copilot but not associated with an application.
+func (cf CloudFormation) GetDefaultTaskStackInfo() ([]deploy.TaskStackInfo, error) {
+	tasks, err := cf.cfnClient.ListStacksWithPrefix(taskStackPrefix)
+	if err != nil {
+		return nil, err
+	}
+	var outputTaskStacks []deploy.TaskStackInfo
+	for _, task := range tasks {
+		var hasTaskTag, hasAppTag bool
+		for _, tag := range task.Tags {
+			if aws.StringValue(tag.Key) == deploy.TaskTagKey {
+				hasTaskTag = true
+			}
+			if aws.StringValue(tag.Key) == deploy.AppTagKey {
+				hasAppTag = true
+			}
+		}
+		if !hasTaskTag || hasAppTag {
+			continue
+		}
+
+		// Check the RoleArn of the task to see if it's created using a copilot EnvManagerRole.
+		if aws.StringValue(task.RoleARN) != "" {
+			continue
+		}
+		outputTaskStacks = append(outputTaskStacks, deploy.TaskStackInfo{
+			StackName: aws.StringValue(task.StackName),
+			App:       "",
+			Env:       "",
+
+			RoleARN: "",
+		})
+	}
+	return outputTaskStacks, nil
+}
+
+// DeleteTask deletes a Copilot-created one-off task stack using the RoleARN that stack was created with.
+func (cf CloudFormation) DeleteTask(task deploy.TaskStackInfo) error {
+	return cf.cfnClient.DeleteAndWaitWithRoleARN(task.StackName, task.RoleARN)
 }

--- a/internal/pkg/deploy/cloudformation/task_test.go
+++ b/internal/pkg/deploy/cloudformation/task_test.go
@@ -7,11 +7,12 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
+	awscfn "github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/copilot-cli/internal/pkg/deploy"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/aws/copilot-cli/internal/pkg/aws/cloudformation"
+	"github.com/stretchr/testify/require"
 
 	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation/mocks"
 	"github.com/golang/mock/gomock"
@@ -80,4 +81,157 @@ func TestCloudFormation_DeployTask(t *testing.T) {
 			}
 		})
 	}
+}
+
+var mockDescription1 = &cloudformation.StackDescription{
+	Tags: []*awscfn.Tag{
+		{
+			Key: aws.String("copilot-task"),
+		},
+		{
+			Key:   aws.String("copilot-application"),
+			Value: aws.String("appname"),
+		},
+		{
+			Key:   aws.String("copilot-environment"),
+			Value: aws.String("test"),
+		},
+	},
+	StackName: aws.String("task-database"),
+	RoleARN:   aws.String("arn:aws:iam::123456789012:role/appname-test-CFNExecutionRole"),
+}
+var mockDescription2 = &cloudformation.StackDescription{
+	Tags: []*awscfn.Tag{
+		{
+			Key: aws.String("copilot-task"),
+		},
+		{
+			Key:   aws.String("copilot-application"),
+			Value: aws.String("otherapp"),
+		},
+	},
+	StackName: aws.String("task-example"),
+	RoleARN:   aws.String("arn:aws:iam::123456789012:role/otherapp-staging-CFNExecutionRole"),
+}
+
+var mockDescription3 = &cloudformation.StackDescription{
+	Tags: []*awscfn.Tag{
+		{
+			Key: aws.String("copilot-task"),
+		},
+	},
+	StackName: aws.String("task-default"),
+	RoleARN:   aws.String(""),
+}
+
+func TestCloudFormation_GetTaskStackInfo(t *testing.T) {
+	testCases := map[string]struct {
+		inAppName   string
+		mockClient  func(*mocks.MockcfnClient)
+		wantedErr   string
+		wantedTasks []deploy.TaskStackInfo
+	}{
+		"successfully gets task stacks while excluding wrongly tagged stack": {
+			inAppName: "appname",
+			mockClient: func(m *mocks.MockcfnClient) {
+				m.EXPECT().ListStacksWithPrefix("task-").Return([]cloudformation.StackDescription{
+					*mockDescription1,
+					*mockDescription2,
+				}, nil)
+			},
+			wantedTasks: []deploy.TaskStackInfo{
+				{
+					StackName: "task-database",
+					App:       "appname",
+					Env:       "test",
+					RoleARN:   aws.StringValue(mockDescription1.RoleARN),
+				},
+			},
+		},
+
+		"error listing stacks": {
+			inAppName: "appname",
+			mockClient: func(m *mocks.MockcfnClient) {
+				m.EXPECT().ListStacksWithPrefix("task-").Return(nil, errors.New("some error"))
+			},
+			wantedErr: "some error",
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// GIVEN
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockCf := mocks.NewMockcfnClient(ctrl)
+			tc.mockClient(mockCf)
+
+			cf := CloudFormation{cfnClient: mockCf}
+
+			// WHEN
+			tasks, err := cf.GetTaskStackInfo("appname", "test")
+
+			if tc.wantedErr != "" {
+				require.EqualError(t, err, tc.wantedErr)
+			} else {
+				require.Equal(t, tc.wantedTasks, tasks)
+			}
+		})
+	}
+}
+
+func TestCloudFormation_GetTaskDefaultStackInfo(t *testing.T) {
+	testCases := map[string]struct {
+		inAppName   string
+		mockClient  func(*mocks.MockcfnClient)
+		wantedErr   string
+		wantedTasks []deploy.TaskStackInfo
+	}{
+		"successfully gets task stacks while excluding wrongly tagged stack": {
+			inAppName: "appname",
+			mockClient: func(m *mocks.MockcfnClient) {
+				m.EXPECT().ListStacksWithPrefix("task-").Return([]cloudformation.StackDescription{
+					*mockDescription1,
+					*mockDescription2,
+					*mockDescription3,
+				}, nil)
+			},
+			wantedTasks: []deploy.TaskStackInfo{
+				{
+					StackName: "task-default",
+				},
+			},
+		},
+
+		"error listing stacks": {
+			inAppName: "appname",
+			mockClient: func(m *mocks.MockcfnClient) {
+				m.EXPECT().ListStacksWithPrefix("task-").Return(nil, errors.New("some error"))
+			},
+			wantedErr: "some error",
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// GIVEN
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockCf := mocks.NewMockcfnClient(ctrl)
+			tc.mockClient(mockCf)
+
+			cf := CloudFormation{cfnClient: mockCf}
+
+			// WHEN
+			tasks, err := cf.GetDefaultTaskStackInfo()
+
+			if tc.wantedErr != "" {
+				require.EqualError(t, err, tc.wantedErr)
+			} else {
+				require.Equal(t, tc.wantedTasks, tasks)
+			}
+
+		})
+	}
+
 }

--- a/internal/pkg/deploy/task.go
+++ b/internal/pkg/deploy/task.go
@@ -5,6 +5,14 @@
 // This file defines service deployment resources.
 package deploy
 
+import (
+	"fmt"
+	"strings"
+)
+
+// FmtTaskECRRepoName is the pattern used to generate the ECR repository's name
+const FmtTaskECRRepoName = "copilot-%s"
+
 // CreateTaskResourcesInput holds the fields required to create a task stack.
 type CreateTaskResourcesInput struct {
 	Name   string
@@ -21,4 +29,24 @@ type CreateTaskResourcesInput struct {
 	Env string
 
 	AdditionalTags map[string]string
+}
+
+// TaskStackInfo contains essential information about a Copilot task stack
+type TaskStackInfo struct {
+	StackName string
+	App       string
+	Env       string
+
+	RoleARN string
+}
+
+// TaskName returns the name of the one-off task. This is the same as the value of the
+// copilot-task tag. For example, a stack called "task-db-migrate" will have the TaskName "db-migrate"
+func (t TaskStackInfo) TaskName() string {
+	return strings.SplitN(t.StackName, "-", 2)[1]
+}
+
+// ECRRepoName returns the name of the ECR repo for the one-off task.
+func (t TaskStackInfo) ECRRepoName() string {
+	return fmt.Sprintf(FmtTaskECRRepoName, t.TaskName())
 }

--- a/templates/environment/partials/environment-manager-role.yml
+++ b/templates/environment/partials/environment-manager-role.yml
@@ -75,6 +75,7 @@ EnvironmentManagerRole:
             "cloudformation:Describe*",
             "cloudformation:DetectStackDrift",
             "cloudformation:DetectStackResourceDrift",
+            "cloudformation:ListStacks",
             "cloudformation:ExecuteChangeSet",
             "cloudformation:GetTemplate",
             "cloudformation:GetTemplateSummary",
@@ -225,3 +226,12 @@ EnvironmentManagerRole:
             - 'cloudformation:DeleteStack'
           Resource:
             - !Sub 'arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${AWS::StackName}/*'
+        - Sid: AdministerTask
+          Effect: Allow
+          Action: [
+            "ecr:BatchDeleteImage"
+          ]
+          Resource: "*"
+          Condition: {"ForAllValues:StringEquals": {"aws:TagKeys": "copilot-task"}}
+
+


### PR DESCRIPTION
This resolves #1306 by changing app delete to cleanup stacks that would be orphaned by removing the CFNExecutionRole of an environment. 

This is preferable to not touching those stacks, which results in orphaned stacks which cannot be deleted except by an IAM role called "app-env-CFNExecutionRole" as detailed in #1306. 


<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
