### PR TITLE
chore: upgrade environments before deploying workloads

### DIFF
--- a/internal/pkg/cli/env_upgrade.go
+++ b/internal/pkg/cli/env_upgrade.go
@@ -148,6 +148,11 @@ func (o *envUpgradeOpts) Execute() error {
 	return nil
 }
 
+// RecommendedActions is a no-op for this command.
+func (o *envUpgradeOpts) RecommendedActions() []string {
+	return nil
+}
+
 func (o *envUpgradeOpts) listEnvsToUpgrade() ([]string, error) {
 	if !o.all {
 		return []string{o.name}, nil

--- a/templates/cicd/buildspec.yml
+++ b/templates/cicd/buildspec.yml
@@ -20,6 +20,8 @@ phases:
     commands:
       - ls -l
       - export COLOR="false"
+      # First, upgrade the cloudformation stack of every environment.
+      - ./copilot-linux env upgrade --all
       # Find all the local services in the workspace.
       - svcs=$(./copilot-linux svc ls --local --json | jq '.services[].name' | sed 's/"//g')
       # Find all the local jobs in the workspace.


### PR DESCRIPTION
- [x] Tested with a legacy environment and deploying two LBWebServices in parallel
- [x] Tested with environment version 1.0.0 and deploying two LBWebServices in parallel

In both of these scenarios the services are deployed successfully :) 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
