### PR TITLE
chore(jobs): add tag propagation to state machine tasks

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/job-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/job-test.stack.yml
@@ -214,6 +214,7 @@ Resources:
                 "PlatformVersion": "LATEST",
                 "Cluster": "${Cluster}",
                 "TaskDefinition": "${TaskDefinition}",
+                "PropagateTags": "TASK_DEFINITION",
                 "Group.$": "$$.Execution.Name",
                 "NetworkConfiguration": {
                   "AwsvpcConfiguration": {

--- a/templates/workloads/common/cf/state-machine-definition.json.yml
+++ b/templates/workloads/common/cf/state-machine-definition.json.yml
@@ -16,6 +16,7 @@
         "PlatformVersion": "LATEST",
         "Cluster": "${Cluster}",
         "TaskDefinition": "${TaskDefinition}",
+        "PropagateTags": "TASK_DEFINITION",
         "Group.$": "$$.Execution.Name",
         "NetworkConfiguration": {
           "AwsvpcConfiguration": {


### PR DESCRIPTION
<!-- Provide summary of changes -->
Allow the State Machine generated by scheduled jobs to propagate tags from the Task Definition to any tasks it launches. 

This allows us to clean up running tasks during app and job deletion.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
