### PR TITLE
chore: fix broken integ tests

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/lb_web_svc_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/lb_web_svc_test.go
@@ -167,7 +167,7 @@ func TestLoadBalancedWebService_Template(t *testing.T) {
 				m.EXPECT().Read(desiredCountGeneratorPath).Return(&template.Content{Buffer: bytes.NewBufferString("something")}, nil)
 				m.EXPECT().Read(envControllerPath).Return(&template.Content{Buffer: bytes.NewBufferString("something")}, nil)
 				m.EXPECT().ParseLoadBalancedWebService(template.WorkloadOpts{
-					HTTPHealthCheck: &template.HTTPHealthCheckOpts{
+					HTTPHealthCheck: template.HTTPHealthCheckOpts{
 						HealthCheckPath:    aws.String("/"),
 						HealthyThreshold:   aws.Int64(2),
 						UnhealthyThreshold: aws.Int64(2),
@@ -199,7 +199,7 @@ func TestLoadBalancedWebService_Template(t *testing.T) {
 						SecretOutputs:   []string{"MySecretArn"},
 						PolicyOutputs:   []string{"AdditionalResourcesPolicyArn"},
 					},
-					HTTPHealthCheck: &template.HTTPHealthCheckOpts{
+					HTTPHealthCheck: template.HTTPHealthCheckOpts{
 						HealthCheckPath:    aws.String("/"),
 						HealthyThreshold:   aws.Int64(2),
 						UnhealthyThreshold: aws.Int64(2),

--- a/internal/pkg/deploy/cloudformation/stack/testdata/autoscaling/autoscaling-svc-cf.params.json
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/autoscaling/autoscaling-svc-cf.params.json
@@ -11,7 +11,6 @@
     "AddonsTemplateURL": "",
     "ContainerPort": "5000",
     "RulePath": "my-svc",
-    "HealthCheckPath": "/",
     "HTTPSEnabled": "true",
     "TargetContainer": "my-svc",
     "TargetPort": "5000",

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/job-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/job-test.stack.yml
@@ -62,10 +62,7 @@ Resources:
             Value: !Sub '${EnvName}'
           - Name: COPILOT_SERVICE_NAME
             Value: !Sub '${WorkloadName}'
-          - Name: COPILOT_LB_DNS
-            Value:
-              Fn::ImportValue:
-                !Sub "${AppName}-${EnvName}-PublicLoadBalancerDNS" 
+          
           LogConfiguration:
             LogDriver: awslogs
             Options:

--- a/internal/pkg/manifest/lb_web_svc.go
+++ b/internal/pkg/manifest/lb_web_svc.go
@@ -61,7 +61,8 @@ func (lc *LoadBalancedWebServiceConfig) LogConfigOpts() *template.LogConfigOpts 
 	return lc.logConfigOpts()
 }
 
-func (lc *LoadBalancedWebServiceConfig) HTTPHealthCheckOpts() *template.HTTPHealthCheckOpts {
+// HTTPHealthCheckOpts converts the ALB health check configuration into a format parsable by the templates pkg.
+func (lc *LoadBalancedWebServiceConfig) HTTPHealthCheckOpts() template.HTTPHealthCheckOpts {
 	opts := template.HTTPHealthCheckOpts{
 		HealthCheckPath:    aws.String(defaultHealthCheckPath),
 		HealthyThreshold:   aws.Int64(defaultHealthyThreshold),
@@ -87,7 +88,7 @@ func (lc *LoadBalancedWebServiceConfig) HTTPHealthCheckOpts() *template.HTTPHeal
 	if lc.RoutingRule.HealthCheck.HealthCheckArgs.Timeout != nil {
 		opts.Timeout = aws.Int64(int64(lc.RoutingRule.HealthCheck.HealthCheckArgs.Timeout.Seconds()))
 	}
-	return &opts
+	return opts
 }
 
 // HTTPHealthCheckArgs holds the configuration to determine if the load balanced web service is healthy.

--- a/internal/pkg/manifest/lb_web_svc_test.go
+++ b/internal/pkg/manifest/lb_web_svc_test.go
@@ -26,7 +26,7 @@ func TestNewLoadBalancedWebService_HTTPHealthCheckOpts(t *testing.T) {
 		inputInterval           *time.Duration
 		inputTimeout            *time.Duration
 
-		wantedOpts *template.HTTPHealthCheckOpts
+		wantedOpts template.HTTPHealthCheckOpts
 	}{
 		"no fields indicated in manifest": {
 			inputPath:               nil,
@@ -35,7 +35,7 @@ func TestNewLoadBalancedWebService_HTTPHealthCheckOpts(t *testing.T) {
 			inputInterval:           nil,
 			inputTimeout:            nil,
 
-			wantedOpts: &template.HTTPHealthCheckOpts{
+			wantedOpts: template.HTTPHealthCheckOpts{
 				HealthCheckPath:    aws.String("/"),
 				HealthyThreshold:   aws.Int64(2),
 				UnhealthyThreshold: aws.Int64(2),
@@ -50,7 +50,7 @@ func TestNewLoadBalancedWebService_HTTPHealthCheckOpts(t *testing.T) {
 			inputInterval:           nil,
 			inputTimeout:            nil,
 
-			wantedOpts: &template.HTTPHealthCheckOpts{
+			wantedOpts: template.HTTPHealthCheckOpts{
 				HealthCheckPath:    aws.String("/"),
 				HealthyThreshold:   aws.Int64(5),
 				UnhealthyThreshold: aws.Int64(2),
@@ -65,7 +65,7 @@ func TestNewLoadBalancedWebService_HTTPHealthCheckOpts(t *testing.T) {
 			inputInterval:           nil,
 			inputTimeout:            nil,
 
-			wantedOpts: &template.HTTPHealthCheckOpts{
+			wantedOpts: template.HTTPHealthCheckOpts{
 				HealthCheckPath:    aws.String("/"),
 				HealthyThreshold:   aws.Int64(2),
 				UnhealthyThreshold: aws.Int64(5),
@@ -80,7 +80,7 @@ func TestNewLoadBalancedWebService_HTTPHealthCheckOpts(t *testing.T) {
 			inputInterval:           durationp(15 * time.Second),
 			inputTimeout:            nil,
 
-			wantedOpts: &template.HTTPHealthCheckOpts{
+			wantedOpts: template.HTTPHealthCheckOpts{
 				HealthCheckPath:    aws.String("/"),
 				HealthyThreshold:   aws.Int64(2),
 				UnhealthyThreshold: aws.Int64(2),
@@ -95,7 +95,7 @@ func TestNewLoadBalancedWebService_HTTPHealthCheckOpts(t *testing.T) {
 			inputInterval:           nil,
 			inputTimeout:            durationp(15 * time.Second),
 
-			wantedOpts: &template.HTTPHealthCheckOpts{
+			wantedOpts: template.HTTPHealthCheckOpts{
 				HealthCheckPath:    aws.String("/"),
 				HealthyThreshold:   aws.Int64(2),
 				UnhealthyThreshold: aws.Int64(2),
@@ -110,7 +110,7 @@ func TestNewLoadBalancedWebService_HTTPHealthCheckOpts(t *testing.T) {
 			inputInterval:           durationp(60 * time.Second),
 			inputTimeout:            durationp(60 * time.Second),
 
-			wantedOpts: &template.HTTPHealthCheckOpts{
+			wantedOpts: template.HTTPHealthCheckOpts{
 				HealthCheckPath:    aws.String("/road/to/nowhere"),
 				HealthyThreshold:   aws.Int64(3),
 				UnhealthyThreshold: aws.Int64(3),

--- a/internal/pkg/template/workload.go
+++ b/internal/pkg/template/workload.go
@@ -117,7 +117,7 @@ type WorkloadOpts struct {
 
 	// Additional options for service templates.
 	HealthCheck         *ecs.HealthCheck
-	HTTPHealthCheck     *HTTPHealthCheckOpts
+	HTTPHealthCheck     HTTPHealthCheckOpts
 	RulePriorityLambda  string
 	DesiredCountLambda  string
 	EnvControllerLambda string


### PR DESCRIPTION
<!-- Provide summary of changes -->
This PR fixes three integ test failures:

1. We removed env var `COPILOT_LB_DNS` from non LB service.
2. We removed `HealthCheckPath` from service stack parameters. 
3. We moved HTTP health check config to a pointer struct but directly references its fields in our [template](https://github.com/aws/copilot-cli/blob/mainline/templates/workloads/services/lb-web/cf.yml#L97-L101), causing nil pointer error in our template integ test.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
