### PR TITLE
feat(workspace): discover dockerfiles with non-'Dockerfile' paths

### DIFF
--- a/internal/pkg/workspace/workspace.go
+++ b/internal/pkg/workspace/workspace.go
@@ -445,7 +445,7 @@ func (ws *Workspace) ListDockerfiles() ([]string, error) {
 	}
 	var dockerfiles = make([]string, 0)
 	for _, wdFile := range wdFiles {
-		// Add current file if it is a Dockerfile and not a directoryotherwise continue.
+		// Add current file if it is a Dockerfile and not a directory; otherwise continue.
 		if !wdFile.IsDir() {
 			fname := wdFile.Name()
 			if strings.Contains(strings.ToLower(fname), dockerfileName) {

--- a/internal/pkg/workspace/workspace.go
+++ b/internal/pkg/workspace/workspace.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/aws/copilot-cli/internal/pkg/manifest"
 	"github.com/spf13/afero"
@@ -41,7 +42,7 @@ const (
 
 	ymlFileExtension = ".yml"
 
-	dockerfileName = "Dockerfile"
+	dockerfileName = "dockerfile"
 )
 
 // Summary is a description of what's associated with this workspace.
@@ -442,12 +443,14 @@ func (ws *Workspace) ListDockerfiles() ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("read directory: %w", err)
 	}
-	var directories []string
+	var dockerfiles = make([]string, 0)
 	for _, wdFile := range wdFiles {
-		// Add current directory if a Dockerfile exists, otherwise continue.
+		// Add current file if it is a Dockerfile and not a directoryotherwise continue.
 		if !wdFile.IsDir() {
-			if wdFile.Name() == dockerfileName {
-				directories = append(directories, filepath.Dir(wdFile.Name()))
+			fname := wdFile.Name()
+			if strings.Contains(strings.ToLower(fname), dockerfileName) {
+				path := filepath.Dir(fname) + "/" + fname
+				dockerfiles = append(dockerfiles, path)
 			}
 			continue
 		}
@@ -462,18 +465,14 @@ func (ws *Workspace) ListDockerfiles() ([]string, error) {
 			if f.IsDir() {
 				continue
 			}
-
-			if f.Name() == dockerfileName {
-				directories = append(directories, wdFile.Name())
+			fname := f.Name()
+			if strings.Contains(strings.ToLower(fname), dockerfileName) {
+				path := wdFile.Name() + "/" + f.Name()
+				dockerfiles = append(dockerfiles, path)
 			}
 		}
 	}
-	sort.Strings(directories)
-	dockerfiles := make([]string, 0, len(directories))
-	for _, dir := range directories {
-		file := dir + "/" + dockerfileName
-		dockerfiles = append(dockerfiles, file)
-	}
+	sort.Strings(dockerfiles)
 	return dockerfiles, nil
 }
 

--- a/internal/pkg/workspace/workspace_test.go
+++ b/internal/pkg/workspace/workspace_test.go
@@ -839,6 +839,28 @@ func TestWorkspace_ListDockerfiles(t *testing.T) {
 			err:         nil,
 			dockerfiles: wantedDockerfiles,
 		},
+		"nonstandard Dockerfile names": {
+			mockFileSystem: func(mockFS afero.Fs) {
+				mockFS.MkdirAll("frontend", 0755)
+				mockFS.MkdirAll("dockerfiles", 0755)
+				afero.WriteFile(mockFS, "Dockerfile", []byte("FROM nginx"), 0644)
+				afero.WriteFile(mockFS, "frontend/dockerfile", []byte("FROM nginx"), 0644)
+				afero.WriteFile(mockFS, "Job.dockerfile", []byte("FROM nginx"), 0644)
+
+			},
+			err:         nil,
+			dockerfiles: []string{"./Dockerfile", "./Job.dockerfile", "frontend/dockerfile"},
+		},
+		/* https://github.com/spf13/afero/issues/150
+		"unreadable directory is skipped without error": {
+			mockFileSystem: func(mockFS afero.Fs) {
+				mockFS.MkdirAll("unreadable", 0000)
+				afero.WriteFile(mockFS, "unreadable/Dockerfile", []byte("FROM nginx"), 0000)
+				afero.WriteFile(mockFS, "dockerfile", []byte("FROM nginx"), 0644)
+			},
+			err:         nil,
+			dockerfiles: []string{"./dockerfile"},
+		}, */
 		"no Dockerfiles": {
 			mockFileSystem: func(mockFS afero.Fs) {},
 			dockerfiles:    []string{},

--- a/internal/pkg/workspace/workspace_test.go
+++ b/internal/pkg/workspace/workspace_test.go
@@ -846,21 +846,10 @@ func TestWorkspace_ListDockerfiles(t *testing.T) {
 				afero.WriteFile(mockFS, "Dockerfile", []byte("FROM nginx"), 0644)
 				afero.WriteFile(mockFS, "frontend/dockerfile", []byte("FROM nginx"), 0644)
 				afero.WriteFile(mockFS, "Job.dockerfile", []byte("FROM nginx"), 0644)
-
 			},
 			err:         nil,
 			dockerfiles: []string{"./Dockerfile", "./Job.dockerfile", "frontend/dockerfile"},
 		},
-		/* https://github.com/spf13/afero/issues/150
-		"unreadable directory is skipped without error": {
-			mockFileSystem: func(mockFS afero.Fs) {
-				mockFS.MkdirAll("unreadable", 0000)
-				afero.WriteFile(mockFS, "unreadable/Dockerfile", []byte("FROM nginx"), 0000)
-				afero.WriteFile(mockFS, "dockerfile", []byte("FROM nginx"), 0644)
-			},
-			err:         nil,
-			dockerfiles: []string{"./dockerfile"},
-		}, */
 		"no Dockerfiles": {
 			mockFileSystem: func(mockFS afero.Fs) {},
 			dockerfiles:    []string{},


### PR DESCRIPTION
<!-- Provide summary of changes -->
Adds the ability for Copilot to discover dockerfiles with nonstandard capitalizations or syntaxes. Copilot will now list all files (not folders) which contain any permutation of the string `dockerfile`. 

Addresses #1748. 

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
