### PR TITLE
refactor(ecs): change get service arn method to a public func in ecs pkg

### DIFF
--- a/internal/pkg/describe/mocks/mock_status.go
+++ b/internal/pkg/describe/mocks/mock_status.go
@@ -7,7 +7,6 @@ package mocks
 import (
 	cloudwatch "github.com/aws/copilot-cli/internal/pkg/aws/cloudwatch"
 	ecs "github.com/aws/copilot-cli/internal/pkg/aws/ecs"
-	resourcegroups "github.com/aws/copilot-cli/internal/pkg/aws/resourcegroups"
 	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
 )
@@ -65,44 +64,6 @@ func (mr *MockalarmStatusGetterMockRecorder) AlarmStatus(alarms interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AlarmStatus", reflect.TypeOf((*MockalarmStatusGetter)(nil).AlarmStatus), alarms)
 }
 
-// MockresourcesGetter is a mock of resourcesGetter interface
-type MockresourcesGetter struct {
-	ctrl     *gomock.Controller
-	recorder *MockresourcesGetterMockRecorder
-}
-
-// MockresourcesGetterMockRecorder is the mock recorder for MockresourcesGetter
-type MockresourcesGetterMockRecorder struct {
-	mock *MockresourcesGetter
-}
-
-// NewMockresourcesGetter creates a new mock instance
-func NewMockresourcesGetter(ctrl *gomock.Controller) *MockresourcesGetter {
-	mock := &MockresourcesGetter{ctrl: ctrl}
-	mock.recorder = &MockresourcesGetterMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use
-func (m *MockresourcesGetter) EXPECT() *MockresourcesGetterMockRecorder {
-	return m.recorder
-}
-
-// GetResourcesByTags mocks base method
-func (m *MockresourcesGetter) GetResourcesByTags(resourceType string, tags map[string]string) ([]*resourcegroups.Resource, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetResourcesByTags", resourceType, tags)
-	ret0, _ := ret[0].([]*resourcegroups.Resource)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetResourcesByTags indicates an expected call of GetResourcesByTags
-func (mr *MockresourcesGetterMockRecorder) GetResourcesByTags(resourceType, tags interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResourcesByTags", reflect.TypeOf((*MockresourcesGetter)(nil).GetResourcesByTags), resourceType, tags)
-}
-
 // MockecsServiceGetter is a mock of ecsServiceGetter interface
 type MockecsServiceGetter struct {
 	ctrl     *gomock.Controller
@@ -154,6 +115,44 @@ func (m *MockecsServiceGetter) Service(clusterName, serviceName string) (*ecs.Se
 func (mr *MockecsServiceGetterMockRecorder) Service(clusterName, serviceName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Service", reflect.TypeOf((*MockecsServiceGetter)(nil).Service), clusterName, serviceName)
+}
+
+// MockserviceARNGetter is a mock of serviceARNGetter interface
+type MockserviceARNGetter struct {
+	ctrl     *gomock.Controller
+	recorder *MockserviceARNGetterMockRecorder
+}
+
+// MockserviceARNGetterMockRecorder is the mock recorder for MockserviceARNGetter
+type MockserviceARNGetterMockRecorder struct {
+	mock *MockserviceARNGetter
+}
+
+// NewMockserviceARNGetter creates a new mock instance
+func NewMockserviceARNGetter(ctrl *gomock.Controller) *MockserviceARNGetter {
+	mock := &MockserviceARNGetter{ctrl: ctrl}
+	mock.recorder = &MockserviceARNGetterMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockserviceARNGetter) EXPECT() *MockserviceARNGetterMockRecorder {
+	return m.recorder
+}
+
+// ServiceARN mocks base method
+func (m *MockserviceARNGetter) ServiceARN(app, env, svc string) (*ecs.ServiceArn, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ServiceARN", app, env, svc)
+	ret0, _ := ret[0].(*ecs.ServiceArn)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ServiceARN indicates an expected call of ServiceARN
+func (mr *MockserviceARNGetterMockRecorder) ServiceARN(app, env, svc interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceARN", reflect.TypeOf((*MockserviceARNGetter)(nil).ServiceARN), app, env, svc)
 }
 
 // MockautoscalingAlarmNamesGetter is a mock of autoscalingAlarmNamesGetter interface

--- a/internal/pkg/describe/status.go
+++ b/internal/pkg/describe/status.go
@@ -13,10 +13,10 @@ import (
 
 	"github.com/aws/copilot-cli/internal/pkg/aws/aas"
 	"github.com/aws/copilot-cli/internal/pkg/aws/cloudwatch"
-	"github.com/aws/copilot-cli/internal/pkg/aws/ecs"
+	awsECS "github.com/aws/copilot-cli/internal/pkg/aws/ecs"
 	"github.com/aws/copilot-cli/internal/pkg/aws/sessions"
 	"github.com/aws/copilot-cli/internal/pkg/deploy"
-	copiEcs "github.com/aws/copilot-cli/internal/pkg/ecs"
+	"github.com/aws/copilot-cli/internal/pkg/ecs"
 	"github.com/aws/copilot-cli/internal/pkg/term/color"
 )
 
@@ -30,12 +30,12 @@ type alarmStatusGetter interface {
 }
 
 type ecsServiceGetter interface {
-	ServiceTasks(clusterName, serviceName string) ([]*ecs.Task, error)
-	Service(clusterName, serviceName string) (*ecs.Service, error)
+	ServiceTasks(clusterName, serviceName string) ([]*awsECS.Task, error)
+	Service(clusterName, serviceName string) (*awsECS.Service, error)
 }
 
 type serviceARNGetter interface {
-	ServiceARN(app, env, svc string) (*ecs.ServiceArn, error)
+	ServiceARN(app, env, svc string) (*awsECS.ServiceArn, error)
 }
 
 type autoscalingAlarmNamesGetter interface {
@@ -56,8 +56,8 @@ type ServiceStatus struct {
 
 // ServiceStatusDesc contains the status for a service.
 type ServiceStatusDesc struct {
-	Service ecs.ServiceStatus
-	Tasks   []ecs.TaskStatus         `json:"tasks"`
+	Service awsECS.ServiceStatus
+	Tasks   []awsECS.TaskStatus      `json:"tasks"`
 	Alarms  []cloudwatch.AlarmStatus `json:"alarms"`
 }
 
@@ -83,9 +83,9 @@ func NewServiceStatus(opt *NewServiceStatusConfig) (*ServiceStatus, error) {
 		app:          opt.App,
 		env:          opt.Env,
 		svc:          opt.Svc,
-		svcARNGetter: copiEcs.New(sess),
+		svcARNGetter: ecs.New(sess),
 		cwSvc:        cloudwatch.New(sess),
-		ecsSvc:       ecs.New(sess),
+		ecsSvc:       awsECS.New(sess),
 		aasSvc:       aas.New(sess),
 	}, nil
 }
@@ -112,7 +112,7 @@ func (s *ServiceStatus) Describe() (*ServiceStatusDesc, error) {
 	if err != nil {
 		return nil, fmt.Errorf("get tasks for service %s: %w", serviceName, err)
 	}
-	var taskStatus []ecs.TaskStatus
+	var taskStatus []awsECS.TaskStatus
 	for _, task := range tasks {
 		status, err := task.TaskStatus()
 		if err != nil {

--- a/internal/pkg/describe/status.go
+++ b/internal/pkg/describe/status.go
@@ -14,14 +14,13 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/aws/aas"
 	"github.com/aws/copilot-cli/internal/pkg/aws/cloudwatch"
 	"github.com/aws/copilot-cli/internal/pkg/aws/ecs"
-	rg "github.com/aws/copilot-cli/internal/pkg/aws/resourcegroups"
 	"github.com/aws/copilot-cli/internal/pkg/aws/sessions"
 	"github.com/aws/copilot-cli/internal/pkg/deploy"
+	copiEcs "github.com/aws/copilot-cli/internal/pkg/ecs"
 	"github.com/aws/copilot-cli/internal/pkg/term/color"
 )
 
 const (
-	ecsServiceResourceType    = "ecs:service"
 	maxAlarmStatusColumnWidth = 30
 )
 
@@ -30,13 +29,13 @@ type alarmStatusGetter interface {
 	AlarmStatus(alarms []string) ([]cloudwatch.AlarmStatus, error)
 }
 
-type resourcesGetter interface {
-	GetResourcesByTags(resourceType string, tags map[string]string) ([]*rg.Resource, error)
-}
-
 type ecsServiceGetter interface {
 	ServiceTasks(clusterName, serviceName string) ([]*ecs.Task, error)
 	Service(clusterName, serviceName string) (*ecs.Service, error)
+}
+
+type serviceARNGetter interface {
+	ServiceARN(app, env, svc string) (*ecs.ServiceArn, error)
 }
 
 type autoscalingAlarmNamesGetter interface {
@@ -49,10 +48,10 @@ type ServiceStatus struct {
 	env string
 	svc string
 
-	ecsSvc ecsServiceGetter
-	cwSvc  alarmStatusGetter
-	aasSvc autoscalingAlarmNamesGetter
-	rgSvc  resourcesGetter
+	svcARNGetter serviceARNGetter
+	ecsSvc       ecsServiceGetter
+	cwSvc        alarmStatusGetter
+	aasSvc       autoscalingAlarmNamesGetter
 }
 
 // ServiceStatusDesc contains the status for a service.
@@ -81,35 +80,19 @@ func NewServiceStatus(opt *NewServiceStatusConfig) (*ServiceStatus, error) {
 		return nil, fmt.Errorf("session for role %s and region %s: %w", env.ManagerRoleARN, env.Region, err)
 	}
 	return &ServiceStatus{
-		app:    opt.App,
-		env:    opt.Env,
-		svc:    opt.Svc,
-		rgSvc:  rg.New(sess),
-		cwSvc:  cloudwatch.New(sess),
-		ecsSvc: ecs.New(sess),
-		aasSvc: aas.New(sess),
+		app:          opt.App,
+		env:          opt.Env,
+		svc:          opt.Svc,
+		svcARNGetter: copiEcs.New(sess),
+		cwSvc:        cloudwatch.New(sess),
+		ecsSvc:       ecs.New(sess),
+		aasSvc:       aas.New(sess),
 	}, nil
-}
-
-func (s *ServiceStatus) getServiceArn() (*ecs.ServiceArn, error) {
-	svcResources, err := s.rgSvc.GetResourcesByTags(ecsServiceResourceType, map[string]string{
-		deploy.AppTagKey:     s.app,
-		deploy.EnvTagKey:     s.env,
-		deploy.ServiceTagKey: s.svc,
-	})
-	if err != nil {
-		return nil, err
-	}
-	if len(svcResources) == 0 {
-		return nil, fmt.Errorf("cannot find service arn in service stack resource")
-	}
-	serviceArn := ecs.ServiceArn(svcResources[0].ARN)
-	return &serviceArn, nil
 }
 
 // Describe returns status of a service.
 func (s *ServiceStatus) Describe() (*ServiceStatusDesc, error) {
-	serviceArn, err := s.getServiceArn()
+	serviceArn, err := s.svcARNGetter.ServiceARN(s.app, s.env, s.svc)
 	if err != nil {
 		return nil, fmt.Errorf("get service ARN: %w", err)
 	}

--- a/internal/pkg/ecs/ecs.go
+++ b/internal/pkg/ecs/ecs.go
@@ -63,7 +63,7 @@ func (c Client) ClusterARN(app, env string) (string, error) {
 	return clusters[0].ARN, nil
 }
 
-// ServiceARN returns the ARN of the ECS service for a Copilot service.
+// ServiceARN returns the ARN of an ECS service created with Copilot.
 func (c Client) ServiceARN(app, env, svc string) (*ecs.ServiceArn, error) {
 	services, err := c.rgGetter.GetResourcesByTags(serviceResourceType, map[string]string{
 		deploy.AppTagKey:     app,
@@ -71,13 +71,13 @@ func (c Client) ServiceARN(app, env, svc string) (*ecs.ServiceArn, error) {
 		deploy.ServiceTagKey: svc,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("get ECS service for %s in environment %s: %w", svc, env, err)
+		return nil, fmt.Errorf("get ECS service with tags (%s, %s, %s): %w", app, env, svc, err)
 	}
 	if len(services) == 0 {
 		return nil, fmt.Errorf("no ECS service found for %s in environment %s", svc, env)
 	}
 	if len(services) > 1 {
-		return nil, fmt.Errorf("more than one ECS service is found for %s in environment %s", svc, env)
+		return nil, fmt.Errorf("more than one ECS service with the name %s found in environment %s", svc, env)
 	}
 	serviceArn := ecs.ServiceArn(services[0].ARN)
 	return &serviceArn, nil

--- a/internal/pkg/ecs/ecs.go
+++ b/internal/pkg/ecs/ecs.go
@@ -16,6 +16,7 @@ import (
 const (
 	fmtWorkloadTaskDefinitionFamily = "%s-%s-%s"
 	clusterResourceType             = "ecs:cluster"
+	serviceResourceType             = "ecs:service"
 )
 
 type resourceGetter interface {
@@ -40,8 +41,8 @@ func New(sess *session.Session) *Client {
 	}
 }
 
-// Cluster returns the ARN of the cluster in an environment.
-func (c Client) Cluster(app, env string) (string, error) {
+// ClusterARN returns the ARN of the cluster in an environment.
+func (c Client) ClusterARN(app, env string) (string, error) {
 	clusters, err := c.rgGetter.GetResourcesByTags(clusterResourceType, map[string]string{
 		deploy.AppTagKey: app,
 		deploy.EnvTagKey: env,
@@ -62,9 +63,29 @@ func (c Client) Cluster(app, env string) (string, error) {
 	return clusters[0].ARN, nil
 }
 
+// ServiceARN returns the ARN of the ECS service for a Copilot service.
+func (c Client) ServiceARN(app, env, svc string) (*ecs.ServiceArn, error) {
+	services, err := c.rgGetter.GetResourcesByTags(serviceResourceType, map[string]string{
+		deploy.AppTagKey:     app,
+		deploy.EnvTagKey:     env,
+		deploy.ServiceTagKey: svc,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get ECS service for %s in environment %s: %w", svc, env, err)
+	}
+	if len(services) == 0 {
+		return nil, fmt.Errorf("no ECS service found for %s in environment %s", svc, env)
+	}
+	if len(services) > 1 {
+		return nil, fmt.Errorf("more than one ECS service is found for %s in environment %s", svc, env)
+	}
+	serviceArn := ecs.ServiceArn(services[0].ARN)
+	return &serviceArn, nil
+}
+
 // ListActiveWorkloadTasks lists all active workload tasks (with desired status to be RUNNING) in the environment.
 func (c Client) ListActiveWorkloadTasks(app, env, workload string) (clusterARN string, taskARNs []string, err error) {
-	clusterARN, err = c.Cluster(app, env)
+	clusterARN, err = c.ClusterARN(app, env)
 	if err != nil {
 		return "", nil, fmt.Errorf("get cluster for env %s: %w", env, err)
 	}

--- a/internal/pkg/ecs/ecs_test.go
+++ b/internal/pkg/ecs/ecs_test.go
@@ -138,7 +138,7 @@ func TestClient_ServiceARN(t *testing.T) {
 						Return(nil, testError),
 				)
 			},
-			wantedError: fmt.Errorf("get ECS service for mockSvc in environment mockEnv: some error"),
+			wantedError: fmt.Errorf("get ECS service with tags (mockApp, mockEnv, mockSvc): some error"),
 		},
 		"errors if no service found": {
 			setupMocks: func(m clientMocks) {
@@ -158,7 +158,7 @@ func TestClient_ServiceARN(t *testing.T) {
 						}, nil),
 				)
 			},
-			wantedError: fmt.Errorf("more than one ECS service is found for mockSvc in environment mockEnv"),
+			wantedError: fmt.Errorf("more than one ECS service with the name mockSvc found in environment mockEnv"),
 		},
 		"success": {
 			setupMocks: func(m clientMocks) {

--- a/internal/pkg/ecs/ecs_test.go
+++ b/internal/pkg/ecs/ecs_test.go
@@ -19,10 +19,10 @@ import (
 
 type clientMocks struct {
 	resourceGetter *mocks.MockresourceGetter
-	ecsTaskGetter  *mocks.MockRunningTasksInFamilyGetter
+	ecsTaskGetter  *mocks.MockrunningTasksInFamilyGetter
 }
 
-func TestClient_Cluster(t *testing.T) {
+func TestClient_ClusterARN(t *testing.T) {
 	const (
 		mockApp = "mockApp"
 		mockEnv = "mockEnv"
@@ -99,7 +99,7 @@ func TestClient_Cluster(t *testing.T) {
 			}
 
 			// WHEN
-			get, err := client.Cluster(mockApp, mockEnv)
+			get, err := client.ClusterARN(mockApp, mockEnv)
 
 			// THEN
 			if test.wantedError != nil {
@@ -107,6 +107,98 @@ func TestClient_Cluster(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, get, test.wantedCluster)
+			}
+		})
+	}
+}
+
+func TestClient_ServiceARN(t *testing.T) {
+	const (
+		mockApp = "mockApp"
+		mockEnv = "mockEnv"
+		mockSvc = "mockSvc"
+	)
+	getRgInput := map[string]string{
+		deploy.AppTagKey:     mockApp,
+		deploy.EnvTagKey:     mockEnv,
+		deploy.ServiceTagKey: mockSvc,
+	}
+	testError := errors.New("some error")
+
+	tests := map[string]struct {
+		setupMocks func(mocks clientMocks)
+
+		wantedError   error
+		wantedService string
+	}{
+		"errors if fail to get resources by tags": {
+			setupMocks: func(m clientMocks) {
+				gomock.InOrder(
+					m.resourceGetter.EXPECT().GetResourcesByTags(serviceResourceType, getRgInput).
+						Return(nil, testError),
+				)
+			},
+			wantedError: fmt.Errorf("get ECS service for mockSvc in environment mockEnv: some error"),
+		},
+		"errors if no service found": {
+			setupMocks: func(m clientMocks) {
+				gomock.InOrder(
+					m.resourceGetter.EXPECT().GetResourcesByTags(serviceResourceType, getRgInput).
+						Return([]*resourcegroups.Resource{}, nil),
+				)
+			},
+			wantedError: fmt.Errorf("no ECS service found for mockSvc in environment mockEnv"),
+		},
+		"errors if more than one service found": {
+			setupMocks: func(m clientMocks) {
+				gomock.InOrder(
+					m.resourceGetter.EXPECT().GetResourcesByTags(serviceResourceType, getRgInput).
+						Return([]*resourcegroups.Resource{
+							{ARN: "mockARN1"}, {ARN: "mockARN2"},
+						}, nil),
+				)
+			},
+			wantedError: fmt.Errorf("more than one ECS service is found for mockSvc in environment mockEnv"),
+		},
+		"success": {
+			setupMocks: func(m clientMocks) {
+				gomock.InOrder(
+					m.resourceGetter.EXPECT().GetResourcesByTags(serviceResourceType, getRgInput).
+						Return([]*resourcegroups.Resource{
+							{ARN: "mockARN"},
+						}, nil),
+				)
+			},
+			wantedService: "mockARN",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			// GIVEN
+			mockRgGetter := mocks.NewMockresourceGetter(ctrl)
+			mocks := clientMocks{
+				resourceGetter: mockRgGetter,
+			}
+
+			test.setupMocks(mocks)
+
+			client := Client{
+				rgGetter: mockRgGetter,
+			}
+
+			// WHEN
+			get, err := client.ServiceARN(mockApp, mockEnv, mockSvc)
+
+			// THEN
+			if test.wantedError != nil {
+				require.EqualError(t, err, test.wantedError.Error())
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, string(*get), test.wantedService)
 			}
 		})
 	}
@@ -181,7 +273,7 @@ func TestClient_ListActiveWorkloadTasks(t *testing.T) {
 
 			// GIVEN
 			mockRgGetter := mocks.NewMockresourceGetter(ctrl)
-			mockECSTasksGetter := mocks.NewMockRunningTasksInFamilyGetter(ctrl)
+			mockECSTasksGetter := mocks.NewMockrunningTasksInFamilyGetter(ctrl)
 			mocks := clientMocks{
 				resourceGetter: mockRgGetter,
 				ecsTaskGetter:  mockECSTasksGetter,

--- a/internal/pkg/ecs/mocks/mock_ecs.go
+++ b/internal/pkg/ecs/mocks/mock_ecs.go
@@ -49,31 +49,31 @@ func (mr *MockresourceGetterMockRecorder) GetResourcesByTags(resourceType, tags 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResourcesByTags", reflect.TypeOf((*MockresourceGetter)(nil).GetResourcesByTags), resourceType, tags)
 }
 
-// MockRunningTasksInFamilyGetter is a mock of RunningTasksInFamilyGetter interface
-type MockRunningTasksInFamilyGetter struct {
+// MockrunningTasksInFamilyGetter is a mock of runningTasksInFamilyGetter interface
+type MockrunningTasksInFamilyGetter struct {
 	ctrl     *gomock.Controller
-	recorder *MockRunningTasksInFamilyGetterMockRecorder
+	recorder *MockrunningTasksInFamilyGetterMockRecorder
 }
 
-// MockRunningTasksInFamilyGetterMockRecorder is the mock recorder for MockRunningTasksInFamilyGetter
-type MockRunningTasksInFamilyGetterMockRecorder struct {
-	mock *MockRunningTasksInFamilyGetter
+// MockrunningTasksInFamilyGetterMockRecorder is the mock recorder for MockrunningTasksInFamilyGetter
+type MockrunningTasksInFamilyGetterMockRecorder struct {
+	mock *MockrunningTasksInFamilyGetter
 }
 
-// NewMockRunningTasksInFamilyGetter creates a new mock instance
-func NewMockRunningTasksInFamilyGetter(ctrl *gomock.Controller) *MockRunningTasksInFamilyGetter {
-	mock := &MockRunningTasksInFamilyGetter{ctrl: ctrl}
-	mock.recorder = &MockRunningTasksInFamilyGetterMockRecorder{mock}
+// NewMockrunningTasksInFamilyGetter creates a new mock instance
+func NewMockrunningTasksInFamilyGetter(ctrl *gomock.Controller) *MockrunningTasksInFamilyGetter {
+	mock := &MockrunningTasksInFamilyGetter{ctrl: ctrl}
+	mock.recorder = &MockrunningTasksInFamilyGetterMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use
-func (m *MockRunningTasksInFamilyGetter) EXPECT() *MockRunningTasksInFamilyGetterMockRecorder {
+func (m *MockrunningTasksInFamilyGetter) EXPECT() *MockrunningTasksInFamilyGetterMockRecorder {
 	return m.recorder
 }
 
 // RunningTasksInFamily mocks base method
-func (m *MockRunningTasksInFamilyGetter) RunningTasksInFamily(cluster, family string) ([]*ecs.Task, error) {
+func (m *MockrunningTasksInFamilyGetter) RunningTasksInFamily(cluster, family string) ([]*ecs.Task, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RunningTasksInFamily", cluster, family)
 	ret0, _ := ret[0].([]*ecs.Task)
@@ -82,7 +82,7 @@ func (m *MockRunningTasksInFamilyGetter) RunningTasksInFamily(cluster, family st
 }
 
 // RunningTasksInFamily indicates an expected call of RunningTasksInFamily
-func (mr *MockRunningTasksInFamilyGetterMockRecorder) RunningTasksInFamily(cluster, family interface{}) *gomock.Call {
+func (mr *MockrunningTasksInFamilyGetterMockRecorder) RunningTasksInFamily(cluster, family interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunningTasksInFamily", reflect.TypeOf((*MockRunningTasksInFamilyGetter)(nil).RunningTasksInFamily), cluster, family)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunningTasksInFamily", reflect.TypeOf((*MockrunningTasksInFamilyGetter)(nil).RunningTasksInFamily), cluster, family)
 }

--- a/internal/pkg/task/env_runner.go
+++ b/internal/pkg/task/env_runner.go
@@ -45,7 +45,7 @@ func (r *EnvRunner) Run() ([]*Task, error) {
 		return nil, err
 	}
 
-	cluster, err := r.ClusterGetter.Cluster(r.App, r.Env)
+	cluster, err := r.ClusterGetter.ClusterARN(r.App, r.Env)
 	if err != nil {
 		return nil, fmt.Errorf("get cluster for environment %s: %w", r.Env, err)
 	}

--- a/internal/pkg/task/env_runner_test.go
+++ b/internal/pkg/task/env_runner_test.go
@@ -32,7 +32,7 @@ func TestEnvRunner_Run(t *testing.T) {
 	}
 
 	MockClusterGetter := func(m *mocks.MockClusterGetter) {
-		m.EXPECT().Cluster(inApp, inEnv).Return("cluster-1", nil)
+		m.EXPECT().ClusterARN(inApp, inEnv).Return("cluster-1", nil)
 	}
 	MockVPCGetterAny := func(m *mocks.MockVPCGetter) {
 		m.EXPECT().SubnetIDs(gomock.Any()).AnyTimes()
@@ -55,7 +55,7 @@ func TestEnvRunner_Run(t *testing.T) {
 	}{
 		"failed to get cluster": {
 			MockClusterGetter: func(m *mocks.MockClusterGetter) {
-				m.EXPECT().Cluster(inApp, inEnv).Return("", errors.New("error getting resources"))
+				m.EXPECT().ClusterARN(inApp, inEnv).Return("", errors.New("error getting resources"))
 			},
 			MockVPCGetter: MockVPCGetterAny,
 			mockStarter:   mockStarterNotRun,

--- a/internal/pkg/task/mocks/mock_task.go
+++ b/internal/pkg/task/mocks/mock_task.go
@@ -114,19 +114,19 @@ func (m *MockClusterGetter) EXPECT() *MockClusterGetterMockRecorder {
 	return m.recorder
 }
 
-// Cluster mocks base method
-func (m *MockClusterGetter) Cluster(app, env string) (string, error) {
+// ClusterARN mocks base method
+func (m *MockClusterGetter) ClusterARN(app, env string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Cluster", app, env)
+	ret := m.ctrl.Call(m, "ClusterARN", app, env)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// Cluster indicates an expected call of Cluster
-func (mr *MockClusterGetterMockRecorder) Cluster(app, env interface{}) *gomock.Call {
+// ClusterARN indicates an expected call of ClusterARN
+func (mr *MockClusterGetterMockRecorder) ClusterARN(app, env interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Cluster", reflect.TypeOf((*MockClusterGetter)(nil).Cluster), app, env)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterARN", reflect.TypeOf((*MockClusterGetter)(nil).ClusterARN), app, env)
 }
 
 // MockDefaultClusterGetter is a mock of DefaultClusterGetter interface

--- a/internal/pkg/task/task.go
+++ b/internal/pkg/task/task.go
@@ -22,7 +22,7 @@ type VPCGetter interface {
 
 // ClusterGetter wraps the method of getting a cluster ARN.
 type ClusterGetter interface {
-	Cluster(app, env string) (string, error)
+	ClusterARN(app, env string) (string, error)
 }
 
 // DefaultClusterGetter wraps the method of getting a default cluster ARN.


### PR DESCRIPTION
<!-- Provide summary of changes -->
Refactor get service arn method in `describe` pkg to a public func in `ecs` pkg for reusability.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
