### PR TITLE
fix(storage)!: allow attaching storage resources to jobs via `storage init`

### DIFF
--- a/internal/pkg/cli/flag.go
+++ b/internal/pkg/cli/flag.go
@@ -17,8 +17,7 @@ const (
 	nameFlag    = "name"
 	appFlag     = "app"
 	envFlag     = "env"
-	svcFlag     = "svc"
-	wkldFlag    = "wkld"
+	forFlag     = "for"
 	svcTypeFlag = "svc-type"
 	jobTypeFlag = "job-type"
 	typeFlag    = "type"
@@ -96,7 +95,6 @@ const (
 	nameFlagShort = "n"
 	appFlagShort  = "a"
 	envFlagShort  = "e"
-	wkldFlagShort = "w"
 	typeFlagShort = "t"
 
 	dockerFileFlagShort        = "d"
@@ -179,7 +177,7 @@ Defaults to all logs. Only one of end-time / follow may be used.`
 	svcPortFlagDescription           = "Optional. The port on which your service listens."
 
 	storageFlagDescription             = "Name of the storage resource to create."
-	storageWorkloadFlagDescription     = "Name of the service or job to associate with storage."
+	storageForFlagDescription          = "Name of the service or job to associate with storage."
 	storagePartitionKeyFlagDescription = `Partition key for the DDB table.
 Must be of the format '<keyName>:<dataType>'.`
 	storageSortKeyFlagDescription = `Optional. Sort key for the DDB table.

--- a/internal/pkg/cli/flag.go
+++ b/internal/pkg/cli/flag.go
@@ -18,6 +18,7 @@ const (
 	appFlag     = "app"
 	envFlag     = "env"
 	svcFlag     = "svc"
+	wkldFlag    = "wkld"
 	svcTypeFlag = "svc-type"
 	jobTypeFlag = "job-type"
 	typeFlag    = "type"
@@ -96,6 +97,7 @@ const (
 	appFlagShort  = "a"
 	envFlagShort  = "e"
 	svcFlagShort  = "s"
+	wkldFlagShort = "w"
 	typeFlagShort = "t"
 
 	dockerFileFlagShort        = "d"
@@ -178,7 +180,7 @@ Defaults to all logs. Only one of end-time / follow may be used.`
 	svcPortFlagDescription           = "Optional. The port on which your service listens."
 
 	storageFlagDescription             = "Name of the storage resource to create."
-	storageServiceFlagDescription      = "Name of the service to associate with storage."
+	storageWorkloadFlagDescription     = "Name of the service or job to associate with storage."
 	storagePartitionKeyFlagDescription = `Partition key for the DDB table.
 Must be of the format '<keyName>:<dataType>'.`
 	storageSortKeyFlagDescription = `Optional. Sort key for the DDB table.

--- a/internal/pkg/cli/flag.go
+++ b/internal/pkg/cli/flag.go
@@ -14,17 +14,17 @@ import (
 // Long flag names.
 const (
 	// Common flags.
-	nameFlag    = "name"
-	appFlag     = "app"
-	envFlag     = "env"
-	forFlag     = "for"
-	svcTypeFlag = "svc-type"
-	jobTypeFlag = "job-type"
-	typeFlag    = "type"
-	profileFlag = "profile"
-	yesFlag     = "yes"
-	jsonFlag    = "json"
-	allFlag     = "all"
+	nameFlag     = "name"
+	appFlag      = "app"
+	envFlag      = "env"
+	workloadFlag = "workload"
+	svcTypeFlag  = "svc-type"
+	jobTypeFlag  = "job-type"
+	typeFlag     = "type"
+	profileFlag  = "profile"
+	yesFlag      = "yes"
+	jsonFlag     = "json"
+	allFlag      = "all"
 
 	// Command specific flags.
 	dockerFileFlag        = "dockerfile"
@@ -92,10 +92,11 @@ const (
 // Short flag names.
 // A short flag only exists if the flag or flag set is mandatory by the command.
 const (
-	nameFlagShort = "n"
-	appFlagShort  = "a"
-	envFlagShort  = "e"
-	typeFlagShort = "t"
+	nameFlagShort     = "n"
+	appFlagShort      = "a"
+	envFlagShort      = "e"
+	typeFlagShort     = "t"
+	workloadFlagShort = "w"
 
 	dockerFileFlagShort        = "d"
 	imageFlagShort             = "i"
@@ -177,7 +178,7 @@ Defaults to all logs. Only one of end-time / follow may be used.`
 	svcPortFlagDescription           = "Optional. The port on which your service listens."
 
 	storageFlagDescription             = "Name of the storage resource to create."
-	storageForFlagDescription          = "Name of the service or job to associate with storage."
+	storageWorkloadFlagDescription     = "Name of the service or job to associate with storage."
 	storagePartitionKeyFlagDescription = `Partition key for the DDB table.
 Must be of the format '<keyName>:<dataType>'.`
 	storageSortKeyFlagDescription = `Optional. Sort key for the DDB table.

--- a/internal/pkg/cli/flag.go
+++ b/internal/pkg/cli/flag.go
@@ -96,7 +96,6 @@ const (
 	nameFlagShort = "n"
 	appFlagShort  = "a"
 	envFlagShort  = "e"
-	svcFlagShort  = "s"
 	wkldFlagShort = "w"
 	typeFlagShort = "t"
 

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -285,7 +285,7 @@ type wsAppManager interface {
 
 type wsAddonManager interface {
 	WriteAddon(f encoding.BinaryMarshaler, svc, name string) (string, error)
-	wsSvcReader
+	wsWlReader
 }
 
 type artifactUploader interface {

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -2843,34 +2843,19 @@ func (mr *MockwsAddonManagerMockRecorder) WriteAddon(f, svc, name interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteAddon", reflect.TypeOf((*MockwsAddonManager)(nil).WriteAddon), f, svc, name)
 }
 
-// ServiceNames mocks base method
-func (m *MockwsAddonManager) ServiceNames() ([]string, error) {
+// WorkloadNames mocks base method
+func (m *MockwsAddonManager) WorkloadNames() ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ServiceNames")
+	ret := m.ctrl.Call(m, "WorkloadNames")
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ServiceNames indicates an expected call of ServiceNames
-func (mr *MockwsAddonManagerMockRecorder) ServiceNames() *gomock.Call {
+// WorkloadNames indicates an expected call of WorkloadNames
+func (mr *MockwsAddonManagerMockRecorder) WorkloadNames() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceNames", reflect.TypeOf((*MockwsAddonManager)(nil).ServiceNames))
-}
-
-// ReadServiceManifest mocks base method
-func (m *MockwsAddonManager) ReadServiceManifest(svcName string) ([]byte, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadServiceManifest", svcName)
-	ret0, _ := ret[0].([]byte)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ReadServiceManifest indicates an expected call of ReadServiceManifest
-func (mr *MockwsAddonManagerMockRecorder) ReadServiceManifest(svcName interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadServiceManifest", reflect.TypeOf((*MockwsAddonManager)(nil).ReadServiceManifest), svcName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadNames", reflect.TypeOf((*MockwsAddonManager)(nil).WorkloadNames))
 }
 
 // MockartifactUploader is a mock of artifactUploader interface

--- a/internal/pkg/cli/storage_init.go
+++ b/internal/pkg/cli/storage_init.go
@@ -42,16 +42,16 @@ var storageTypes = []string{
 // General-purpose prompts, collected for all storage resources.
 var (
 	fmtStorageInitTypePrompt = "What " + color.Emphasize("type") + " of storage would you like to associate with %s?"
-	storageInitTypeHelp      = `The type of storage you'd like to add to your service. 
+	storageInitTypeHelp      = `The type of storage you'd like to add to your workload. 
 DynamoDB is a key-value and document database that delivers single-digit millisecond performance at any scale.
 S3 is a web object store built to store and retrieve any amount of data from anywhere on the Internet.`
 
 	fmtStorageInitNamePrompt = "What would you like to " + color.Emphasize("name") + " this %s?"
 	storageInitNameHelp      = "The name of this storage resource. You can use the following characters: a-zA-Z0-9-_"
 
-	storageInitSvcPrompt = "Which " + color.Emphasize("service") + " would you like to associate with this storage resource?"
-	storageInitSvcHelp   = `The service you'd like to have access to this storage resource. 
-We'll deploy the resources for the storage when you run 'svc deploy'.`
+	storageInitSvcPrompt = "Which " + color.Emphasize("workload") + " would you like to associate with this storage resource?"
+	storageInitSvcHelp   = `The job or service you'd like to have access to this storage resource. 
+We'll deploy the resources for the storage when you run ` + color.HighlightCode("job deploy") + ` or ` + color.HighlightCode("svc deploy") + `.`
 )
 
 // DDB-specific questions and help prompts.
@@ -142,7 +142,7 @@ func (o *initStorageOpts) Validate() error {
 		return errNoAppInWorkspace
 	}
 	if o.storageSvc != "" {
-		if err := o.validateServiceName(); err != nil {
+		if err := o.validateWorkloadName(); err != nil {
 			return err
 		}
 	}
@@ -275,7 +275,7 @@ func (o *initStorageOpts) askStorageSvc() error {
 	if o.storageSvc != "" {
 		return nil
 	}
-	svc, err := o.sel.Service(storageInitSvcPrompt, storageInitSvcHelp)
+	svc, err := o.sel.Workload(storageInitSvcPrompt, storageInitSvcHelp)
 	if err != nil {
 		return fmt.Errorf("retrieve local service names: %w", err)
 	}
@@ -422,8 +422,8 @@ func (o *initStorageOpts) askDynamoLSIConfig() error {
 	}
 }
 
-func (o *initStorageOpts) validateServiceName() error {
-	names, err := o.ws.ServiceNames()
+func (o *initStorageOpts) validateWorkloadName() error {
+	names, err := o.ws.WorkloadNames()
 	if err != nil {
 		return fmt.Errorf("retrieve local service names: %w", err)
 	}
@@ -545,11 +545,11 @@ func buildStorageInitCmd() *cobra.Command {
 	vars := initStorageVars{}
 	cmd := &cobra.Command{
 		Use:   "init",
-		Short: "Creates a new storage config file in a service's addons directory.",
-		Long: `Creates a new storage config file in a service's addons directory.
-Storage resources are deployed to your service's environments when you run
-'copilot svc deploy'. Resource names are injected into your service containers as
-environment variables for easy access.`,
+		Short: "Creates a new storage config file in a workload's addons directory.",
+		Long: `Creates a new storage config file in a workload's addons directory.
+Storage resources are deployed to your environments when you run ` + color.HighlightCode("copilot svc deploy") + `.` +
+			`Resource names are injected into your service containers as environment 
+ variables for easy access.`,
 		Example: `
   Create an S3 bucket named "my-bucket" attached to the "frontend" service.
   /code $ copilot storage init -n my-bucket -t S3 -s frontend

--- a/internal/pkg/cli/storage_init.go
+++ b/internal/pkg/cli/storage_init.go
@@ -50,8 +50,6 @@ S3 is a web object store built to store and retrieve any amount of data from any
 	storageInitNameHelp      = "The name of this storage resource. You can use the following characters: a-zA-Z0-9-_"
 
 	storageInitSvcPrompt = "Which " + color.Emphasize("workload") + " would you like to associate with this storage resource?"
-	storageInitSvcHelp   = `The job or service you'd like to have access to this storage resource. 
-We'll deploy the resources for the storage when you run ` + color.HighlightCode("job deploy") + ` or ` + color.HighlightCode("svc deploy") + `.`
 )
 
 // DDB-specific questions and help prompts.
@@ -89,9 +87,9 @@ var attributeTypes = []string{
 }
 
 type initStorageVars struct {
-	storageType string
-	storageName string
-	storageWl   string
+	storageType  string
+	storageName  string
+	workloadName string
 
 	// Dynamo DB specific values collected via flags or prompts
 	partitionKey string
@@ -141,7 +139,7 @@ func (o *initStorageOpts) Validate() error {
 	if o.appName == "" {
 		return errNoAppInWorkspace
 	}
-	if o.storageWl != "" {
+	if o.workloadName != "" {
 		if err := o.validateWorkloadName(); err != nil {
 			return err
 		}
@@ -231,7 +229,7 @@ func (o *initStorageOpts) askStorageType() error {
 	}
 
 	storageType, err := o.prompt.SelectOne(fmt.Sprintf(
-		fmtStorageInitTypePrompt, color.HighlightUserInput(o.storageWl)),
+		fmtStorageInitTypePrompt, color.HighlightUserInput(o.workloadName)),
 		storageInitTypeHelp,
 		storageTypes,
 		prompt.WithFinalMessage("Storage type:"))
@@ -272,14 +270,14 @@ func (o *initStorageOpts) askStorageName() error {
 }
 
 func (o *initStorageOpts) askStorageWl() error {
-	if o.storageWl != "" {
+	if o.workloadName != "" {
 		return nil
 	}
-	svc, err := o.sel.Workload(storageInitSvcPrompt, storageInitSvcHelp)
+	workload, err := o.sel.Workload(storageInitSvcPrompt, "")
 	if err != nil {
 		return fmt.Errorf("retrieve local workload names: %w", err)
 	}
-	o.storageWl = svc
+	o.workloadName = workload
 	return nil
 }
 
@@ -428,11 +426,11 @@ func (o *initStorageOpts) validateWorkloadName() error {
 		return fmt.Errorf("retrieve local workload names: %w", err)
 	}
 	for _, name := range names {
-		if o.storageWl == name {
+		if o.workloadName == name {
 			return nil
 		}
 	}
-	return fmt.Errorf("workload %s not found in the workspace", o.storageWl)
+	return fmt.Errorf("workload %s not found in the workspace", o.workloadName)
 }
 
 func (o *initStorageOpts) Execute() error {
@@ -446,7 +444,7 @@ func (o *initStorageOpts) createAddon() error {
 		return err
 	}
 
-	addonPath, err := o.ws.WriteAddon(addonCf, o.storageWl, o.storageName)
+	addonPath, err := o.ws.WriteAddon(addonCf, o.workloadName, o.storageName)
 	if err != nil {
 		e, ok := err.(*workspace.ErrFileExists)
 		if !ok {
@@ -474,10 +472,6 @@ func (o *initStorageOpts) createAddon() error {
 		color.HighlightUserInput(o.storageName),
 		color.HighlightResource(addonPath),
 	)
-	log.Infoln(color.Help(`The Cloudformation template is a nested stack which fully describes your resource,
-the IAM policy necessary for an ECS task to access that resource, and outputs
-which are injected as environment variables into the Copilot workload this addon
-is associated with.`))
 	log.Infoln()
 
 	return nil
@@ -532,11 +526,11 @@ func (o *initStorageOpts) RecommendedActions() []string {
 
 	newVar := template.ToSnakeCaseFunc(template.EnvVarNameFunc(o.storageName))
 
-	svcDeployCmd := fmt.Sprintf("copilot svc deploy --name %s", o.storageWl)
+	deployCmd := fmt.Sprintf("copilot deploy --name %s", o.workloadName)
 
 	return []string{
-		fmt.Sprintf("Update your service or job code to leverage the injected environment variable %s", color.HighlightCode(newVar)),
-		fmt.Sprintf("Run %s to deploy your storage resources to your environments.", color.HighlightCode(svcDeployCmd)),
+		fmt.Sprintf("Update %s's code to leverage the injected environment variable %s", color.HighlightUserInput(o.workloadName), color.HighlightCode(newVar)),
+		fmt.Sprintf("Run %s to deploy your storage resources.", color.HighlightCode(deployCmd)),
 	}
 }
 
@@ -545,18 +539,18 @@ func buildStorageInitCmd() *cobra.Command {
 	vars := initStorageVars{}
 	cmd := &cobra.Command{
 		Use:   "init",
-		Short: "Creates a new storage config file in a workload's addons directory.",
-		Long: `Creates a new storage config file in a workload's addons directory.
-Storage resources are deployed to your environments when you run ` + color.HighlightCode("copilot svc deploy") + `.` +
-			`Resource names are injected into your service or job containers as environment 
- variables for easy access.`,
+		Short: "Creates a new AWS CloudFormation template for a storage resource.",
+		Long: `Creates a new AWS CloudFormation template for a storage resource.
+Storage resources are stored in the Copilot addons directory (e.g. ./copilot/frontend/addons) for a given
+workload and deployed to your environments when you run ` + color.HighlightCode("copilot deploy") + `. Resource names
+are injected into your containers as environment variables for easy access.`,
 		Example: `
   Create an S3 bucket named "my-bucket" attached to the "frontend" service.
-  /code $ copilot storage init -n my-bucket -t S3 -w frontend
+  /code $ copilot storage init -n my-bucket -t S3 --for frontend
   Create a basic DynamoDB table named "my-table" attached to the "frontend" service with a sort key specified.
-  /code $ copilot storage init -n my-table -t DynamoDB -w frontend --partition-key Email:S --sort-key UserId:N --no-lsi
+  /code $ copilot storage init -n my-table -t DynamoDB --for frontend --partition-key Email:S --sort-key UserId:N --no-lsi
   Create a DynamoDB table with multiple alternate sort keys.
-  /code $ copilot storage init -n my-table -t DynamoDB -w frontend --partition-key Email:S --sort-key UserId:N --lsi Points:N --lsi Goodness:N`,
+  /code $ copilot storage init -n my-table -t DynamoDB --for frontend --partition-key Email:S --sort-key UserId:N --lsi Points:N --lsi Goodness:N`,
 		RunE: runCmdE(func(cmd *cobra.Command, args []string) error {
 			opts, err := newStorageInitOpts(vars)
 			if err != nil {
@@ -580,7 +574,7 @@ Storage resources are deployed to your environments when you run ` + color.Highl
 	}
 	cmd.Flags().StringVarP(&vars.storageName, nameFlag, nameFlagShort, "", storageFlagDescription)
 	cmd.Flags().StringVarP(&vars.storageType, storageTypeFlag, typeFlagShort, "", storageTypeFlagDescription)
-	cmd.Flags().StringVarP(&vars.storageWl, wkldFlag, wkldFlagShort, "", storageWorkloadFlagDescription)
+	cmd.Flags().StringVar(&vars.workloadName, forFlag, "", storageForFlagDescription)
 
 	cmd.Flags().StringVar(&vars.partitionKey, storagePartitionKeyFlag, "", storagePartitionKeyFlagDescription)
 	cmd.Flags().StringVar(&vars.sortKey, storageSortKeyFlag, "", storageSortKeyFlagDescription)
@@ -591,7 +585,7 @@ Storage resources are deployed to your environments when you run ` + color.Highl
 	requiredFlags := pflag.NewFlagSet("Required", pflag.ContinueOnError)
 	requiredFlags.AddFlag(cmd.Flags().Lookup(nameFlag))
 	requiredFlags.AddFlag(cmd.Flags().Lookup(storageTypeFlag))
-	requiredFlags.AddFlag(cmd.Flags().Lookup(svcFlag))
+	requiredFlags.AddFlag(cmd.Flags().Lookup(forFlag))
 
 	ddbFlags := pflag.NewFlagSet("DynamoDB", pflag.ContinueOnError)
 	ddbFlags.AddFlag(cmd.Flags().Lookup(storagePartitionKeyFlag))

--- a/internal/pkg/cli/storage_init.go
+++ b/internal/pkg/cli/storage_init.go
@@ -546,11 +546,11 @@ workload and deployed to your environments when you run ` + color.HighlightCode(
 are injected into your containers as environment variables for easy access.`,
 		Example: `
   Create an S3 bucket named "my-bucket" attached to the "frontend" service.
-  /code $ copilot storage init -n my-bucket -t S3 --for frontend
+  /code $ copilot storage init -n my-bucket -t S3 -w frontend
   Create a basic DynamoDB table named "my-table" attached to the "frontend" service with a sort key specified.
-  /code $ copilot storage init -n my-table -t DynamoDB --for frontend --partition-key Email:S --sort-key UserId:N --no-lsi
+  /code $ copilot storage init -n my-table -t DynamoDB -w frontend --partition-key Email:S --sort-key UserId:N --no-lsi
   Create a DynamoDB table with multiple alternate sort keys.
-  /code $ copilot storage init -n my-table -t DynamoDB --for frontend --partition-key Email:S --sort-key UserId:N --lsi Points:N --lsi Goodness:N`,
+  /code $ copilot storage init -n my-table -t DynamoDB -w frontend --partition-key Email:S --sort-key UserId:N --lsi Points:N --lsi Goodness:N`,
 		RunE: runCmdE(func(cmd *cobra.Command, args []string) error {
 			opts, err := newStorageInitOpts(vars)
 			if err != nil {
@@ -574,7 +574,7 @@ are injected into your containers as environment variables for easy access.`,
 	}
 	cmd.Flags().StringVarP(&vars.storageName, nameFlag, nameFlagShort, "", storageFlagDescription)
 	cmd.Flags().StringVarP(&vars.storageType, storageTypeFlag, typeFlagShort, "", storageTypeFlagDescription)
-	cmd.Flags().StringVar(&vars.workloadName, forFlag, "", storageForFlagDescription)
+	cmd.Flags().StringVarP(&vars.workloadName, workloadFlag, workloadFlagShort, "", storageWorkloadFlagDescription)
 
 	cmd.Flags().StringVar(&vars.partitionKey, storagePartitionKeyFlag, "", storagePartitionKeyFlagDescription)
 	cmd.Flags().StringVar(&vars.sortKey, storageSortKeyFlag, "", storageSortKeyFlagDescription)
@@ -585,7 +585,7 @@ are injected into your containers as environment variables for easy access.`,
 	requiredFlags := pflag.NewFlagSet("Required", pflag.ContinueOnError)
 	requiredFlags.AddFlag(cmd.Flags().Lookup(nameFlag))
 	requiredFlags.AddFlag(cmd.Flags().Lookup(storageTypeFlag))
-	requiredFlags.AddFlag(cmd.Flags().Lookup(forFlag))
+	requiredFlags.AddFlag(cmd.Flags().Lookup(workloadFlag))
 
 	ddbFlags := pflag.NewFlagSet("DynamoDB", pflag.ContinueOnError)
 	ddbFlags.AddFlag(cmd.Flags().Lookup(storagePartitionKeyFlag))

--- a/internal/pkg/cli/storage_init_test.go
+++ b/internal/pkg/cli/storage_init_test.go
@@ -175,7 +175,7 @@ func TestStorageInitOpts_Validate(t *testing.T) {
 				initStorageVars: initStorageVars{
 					storageType:  tc.inStorageType,
 					storageName:  tc.inStorageName,
-					storageWl:    tc.inSvcName,
+					workloadName: tc.inSvcName,
 					partitionKey: tc.inPartition,
 					sortKey:      tc.inSort,
 					lsiSorts:     tc.inLSISorts,
@@ -557,9 +557,9 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 			mockCfg: func(m *mocks.MockwsSelector) {},
 
 			wantedVars: &initStorageVars{
-				storageName: wantedTableName,
-				storageWl:   wantedSvcName,
-				storageType: dynamoDBStorageType,
+				storageName:  wantedTableName,
+				workloadName: wantedSvcName,
+				storageType:  dynamoDBStorageType,
 
 				partitionKey: wantedPartitionKey,
 				sortKey:      wantedSortKey,
@@ -585,9 +585,9 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 			mockCfg: func(m *mocks.MockwsSelector) {},
 
 			wantedVars: &initStorageVars{
-				storageName: wantedTableName,
-				storageWl:   wantedSvcName,
-				storageType: dynamoDBStorageType,
+				storageName:  wantedTableName,
+				workloadName: wantedSvcName,
+				storageType:  dynamoDBStorageType,
 
 				partitionKey: wantedPartitionKey,
 				sortKey:      wantedSortKey,
@@ -611,9 +611,9 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 			mockCfg: func(m *mocks.MockwsSelector) {},
 
 			wantedVars: &initStorageVars{
-				storageName: wantedTableName,
-				storageWl:   wantedSvcName,
-				storageType: dynamoDBStorageType,
+				storageName:  wantedTableName,
+				workloadName: wantedSvcName,
+				storageType:  dynamoDBStorageType,
 
 				partitionKey: wantedPartitionKey,
 				noLSI:        true,
@@ -720,7 +720,7 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 				initStorageVars: initStorageVars{
 					storageType:  tc.inStorageType,
 					storageName:  tc.inStorageName,
-					storageWl:    tc.inSvcName,
+					workloadName: tc.inSvcName,
 					partitionKey: tc.inPartition,
 					sortKey:      tc.inSort,
 					lsiSorts:     tc.inLSISorts,
@@ -852,7 +852,7 @@ func TestStorageInitOpts_Execute(t *testing.T) {
 				initStorageVars: initStorageVars{
 					storageType:  tc.inStorageType,
 					storageName:  tc.inStorageName,
-					storageWl:    tc.inSvcName,
+					workloadName: tc.inSvcName,
 					partitionKey: tc.inPartition,
 					sortKey:      tc.inSort,
 					lsiSorts:     tc.inLSISorts,

--- a/internal/pkg/cli/storage_init_test.go
+++ b/internal/pkg/cli/storage_init_test.go
@@ -41,7 +41,7 @@ func TestStorageInitOpts_Validate(t *testing.T) {
 		},
 		"svc not in workspace": {
 			mockWs: func(m *mocks.MockwsAddonManager) {
-				m.EXPECT().ServiceNames().Return([]string{"bad", "workspace"}, nil)
+				m.EXPECT().WorkloadNames().Return([]string{"bad", "workspace"}, nil)
 			},
 			mockStore: func(m *mocks.Mockstore) {},
 
@@ -49,11 +49,11 @@ func TestStorageInitOpts_Validate(t *testing.T) {
 			inStorageType: s3StorageType,
 			inSvcName:     "frontend",
 			inStorageName: "my-bucket",
-			wantedErr:     errors.New("service frontend not found in the workspace"),
+			wantedErr:     errors.New("workload frontend not found in the workspace"),
 		},
 		"workspace error": {
 			mockWs: func(m *mocks.MockwsAddonManager) {
-				m.EXPECT().ServiceNames().Return(nil, errors.New("wanted err"))
+				m.EXPECT().WorkloadNames().Return(nil, errors.New("wanted err"))
 			},
 			mockStore: func(m *mocks.Mockstore) {},
 
@@ -61,7 +61,7 @@ func TestStorageInitOpts_Validate(t *testing.T) {
 			inStorageType: s3StorageType,
 			inSvcName:     "frontend",
 			inStorageName: "my-bucket",
-			wantedErr:     errors.New("retrieve local service names: wanted err"),
+			wantedErr:     errors.New("retrieve local workload names: wanted err"),
 		},
 		"successfully validates valid s3 bucket name": {
 			mockWs:        func(m *mocks.MockwsAddonManager) {},
@@ -175,7 +175,7 @@ func TestStorageInitOpts_Validate(t *testing.T) {
 				initStorageVars: initStorageVars{
 					storageType:  tc.inStorageType,
 					storageName:  tc.inStorageName,
-					storageSvc:   tc.inSvcName,
+					storageWl:    tc.inSvcName,
 					partitionKey: tc.inPartition,
 					sortKey:      tc.inSort,
 					lsiSorts:     tc.inLSISorts,
@@ -251,14 +251,14 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 
 			wantedErr: fmt.Errorf("select storage type: some error"),
 		},
-		"asks for storage svc": {
+		"asks for storage workload": {
 			inAppName:     wantedAppName,
 			inStorageName: wantedBucketName,
 			inStorageType: s3StorageType,
 
 			mockPrompt: func(m *mocks.Mockprompter) {},
 			mockCfg: func(m *mocks.MockwsSelector) {
-				m.EXPECT().Service(gomock.Eq(storageInitSvcPrompt), gomock.Any()).Return(wantedSvcName, nil)
+				m.EXPECT().Workload(gomock.Eq(storageInitSvcPrompt), gomock.Any()).Return(wantedSvcName, nil)
 			},
 
 			wantedErr: nil,
@@ -270,10 +270,10 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 
 			mockPrompt: func(m *mocks.Mockprompter) {},
 			mockCfg: func(m *mocks.MockwsSelector) {
-				m.EXPECT().Service(gomock.Any(), gomock.Any()).Return("", errors.New("some error"))
+				m.EXPECT().Workload(gomock.Any(), gomock.Any()).Return("", errors.New("some error"))
 			},
 
-			wantedErr: fmt.Errorf("retrieve local service names: some error"),
+			wantedErr: fmt.Errorf("retrieve local workload names: some error"),
 		},
 		"asks for storage name": {
 			inAppName:     wantedAppName,
@@ -558,7 +558,7 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 
 			wantedVars: &initStorageVars{
 				storageName: wantedTableName,
-				storageSvc:  wantedSvcName,
+				storageWl:   wantedSvcName,
 				storageType: dynamoDBStorageType,
 
 				partitionKey: wantedPartitionKey,
@@ -586,7 +586,7 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 
 			wantedVars: &initStorageVars{
 				storageName: wantedTableName,
-				storageSvc:  wantedSvcName,
+				storageWl:   wantedSvcName,
 				storageType: dynamoDBStorageType,
 
 				partitionKey: wantedPartitionKey,
@@ -612,7 +612,7 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 
 			wantedVars: &initStorageVars{
 				storageName: wantedTableName,
-				storageSvc:  wantedSvcName,
+				storageWl:   wantedSvcName,
 				storageType: dynamoDBStorageType,
 
 				partitionKey: wantedPartitionKey,
@@ -720,7 +720,7 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 				initStorageVars: initStorageVars{
 					storageType:  tc.inStorageType,
 					storageName:  tc.inStorageName,
-					storageSvc:   tc.inSvcName,
+					storageWl:    tc.inSvcName,
 					partitionKey: tc.inPartition,
 					sortKey:      tc.inSort,
 					lsiSorts:     tc.inLSISorts,
@@ -852,7 +852,7 @@ func TestStorageInitOpts_Execute(t *testing.T) {
 				initStorageVars: initStorageVars{
 					storageType:  tc.inStorageType,
 					storageName:  tc.inStorageName,
-					storageSvc:   tc.inSvcName,
+					storageWl:    tc.inSvcName,
 					partitionKey: tc.inPartition,
 					sortKey:      tc.inSort,
 					lsiSorts:     tc.inLSISorts,


### PR DESCRIPTION
<!-- Provide summary of changes -->
This PR enables customers to select from the list of services AND jobs when creating a new addons template through Storage Init. 

It also replaces the `--svc/-s` flag with a generic `--for` flag, which may be a breaking change for some customers. 

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->
Addresses #1595 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
