### PR TITLE
fix(buildspec): addons template url uses dot region

### DIFF
--- a/templates/cicd/buildspec.yml
+++ b/templates/cicd/buildspec.yml
@@ -51,7 +51,7 @@ phases:
             tmp=$(mktemp)
             timestamp=$(date +%s){{range $bucket := .ArtifactBuckets}}
             aws s3 cp "$ADDONSFILE" "s3://{{$bucket.BucketName}}/manual/$timestamp/$workload.addons.stack.yml";{{range $envName := $bucket.Environments}}
-            jq --arg a "https://{{$bucket.BucketName}}.s3-{{$bucket.Region}}.amazonaws.com/manual/$timestamp/$workload.addons.stack.yml" '.Parameters.AddonsTemplateURL = $a' ./infrastructure/$workload-{{$envName}}.params.json > "$tmp" && mv "$tmp" ./infrastructure/$workload-{{$envName}}.params.json{{end}}{{end}}
+            jq --arg a "https://{{$bucket.BucketName}}.s3.{{$bucket.Region}}.amazonaws.com/manual/$timestamp/$workload.addons.stack.yml" '.Parameters.AddonsTemplateURL = $a' ./infrastructure/$workload-{{$envName}}.params.json > "$tmp" && mv "$tmp" ./infrastructure/$workload-{{$envName}}.params.json{{end}}{{end}}
           fi
         done;
       # Build images


### PR DESCRIPTION
<!-- Provide summary of changes -->

I saw this error in cloudformation when deploying a service via a pipeline: `"TemplateURL must reference a valid S3 object to which you have access."` Updating my buildspec with this change fixed the issue. [S3 docs](https://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html) show this is a legacy URL that doesn't work for all regions.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
