### PR TITLE
fix(cli): best-effort create service linked role for ECS on env init

### DIFF
--- a/internal/pkg/aws/iam/iam.go
+++ b/internal/pkg/aws/iam/iam.go
@@ -69,7 +69,7 @@ func (c *IAM) CreateECSServiceLinkedRole() error {
 	if _, err := c.client.CreateServiceLinkedRole(&iam.CreateServiceLinkedRoleInput{
 		AWSServiceName: aws.String(ecsServiceName),
 	}); err != nil {
-		return fmt.Errorf("create service linked role for Amazon ECS: %w", err)
+		return fmt.Errorf("create service linked role for %s: %w", ecsServiceName, err)
 	}
 	return nil
 }

--- a/internal/pkg/aws/iam/iam.go
+++ b/internal/pkg/aws/iam/iam.go
@@ -15,10 +15,15 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam"
 )
 
+const (
+	ecsServiceName = "ecs.amazonaws.com"
+)
+
 type api interface {
 	DeleteRolePolicy(input *iam.DeleteRolePolicyInput) (*iam.DeleteRolePolicyOutput, error)
 	ListRolePolicies(input *iam.ListRolePoliciesInput) (*iam.ListRolePoliciesOutput, error)
 	DeleteRole(input *iam.DeleteRoleInput) (*iam.DeleteRoleOutput, error)
+	CreateServiceLinkedRole(input *iam.CreateServiceLinkedRoleInput) (*iam.CreateServiceLinkedRoleOutput, error)
 }
 
 // IAM wraps the AWS SDK's IAM client.
@@ -53,6 +58,18 @@ func (c *IAM) DeleteRole(roleARN string) error {
 			return nil
 		}
 		return fmt.Errorf("delete role named %s: %w", roleName, err)
+	}
+	return nil
+}
+
+// CreateECSServiceLinkedRole creates a Service-Linked Role for Amazon ECS.
+// This role is necessary so that Amazon ECS can call AWS APIs.
+// https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using-service-linked-roles.html
+func (c *IAM) CreateECSServiceLinkedRole() error {
+	if _, err := c.client.CreateServiceLinkedRole(&iam.CreateServiceLinkedRoleInput{
+		AWSServiceName: aws.String(ecsServiceName),
+	}); err != nil {
+		return fmt.Errorf("create service linked role for Amazon ECS: %w", err)
 	}
 	return nil
 }

--- a/internal/pkg/aws/iam/iam_test.go
+++ b/internal/pkg/aws/iam/iam_test.go
@@ -137,7 +137,7 @@ func TestIAM_CreateECSServiceLinkedRole(t *testing.T) {
 				return m
 			},
 
-			wantedErr: errors.New("create service linked role for Amazon ECS: some error"),
+			wantedErr: errors.New("create service linked role for ecs.amazonaws.com: some error"),
 		},
 	}
 

--- a/internal/pkg/aws/iam/mocks/mock_iam.go
+++ b/internal/pkg/aws/iam/mocks/mock_iam.go
@@ -77,3 +77,18 @@ func (mr *MockapiMockRecorder) DeleteRole(input interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRole", reflect.TypeOf((*Mockapi)(nil).DeleteRole), input)
 }
+
+// CreateServiceLinkedRole mocks base method
+func (m *Mockapi) CreateServiceLinkedRole(input *iam.CreateServiceLinkedRoleInput) (*iam.CreateServiceLinkedRoleOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateServiceLinkedRole", input)
+	ret0, _ := ret[0].(*iam.CreateServiceLinkedRoleOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateServiceLinkedRole indicates an expected call of CreateServiceLinkedRole
+func (mr *MockapiMockRecorder) CreateServiceLinkedRole(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateServiceLinkedRole", reflect.TypeOf((*Mockapi)(nil).CreateServiceLinkedRole), input)
+}

--- a/internal/pkg/cli/env_init_test.go
+++ b/internal/pkg/cli/env_init_test.go
@@ -23,6 +23,11 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/cli/mocks"
 )
 
+// mockServiceLinkedRoleCreator satisfies the serviceLinkedRoleCreator and is a no-op.
+type mockServiceLinkedRoleCreator struct{}
+
+func (m *mockServiceLinkedRoleCreator) CreateECSServiceLinkedRole() error { return nil }
+
 type initEnvMocks struct {
 	sessProvider *mocks.MocksessionProvider
 	prompt       *mocks.Mockprompter
@@ -913,6 +918,7 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 				appDeployer: mockDeployer,
 				identity:    mockIdentity,
 				envIdentity: mockIdentity,
+				iam:         &mockServiceLinkedRoleCreator{},
 				prog:        mockProgress,
 			}
 

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -490,3 +490,7 @@ type activeWorkloadTasksLister interface {
 type tasksStopper interface {
 	StopTasks(tasks []string, opts ...ecs.StopTasksOpts) error
 }
+
+type serviceLinkedRoleCreator interface {
+	CreateECSServiceLinkedRole() error
+}

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -5272,3 +5272,40 @@ func (mr *MocktasksStopperMockRecorder) StopTasks(tasks interface{}, opts ...int
 	varargs := append([]interface{}{tasks}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopTasks", reflect.TypeOf((*MocktasksStopper)(nil).StopTasks), varargs...)
 }
+
+// MockserviceLinkedRoleCreator is a mock of serviceLinkedRoleCreator interface
+type MockserviceLinkedRoleCreator struct {
+	ctrl     *gomock.Controller
+	recorder *MockserviceLinkedRoleCreatorMockRecorder
+}
+
+// MockserviceLinkedRoleCreatorMockRecorder is the mock recorder for MockserviceLinkedRoleCreator
+type MockserviceLinkedRoleCreatorMockRecorder struct {
+	mock *MockserviceLinkedRoleCreator
+}
+
+// NewMockserviceLinkedRoleCreator creates a new mock instance
+func NewMockserviceLinkedRoleCreator(ctrl *gomock.Controller) *MockserviceLinkedRoleCreator {
+	mock := &MockserviceLinkedRoleCreator{ctrl: ctrl}
+	mock.recorder = &MockserviceLinkedRoleCreatorMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockserviceLinkedRoleCreator) EXPECT() *MockserviceLinkedRoleCreatorMockRecorder {
+	return m.recorder
+}
+
+// CreateECSServiceLinkedRole mocks base method
+func (m *MockserviceLinkedRoleCreator) CreateECSServiceLinkedRole() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateECSServiceLinkedRole")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateECSServiceLinkedRole indicates an expected call of CreateECSServiceLinkedRole
+func (mr *MockserviceLinkedRoleCreatorMockRecorder) CreateECSServiceLinkedRole() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateECSServiceLinkedRole", reflect.TypeOf((*MockserviceLinkedRoleCreator)(nil).CreateECSServiceLinkedRole))
+}


### PR DESCRIPTION
For accounts that never used ECS before, the [service linked role](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using-service-linked-roles.html) does not exist which results in ECS not being able to create the cluster during `env init`.

This change attempts a best-effort creation of the role before creating the environment stack.

Resolves #1324


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
