### PR TITLE
fix(env-init#examples): clean up typos

### DIFF
--- a/site/content/docs/commands/env-init.md
+++ b/site/content/docs/commands/env-init.md
@@ -47,7 +47,7 @@ Creates a prod-iad environment using your "prod-admin" AWS profile using existin
 ```bash
 $ copilot env init --name prod-iad --profile prod-admin --prod \
 --import-vpc-id vpc-099c32d2b98cdcf47 \
---import-public-subnets subnet-013e8b691862966cf,subnet -014661ebb7ab8681a \
+--import-public-subnets subnet-013e8b691862966cf,subnet-014661ebb7ab8681a \
 --import-private-subnets subnet-055fafef48fb3c547,subnet-00c9e76f288363e7f
 ```
 


### PR DESCRIPTION
Fixed whitespace typos.
https://aws.github.io/copilot-cli/docs/commands/env-init/#examples

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
