### PR TITLE
fix: add output consts for workload resource delete failure

### DIFF
--- a/internal/pkg/cli/job_delete.go
+++ b/internal/pkg/cli/job_delete.go
@@ -38,7 +38,8 @@ const (
 	fmtJobDeleteStart             = "Deleting job %s from environment %s."
 	fmtJobDeleteFailed            = "Failed to delete job %s from environment %s: %v.\n"
 	fmtJobDeleteComplete          = "Deleted job %s from environment %s.\n"
-	fmtJobDeleteResourcesStart    = "Deleting resources of job %s from application %s.\n"
+	fmtJobDeleteResourcesStart    = "Deleting resources of job %s from application %s."
+	fmtJobDeleteResourcesFailed   = "Failed to delete resources of job %s from application %s.\n"
 	fmtJobDeleteResourcesComplete = "Deleted resources of job %s from application %s.\n"
 )
 
@@ -315,7 +316,7 @@ func (o *deleteJobOpts) removeJobFromApp() error {
 	o.spinner.Start(fmt.Sprintf(fmtJobDeleteResourcesStart, o.name, o.appName))
 	if err := o.appCFN.RemoveJobFromApp(proj, o.name); err != nil {
 		if !isStackSetNotExistsErr(err) {
-			o.spinner.Stop(log.Serrorf(fmtJobDeleteResourcesStart, o.name, o.appName))
+			o.spinner.Stop(log.Serrorf(fmtJobDeleteResourcesFailed, o.name, o.appName))
 			return err
 		}
 	}

--- a/internal/pkg/cli/svc_delete.go
+++ b/internal/pkg/cli/svc_delete.go
@@ -38,7 +38,8 @@ const (
 	fmtSvcDeleteStart             = "Deleting service %s from environment %s."
 	fmtSvcDeleteFailed            = "Failed to delete service %s from environment %s: %v.\n"
 	fmtSvcDeleteComplete          = "Deleted service %s from environment %s.\n"
-	fmtSvcDeleteResourcesStart    = "Deleting resources of service %s from application %s.\n"
+	fmtSvcDeleteResourcesStart    = "Deleting resources of service %s from application %s."
+	fmtSvcDeleteResourcesFailed   = "Failed to delete resources of service %s from application %s.\n"
 	fmtSvcDeleteResourcesComplete = "Deleted resources of service %s from application %s.\n"
 )
 
@@ -309,7 +310,7 @@ func (o *deleteSvcOpts) removeSvcFromApp() error {
 	o.spinner.Start(fmt.Sprintf(fmtSvcDeleteResourcesStart, o.name, o.appName))
 	if err := o.appCFN.RemoveServiceFromApp(proj, o.name); err != nil {
 		if !isStackSetNotExistsErr(err) {
-			o.spinner.Stop(log.Serrorf(fmtSvcDeleteResourcesStart, o.name, o.appName))
+			o.spinner.Stop(log.Serrorf(fmtSvcDeleteResourcesFailed, o.name, o.appName))
 			return err
 		}
 	}


### PR DESCRIPTION
We had been missing an output const to go with the spinner Stop() for `svc_delete` and `job_delete`. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
