### PR TITLE
fix(templates): environment creations for new apps with domains

### DIFF
--- a/internal/pkg/deploy/env.go
+++ b/internal/pkg/deploy/env.go
@@ -13,7 +13,7 @@ const (
 	// LegacyEnvTemplateVersion is the version associated with the environment template before we started versioning.
 	LegacyEnvTemplateVersion = "v0.0.0"
 	// LatestEnvTemplateVersion is the latest version number available for environment templates.
-	LatestEnvTemplateVersion = "v1.0.0"
+	LatestEnvTemplateVersion = "v1.0.1"
 )
 
 // CreateEnvironmentInput holds the fields required to deploy an environment.

--- a/templates/environment/versions/cf-v1.0.1.yml
+++ b/templates/environment/versions/cf-v1.0.1.yml
@@ -1,0 +1,293 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+Metadata:
+  Version: 'v1.0.1'
+
+Parameters:
+  AppName:
+    Type: String
+
+  EnvironmentName:
+    Type: String
+
+  ALBWorkloads:
+    Type: String
+    Default: ""
+
+  ToolsAccountPrincipalARN:
+    Type: String
+
+  AppDNSName:
+    Type: String
+    Default: ""
+
+  AppDNSDelegationRole:
+    Type: String
+    Default: ""
+
+Conditions:
+  CreateALB:
+    !Not [!Equals [ !Ref ALBWorkloads, "" ]]
+  DelegateDNS:
+    !Not [!Equals [ !Ref AppDNSName, "" ]]
+  ExportHTTPSListener: !And
+    - !Condition DelegateDNS
+    - !Condition CreateALB
+
+Resources:
+{{- if not .ImportVPC}}
+{{include "vpc-resources" .VPCConfig | indent 2}}
+{{- end}}
+
+  # Creates a service discovery namespace with the form:
+  # {svc}.{appname}.local
+  ServiceDiscoveryNamespace:
+    Type: AWS::ServiceDiscovery::PrivateDnsNamespace
+    Properties:
+        Name: !Sub ${AppName}.local
+{{- if .ImportVPC}}
+        Vpc: {{.ImportVPC.ID}}
+{{- else}}
+        Vpc: !Ref VPC
+{{- end}}
+
+  Cluster:
+    Type: AWS::ECS::Cluster
+    Properties:
+      CapacityProviders: ['FARGATE', 'FARGATE_SPOT']
+
+  PublicLoadBalancerSecurityGroup:
+    Condition: CreateALB
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Access to the public facing load balancer
+      SecurityGroupIngress:
+        - CidrIp: 0.0.0.0/0
+          Description: Allow from anyone on port 80
+          FromPort: 80
+          IpProtocol: tcp
+          ToPort: 80
+        - CidrIp: 0.0.0.0/0
+          Description: Allow from anyone on port 443
+          FromPort: 443
+          IpProtocol: tcp
+          ToPort: 443
+{{- if .ImportVPC}}
+      VpcId: {{.ImportVPC.ID}}
+{{- else}}
+      VpcId: !Ref VPC
+{{- end}}
+      Tags:
+        - Key: Name
+          Value: !Sub 'copilot-${AppName}-${EnvironmentName}-lb'
+
+  # Only accept requests coming from the public ALB or other containers in the same security group.
+  EnvironmentSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: !Join ['', [!Ref AppName, '-', !Ref EnvironmentName, EnvironmentSecurityGroup]]
+{{- if .ImportVPC}}
+      VpcId: {{.ImportVPC.ID}}
+{{- else}}
+      VpcId: !Ref VPC
+{{- end}}
+      Tags:
+        - Key: Name
+          Value: !Sub 'copilot-${AppName}-${EnvironmentName}-env'
+
+  EnvironmentSecurityGroupIngressFromPublicALB:
+    Type: AWS::EC2::SecurityGroupIngress
+    Condition: CreateALB
+    Properties:
+      Description: Ingress from the public ALB
+      GroupId: !Ref EnvironmentSecurityGroup
+      IpProtocol: -1
+      SourceSecurityGroupId: !Ref PublicLoadBalancerSecurityGroup
+
+  EnvironmentSecurityGroupIngressFromSelf:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      Description: Ingress from other containers in the same security group
+      GroupId: !Ref EnvironmentSecurityGroup
+      IpProtocol: -1
+      SourceSecurityGroupId: !Ref EnvironmentSecurityGroup
+
+  PublicLoadBalancer:
+    Condition: CreateALB
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Scheme: internet-facing
+      SecurityGroups: [ !GetAtt PublicLoadBalancerSecurityGroup.GroupId ]
+{{- if .ImportVPC}}
+      Subnets: [ {{range $id := .ImportVPC.PublicSubnetIDs}}{{$id}}, {{end}} ]
+{{- else}}
+      Subnets: [ {{range $ind, $cidr := .VPCConfig.PublicSubnetCIDRs}}!Ref PublicSubnet{{inc $ind}}, {{end}} ]
+{{- end}}
+      Type: application
+
+  # Assign a dummy target group that with no real services as targets, so that we can create
+  # the listeners for the services.
+  DefaultHTTPTargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Condition: CreateALB
+    Properties:
+      #  Check if your application is healthy within 20 = 10*2 seconds, compared to 2.5 mins = 30*5 seconds.
+      HealthCheckIntervalSeconds: 10 # Default is 30.
+      HealthyThresholdCount: 2       # Default is 5.
+      HealthCheckTimeoutSeconds: 5
+      Port: 80
+      Protocol: HTTP
+      TargetGroupAttributes:
+        - Key: deregistration_delay.timeout_seconds
+          Value: 60                  # Default is 300.
+      TargetType: ip
+{{- if .ImportVPC}}
+      VpcId: {{.ImportVPC.ID}}
+{{- else}}
+      VpcId: !Ref VPC
+{{- end}}
+
+  HTTPListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Condition: CreateALB
+    Properties:
+      DefaultActions:
+        - TargetGroupArn: !Ref DefaultHTTPTargetGroup
+          Type: forward
+      LoadBalancerArn: !Ref PublicLoadBalancer
+      Port: 80
+      Protocol: HTTP
+
+  HTTPSListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    DependsOn: HTTPSCert
+    Condition: ExportHTTPSListener
+    Properties:
+      Certificates:
+        - CertificateArn: !Ref HTTPSCert
+      DefaultActions:
+        - TargetGroupArn: !Ref DefaultHTTPTargetGroup
+          Type: forward
+      LoadBalancerArn: !Ref PublicLoadBalancer
+      Port: 443
+      Protocol: HTTPS
+
+{{include "cfn-execution-role" . | indent 2}}
+
+{{include "environment-manager-role" . | indent 2}}
+
+{{include "custom-resources-role" . | indent 2}}
+
+  EnvironmentHostedZone:
+    Type: "AWS::Route53::HostedZone"
+    Condition: DelegateDNS
+    Properties:
+      HostedZoneConfig:
+        Comment: !Sub "HostedZone for environment ${EnvironmentName} - ${EnvironmentName}.${AppName}.${AppDNSName}"
+      Name: !Sub ${EnvironmentName}.${AppName}.${AppDNSName}
+
+{{include "lambdas" . | indent 2}}
+
+{{include "custom-resources" . | indent 2}}
+Outputs:
+  VpcId:
+{{- if .ImportVPC}}
+    Value: {{.ImportVPC.ID}}
+{{- else}}
+    Value: !Ref VPC
+{{- end}}
+    Export:
+      Name: !Sub ${AWS::StackName}-VpcId
+
+  PublicSubnets:
+{{- if .ImportVPC}}
+    Value: !Join [ ',', [ {{range $id := .ImportVPC.PublicSubnetIDs}}{{$id}}, {{end}}] ]
+{{- else}}
+    Value: !Join [ ',', [ {{range $ind, $cidr := .VPCConfig.PublicSubnetCIDRs}}!Ref PublicSubnet{{inc $ind}}, {{end}}] ]
+{{- end}}
+    Export:
+      Name: !Sub ${AWS::StackName}-PublicSubnets
+
+  PrivateSubnets:
+{{- if .ImportVPC}}
+    Value: !Join [ ',', [ {{range $id := .ImportVPC.PrivateSubnetIDs}}{{$id}}, {{end}}] ]
+{{- else}}
+    Value: !Join [ ',', [ {{range $ind, $cidr := .VPCConfig.PrivateSubnetCIDRs}}!Ref PrivateSubnet{{inc $ind}}, {{end}}] ]
+{{- end}}
+    Export:
+      Name: !Sub ${AWS::StackName}-PrivateSubnets
+
+  ServiceDiscoveryNamespaceID:
+    Value: !GetAtt ServiceDiscoveryNamespace.Id
+    Export:
+      Name: !Sub ${AWS::StackName}-ServiceDiscoveryNamespaceID
+
+  EnvironmentSecurityGroup:
+    Value: !Ref EnvironmentSecurityGroup
+    Export:
+      Name: !Sub ${AWS::StackName}-EnvironmentSecurityGroup
+
+  PublicLoadBalancerDNSName:
+    Condition: CreateALB
+    Value: !GetAtt PublicLoadBalancer.DNSName
+    Export:
+      Name: !Sub ${AWS::StackName}-PublicLoadBalancerDNS
+
+  PublicLoadBalancerHostedZone:
+    Condition: CreateALB
+    Value: !GetAtt PublicLoadBalancer.CanonicalHostedZoneID
+    Export:
+      Name: !Sub ${AWS::StackName}-CanonicalHostedZoneID
+
+  HTTPListenerArn:
+    Condition: CreateALB
+    Value: !Ref HTTPListener
+    Export:
+      Name: !Sub ${AWS::StackName}-HTTPListenerArn
+
+  HTTPSListenerArn:
+    Condition: ExportHTTPSListener
+    Value: !Ref HTTPSListener
+    Export:
+      Name: !Sub ${AWS::StackName}-HTTPSListenerArn
+
+  DefaultHTTPTargetGroupArn:
+    Condition: CreateALB
+    Value: !Ref DefaultHTTPTargetGroup
+    Export:
+      Name: !Sub ${AWS::StackName}-DefaultHTTPTargetGroup
+
+  ClusterId:
+    Value: !Ref Cluster
+    Export:
+      Name: !Sub ${AWS::StackName}-ClusterId
+
+  EnvironmentManagerRoleARN:
+    Value: !GetAtt EnvironmentManagerRole.Arn
+    Description: The role to be assumed by the ecs-cli to manage environments.
+    Export:
+      Name: !Sub ${AWS::StackName}-EnvironmentManagerRoleARN
+
+  CFNExecutionRoleARN:
+    Value: !GetAtt CloudformationExecutionRole.Arn
+    Description: The role to be assumed by the Cloudformation service when it deploys application infrastructure.
+    Export:
+      Name: !Sub ${AWS::StackName}-CFNExecutionRoleARN
+
+  EnvironmentHostedZone:
+    Condition: DelegateDNS
+    Value: !Ref EnvironmentHostedZone
+    Description: The HostedZone for this environment's private DNS.
+    Export:
+      Name: !Sub ${AWS::StackName}-HostedZone
+
+  EnvironmentSubdomain:
+    Condition: DelegateDNS
+    Value: !Sub ${EnvironmentName}.${AppName}.${AppDNSName}
+    Description: The domain name of this environment.
+    Export:
+      Name: !Sub ${AWS::StackName}-SubDomain
+
+  EnabledFeatures:
+    Value: !Ref ALBWorkloads
+    Description: Required output to force the stack to update if mutating feature params, like ALBWorkloads, does not change the template.

