### PR TITLE
test(e2e): truncate app name to timestamp to remain <= 64 chars

### DIFF
--- a/e2e/app-with-domain/app_with_domain_suite_test.go
+++ b/e2e/app-with-domain/app_with_domain_suite_test.go
@@ -25,7 +25,7 @@ var _ = BeforeSuite(func() {
 	copilotCLI, err := client.NewCLI()
 	cli = copilotCLI
 	Expect(err).NotTo(HaveOccurred())
-	appName = fmt.Sprintf("e2e-app-with-domain-%d", time.Now().Unix())
+	appName = fmt.Sprintf("e2e-domain-%d", time.Now().Unix())
 })
 
 var _ = AfterSuite(func() {


### PR DESCRIPTION
Currently, the domain name seems to be exceed 64 characters resulting
in an error during deployments.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
