### PR TITLE
test(e2e): add e2e tests for app with a domain

### DIFF
--- a/.release/buildspec_e2e.yml
+++ b/.release/buildspec_e2e.yml
@@ -31,6 +31,7 @@ batch:
             - root
             - sidecars
             - task
+            - app-with-domain
 
 phases:
   install:

--- a/e2e/app-with-domain/app_with_domain_suite_test.go
+++ b/e2e/app-with-domain/app_with_domain_suite_test.go
@@ -1,0 +1,44 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package app_with_domain_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/aws/copilot-cli/e2e/internal/client"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var cli *client.CLI
+var appName string
+
+func TestAppWithDomain(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Multiple Svc Suite (one workspace)")
+}
+
+var _ = BeforeSuite(func() {
+	copilotCLI, err := client.NewCLI()
+	cli = copilotCLI
+	Expect(err).NotTo(HaveOccurred())
+	appName = fmt.Sprintf("e2e-app-with-domain-%d", time.Now().Unix())
+})
+
+var _ = AfterSuite(func() {
+	_, err := cli.AppDelete()
+	Expect(err).NotTo(HaveOccurred())
+})
+
+func BeforeAll(fn func()) {
+	first := true
+	BeforeEach(func() {
+		if first {
+			fn()
+			first = false
+		}
+	})
+}

--- a/e2e/app-with-domain/app_with_domain_test.go
+++ b/e2e/app-with-domain/app_with_domain_test.go
@@ -1,0 +1,122 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package app_with_domain_test
+
+import (
+	"fmt"
+	"net/http"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/aws/copilot-cli/e2e/internal/client"
+)
+
+var _ = Describe("App With Domain", func() {
+	const domainName = "copilot-e2e-tests.ecs.aws.dev"
+	const svcName = "nginx"
+	const envName = "test"
+
+	Context("when creating a new app", func() {
+		var appInitErr error
+
+		BeforeAll(func() {
+			_, appInitErr = cli.AppInit(&client.AppInitRequest{
+				AppName: appName,
+				Domain:  domainName,
+			})
+		})
+
+		It("app init succeeds", func() {
+			Expect(appInitErr).NotTo(HaveOccurred())
+		})
+
+		It("app init creates a copilot directory", func() {
+			Expect("./copilot").Should(BeADirectory())
+		})
+
+		It("app ls includes new application", func() {
+			Eventually(cli.AppList, "30s", "5s").Should(ContainSubstring(appName))
+		})
+
+		It("app show includes domain name", func() {
+			appShowOutput, err := cli.AppShow(appName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(appShowOutput.Name).To(Equal(appName))
+			Expect(appShowOutput.URI).To(Equal(domainName))
+		})
+	})
+
+	Context("when creating a new environment", func() {
+		var envInitErr error
+
+		BeforeAll(func() {
+			_, envInitErr = cli.EnvInit(&client.EnvInitRequest{
+				AppName: appName,
+				EnvName: envName,
+				Profile: "default",
+				Prod:    false,
+			})
+		})
+
+		It("env init should succeed", func() {
+			Expect(envInitErr).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("when initializing a Load Balanced Web Service", func() {
+		var svcInitErr error
+
+		BeforeAll(func() {
+			_, svcInitErr = cli.SvcInit(&client.SvcInitRequest{
+				Name:    svcName,
+				SvcType: "Load Balanced Web Service",
+				Image:   "nginx",
+				SvcPort: "80",
+			})
+		})
+
+		It("svc init should succeed", func() {
+			Expect(svcInitErr).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("when deploying a Load Balanced Web Service", func() {
+		var deployErr error
+		BeforeAll(func() {
+			_, deployErr = cli.SvcDeploy(&client.SvcDeployInput{
+				Name:     svcName,
+				EnvName:  envName,
+				ImageTag: "hello",
+			})
+		})
+
+		It("svc deploy should succeed", func() {
+			Expect(deployErr).NotTo(HaveOccurred())
+		})
+
+		It("svc show should contain the expected domain and the request should succeed", func() {
+			svc, err := cli.SvcShow(&client.SvcShowRequest{
+				Name:    svcName,
+				AppName: appName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(svc.Routes)).To(Equal(1))
+
+			// Validate route has the expected HTTPS endpoint.
+			route := svc.Routes[0]
+			Expect(route.Environment).To(Equal(envName))
+			Expect(route.URL).To(Equal(fmt.Sprintf("https://%s.%s.%s.%s", svcName, envName, appName, domainName)))
+
+			// Make sure the response is OK.
+			// Since the www app was added second, it should have app appended to the name.
+			var resp *http.Response
+			var fetchErr error
+			Eventually(func() (int, error) {
+				resp, fetchErr = http.Get(route.URL)
+				return resp.StatusCode, fetchErr
+			}, "60s", "1s").Should(Equal(200))
+		})
+	})
+})

--- a/e2e/internal/client/cli.go
+++ b/e2e/internal/client/cli.go
@@ -81,6 +81,7 @@ type SvcInitRequest struct {
 	Name       string
 	SvcType    string
 	Dockerfile string
+	Image      string
 	SvcPort    string
 }
 
@@ -229,7 +230,6 @@ func (cli *CLI) Init(opts *InitRequest) (string, error) {
 copilot svc init
 	--name $n
 	--svc-type $t
-	--dockerfile $d
 	--port $port
 */
 func (cli *CLI) SvcInit(opts *SvcInitRequest) (string, error) {
@@ -238,11 +238,16 @@ func (cli *CLI) SvcInit(opts *SvcInitRequest) (string, error) {
 		"init",
 		"--name", opts.Name,
 		"--svc-type", opts.SvcType,
-		"--dockerfile", opts.Dockerfile,
 	}
 	// Apply optional flags only if a value is provided.
 	if opts.SvcPort != "" {
 		args = append(args, "--port", opts.SvcPort)
+	}
+	if opts.Dockerfile != "" {
+		args = append(args, "--dockerfile", opts.Dockerfile)
+	}
+	if opts.Image != "" {
+		args = append(args, "--image", opts.Image)
 	}
 	return cli.exec(
 		exec.Command(cli.path, args...))


### PR DESCRIPTION
Ran the e2e test on my personal AWS account:
```
Ran 8 of 8 Specs in 1292.063 seconds
SUCCESS! -- 8 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 21m34.132040667s
Test Suite Passed
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
