### PR TITLE
test(e2e): call docker login before running copilot commands in codebuild test containers

### DIFF
--- a/.release/buildspec_e2e.yml
+++ b/.release/buildspec_e2e.yml
@@ -51,4 +51,9 @@ phases:
        - sed -i -e '$s/$/ --noColor/' e2e/e2e.sh
        - make build-e2e
        - docker build -t copilot-cli/e2e . -f e2e/Dockerfile
-       - docker run --privileged -v /tmp/.aws:/home/.aws -e "HOME=/home" -e "TEST_SUITE=$TEST_SUITE" copilot-cli/e2e:latest
+       - >
+         docker run --privileged -v /tmp/.aws:/home/.aws -e "HOME=/home"
+         -e "TEST_SUITE=$TEST_SUITE"
+         -e "DOCKERHUB_USERNAME=$DOCKERHUB_USERNAME"
+         -e "DOCKERHUB_TOKEN=$DOCKERHUB_TOKEN" 
+         copilot-cli/e2e:latest

--- a/e2e/e2e.sh
+++ b/e2e/e2e.sh
@@ -20,5 +20,7 @@ do
 	sleep 1
 done
 
+echo $DOCKERHUB_TOKEN | docker login --password-stdin -u $DOCKERHUB_USERNAME
+
 #Run all the e2e tests
 cd /github.com/aws/copilot-cli/e2e/$TEST_SUITE && /go/bin/ginkgo -v -r


### PR DESCRIPTION
<!-- Provide summary of changes -->
This PR passes existing secrets down into the docker container running inside of the e2e docker:stable-dind e2e image. This should help us get around the rate limit that throttles our e2es by distinguishing our pulls from Codebuild anonymous traffic.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
