### PR TITLE
chore(stream): add new pkg that streams AWS events to subscribers

### DIFF
--- a/internal/pkg/deploy/cloudformation/env.go
+++ b/internal/pkg/deploy/cloudformation/env.go
@@ -40,6 +40,7 @@ func (cf CloudFormation) DeployEnvironment(env *deploy.CreateEnvironmentInput) e
 // StreamEnvironmentCreation streams resource update events while a deployment is taking place.
 // Once the CloudFormation stack operation halts, the update channel is closed and a
 // CreateEnvironmentResponse is sent to the second channel.
+// Deprecated: Use stream.Stream with a stream.StackStreamer instead.
 func (cf CloudFormation) StreamEnvironmentCreation(env *deploy.CreateEnvironmentInput) (<-chan []deploy.ResourceEvent, <-chan deploy.CreateEnvironmentResponse) {
 	done := make(chan struct{})
 	events := make(chan []deploy.ResourceEvent)

--- a/internal/pkg/stream/cloudformation.go
+++ b/internal/pkg/stream/cloudformation.go
@@ -1,0 +1,105 @@
+package stream
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+)
+
+// StackEventsDescriber is the CloudFormation interface needed to describe stack events.
+type StackEventsDescriber interface {
+	DescribeStackEvents(*cloudformation.DescribeStackEventsInput) (*cloudformation.DescribeStackEventsOutput, error)
+}
+
+// StackEvent is a CloudFormation stack event.
+type StackEvent struct {
+	LogicalResourceID string
+	ResourceType      string
+	ResourceStatus    string
+}
+
+// StackStreamer is a FetchNotifier for StackEvent events started by a change set.
+type StackStreamer struct {
+	Client                StackEventsDescriber // The CloudFormation client.
+	StackName             string               // The name of the stack to retrieve events from.
+	ChangeSetCreationTime time.Time            // The creation timestamp of the changeset being executed.
+
+	subscribers   []chan StackEvent
+	pastEventIDs  map[string]struct{}
+	eventsToFlush []StackEvent
+}
+
+// Subscribe registers the channels to receive notifications from the streamer.
+func (s *StackStreamer) Subscribe(channels ...chan StackEvent) {
+	s.subscribers = append(s.subscribers, channels...)
+}
+
+// Fetch retrieves and stores any new CloudFormation stack events since the ChangeSetCreationTime in chronological order.
+// If an error occurs from describe stack events, returns a wrapped error.
+func (s *StackStreamer) Fetch() (next time.Time, err error) {
+	if s.pastEventIDs == nil {
+		s.pastEventIDs = make(map[string]struct{})
+	}
+
+	var events []StackEvent
+	var nextToken *string
+	for {
+		out, err := s.Client.DescribeStackEvents(&cloudformation.DescribeStackEventsInput{
+			NextToken: nextToken,
+			StackName: aws.String(s.StackName),
+		})
+		if err != nil {
+			return next, fmt.Errorf("describe stack events %s: %w", s.StackName, err)
+		}
+
+		// Retrieve new events until we go past the ChangeSetCreationTime or we see an already seen event ID.
+		// This logic is taken from the AWS CDK:
+		// https://github.com/aws/aws-cdk/blob/43f3f09cc561fd32d651b2c327e877ad81c2ddb2/packages/aws-cdk/lib/api/util/cloudformation/stack-activity-monitor.ts#L230-L234
+		var finished bool
+		for _, event := range out.StackEvents {
+			if event.Timestamp.Before(s.ChangeSetCreationTime) {
+				finished = true
+				break
+			}
+			if _, seen := s.pastEventIDs[aws.StringValue(event.EventId)]; seen {
+				finished = true
+				break
+			}
+			events = append(events, StackEvent{
+				LogicalResourceID: aws.StringValue(event.LogicalResourceId),
+				ResourceType:      aws.StringValue(event.ResourceType),
+				ResourceStatus:    aws.StringValue(event.ResourceStatus),
+			})
+			s.pastEventIDs[aws.StringValue(event.EventId)] = struct{}{}
+		}
+		if finished || out.NextToken == nil {
+			break
+		}
+		nextToken = out.NextToken
+	}
+
+	// Store events to flush in chronological order.
+	reverse(events)
+	s.eventsToFlush = append(s.eventsToFlush, events...)
+	return time.Now().Add(3 * time.Second), nil
+}
+
+// Notify flushes all new events to the streamer's subscribers.
+func (s *StackStreamer) Notify() {
+	for _, event := range s.eventsToFlush {
+		for _, sub := range s.subscribers {
+			sub <- event
+		}
+	}
+	s.eventsToFlush = nil // reset after flushing all events.
+}
+
+// Taken from https://github.com/golang/go/wiki/SliceTricks#reversing
+func reverse(arr []StackEvent) {
+	for i := len(arr)/2 - 1; i >= 0; i-- {
+		opp := len(arr) - 1 - i
+		arr[i], arr[opp] = arr[opp], arr[i]
+	}
+}

