### PR TITLE
chore(command): add interactive run

### DIFF
--- a/internal/pkg/term/command/interactive_run.go
+++ b/internal/pkg/term/command/interactive_run.go
@@ -1,0 +1,24 @@
+// +build !windows
+
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package command
+
+import (
+	"os"
+	"os/exec"
+	"os/signal"
+)
+
+// InteractiveRun runs the input command that starts a child process.
+func (s Service) InteractiveRun(name string, args []string) error {
+	// Ignore interrupt signal otherwise the program exits.
+	signal.Ignore(os.Interrupt)
+	defer signal.Reset(os.Interrupt)
+	cmd := exec.Command(name, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stdin = os.Stdin
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/internal/pkg/term/command/interactive_run_windows.go
+++ b/internal/pkg/term/command/interactive_run_windows.go
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package command
+
+import (
+	"os"
+	"os/exec"
+	"os/signal"
+)
+
+// InteractiveRun runs the input command that starts a child process.
+func (s Service) InteractiveRun(name string, args []string) error {
+	sig := make(chan os.Signal, 1)
+	// See https://golang.org/pkg/os/signal/#hdr-Windows
+	signal.Notify(sig, os.Interrupt)
+	defer signal.Reset(os.Interrupt)
+	cmd := exec.Command(name, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stdin = os.Stdin
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}


### PR DESCRIPTION
<!-- Provide summary of changes -->
Our `command.Run` doesn't work well if the command starts a child process, which allow users to run commands interactively: when the users press `ctrl+c`, the SIGINT will be passed to the parent process instead of the child process that users are interacting with. This PR adds a new method that allows interactive run: SIGINT signals can be received by the child process and ignored by the parent process, so that the parent process won't quit.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
