### PR TITLE
chore: add validations to pipeline_init

### DIFF
--- a/internal/pkg/cli/pipeline_init.go
+++ b/internal/pkg/cli/pipeline_init.go
@@ -157,7 +157,7 @@ func (o *initPipelineOpts) Validate() error {
 			return err
 		}
 		if !strings.Contains(o.URL, githubURL) && !strings.Contains(o.URL, "codecommit") {
-			return errors.New("Copilot currently accepts only urls to GitHub and CodeCommit repository sources")
+			return errors.New("Copilot currently accepts only URLs to GitHub and CodeCommit repository sources")
 		}
 	}
 	if o.environments != nil {

--- a/internal/pkg/cli/pipeline_init.go
+++ b/internal/pkg/cli/pipeline_init.go
@@ -44,6 +44,7 @@ Please enter full repository URL, e.g. "https://github.com/myCompany/myRepo", or
 const (
 	buildspecTemplatePath = "cicd/buildspec.yml"
 	githubURL             = "github.com"
+	ccSubstring           = "codecommit"
 	defaultBranch         = "main"
 )
 
@@ -59,7 +60,7 @@ type initPipelineVars struct {
 	environments      []string
 	githubOwner       string
 	githubRepo        string
-	URL               string
+	repoURL           string
 	githubAccessToken string
 	gitBranch         string
 }
@@ -150,13 +151,11 @@ func newInitPipelineOpts(vars initPipelineVars) (*initPipelineOpts, error) {
 
 // Validate returns an error if the flag values passed by the user are invalid.
 func (o *initPipelineOpts) Validate() error {
-	// May consider validating githubAccessToken and gitBranch flag values in the future.
-
-	if o.URL != "" {
-		if err := validateDomainName(o.URL); err != nil {
+	if o.repoURL != "" {
+		if err := validateDomainName(o.repoURL); err != nil {
 			return err
 		}
-		if !strings.Contains(o.URL, githubURL) && !strings.Contains(o.URL, "codecommit") {
+		if !strings.Contains(o.repoURL, githubURL) && !strings.Contains(o.repoURL, ccSubstring) {
 			return errors.New("Copilot currently accepts only URLs to GitHub and CodeCommit repository sources")
 		}
 	}
@@ -181,12 +180,12 @@ func (o *initPipelineOpts) Ask() error {
 		}
 	}
 
-	if o.URL == "" {
+	if o.repoURL == "" {
 		if err = o.selectGitHubURL(); err != nil {
 			return err
 		}
 	}
-	if o.githubOwner, o.githubRepo, err = o.parseOwnerRepoName(o.URL); err != nil {
+	if o.githubOwner, o.githubRepo, err = o.parseOwnerRepoName(o.repoURL); err != nil {
 		return err
 	}
 
@@ -471,7 +470,7 @@ func (o *initPipelineOpts) selectGitHubURL() error {
 	if err != nil {
 		return fmt.Errorf("select GitHub URL: %w", err)
 	}
-	o.URL = url
+	o.repoURL = url
 
 	return nil
 }
@@ -580,7 +579,7 @@ func buildPipelineInitCmd() *cobra.Command {
 		}),
 	}
 	cmd.Flags().StringVarP(&vars.appName, appFlag, appFlagShort, tryReadingAppName(), appFlagDescription)
-	cmd.Flags().StringVarP(&vars.URL, githubURLFlag, githubURLFlagShort, "", githubURLFlagDescription)
+	cmd.Flags().StringVarP(&vars.repoURL, githubURLFlag, githubURLFlagShort, "", githubURLFlagDescription)
 	cmd.Flags().StringVarP(&vars.githubAccessToken, githubAccessTokenFlag, githubAccessTokenFlagShort, "", githubAccessTokenFlagDescription)
 	cmd.Flags().StringVarP(&vars.gitBranch, gitBranchFlag, gitBranchFlagShort, "", gitBranchFlagDescription)
 	cmd.Flags().StringSliceVarP(&vars.environments, envsFlag, envsFlagShort, []string{}, pipelineEnvsFlagDescription)

--- a/internal/pkg/cli/pipeline_init_test.go
+++ b/internal/pkg/cli/pipeline_init_test.go
@@ -21,10 +21,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type initPipelineMocks struct {
-	storeSvc *mocks.Mockstore
-}
-
 func TestInitPipelineOpts_Validate(t *testing.T) {
 	testCases := map[string]struct {
 		inAppName     string

--- a/internal/pkg/cli/pipeline_init_test.go
+++ b/internal/pkg/cli/pipeline_init_test.go
@@ -53,6 +53,23 @@ func TestInitPipelineOpts_Validate(t *testing.T) {
 
 			expectedError: errors.New("some error"),
 		},
+		"success": {
+			inAppName: "my-app",
+			inEnvs:    []string{"test", "prod"},
+
+			setupMocks: func(m *mocks.Mockstore) {
+				m.EXPECT().GetEnvironment("my-app", "test").Return(
+					&config.Environment{
+						Name: "test",
+					}, nil)
+				m.EXPECT().GetEnvironment("my-app", "prod").Return(
+					&config.Environment{
+						Name: "prod",
+					}, nil)
+			},
+
+			expectedError: nil,
+		},
 	}
 
 	for name, tc := range testCases {

--- a/internal/pkg/cli/pipeline_init_test.go
+++ b/internal/pkg/cli/pipeline_init_test.go
@@ -33,7 +33,7 @@ func TestInitPipelineOpts_Validate(t *testing.T) {
 		setupMocks    func(m *mocks.Mockstore)
 		expectedError error
 	}{
-		"invalid url": {
+		"invalid URL": {
 			inAppName:     "my-app",
 			inURL:         "somethingdotcom",
 			inEnvs:        []string{"test"},

--- a/internal/pkg/cli/pipeline_init_test.go
+++ b/internal/pkg/cli/pipeline_init_test.go
@@ -45,7 +45,7 @@ func TestInitPipelineOpts_Validate(t *testing.T) {
 			inURL:         "bitbucket.org/repositories/repoName",
 			inEnvs:        []string{"test"},
 			setupMocks:    func(m *mocks.Mockstore) {},
-			expectedError: errors.New("Copilot currently accepts only urls to GitHub and CodeCommit repository sources"),
+			expectedError: errors.New("Copilot currently accepts only URLs to GitHub and CodeCommit repository sources"),
 		},
 		"invalid environments": {
 			inAppName: "my-app",

--- a/internal/pkg/cli/pipeline_init_test.go
+++ b/internal/pkg/cli/pipeline_init_test.go
@@ -85,7 +85,7 @@ func TestInitPipelineOpts_Validate(t *testing.T) {
 			opts := &initPipelineOpts{
 				initPipelineVars: initPipelineVars{
 					appName:      tc.inAppName,
-					URL:          tc.inURL,
+					repoURL:      tc.inURL,
 					environments: tc.inEnvs,
 				},
 				store: mockStore,


### PR DESCRIPTION
The one validation that was previously in Validate() was never reached-- users passing invalid (empty or nonexistent) appName via the `-a` flag got an `errNoEnvsInApp` because the constructor called getEnvs(), which threw that error. 

This adds appName validation within getEnvs() and also validates input for `-u` and `-e`. (Flag renaming-- `--github-url` -> `--url`-- will be in the next PR.)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