--- a/internal/pkg/stream/cloudformation.go
+++ b/internal/pkg/stream/cloudformation.go
@@ -27,7 +27,7 @@ type StackStreamer struct {
 	ChangeSetCreationTime time.Time            // The creation timestamp of the changeset being executed.
 
 	subscribers   []chan StackEvent
-	pastEventIDs  map[string]struct{}
+	pastEventIDs  map[string]bool
 	eventsToFlush []StackEvent
 }
 
@@ -40,7 +40,7 @@ func (s *StackStreamer) Subscribe(channels ...chan StackEvent) {
 // If an error occurs from describe stack events, returns a wrapped error.
 func (s *StackStreamer) Fetch() (next time.Time, err error) {
 	if s.pastEventIDs == nil {
-		s.pastEventIDs = make(map[string]struct{})
+		s.pastEventIDs = make(map[string]bool)
 	}
 
 	var events []StackEvent
@@ -73,7 +73,7 @@ func (s *StackStreamer) Fetch() (next time.Time, err error) {
 				ResourceType:      aws.StringValue(event.ResourceType),
 				ResourceStatus:    aws.StringValue(event.ResourceStatus),
 			})
-			s.pastEventIDs[aws.StringValue(event.EventId)] = struct{}{}
+			s.pastEventIDs[aws.StringValue(event.EventId)] = true
 		}
 		if finished || out.NextToken == nil {
 			break

--- a/internal/pkg/stream/cloudformation_test.go
+++ b/internal/pkg/stream/cloudformation_test.go
@@ -1,0 +1,205 @@
+package stream
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/stretchr/testify/require"
+)
+
+type mockCloudFormation struct {
+	out *cloudformation.DescribeStackEventsOutput
+	err error
+}
+
+func (m mockCloudFormation) DescribeStackEvents(*cloudformation.DescribeStackEventsInput) (*cloudformation.DescribeStackEventsOutput, error) {
+	return m.out, m.err
+}
+
+func TestStackStreamer_Subscribe(t *testing.T) {
+	// GIVEN
+	streamer := &StackStreamer{}
+	sub1 := make(chan StackEvent)
+	sub2 := make(chan StackEvent)
+
+	// WHEN
+	streamer.Subscribe(sub1, sub2)
+
+	// THEN
+	require.Equal(t, 2, len(streamer.subscribers), "expected number of subscribers to match")
+	require.ElementsMatch(t, []chan StackEvent{sub1, sub2}, streamer.subscribers)
+}
+
+func TestStackStreamer_Fetch(t *testing.T) {
+	t.Run("stores all events in chronological order on fetch", testStackStreamer_Fetch_Success)
+	t.Run("stores only events after the changeset creation time", testStackStreamer_Fetch_PostChangeSet)
+	t.Run("stores only events that have not been seen yet", testStackStreamer_Fetch_WithSeenEvents)
+	t.Run("returns wrapped error if describe call fails", testStackStreamer_Fetch_WithError)
+}
+
+func TestStackStreamer_Notify(t *testing.T) {
+	// GIVEN
+	wantedEvents := []StackEvent{
+		{
+			LogicalResourceID: "Cluster",
+			ResourceType:      "AWS::ECS::Cluster",
+			ResourceStatus:    "CREATE_COMPLETE",
+		},
+		{
+			LogicalResourceID: "PublicLoadBalancer",
+			ResourceType:      "AWS::ElasticLoadBalancingV2::LoadBalancer",
+			ResourceStatus:    "CREATE_COMPLETE",
+		},
+	}
+	sub := make(chan StackEvent, 2)
+	streamer := &StackStreamer{
+		subscribers:   []chan StackEvent{sub},
+		eventsToFlush: wantedEvents,
+	}
+
+	// WHEN
+	streamer.Notify()
+	close(sub) // Close the channel to stop expecting to receive new events.
+
+	// THEN
+	var actualEvents []StackEvent
+	for event := range sub {
+		actualEvents = append(actualEvents, event)
+	}
+	require.ElementsMatch(t, wantedEvents, actualEvents)
+}
+
+func testStackStreamer_Fetch_Success(t *testing.T) {
+	// GIVEN
+	client := mockCloudFormation{
+		// Events are in reverse chronological order.
+		out: &cloudformation.DescribeStackEventsOutput{
+			StackEvents: []*cloudformation.StackEvent{
+				{
+					EventId:           aws.String("abc"),
+					LogicalResourceId: aws.String("Cluster"),
+					ResourceStatus:    aws.String("CREATE_COMPLETE"),
+					Timestamp:         aws.Time(time.Date(2020, time.November, 23, 18, 0, 0, 0, time.UTC)),
+				},
+				{
+					EventId:           aws.String("def"),
+					LogicalResourceId: aws.String("PublicLoadBalancer"),
+					ResourceStatus:    aws.String("CREATE_COMPLETE"),
+					Timestamp:         aws.Time(time.Date(2020, time.November, 23, 17, 0, 0, 0, time.UTC)),
+				},
+			},
+		},
+	}
+	streamer := &StackStreamer{
+		Client:                client,
+		StackName:             "phonetool-test",
+		ChangeSetCreationTime: time.Date(2020, time.November, 23, 16, 0, 0, 0, time.UTC),
+	}
+
+	// WHEN
+	_, err := streamer.Fetch()
+
+	// THEN
+	require.NoError(t, err)
+	require.ElementsMatch(t, []StackEvent{
+		{
+			LogicalResourceID: "PublicLoadBalancer",
+			ResourceStatus:    "CREATE_COMPLETE",
+		},
+		{
+			LogicalResourceID: "Cluster",
+			ResourceStatus:    "CREATE_COMPLETE",
+		},
+	}, streamer.eventsToFlush, "expected eventsToFlush to appear in chronological order")
+}
+
+func testStackStreamer_Fetch_PostChangeSet(t *testing.T) {
+	// GIVEN
+	client := mockCloudFormation{
+		out: &cloudformation.DescribeStackEventsOutput{
+			StackEvents: []*cloudformation.StackEvent{
+				{
+					EventId:           aws.String("abc"),
+					LogicalResourceId: aws.String("Cluster"),
+					ResourceStatus:    aws.String("CREATE_COMPLETE"),
+					Timestamp:         aws.Time(time.Date(2020, time.November, 23, 18, 0, 0, 0, time.UTC)),
+				},
+			},
+		},
+	}
+	streamer := &StackStreamer{
+		Client:                client,
+		StackName:             "phonetool-test",
+		ChangeSetCreationTime: time.Date(2020, time.November, 23, 19, 0, 0, 0, time.UTC), // An hour after the last event.
+	}
+
+	// WHEN
+	_, err := streamer.Fetch()
+
+	// THEN
+	require.NoError(t, err)
+	require.Empty(t, streamer.eventsToFlush, "expected eventsToFlush to be empty")
+}
+
+func testStackStreamer_Fetch_WithSeenEvents(t *testing.T) {
+	// GIVEN
+	client := mockCloudFormation{
+		out: &cloudformation.DescribeStackEventsOutput{
+			StackEvents: []*cloudformation.StackEvent{
+				{
+					EventId:           aws.String("abc"),
+					LogicalResourceId: aws.String("Cluster"),
+					ResourceStatus:    aws.String("CREATE_COMPLETE"),
+					Timestamp:         aws.Time(time.Date(2020, time.November, 23, 18, 0, 0, 0, time.UTC)),
+				},
+				{
+					EventId:           aws.String("def"),
+					LogicalResourceId: aws.String("PublicLoadBalancer"),
+					ResourceStatus:    aws.String("CREATE_COMPLETE"),
+					Timestamp:         aws.Time(time.Date(2020, time.November, 23, 17, 0, 0, 0, time.UTC)),
+				},
+			},
+		},
+	}
+	streamer := &StackStreamer{
+		Client:                client,
+		StackName:             "phonetool-test",
+		ChangeSetCreationTime: time.Date(2020, time.November, 23, 16, 0, 0, 0, time.UTC),
+		pastEventIDs: map[string]struct{}{
+			"def": {},
+		},
+	}
+
+	// WHEN
+	_, err := streamer.Fetch()
+
+	// THEN
+	require.NoError(t, err)
+	require.ElementsMatch(t, []StackEvent{
+		{
+			LogicalResourceID: "Cluster",
+			ResourceStatus:    "CREATE_COMPLETE",
+		},
+	}, streamer.eventsToFlush, "expected only the event not seen yet to be flushed")
+}
+
+func testStackStreamer_Fetch_WithError(t *testing.T) {
+	// GIVEN
+	client := mockCloudFormation{
+		err: errors.New("some error"),
+	}
+	streamer := &StackStreamer{
+		Client:                client,
+		StackName:             "phonetool-test",
+		ChangeSetCreationTime: time.Date(2020, time.November, 23, 16, 0, 0, 0, time.UTC),
+	}
+
+	// WHEN
+	_, err := streamer.Fetch()
+
+	// THEN
+	require.EqualError(t, err, "describe stack events phonetool-test: some error")
+}

