### PR TITLE
refactor(cli): streamline pipeline init

### DIFF
--- a/internal/pkg/cli/pipeline_init.go
+++ b/internal/pkg/cli/pipeline_init.go
@@ -223,14 +223,15 @@ func (o *initPipelineOpts) RecommendedActions() []string {
 }
 
 func (o *initPipelineOpts) askEnvs() error {
-	if len(o.environments) == 0 {
-		err := o.getEnvs()
-		if err != nil {
-			return err
-		}
-		if err = o.selectEnvironments(); err != nil {
-			return err
-		}
+	if len(o.environments) != 0 {
+		return nil
+	}
+	err := o.getEnvs()
+	if err != nil {
+		return err
+	}
+	if err = o.selectEnvironments(); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/pkg/cli/pipeline_init.go
+++ b/internal/pkg/cli/pipeline_init.go
@@ -44,8 +44,8 @@ Please enter full repository URL, e.g. "https://github.com/myCompany/myRepo", or
 const (
 	buildspecTemplatePath = "cicd/buildspec.yml"
 	githubURL             = "github.com"
-	ccSubstring           = "codecommit"
-	defaultBranch         = "main"
+	//ccSubstring           = "codecommit"
+	defaultBranch = "main"
 )
 
 var (
@@ -58,9 +58,9 @@ var errNoEnvsInApp = errors.New("there were no more environments found that can 
 type initPipelineVars struct {
 	appName           string
 	environments      []string
+	repoURL           string
 	githubOwner       string
 	githubRepo        string
-	repoURL           string
 	githubAccessToken string
 	gitBranch         string
 }
@@ -93,72 +93,67 @@ type artifactBucket struct {
 }
 
 func newInitPipelineOpts(vars initPipelineVars) (*initPipelineOpts, error) {
-	opts := &initPipelineOpts{
-		initPipelineVars: vars,
-		runner:           command.New(),
-		fs:               &afero.Afero{Fs: afero.NewOsFs()},
-	}
-
-	ssmStore, err := config.NewStore()
-	if err != nil {
-		return nil, fmt.Errorf("new config store client: %w", err)
-	}
-	opts.store = ssmStore
-
-	envs, err := opts.getEnvs()
-	if err != nil {
-		return nil, err
-	}
-	if len(envs) == 0 {
-		return nil, errNoEnvsInApp
-	}
-	opts.envs = envs
-
 	ws, err := workspace.New()
 	if err != nil {
 		return nil, fmt.Errorf("new workspace client: %w", err)
 	}
-	opts.workspace = ws
 
 	secretsmanager, err := secretsmanager.New()
 	if err != nil {
 		return nil, fmt.Errorf("new secretsmanager client: %w", err)
 	}
-	opts.secretsmanager = secretsmanager
-	opts.parser = template.New()
 
-	err = opts.runner.Run("git", []string{"remote", "-v"}, command.Stdout(&opts.buffer))
-	if err != nil {
-		return nil, fmt.Errorf("get remote repository info: %w, run `git remote add` first please", err)
-	}
-	urls, err := opts.parseGitRemoteResult(strings.TrimSpace(opts.buffer.String()))
-	if err != nil {
-		return nil, err
-	}
-	opts.repoURLs = urls
-	opts.buffer.Reset()
+	parser := template.New()
 
 	p := sessions.NewProvider()
 	defaultSession, err := p.Default()
 	if err != nil {
 		return nil, err
 	}
-	opts.cfnClient = cloudformation.New(defaultSession)
 
-	opts.prompt = prompt.New()
-	return opts, nil
+	cfnClient := cloudformation.New(defaultSession)
+
+	ssmStore, err := config.NewStore()
+	if err != nil {
+		return nil, fmt.Errorf("new config store client: %w", err)
+	}
+
+	prompter := prompt.New()
+
+	return &initPipelineOpts{
+		initPipelineVars: vars,
+		workspace:        ws,
+		secretsmanager:   secretsmanager,
+		parser:           parser,
+		cfnClient:        cfnClient,
+		store:            ssmStore,
+		prompt:           prompter,
+		runner:           command.New(),
+		fs:               &afero.Afero{Fs: afero.NewOsFs()},
+	}, nil
 }
 
 // Validate returns an error if the flag values passed by the user are invalid.
 func (o *initPipelineOpts) Validate() error {
+	if o.appName == "" {
+		return errNoAppInWorkspace
+	}
+	if o.appName != "" {
+		if _, err := o.store.GetApplication(o.appName); err != nil {
+			return err
+		}
+	}
+
 	if o.repoURL != "" {
 		if err := validateDomainName(o.repoURL); err != nil {
 			return err
 		}
-		if !strings.Contains(o.repoURL, githubURL) && !strings.Contains(o.repoURL, ccSubstring) {
-			return errors.New("Copilot currently accepts only URLs to GitHub and CodeCommit repository sources")
+		// TODO: add "&& !strings.Contains(o.repoURL, ccURL)" to 'if' and "and CodeCommit" to error
+		if !strings.Contains(o.repoURL, githubURL) {
+			return errors.New("Copilot currently accepts only URLs to GitHub repository sources")
 		}
 	}
+
 	if o.environments != nil {
 		for _, env := range o.environments {
 			_, err := o.store.GetEnvironment(o.appName, env)
@@ -173,30 +168,12 @@ func (o *initPipelineOpts) Validate() error {
 
 // Ask prompts for fields that are required but not passed in.
 func (o *initPipelineOpts) Ask() error {
-	var err error
-	if len(o.environments) == 0 {
-		if err = o.selectEnvironments(); err != nil {
-			return err
-		}
-	}
-
-	if o.repoURL == "" {
-		if err = o.selectGitHubURL(); err != nil {
-			return err
-		}
-	}
-	if o.githubOwner, o.githubRepo, err = o.parseOwnerRepoName(o.repoURL); err != nil {
+	if err := o.askEnvs(); err != nil {
 		return err
 	}
-
-	if o.githubAccessToken == "" {
-		if err = o.getGitHubAccessToken(); err != nil {
-			return err
-		}
-	}
-
-	if o.gitBranch == "" {
-		o.gitBranch = defaultBranch
+	// TODO: Do a switch/case here after adding more repo providers.
+	if err := o.askRepoDetails(); err != nil {
+		return err
 	}
 	return nil
 }
@@ -245,30 +222,201 @@ func (o *initPipelineOpts) RecommendedActions() []string {
 	}
 }
 
-func (o *initPipelineOpts) createSecretName() string {
-	return fmt.Sprintf("github-token-%s-%s", o.appName, o.githubRepo)
-}
-
-func (o *initPipelineOpts) createPipelineName() string {
-	return fmt.Sprintf("pipeline-%s-%s-%s", o.appName, o.githubOwner, o.githubRepo)
-}
-
-func (o *initPipelineOpts) createPipelineProvider() (manifest.Provider, error) {
-	config := &manifest.GitHubProperties{
-		OwnerAndRepository:    "https://" + githubURL + "/" + o.githubOwner + "/" + o.githubRepo,
-		Branch:                o.gitBranch,
-		GithubSecretIdKeyName: o.secretName,
-	}
-	return manifest.NewProvider(config)
-}
-
-func (o *initPipelineOpts) getEnvConfig(environmentName string) (*config.Environment, error) {
-	for _, env := range o.envs {
-		if env.Name == environmentName {
-			return env, nil
+func (o *initPipelineOpts) askEnvs() error {
+	if len(o.environments) == 0 {
+		err := o.getEnvs()
+		if err != nil {
+			return err
+		}
+		if err = o.selectEnvironments(); err != nil {
+			return err
 		}
 	}
-	return nil, fmt.Errorf("environment %s in application %s is not found", environmentName, o.appName)
+	return nil
+}
+
+func (o *initPipelineOpts) getEnvs() error {
+	envs, err := o.store.ListEnvironments(o.appName)
+	if err != nil {
+		return fmt.Errorf("list environments for application %s: %w", o.appName, err)
+	}
+	if len(envs) == 0 {
+		return errNoEnvsInApp
+	}
+	o.envs = envs
+	return nil
+}
+
+func (o *initPipelineOpts) selectEnvironments() error {
+	for {
+		promptMsg := pipelineInitAddEnvPrompt
+		promptHelpMsg := pipelineInitAddEnvHelpPrompt
+		if len(o.environments) > 0 {
+			promptMsg = pipelineInitAddMoreEnvPrompt
+			promptHelpMsg = pipelineInitAddMoreEnvHelpPrompt
+		}
+		addEnv, err := o.prompt.Confirm(promptMsg, promptHelpMsg)
+		if err != nil {
+			return fmt.Errorf("confirm adding an environment: %w", err)
+		}
+		if !addEnv {
+			break
+		}
+		if err := o.selectEnvironment(); err != nil {
+			return fmt.Errorf("add environment: %w", err)
+		}
+		if len(o.listAvailableEnvironments()) == 0 {
+			break
+		}
+	}
+
+	return nil
+}
+
+func (o *initPipelineOpts) listAvailableEnvironments() []string {
+	var envs []string
+	for _, env := range o.envs {
+		// Check if environment has already been added to pipeline
+		if o.envCanBeAdded(env.Name) {
+			envs = append(envs, env.Name)
+		}
+	}
+
+	return envs
+}
+
+func (o *initPipelineOpts) envCanBeAdded(selectedEnv string) bool {
+	for _, env := range o.environments {
+		if selectedEnv == env {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (o *initPipelineOpts) selectEnvironment() error {
+	envs := o.listAvailableEnvironments()
+
+	if len(envs) == 0 && len(o.environments) != 0 {
+		log.Infoln("There are no more environments to add.")
+		return nil
+	}
+
+	env, err := o.prompt.SelectOne(
+		pipelineSelectEnvPrompt,
+		"Environment to be added as the next stage in your pipeline.",
+		envs,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	o.environments = append(o.environments, env)
+
+	return nil
+}
+
+func (o *initPipelineOpts) askRepoDetails() error {
+	var err error
+	if o.repoURL == "" {
+		if err = o.fetchRepoURLs(); err != nil {
+			return err
+		}
+		if err = o.selectGitHubURL(); err != nil {
+			return err
+		}
+	}
+	if o.githubOwner, o.githubRepo, err = o.parseOwnerRepoName(o.repoURL); err != nil {
+		return err
+	}
+	if o.githubAccessToken == "" {
+		if err = o.getGitHubAccessToken(); err != nil {
+			return err
+		}
+	}
+	if o.gitBranch == "" {
+		o.gitBranch = defaultBranch
+	}
+	return nil
+}
+
+func (o *initPipelineOpts) fetchRepoURLs() error {
+	err := o.runner.Run("git", []string{"remote", "-v"}, command.Stdout(&o.buffer))
+	if err != nil {
+		return fmt.Errorf("get remote repository info: %w, run `git remote add` first please", err)
+	}
+	urls, err := o.parseGitRemoteResult(strings.TrimSpace(o.buffer.String()))
+	if err != nil {
+		return err
+	}
+	o.repoURLs = urls
+	o.buffer.Reset()
+
+	return nil
+}
+
+func (o *initPipelineOpts) selectGitHubURL() error {
+	url, err := o.prompt.SelectOne(
+		pipelineSelectGitHubURLPrompt,
+		pipelineSelectGitHubURLHelpPrompt,
+		o.repoURLs,
+	)
+	if err != nil {
+		return fmt.Errorf("select GitHub URL: %w", err)
+	}
+	o.repoURL = url
+
+	return nil
+}
+
+func (o *initPipelineOpts) parseOwnerRepoName(url string) (string, string, error) {
+	regexPattern := regexp.MustCompile(`.*(github.com)(:|\/)`)
+	parsedURL := strings.TrimPrefix(url, regexPattern.FindString(url))
+	parsedURL = strings.TrimSuffix(parsedURL, ".git")
+	ownerRepo := strings.Split(parsedURL, "/")
+	if len(ownerRepo) != 2 {
+		return "", "", fmt.Errorf("unable to parse the GitHub repository owner and name from %s: please pass the repository URL with the format `--github-url https://github.com/{owner}/{repositoryName}`", url)
+	}
+	return ownerRepo[0], ownerRepo[1], nil
+}
+
+// examples:
+// efekarakus	git@github.com:efekarakus/grit.git (fetch)
+// efekarakus	https://github.com/karakuse/grit.git (fetch)
+// origin	    https://github.com/koke/grit (fetch)
+// koke         git://github.com/koke/grit.git (push)
+func (o *initPipelineOpts) parseGitRemoteResult(s string) ([]string, error) {
+	var urls []string
+	urlSet := make(map[string]bool)
+	items := strings.Split(s, "\n")
+	for _, item := range items {
+		if !strings.Contains(item, githubURL) {
+			continue
+		}
+		cols := strings.Split(item, "\t")
+		url := strings.TrimSpace(strings.TrimSuffix(strings.Split(cols[1], " ")[0], ".git"))
+		urlSet[url] = true
+	}
+	for url := range urlSet {
+		urls = append(urls, url)
+	}
+	return urls, nil
+}
+
+func (o *initPipelineOpts) getGitHubAccessToken() error {
+	token, err := o.prompt.GetSecret(
+		fmt.Sprintf("Please enter your GitHub Personal Access Token for your repository %s:", color.HighlightUserInput(o.githubRepo)),
+		`The personal access token for the GitHub repository linked to your workspace. 
+For more information, please refer to: https://git.io/JfDFD.`,
+	)
+
+	if err != nil {
+		return fmt.Errorf("get GitHub access token: %w", err)
+	}
+	o.githubAccessToken = token
+	return nil
 }
 
 func (o *initPipelineOpts) createPipelineManifest() error {
@@ -362,6 +510,32 @@ func (o *initPipelineOpts) createBuildspec() error {
 	return nil
 }
 
+func (o *initPipelineOpts) createSecretName() string {
+	return fmt.Sprintf("github-token-%s-%s", o.appName, o.githubRepo)
+}
+
+func (o *initPipelineOpts) createPipelineName() string {
+	return fmt.Sprintf("pipeline-%s-%s-%s", o.appName, o.githubOwner, o.githubRepo)
+}
+
+func (o *initPipelineOpts) createPipelineProvider() (manifest.Provider, error) {
+	config := &manifest.GitHubProperties{
+		OwnerAndRepository:    "https://" + githubURL + "/" + o.githubOwner + "/" + o.githubRepo,
+		Branch:                o.gitBranch,
+		GithubSecretIdKeyName: o.secretName,
+	}
+	return manifest.NewProvider(config)
+}
+
+func (o *initPipelineOpts) getEnvConfig(environmentName string) (*config.Environment, error) {
+	for _, env := range o.envs {
+		if env.Name == environmentName {
+			return env, nil
+		}
+	}
+	return nil, fmt.Errorf("environment %s in application %s is not found", environmentName, o.appName)
+}
+
 func (o *initPipelineOpts) artifactBuckets() ([]artifactBucket, error) {
 	app, err := o.store.GetApplication(o.appName)
 	if err != nil {
@@ -388,159 +562,6 @@ func (o *initPipelineOpts) artifactBuckets() ([]artifactBucket, error) {
 		buckets = append(buckets, bucket)
 	}
 	return buckets, nil
-}
-
-func (o *initPipelineOpts) selectEnvironments() error {
-	for {
-		promptMsg := pipelineInitAddEnvPrompt
-		promptHelpMsg := pipelineInitAddEnvHelpPrompt
-		if len(o.environments) > 0 {
-			promptMsg = pipelineInitAddMoreEnvPrompt
-			promptHelpMsg = pipelineInitAddMoreEnvHelpPrompt
-		}
-		addEnv, err := o.prompt.Confirm(promptMsg, promptHelpMsg)
-		if err != nil {
-			return fmt.Errorf("confirm adding an environment: %w", err)
-		}
-		if !addEnv {
-			break
-		}
-		if err := o.selectEnvironment(); err != nil {
-			return fmt.Errorf("add environment: %w", err)
-		}
-		if len(o.listAvailableEnvironments()) == 0 {
-			break
-		}
-	}
-
-	return nil
-}
-
-func (o *initPipelineOpts) listAvailableEnvironments() []string {
-	var envs []string
-	for _, env := range o.envs {
-		// Check if environment has already been added to pipeline
-		if o.envCanBeAdded(env.Name) {
-			envs = append(envs, env.Name)
-		}
-	}
-
-	return envs
-}
-
-func (o *initPipelineOpts) envCanBeAdded(selectedEnv string) bool {
-	for _, env := range o.environments {
-		if selectedEnv == env {
-			return false
-		}
-	}
-
-	return true
-}
-
-func (o *initPipelineOpts) selectEnvironment() error {
-	envs := o.listAvailableEnvironments()
-
-	if len(envs) == 0 && len(o.environments) != 0 {
-		log.Infoln("There are no more environments to add.")
-		return nil
-	}
-
-	env, err := o.prompt.SelectOne(
-		pipelineSelectEnvPrompt,
-		"Environment to be added as the next stage in your pipeline.",
-		envs,
-	)
-
-	if err != nil {
-		return err
-	}
-
-	o.environments = append(o.environments, env)
-
-	return nil
-}
-
-func (o *initPipelineOpts) selectGitHubURL() error {
-	url, err := o.prompt.SelectOne(
-		pipelineSelectGitHubURLPrompt,
-		pipelineSelectGitHubURLHelpPrompt,
-		o.repoURLs,
-	)
-	if err != nil {
-		return fmt.Errorf("select GitHub URL: %w", err)
-	}
-	o.repoURL = url
-
-	return nil
-}
-
-func (o *initPipelineOpts) parseOwnerRepoName(url string) (string, string, error) {
-	regexPattern := regexp.MustCompile(`.*(github.com)(:|\/)`)
-	parsedURL := strings.TrimPrefix(url, regexPattern.FindString(url))
-	parsedURL = strings.TrimSuffix(parsedURL, ".git")
-	ownerRepo := strings.Split(parsedURL, "/")
-	if len(ownerRepo) != 2 {
-		return "", "", fmt.Errorf("unable to parse the GitHub repository owner and name from %s: please pass the repository URL with the format `--github-url https://github.com/{owner}/{repositoryName}`", url)
-	}
-	return ownerRepo[0], ownerRepo[1], nil
-}
-
-// examples:
-// efekarakus	git@github.com:efekarakus/grit.git (fetch)
-// efekarakus	https://github.com/karakuse/grit.git (fetch)
-// origin	    https://github.com/koke/grit (fetch)
-// koke         git://github.com/koke/grit.git (push)
-func (o *initPipelineOpts) parseGitRemoteResult(s string) ([]string, error) {
-	var urls []string
-	urlSet := make(map[string]bool)
-	items := strings.Split(s, "\n")
-	for _, item := range items {
-		if !strings.Contains(item, githubURL) {
-			continue
-		}
-		cols := strings.Split(item, "\t")
-		url := strings.TrimSpace(strings.TrimSuffix(strings.Split(cols[1], " ")[0], ".git"))
-		urlSet[url] = true
-	}
-	for url := range urlSet {
-		urls = append(urls, url)
-	}
-	return urls, nil
-}
-
-func (o *initPipelineOpts) getGitHubAccessToken() error {
-	token, err := o.prompt.GetSecret(
-		fmt.Sprintf("Please enter your GitHub Personal Access Token for your repository %s:", color.HighlightUserInput(o.githubRepo)),
-		`The personal access token for the GitHub repository linked to your workspace. 
-For more information, please refer to: https://git.io/JfDFD.`,
-	)
-
-	if err != nil {
-		return fmt.Errorf("get GitHub access token: %w", err)
-	}
-	o.githubAccessToken = token
-	return nil
-}
-
-func (o *initPipelineOpts) getEnvs() ([]*config.Environment, error) {
-	// If app name is passed in via flag, validate here.
-	if o.appName == "" {
-		return nil, errValueEmpty
-	}
-	if o.appName != "" {
-		if _, err := o.store.GetApplication(o.appName); err != nil {
-			return nil, err
-		}
-	}
-	envs, err := o.store.ListEnvironments(o.appName)
-	if err != nil {
-		return nil, fmt.Errorf("list environments for application %s: %w", o.appName, err)
-	}
-	if len(envs) == 0 {
-		return nil, errNoEnvsInApp
-	}
-	return envs, nil
 }
 
 // buildPipelineInitCmd build the command for creating a new pipeline.

--- a/internal/pkg/cli/pipeline_init.go
+++ b/internal/pkg/cli/pipeline_init.go
@@ -549,7 +549,11 @@ func (o *initPipelineOpts) artifactBuckets() ([]artifactBucket, error) {
 	var buckets []artifactBucket
 	for _, resource := range regionalResources {
 		var envNames []string
-		for _, env := range o.envs {
+		for _, environment := range o.environments {
+			env, err := o.getEnvConfig(environment)
+			if err != nil {
+				return nil, err
+			}
 			if env.Region == resource.Region {
 				envNames = append(envNames, env.Name)
 			}

--- a/internal/pkg/cli/pipeline_init_test.go
+++ b/internal/pkg/cli/pipeline_init_test.go
@@ -835,7 +835,7 @@ func TestInitPipelineOpts_createPipelineName(t *testing.T) {
 			}
 
 			// WHEN
-			actual := opts.createPipelineName()
+			actual := opts.pipelineName()
 
 			// THEN
 			require.Equal(t, tc.expected, actual)

--- a/internal/pkg/cli/pipeline_init_test.go
+++ b/internal/pkg/cli/pipeline_init_test.go
@@ -135,8 +135,6 @@ func TestInitPipelineOpts_Ask(t *testing.T) {
 	testCases := map[string]struct {
 		inEnvironments      []string
 		inRepoURL           string
-		inGitHubOwner       string
-		inGitHubRepo        string
 		inGitHubAccessToken string
 		inGitBranch         string
 
@@ -156,8 +154,6 @@ func TestInitPipelineOpts_Ask(t *testing.T) {
 		"no flags, prompts for all input": {
 			inEnvironments:      []string{},
 			inRepoURL:           "",
-			inGitHubOwner:       "",
-			inGitHubRepo:        "",
 			inGitHubAccessToken: "",
 			inGitBranch:         "",
 			buffer:              *bytes.NewBufferString("archer\tgit@github.com:goodGoose/bhaOS (fetch)\narcher\thttps://github.com/badGoose/chaOS (push)\n"),
@@ -261,7 +257,6 @@ func TestInitPipelineOpts_Ask(t *testing.T) {
 		"returns error if fail to select GitHub URL": {
 			inRepoURL:      "",
 			inEnvironments: []string{},
-			inGitHubRepo:   "",
 			buffer:         *bytes.NewBufferString("archer\tgit@github.com:goodGoose/bhaOS (fetch)\narcher\thttps://github.com/badGoose/chaOS (push)\n"),
 
 			mockStore: func(m *mocks.Mockstore) {
@@ -302,7 +297,6 @@ func TestInitPipelineOpts_Ask(t *testing.T) {
 		"returns error if fail to parse GitHub URL": {
 			inEnvironments:      []string{},
 			inRepoURL:           "",
-			inGitHubRepo:        "",
 			inGitHubAccessToken: "",
 			inGitBranch:         "",
 			buffer:              *bytes.NewBufferString("archer\treallybadGoosegithub.comNotEvenAURL (fetch)\n"),
@@ -345,7 +339,6 @@ func TestInitPipelineOpts_Ask(t *testing.T) {
 		"returns error if fail to get GitHub access token": {
 			inEnvironments:      []string{},
 			inRepoURL:           "",
-			inGitHubRepo:        "",
 			inGitHubAccessToken: "",
 			inGitBranch:         "",
 			buffer:              *bytes.NewBufferString("archer\tgit@github.com:goodGoose/bhaOS (fetch)\narcher\thttps://github.com/badGoose/chaOS (push)\n"),
@@ -403,8 +396,6 @@ func TestInitPipelineOpts_Ask(t *testing.T) {
 					appName:           "my-app",
 					environments:      tc.inEnvironments,
 					repoURL:           tc.inRepoURL,
-					githubOwner:       tc.inGitHubOwner,
-					githubRepo:        tc.inGitHubRepo,
 					githubAccessToken: tc.inGitHubAccessToken,
 				},
 				envs:   []*config.Environment{},


### PR DESCRIPTION
Refactored pipeline_init to align with other cli files. Moved some logic out of `newInitPipelineOpts` and into the main body. Didn't utilize the selector package because the needs here are a little different than the options available, but will consider adding sel in subsequent PRs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
