### PR TITLE
chore: add retry to EnvController waitFor requests

### DIFF
--- a/cf-custom-resources/lib/env-controller.js
+++ b/cf-custom-resources/lib/env-controller.js
@@ -7,6 +7,11 @@ const aws = require("aws-sdk");
 // These are used for test purposes only
 let defaultResponseURL;
 
+const updateStackWaiter = {
+  delay: 30,
+  maxAttempts: 29,
+};
+
 /**
  * Upload a CloudFormation response object to S3.
  *
@@ -136,10 +141,7 @@ const controlEnv = async function (
       await cfn
         .waitFor("stackUpdateComplete", {
           StackName: stackName,
-          $waiter: {
-            delay: 30,
-            maxAttempts: 29,
-          },
+          $waiter: updateStackWaiter,
         })
         .promise();
       continue;
@@ -148,10 +150,7 @@ const controlEnv = async function (
     await cfn
       .waitFor("stackUpdateComplete", {
         StackName: stackName,
-        $waiter: {
-          delay: 30,
-          maxAttempts: 29,
-        },
+        $waiter: updateStackWaiter,
       })
       .promise();
     describeStackResp = await cfn

--- a/cf-custom-resources/test/env-controller-test.js
+++ b/cf-custom-resources/test/env-controller-test.js
@@ -30,6 +30,9 @@ describe("Env Controller Handler", () => {
 
   beforeEach(() => {
     EnvController.withDefaultResponseURL(ResponseURL);
+    EnvController.deadlineExpired = function () {
+      return new Promise(function (resolve, reject) {});
+    };
     // Prevent logging.
     console.log = function () {};
   });
@@ -208,7 +211,7 @@ describe("Env Controller Handler", () => {
         {
           StackName: "mockEnvStack",
           Parameters: testParams,
-          Outputs: []
+          Outputs: [],
         },
       ],
     });


### PR DESCRIPTION
<!-- Provide summary of changes -->
Address this [comment](https://github.com/aws/copilot-cli/pull/1508#discussion_r505919833) left in #1508. Add retry to EnvController when we call `cfn.waitFor()`, so that it won't immediately error out when the request gets throttled.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