--- a/internal/pkg/stream/cloudformation_test.go
+++ b/internal/pkg/stream/cloudformation_test.go
@@ -168,8 +168,8 @@ func testStackStreamer_Fetch_WithSeenEvents(t *testing.T) {
 		Client:                client,
 		StackName:             "phonetool-test",
 		ChangeSetCreationTime: time.Date(2020, time.November, 23, 16, 0, 0, 0, time.UTC),
-		pastEventIDs: map[string]struct{}{
-			"def": {},
+		pastEventIDs: map[string]bool{
+			"def": true,
 		},
 	}
 

--- a/internal/pkg/stream/stream.go
+++ b/internal/pkg/stream/stream.go
@@ -1,0 +1,52 @@
+// Package stream implements streamers that publish AWS events periodically.
+// A streamer fetches AWS events periodically and notifies subscribed channels of them.
+package stream
+
+import (
+	"context"
+	"time"
+)
+
+// Fetcher fetches events, updates its internal state with new events and returns the next time
+// the Fetch call should be attempted. On failure, Fetch returns an error.
+type Fetcher interface {
+	Fetch() (next time.Time, err error)
+}
+
+// Notifier notifies all of its subscribers of any new event updates.
+type Notifier interface {
+	Notify()
+}
+
+// FetchNotifier is the interface that groups the Fetch and a Notify methods.
+type FetchNotifier interface {
+	Fetcher
+	Notifier
+}
+
+// Stream streams event updates by calling Fetch followed with Notify until the context is canceled or Fetch errors.
+// Once the context is canceled, a best effort Fetch and Notify is called one last time.
+func Stream(ctx context.Context, fn FetchNotifier) error {
+	var next time.Time
+	var err error
+	for {
+		var fetchDelay time.Duration // By default there is no delay.
+		if now := time.Now(); next.After(now) {
+			fetchDelay = next.Sub(now)
+		}
+
+		select {
+		case <-ctx.Done():
+			// The parent context is canceled. Try Fetch and Notify one last time and exit successfully.
+			fn.Fetch()
+			fn.Notify()
+			return nil
+		case <-time.After(fetchDelay):
+			next, err = fn.Fetch()
+			if err != nil {
+				return err
+			}
+			fn.Notify()
+		}
+	}
+}

--- a/internal/pkg/stream/stream.go
+++ b/internal/pkg/stream/stream.go
@@ -38,7 +38,7 @@ func Stream(ctx context.Context, fn FetchNotifier) error {
 		select {
 		case <-ctx.Done():
 			// The parent context is canceled. Try Fetch and Notify one last time and exit successfully.
-			fn.Fetch()
+			_, _ = fn.Fetch()
 			fn.Notify()
 			return nil
 		case <-time.After(fetchDelay):

--- a/internal/pkg/stream/stream_test.go
+++ b/internal/pkg/stream/stream_test.go
@@ -1,0 +1,90 @@
+package stream
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// counterStreamer counts the number of times Fetch and Notify are invoked.
+type counterStreamer struct {
+	fetchCount  int
+	notifyCount int
+
+	next func() time.Time
+}
+
+func (s *counterStreamer) Fetch() (time.Time, error) {
+	s.fetchCount += 1
+	return s.next(), nil
+}
+
+func (s *counterStreamer) Notify() {
+	s.notifyCount += 1
+}
+
+// errStreamer returns an error when Fetch is invoked.
+type errStreamer struct {
+	err error
+}
+
+func (s *errStreamer) Fetch() (time.Time, error) {
+	return time.Now(), s.err
+}
+
+func (s *errStreamer) Notify() {}
+
+func TestStream(t *testing.T) {
+	t.Run("calls Fetch and Notify if context is canceled", func(t *testing.T) {
+		// GIVEN
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // call cancel immediately.
+		streamer := &counterStreamer{
+			next: func() time.Time {
+				return time.Now()
+			},
+		}
+
+		// WHEN
+		err := Stream(ctx, streamer)
+
+		// THEN
+		require.NoError(t, err)
+		require.Equal(t, 1, streamer.fetchCount, "expected number of Fetch calls to match")
+		require.Equal(t, 1, streamer.notifyCount, "expected number of Notify calls to match")
+	})
+
+	t.Run("returns error from Fetch", func(t *testing.T) {
+		// GIVEN
+		wantedErr := errors.New("unexpected fetch error")
+		streamer := &errStreamer{err: wantedErr}
+
+		// WHEN
+		actualErr := Stream(context.Background(), streamer)
+
+		// THEN
+		require.EqualError(t, actualErr, wantedErr.Error())
+	})
+
+	t.Run("calls Fetch and Notify multiple times until context is canceled", func(t *testing.T) {
+		// GIVEN
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		defer cancel()
+		streamer := &counterStreamer{
+			next: func() time.Time {
+				return time.Now().Add(100 * time.Millisecond)
+			},
+		}
+
+		// WHEN
+		err := Stream(ctx, streamer)
+
+		// THEN
+		require.NoError(t, err)
+		require.Greater(t, streamer.fetchCount, 1, "expected more than one call to Fetch within a second")
+		require.Greater(t, streamer.notifyCount, 1, "expected more than one call to Notify within a second")
+	})
+}


### PR DESCRIPTION
Add a `stream` package that allows clients to subscribe their channel for new cloudformation stack events.

A typical client will use this package like this:
```go
streamer := &stream.StackStreamer{ } // Define your streamer.
streamer.Subscribe(channels...)      // Assign all channels that want to receive notifications.
go stream.Stream(ctx, streamer)      // Start streaming.
```

Related #1742

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
