### PR TITLE
test(e2e): scatter e2e tests across US regions

### DIFF
--- a/.release/buildspec_e2e.yml
+++ b/.release/buildspec_e2e.yml
@@ -5,33 +5,93 @@ env:
     DOCKERHUB_USERNAME: prod/ecs-cicd-bot/dockerhub-account-info:username
     DOCKERHUB_TOKEN: prod/ecs-cicd-bot/dockerhub-token:dockerhub-token
 
+# We increased the number of VPCs limit to 15 from 5 in the e2e test's app account/region pair.
+# If the number of tests running in a region is larger than 15, this comment should be updated.
 batch:
   fast-fail: false
-  build-matrix:
-    static:
+  build-graph:
+    - identifier: addons
       env:
         privileged-mode: true
         type: LINUX_CONTAINER
-    dynamic:
-      env:
-        compute-type:
-          - BUILD_GENERAL1_LARGE
-        image:
-          - aws/codebuild/standard:4.0
+        compute-type: BUILD_GENERAL1_LARGE
+        image: aws/codebuild/standard:4.0
         variables:
-          # We increase the number of VPCs/region limit to 15 from 5 in our e2e tests accounts
-          # to accommodate running them in parallel.
-          # If TEST_SUITE goes above 15 e2e tests the limits and this comment should be updated.
-          TEST_SUITE:
-            - addons
-            - customized-env
-            - init
-            - multi-env-app
-            - multi-svc-app
-            - root
-            - sidecars
-            - task
-            - app-with-domain
+          TEST_SUITE: addons
+          APP_REGION: us-west-2
+    - identifier: customized-env
+      env:
+        privileged-mode: true
+        type: LINUX_CONTAINER
+        compute-type: BUILD_GENERAL1_LARGE
+        image: aws/codebuild/standard:4.0
+        variables:
+          TEST_SUITE: customized-env
+          APP_REGION: us-west-1
+    - identifier: init
+      env:
+        privileged-mode: true
+        type: LINUX_CONTAINER
+        compute-type: BUILD_GENERAL1_LARGE
+        image: aws/codebuild/standard:4.0
+        variables:
+          TEST_SUITE: init
+          APP_REGION: us-east-1
+    - identifier: multi-env-app
+      env:
+        privileged-mode: true
+        type: LINUX_CONTAINER
+        compute-type: BUILD_GENERAL1_LARGE
+        image: aws/codebuild/standard:4.0
+        variables:
+          TEST_SUITE: multi-env-app
+          APP_REGION: us-east-2
+    - identifier: multi-svc-app
+      env:
+        privileged-mode: true
+        type: LINUX_CONTAINER
+        compute-type: BUILD_GENERAL1_LARGE
+        image: aws/codebuild/standard:4.0
+        variables:
+          TEST_SUITE: multi-svc-app
+          APP_REGION: us-west-2
+    - identifier: root
+      env:
+        privileged-mode: true
+        type: LINUX_CONTAINER
+        compute-type: BUILD_GENERAL1_LARGE
+        image: aws/codebuild/standard:4.0
+        variables:
+          TEST_SUITE: root
+          APP_REGION: us-west-1
+    - identifier: sidecars
+      env:
+        privileged-mode: true
+        type: LINUX_CONTAINER
+        compute-type: BUILD_GENERAL1_LARGE
+        image: aws/codebuild/standard:4.0
+        variables:
+          TEST_SUITE: sidecars
+          APP_REGION: us-east-1
+    - identifier: task
+      env:
+        privileged-mode: true
+        type: LINUX_CONTAINER
+        compute-type: BUILD_GENERAL1_LARGE
+        image: aws/codebuild/standard:4.0
+        variables:
+          TEST_SUITE: task
+          APP_REGION: us-east-2
+    - identifier: app-with-domain
+      env:
+        privileged-mode: true
+        type: LINUX_CONTAINER
+        compute-type: BUILD_GENERAL1_LARGE
+        image: aws/codebuild/standard:4.0
+        variables:
+          TEST_SUITE: app-with-domain
+          APP_REGION: us-west-2
+
 
 phases:
   install:
@@ -47,7 +107,7 @@ phases:
        - export GOPATH=/go
        - rm -rf cf-custom-resources/node_modules
        - mkdir -p /tmp/.aws
-       - printf "[default]\nregion = us-west-2\n[profile e2etestenv]\nregion=us-west-1\n[profile e2eprodenv]\nregion=us-east-1\n" > /tmp/.aws/config
+       - printf "[default]\nregion = $APP_REGION\n[profile e2etestenv]\nregion=us-west-1\n[profile e2eprodenv]\nregion=us-east-1\n" > /tmp/.aws/config
        - printf "[default]\naws_access_key_id=$E2E_USER_1_ACCESS_KEY\naws_secret_access_key=$E2E_USER_1_SECRET_KEY\n\n[e2etestenv]\naws_access_key_id=$E2E_USER_2_ACCESS_KEY\naws_secret_access_key=$E2E_USER_2_SECRET_KEY\n\n[e2eprodenv]\naws_access_key_id=$E2E_USER_3_ACCESS_KEY\naws_secret_access_key=$E2E_USER_3_SECRET_KEY\n" > /tmp/.aws/credentials
        - sed -i -e '$s/$/ --noColor/' e2e/e2e.sh
        - make build-e2e


### PR DESCRIPTION
Currently, all of our e2e tests except multi-env-app creates their
environments and services in us-west-2.
With this change, we should be spreading them across 4 different US
regions and hopefully not get throttled.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
