### PR TITLE
fix(workspace): ignore unreadable directories when listing Dockerfiles

### DIFF
--- a/internal/pkg/term/prompt/prompt.go
+++ b/internal/pkg/term/prompt/prompt.go
@@ -171,9 +171,9 @@ func (p Prompt) Get(message, help string, validator ValidatorFunc, promptOpts ..
 	var result string
 	var err error
 	if validator == nil {
-		err = p(prompt, &result, stdio(), icons())
+		err = p(prompt, &result, stdio(), icons(), noInterrupt())
 	} else {
-		err = p(prompt, &result, stdio(), validators(validator), icons())
+		err = p(prompt, &result, stdio(), validators(validator), icons(), noInterrupt())
 	}
 	return result, err
 }
@@ -220,7 +220,7 @@ func (p Prompt) GetSecret(message, help string, promptOpts ...Option) (string, e
 	}
 
 	var result string
-	err := p(prompt, &result, stdio(), icons())
+	err := p(prompt, &result, stdio(), icons(), noInterrupt())
 	return result, err
 }
 
@@ -248,7 +248,7 @@ func (p Prompt) SelectOne(message, help string, options []string, promptOpts ...
 	}
 
 	var result string
-	err := p(prompt, &result, stdio(), icons())
+	err := p(prompt, &result, stdio(), icons(), noInterrupt())
 	return result, err
 }
 
@@ -275,7 +275,7 @@ func (p Prompt) MultiSelect(message, help string, options []string, promptOpts .
 		option(prompt)
 	}
 
-	err := p(prompt, &result, stdio(), icons())
+	err := p(prompt, &result, stdio(), icons(), noInterrupt())
 	return result, err
 }
 
@@ -296,7 +296,7 @@ func (p Prompt) Confirm(message, help string, promptOpts ...Option) (bool, error
 	}
 
 	var result bool
-	err := p(prompt, &result, stdio(), icons())
+	err := p(prompt, &result, stdio(), icons(), noInterrupt())
 	return result, err
 }
 
@@ -330,6 +330,10 @@ func WithTrueDefault() Option {
 
 func stdio() survey.AskOpt {
 	return survey.WithStdio(os.Stdin, os.Stderr, os.Stderr)
+}
+
+func noInterrupt() survey.AskOpt {
+	return survey.WithInterruptFunc(func() {})
 }
 
 func icons() survey.AskOpt {

--- a/internal/pkg/term/prompt/prompt_test.go
+++ b/internal/pkg/term/prompt/prompt_test.go
@@ -46,7 +46,7 @@ func TestPrompt_Get(t *testing.T) {
 
 				*result = mockInput
 
-				require.Equal(t, 3, len(opts))
+				require.Equal(t, 4, len(opts))
 
 				return nil
 			},
@@ -100,7 +100,7 @@ func TestPrompt_GetSecret(t *testing.T) {
 
 				*result = mockSecret
 
-				require.Equal(t, 2, len(opts))
+				require.Equal(t, 3, len(opts))
 
 				return nil
 			},
@@ -154,7 +154,7 @@ func TestPrompt_SelectOne(t *testing.T) {
 
 				*result = sel.Options[0]
 
-				require.Equal(t, 2, len(opts))
+				require.Equal(t, 3, len(opts))
 
 				return nil
 			},
@@ -215,7 +215,7 @@ func TestPrompt_MultiSelect(t *testing.T) {
 
 				*result = sel.Options
 
-				require.Equal(t, 2, len(opts))
+				require.Equal(t, 3, len(opts))
 
 				return nil
 			},
@@ -275,7 +275,7 @@ func TestPrompt_Confirm(t *testing.T) {
 
 				*result = true
 
-				require.Equal(t, 2, len(opts))
+				require.Equal(t, 3, len(opts))
 
 				return nil
 			},

--- a/internal/pkg/workspace/workspace.go
+++ b/internal/pkg/workspace/workspace.go
@@ -455,7 +455,8 @@ func (ws *Workspace) ListDockerfiles() ([]string, error) {
 		// Add sub-directories containing a Dockerfile one level below current directory.
 		subFiles, err := ws.fsUtils.ReadDir(wdFile.Name())
 		if err != nil {
-			return nil, fmt.Errorf("read directory: %w", err)
+			// swallow errors for unreadable directories
+			continue
 		}
 		for _, f := range subFiles {
 			// NOTE: ignore directories in sub-directories.


### PR DESCRIPTION
<!-- Provide summary of changes -->
This is a quick change to skip over directories with invalid permissions when reading dockerfiles. If a directory doesn't have appropriate permissions, it's not essential that we read it--customers can always specify paths directly. 

This also fixes an issue introduced by the newest version of Survey (#1754) where the new OnInterrupt field was not populated, causing segfaults whenever ctrl+c was pressed at a prompt. 


<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