--- a/templates/workloads/services/lb-web/cf.yml
+++ b/templates/workloads/services/lb-web/cf.yml
@@ -129,9 +129,7 @@ Resources:
               - ""
         Type: A
         AliasTarget:
-          HostedZoneId:
-            Fn::ImportValue:
-              !Sub "${AppName}-${EnvName}-CanonicalHostedZoneID"
+          HostedZoneId: !GetAtt EnvControllerAction.PublicLoadBalancerHostedZone
           DNSName: !GetAtt EnvControllerAction.PublicLoadBalancerDNSName
 
   RulePriorityFunction:
@@ -206,9 +204,7 @@ Resources:
     Type: Custom::RulePriorityFunction
     Properties:
       ServiceToken: !GetAtt RulePriorityFunction.Arn
-      ListenerArn:
-        Fn::ImportValue:
-          !Sub "${AppName}-${EnvName}-HTTPSListenerArn"
+      ListenerArn: !GetAtt EnvControllerAction.HTTPSListenerArn
 
   HTTPSListenerRule:
     Type: AWS::ElasticLoadBalancingV2::ListenerRule
@@ -226,9 +222,7 @@ Resources:
                 - - !Ref WorkloadName
                   - Fn::ImportValue:
                       !Sub "${AppName}-${EnvName}-SubDomain"
-      ListenerArn:
-        Fn::ImportValue:
-          !Sub "${AppName}-${EnvName}-HTTPSListenerArn"
+      ListenerArn: !GetAtt EnvControllerAction.HTTPSListenerArn
       Priority: !GetAtt HTTPSRulePriorityAction.Priority
 
   HTTPRulePriorityAction:


### PR DESCRIPTION
Fixes #1662

Although not visible here, the [diff](https://diff.corp.amazon.com/compare/2az4ioz9 ) between v1.0.1 and v1.0.0 for the env template is just the condition for the HTTPSListener resource: 
```
 -     Condition: DelegateDNS 
 +     Condition: ExportHTTPSListener 
```

I'll investigate how we can add e2e tests for apps initialized with a domain.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
