### PR TITLE
fix(cli): apply environment overrides to docker build configuration

### DIFF
--- a/internal/pkg/cli/job_deploy.go
+++ b/internal/pkg/cli/job_deploy.go
@@ -263,7 +263,7 @@ func (o *deployJobOpts) dfBuildArgs(job interface{}) (*docker.BuildArguments, er
 	if err != nil {
 		return nil, fmt.Errorf("get copilot directory: %w", err)
 	}
-	return buildArgs(o.name, o.imageTag, copilotDir, job)
+	return buildArgs(o.name, o.imageTag, o.envName, copilotDir, job)
 }
 
 func (o *deployJobOpts) deployJob(addonsURL string) error {

--- a/internal/pkg/manifest/backend_svc.go
+++ b/internal/pkg/manifest/backend_svc.go
@@ -4,6 +4,7 @@
 package manifest
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -103,9 +104,13 @@ func (s *BackendService) BuildRequired() (bool, error) {
 	return requiresBuild(s.ImageConfig.Image)
 }
 
-// BuildArgs returns a docker.BuildArguments object for the service given a workspace root directory
-func (s *BackendService) BuildArgs(wsRoot string) *DockerBuildArgs {
-	return s.ImageConfig.BuildConfig(wsRoot)
+// BuildArgs returns a docker.BuildArguments object for the service given a workspace root directory and environment
+func (s *BackendService) BuildArgs(wsRoot, envName string) (*DockerBuildArgs, error) {
+	envService, err := s.ApplyEnv(envName)
+	if err != nil {
+		return nil, fmt.Errorf("apply environment %s: %w", envName, err)
+	}
+	return envService.ImageConfig.BuildConfig(wsRoot), nil
 }
 
 // ApplyEnv returns the service manifest with environment overrides.

--- a/internal/pkg/manifest/job.go
+++ b/internal/pkg/manifest/job.go
@@ -5,6 +5,8 @@
 package manifest
 
 import (
+	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/copilot-cli/internal/pkg/template"
 	"github.com/imdario/mergo"
@@ -133,8 +135,12 @@ func (j ScheduledJob) ApplyEnv(envName string) (*ScheduledJob, error) {
 }
 
 // BuildArgs returns a docker.BuildArguments object for the job given a workspace root.
-func (j *ScheduledJob) BuildArgs(wsRoot string) *DockerBuildArgs {
-	return j.ImageConfig.BuildConfig(wsRoot)
+func (j *ScheduledJob) BuildArgs(wsRoot, envName string) (*DockerBuildArgs, error) {
+	envJob, err := j.ApplyEnv(envName)
+	if err != nil {
+		return nil, fmt.Errorf("apply environment %s: %w", envName, err)
+	}
+	return envJob.ImageConfig.BuildConfig(wsRoot), nil
 }
 
 // BuildRequired returns if the service requires building from the local Dockerfile.

--- a/internal/pkg/manifest/lb_web_svc.go
+++ b/internal/pkg/manifest/lb_web_svc.go
@@ -5,6 +5,7 @@ package manifest
 
 import (
 	"errors"
+	"fmt"
 	"path/filepath"
 	"time"
 
@@ -202,9 +203,13 @@ func (s *LoadBalancedWebService) BuildRequired() (bool, error) {
 	return requiresBuild(s.ImageConfig.Image)
 }
 
-// BuildArgs returns a docker.BuildArguments object given a ws root directory.
-func (s *LoadBalancedWebService) BuildArgs(wsRoot string) *DockerBuildArgs {
-	return s.ImageConfig.BuildConfig(wsRoot)
+// BuildArgs returns a docker.BuildArguments object for the service given a workspace root directory and environment
+func (s *LoadBalancedWebService) BuildArgs(wsRoot, envName string) (*DockerBuildArgs, error) {
+	envService, err := s.ApplyEnv(envName)
+	if err != nil {
+		return nil, fmt.Errorf("apply environment %s: %w", envName, err)
+	}
+	return envService.ImageConfig.BuildConfig(wsRoot), nil
 }
 
 // ApplyEnv returns the service manifest with environment overrides.


### PR DESCRIPTION
<!-- Provide summary of changes -->
Previously, environment overrides worked for every part of the manifest except for Docker build configuration. Now that we support things like `cache_from` and `target`, we should support customizing the Docker build process per environment as well. 

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->
Fixes #1702 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
