### PR TITLE
fix(progress): remove newline after Stop()

### DIFF
--- a/internal/pkg/term/progress/spinner.go
+++ b/internal/pkg/term/progress/spinner.go
@@ -77,7 +77,7 @@ func (s *Spinner) Start(label string) {
 
 // Stop stops the spinner and replaces it with a label.
 func (s *Spinner) Stop(label string) {
-	s.finalMSG(fmt.Sprintln(label))
+	s.finalMSG(fmt.Sprint(label))
 	s.spin.Stop()
 
 	// Maintain old progress entries on the screen.


### PR DESCRIPTION
Previously, `env init`'s progress output contained a line printed twice and an extra line of whitespace:
```
✔ Created the infrastructure for the env-two environment.
- Virtual private cloud on 2 availability zones to hold your services and jobs     [Complete]
- Virtual private cloud on 2 availability zones to hold your services and jobs     [Complete]
  - Internet gateway to connect the network to the internet                        [Complete]
  - Public subnets for internet facing services and jobs                           [Complete]
  - Private subnets for services and jobs that can't be reached from the internet  [Complete]
  - Routing tables for services and jobs to talk with each other                   [Complete]
- ECS Cluster to hold your services and jobs 
✔ Linked account 240594714208 and region us-west-2 to application video-store.

✔ Created environment env-two in region us-west-2 under application video-store.
```
This was caused by a new line being inserted after each `prog.Stop`. 

Now:
``` 
✔ Created the infrastructure for the env-two environment.
- Virtual private cloud on 2 availability zones to hold your services and jobs     [Complete]
  - Internet gateway to connect the network to the internet                        [Complete]
  - Public subnets for internet facing services and jobs                           [Complete]
  - Private subnets for services and jobs that can't be reached from the internet  [Complete]
  - Routing tables for services and jobs to talk with each other                   [Complete]
- ECS Cluster to hold your services and jobs                                       [Complete]
✔ Linked account 240594714208 and region us-west-2 to application video-store.
✔ Created environment env-two in region us-west-2 under application video-store.
```

Fixes https://github.com/aws/copilot-cli/issues/1591.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
