### PR TITLE
chore: bump survey version and revert `OnInterrupt` shims

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws/copilot-cli
 go 1.14
 
 require (
-	github.com/AlecAivazis/survey/v2 v2.2.5
+	github.com/AlecAivazis/survey/v2 v2.2.7
 	github.com/Netflix/go-expect v0.0.0-20190729225929-0e00d9168667 // indirect
 	github.com/aws/aws-sdk-go v1.36.12
 	github.com/awslabs/goformation/v4 v4.15.2

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2k
 cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiyrjsg+URw=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/AkihiroSuda/containerd-fuse-overlayfs v0.0.0-20200220082720-bb896865146c/go.mod h1:K4kx7xAA5JimeQCnN+dbeLlfaBxzZLaLiDD8lusFI8w=
-github.com/AlecAivazis/survey/v2 v2.2.5 h1:peRnrLnIgJVtyLpg9o6Od2diCdFkHlUHQPVHGB5Qi9Y=
-github.com/AlecAivazis/survey/v2 v2.2.5/go.mod h1:9FJRdMdDm8rnT+zHVbvQT2RTSTLq0Ttd6q3Vl2fahjk=
+github.com/AlecAivazis/survey/v2 v2.2.7 h1:5NbxkF4RSKmpywYdcRgUmos1o+roJY8duCLZXbVjoig=
+github.com/AlecAivazis/survey/v2 v2.2.7/go.mod h1:9DYvHgXtiXm6nCn+jXnOXLKbH+Yo9u8fAS/SduGdoPk=
 github.com/Azure/azure-sdk-for-go v16.2.1+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/go-autorest v10.8.1+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=

--- a/internal/pkg/term/prompt/prompt.go
+++ b/internal/pkg/term/prompt/prompt.go
@@ -171,9 +171,9 @@ func (p Prompt) Get(message, help string, validator ValidatorFunc, promptOpts ..
 	var result string
 	var err error
 	if validator == nil {
-		err = p(prompt, &result, stdio(), icons(), noInterrupt())
+		err = p(prompt, &result, stdio(), icons())
 	} else {
-		err = p(prompt, &result, stdio(), validators(validator), icons(), noInterrupt())
+		err = p(prompt, &result, stdio(), validators(validator), icons())
 	}
 	return result, err
 }
@@ -220,7 +220,7 @@ func (p Prompt) GetSecret(message, help string, promptOpts ...Option) (string, e
 	}
 
 	var result string
-	err := p(prompt, &result, stdio(), icons(), noInterrupt())
+	err := p(prompt, &result, stdio(), icons())
 	return result, err
 }
 
@@ -248,7 +248,7 @@ func (p Prompt) SelectOne(message, help string, options []string, promptOpts ...
 	}
 
 	var result string
-	err := p(prompt, &result, stdio(), icons(), noInterrupt())
+	err := p(prompt, &result, stdio(), icons())
 	return result, err
 }
 
@@ -275,7 +275,7 @@ func (p Prompt) MultiSelect(message, help string, options []string, promptOpts .
 		option(prompt)
 	}
 
-	err := p(prompt, &result, stdio(), icons(), noInterrupt())
+	err := p(prompt, &result, stdio(), icons())
 	return result, err
 }
 
@@ -296,7 +296,7 @@ func (p Prompt) Confirm(message, help string, promptOpts ...Option) (bool, error
 	}
 
 	var result bool
-	err := p(prompt, &result, stdio(), icons(), noInterrupt())
+	err := p(prompt, &result, stdio(), icons())
 	return result, err
 }
 
@@ -330,10 +330,6 @@ func WithTrueDefault() Option {
 
 func stdio() survey.AskOpt {
 	return survey.WithStdio(os.Stdin, os.Stderr, os.Stderr)
-}
-
-func noInterrupt() survey.AskOpt {
-	return survey.WithInterruptFunc(func() {})
 }
 
 func icons() survey.AskOpt {

--- a/internal/pkg/term/prompt/prompt_test.go
+++ b/internal/pkg/term/prompt/prompt_test.go
@@ -46,7 +46,7 @@ func TestPrompt_Get(t *testing.T) {
 
 				*result = mockInput
 
-				require.Equal(t, 4, len(opts))
+				require.Equal(t, 3, len(opts))
 
 				return nil
 			},
@@ -100,7 +100,7 @@ func TestPrompt_GetSecret(t *testing.T) {
 
 				*result = mockSecret
 
-				require.Equal(t, 3, len(opts))
+				require.Equal(t, 2, len(opts))
 
 				return nil
 			},
@@ -154,7 +154,7 @@ func TestPrompt_SelectOne(t *testing.T) {
 
 				*result = sel.Options[0]
 
-				require.Equal(t, 3, len(opts))
+				require.Equal(t, 2, len(opts))
 
 				return nil
 			},
@@ -215,7 +215,7 @@ func TestPrompt_MultiSelect(t *testing.T) {
 
 				*result = sel.Options
 
-				require.Equal(t, 3, len(opts))
+				require.Equal(t, 2, len(opts))
 
 				return nil
 			},
@@ -275,7 +275,7 @@ func TestPrompt_Confirm(t *testing.T) {
 
 				*result = true
 
-				require.Equal(t, 3, len(opts))
+				require.Equal(t, 2, len(opts))
 
 				return nil
 			},


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->
The newest survey release reverts a commit which was introduced in the previous release, which added unstable behavior for all users of survey. 

This commit bumps to the latest version and reverts changes introduced in #1764 to handle the instability.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
