### PR TITLE
refactor(cli): move selection of pipeline envs into selector package

### DIFF
--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -442,7 +442,7 @@ type deploySelector interface {
 }
 
 type pipelineSelector interface {
-	Environments(prompt, help, app string, opt prompt.Option) ([]string, error)
+	Environments(prompt, help, app string, finalMsgFunc func(int) prompt.Option) ([]string, error)
 }
 
 type wsSelector interface {

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -441,6 +441,10 @@ type deploySelector interface {
 	DeployedService(prompt, help string, app string, opts ...selector.GetDeployedServiceOpts) (*selector.DeployedService, error)
 }
 
+type pipelineSelector interface {
+	Environments(prompt, help, app string, opt prompt.Option, additionalOpts ...string) ([]string, error)
+}
+
 type wsSelector interface {
 	appEnvSelector
 	Service(prompt, help string) (string, error)

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -442,7 +442,7 @@ type deploySelector interface {
 }
 
 type pipelineSelector interface {
-	Environments(prompt, help, app string, opt prompt.Option, additionalOpts ...string) ([]string, error)
+	Environments(prompt, help, app string, opt prompt.Option) ([]string, error)
 }
 
 type wsSelector interface {

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -4760,23 +4760,18 @@ func (m *MockpipelineSelector) EXPECT() *MockpipelineSelectorMockRecorder {
 }
 
 // Environments mocks base method
-func (m *MockpipelineSelector) Environments(prompt, help, app string, opt prompt.Option, additionalOpts ...string) ([]string, error) {
+func (m *MockpipelineSelector) Environments(prompt, help, app string, opt prompt.Option) ([]string, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{prompt, help, app, opt}
-	for _, a := range additionalOpts {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "Environments", varargs...)
+	ret := m.ctrl.Call(m, "Environments", prompt, help, app, opt)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Environments indicates an expected call of Environments
-func (mr *MockpipelineSelectorMockRecorder) Environments(prompt, help, app, opt interface{}, additionalOpts ...interface{}) *gomock.Call {
+func (mr *MockpipelineSelectorMockRecorder) Environments(prompt, help, app, opt interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{prompt, help, app, opt}, additionalOpts...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Environments", reflect.TypeOf((*MockpipelineSelector)(nil).Environments), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Environments", reflect.TypeOf((*MockpipelineSelector)(nil).Environments), prompt, help, app, opt)
 }
 
 // MockwsSelector is a mock of wsSelector interface

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -4736,6 +4736,49 @@ func (mr *MockdeploySelectorMockRecorder) DeployedService(prompt, help, app inte
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeployedService", reflect.TypeOf((*MockdeploySelector)(nil).DeployedService), varargs...)
 }
 
+// MockpipelineSelector is a mock of pipelineSelector interface
+type MockpipelineSelector struct {
+	ctrl     *gomock.Controller
+	recorder *MockpipelineSelectorMockRecorder
+}
+
+// MockpipelineSelectorMockRecorder is the mock recorder for MockpipelineSelector
+type MockpipelineSelectorMockRecorder struct {
+	mock *MockpipelineSelector
+}
+
+// NewMockpipelineSelector creates a new mock instance
+func NewMockpipelineSelector(ctrl *gomock.Controller) *MockpipelineSelector {
+	mock := &MockpipelineSelector{ctrl: ctrl}
+	mock.recorder = &MockpipelineSelectorMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockpipelineSelector) EXPECT() *MockpipelineSelectorMockRecorder {
+	return m.recorder
+}
+
+// Environments mocks base method
+func (m *MockpipelineSelector) Environments(prompt, help, app string, opt prompt.Option, additionalOpts ...string) ([]string, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{prompt, help, app, opt}
+	for _, a := range additionalOpts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Environments", varargs...)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Environments indicates an expected call of Environments
+func (mr *MockpipelineSelectorMockRecorder) Environments(prompt, help, app, opt interface{}, additionalOpts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{prompt, help, app, opt}, additionalOpts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Environments", reflect.TypeOf((*MockpipelineSelector)(nil).Environments), varargs...)
+}
+
 // MockwsSelector is a mock of wsSelector interface
 type MockwsSelector struct {
 	ctrl     *gomock.Controller

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -4760,18 +4760,18 @@ func (m *MockpipelineSelector) EXPECT() *MockpipelineSelectorMockRecorder {
 }
 
 // Environments mocks base method
-func (m *MockpipelineSelector) Environments(prompt, help, app string, opt prompt.Option) ([]string, error) {
+func (m *MockpipelineSelector) Environments(prompt, help, app string, finalMsgFunc func(int) prompt.Option) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Environments", prompt, help, app, opt)
+	ret := m.ctrl.Call(m, "Environments", prompt, help, app, finalMsgFunc)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Environments indicates an expected call of Environments
-func (mr *MockpipelineSelectorMockRecorder) Environments(prompt, help, app, opt interface{}) *gomock.Call {
+func (mr *MockpipelineSelectorMockRecorder) Environments(prompt, help, app, finalMsgFunc interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Environments", reflect.TypeOf((*MockpipelineSelector)(nil).Environments), prompt, help, app, opt)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Environments", reflect.TypeOf((*MockpipelineSelector)(nil).Environments), prompt, help, app, finalMsgFunc)
 }
 
 // MockwsSelector is a mock of wsSelector interface

--- a/internal/pkg/cli/pipeline_init.go
+++ b/internal/pkg/cli/pipeline_init.go
@@ -55,8 +55,6 @@ var (
 	binaryS3BucketPath string
 )
 
-var errNoEnvsInApp = errors.New("there were no more environments found that can be added to your pipeline. Please run `copilot env init` to create a new environment")
-
 type initPipelineVars struct {
 	appName           string
 	environments      []string

--- a/internal/pkg/cli/pipeline_init.go
+++ b/internal/pkg/cli/pipeline_init.go
@@ -220,7 +220,7 @@ func (o *initPipelineOpts) RecommendedActions() []string {
 
 func (o *initPipelineOpts) askEnvs() error {
 	if len(o.environments) == 0 {
-		envs, err := o.sel.Environments(pipelineSelectEnvPrompt, pipelineSelectEnvHelpPrompt, o.appName, prompt.WithFinalMessage("Environment pipeline will deploy to, in order:"), "[No additional environments]")
+		envs, err := o.sel.Environments(pipelineSelectEnvPrompt, pipelineSelectEnvHelpPrompt, o.appName, prompt.WithFinalMessage("Environment pipeline will deploy to, in order:"))
 		if err != nil {
 			return fmt.Errorf("select environments: %w", err)
 		}

--- a/internal/pkg/cli/pipeline_init.go
+++ b/internal/pkg/cli/pipeline_init.go
@@ -10,6 +10,8 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/dustin/go-humanize"
+
 	"github.com/aws/copilot-cli/internal/pkg/term/selector"
 
 	"github.com/aws/copilot-cli/internal/pkg/aws/secretsmanager"
@@ -229,7 +231,9 @@ func (o *initPipelineOpts) RecommendedActions() []string {
 
 func (o *initPipelineOpts) askEnvs() error {
 	if len(o.environments) == 0 {
-		envs, err := o.sel.Environments(pipelineSelectEnvPrompt, pipelineSelectEnvHelpPrompt, o.appName, prompt.WithFinalMessage("Pipeline deployment stage (in order):"))
+		envs, err := o.sel.Environments(pipelineSelectEnvPrompt, pipelineSelectEnvHelpPrompt, o.appName, func(order int) prompt.Option {
+			return prompt.WithFinalMessage(fmt.Sprintf("%s stage:", humanize.Ordinal(order)))
+		})
 		if err != nil {
 			return fmt.Errorf("select environments: %w", err)
 		}

--- a/internal/pkg/cli/pipeline_init.go
+++ b/internal/pkg/cli/pipeline_init.go
@@ -229,7 +229,7 @@ func (o *initPipelineOpts) RecommendedActions() []string {
 
 func (o *initPipelineOpts) askEnvs() error {
 	if len(o.environments) == 0 {
-		envs, err := o.sel.Environments(pipelineSelectEnvPrompt, pipelineSelectEnvHelpPrompt, o.appName, prompt.WithFinalMessage("Environment pipeline will deploy to, in order:"))
+		envs, err := o.sel.Environments(pipelineSelectEnvPrompt, pipelineSelectEnvHelpPrompt, o.appName, prompt.WithFinalMessage("Pipeline deployment stage (in order):"))
 		if err != nil {
 			return fmt.Errorf("select environments: %w", err)
 		}

--- a/internal/pkg/cli/pipeline_init_test.go
+++ b/internal/pkg/cli/pipeline_init_test.go
@@ -138,10 +138,11 @@ func TestInitPipelineOpts_Ask(t *testing.T) {
 		inGitHubAccessToken string
 		inGitBranch         string
 
-		mockStore  func(m *mocks.Mockstore)
-		mockPrompt func(m *mocks.Mockprompter)
-		mockRunner func(m *mocks.Mockrunner)
-		buffer     bytes.Buffer
+		//mockStore    func(m *mocks.Mockstore)
+		mockPrompt   func(m *mocks.Mockprompter)
+		mockRunner   func(m *mocks.Mockrunner)
+		mockSelector func(m *mocks.MockpipelineSelector)
+		buffer       bytes.Buffer
 
 		expectedEnvironments      []string
 		expectedRepoURL           string
@@ -158,30 +159,13 @@ func TestInitPipelineOpts_Ask(t *testing.T) {
 			inGitBranch:         "",
 			buffer:              *bytes.NewBufferString("archer\tgit@github.com:goodGoose/bhaOS (fetch)\narcher\thttps://github.com/badGoose/chaOS (push)\n"),
 
-			mockStore: func(m *mocks.Mockstore) {
-				m.EXPECT().ListEnvironments("my-app").Return([]*config.Environment{
-					{
-						Name:      "test",
-						Region:    "us-west-2",
-						AccountID: "123456789",
-						Prod:      false,
-					},
-					{
-						Name:      "prod",
-						AccountID: "123456789",
-						Region:    "us-west-1",
-						Prod:      true,
-					},
-				}, nil)
+			mockSelector: func(m *mocks.MockpipelineSelector) {
+				m.EXPECT().Environments(pipelineSelectEnvPrompt, gomock.Any(), "my-app", gomock.Any(), gomock.Any()).Return([]string{"test", "prod"}, nil)
 			},
 			mockRunner: func(m *mocks.Mockrunner) {
 				m.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			},
 			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().Confirm(pipelineInitAddEnvPrompt, gomock.Any()).Return(true, nil).Times(1)
-				m.EXPECT().Confirm(pipelineInitAddMoreEnvPrompt, gomock.Any()).Return(true, nil).Times(1)
-				m.EXPECT().SelectOne(pipelineSelectEnvPrompt, gomock.Any(), []string{"test", "prod"}).Return("test", nil).Times(1)
-				m.EXPECT().SelectOne(pipelineSelectEnvPrompt, gomock.Any(), []string{"prod"}).Return("prod", nil).Times(1)
 				m.EXPECT().SelectOne(pipelineSelectGitHubURLPrompt, gomock.Any(), gomock.Any()).Return(githubAnotherURL, nil).Times(1)
 				m.EXPECT().GetSecret(gomock.Eq("Please enter your GitHub Personal Access Token for your repository bhaOS:"), gomock.Any()).Return(githubToken, nil).Times(1)
 			},
@@ -197,93 +181,28 @@ func TestInitPipelineOpts_Ask(t *testing.T) {
 		"returns error if fail to list environments": {
 			inEnvironments: []string{},
 
-			mockStore: func(m *mocks.Mockstore) {
-				m.EXPECT().ListEnvironments("my-app").Return(nil, errors.New("some error"))
+			mockSelector: func(m *mocks.MockpipelineSelector) {
+				m.EXPECT().Environments(pipelineSelectEnvPrompt, gomock.Any(), "my-app", gomock.Any(), gomock.Any()).Return(nil, errors.New("some error"))
 			},
 			mockRunner: func(m *mocks.Mockrunner) {},
 			mockPrompt: func(m *mocks.Mockprompter) {},
 
 			expectedEnvironments: []string{},
-			expectedError:        fmt.Errorf("list environments for application my-app: some error"),
+			expectedError:        fmt.Errorf("select environments: some error"),
 		},
-		"returns error if fail to confirm adding environment": {
-			inEnvironments: []string{},
 
-			mockStore: func(m *mocks.Mockstore) {
-				m.EXPECT().ListEnvironments("my-app").Return([]*config.Environment{
-					{
-						Name:      "test",
-						Region:    "us-west-2",
-						AccountID: "123456789",
-						Prod:      false,
-					},
-				}, nil)
-			},
-			mockRunner: func(m *mocks.Mockrunner) {},
-			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().Confirm(pipelineInitAddEnvPrompt, gomock.Any()).Return(false, errors.New("some error")).Times(1)
-			},
-
-			expectedEnvironments: []string{},
-			expectedError:        fmt.Errorf("confirm adding an environment: some error"),
-		},
-		"returns error if fail to add an environment": {
-			inEnvironments: []string{},
-
-			mockStore: func(m *mocks.Mockstore) {
-				m.EXPECT().ListEnvironments("my-app").Return([]*config.Environment{
-					{
-						Name:      "test",
-						Region:    "us-west-2",
-						AccountID: "123456789",
-						Prod:      false,
-					},
-					{
-						Name:      "prod",
-						AccountID: "123456789",
-						Region:    "us-west-1",
-						Prod:      true,
-					},
-				}, nil)
-			},
-			mockRunner: func(m *mocks.Mockrunner) {},
-			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().Confirm(pipelineInitAddEnvPrompt, gomock.Any()).Return(true, nil).Times(1)
-				m.EXPECT().SelectOne(pipelineSelectEnvPrompt, gomock.Any(), []string{"test", "prod"}).Return("", errors.New("some error")).Times(1)
-			},
-
-			expectedError: fmt.Errorf("add environment: some error"),
-		},
 		"returns error if fail to select GitHub URL": {
 			inRepoURL:      "",
 			inEnvironments: []string{},
 			buffer:         *bytes.NewBufferString("archer\tgit@github.com:goodGoose/bhaOS (fetch)\narcher\thttps://github.com/badGoose/chaOS (push)\n"),
 
-			mockStore: func(m *mocks.Mockstore) {
-				m.EXPECT().ListEnvironments("my-app").Return([]*config.Environment{
-					{
-						Name:      "test",
-						Region:    "us-west-2",
-						AccountID: "123456789",
-						Prod:      false,
-					},
-					{
-						Name:      "prod",
-						AccountID: "123456789",
-						Region:    "us-west-1",
-						Prod:      true,
-					},
-				}, nil)
+			mockSelector: func(m *mocks.MockpipelineSelector) {
+				m.EXPECT().Environments(pipelineSelectEnvPrompt, gomock.Any(), "my-app", gomock.Any(), gomock.Any()).Return([]string{"test", "prod"}, nil)
 			},
 			mockRunner: func(m *mocks.Mockrunner) {
 				m.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			},
 			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().Confirm(pipelineInitAddEnvPrompt, gomock.Any()).Return(true, nil).Times(1)
-				m.EXPECT().Confirm(pipelineInitAddMoreEnvPrompt, gomock.Any()).Return(true, nil).Times(1)
-				m.EXPECT().SelectOne(pipelineSelectEnvPrompt, gomock.Any(), []string{"test", "prod"}).Return("test", nil).Times(1)
-				m.EXPECT().SelectOne(pipelineSelectEnvPrompt, gomock.Any(), []string{"prod"}).Return("prod", nil).Times(1)
-
 				m.EXPECT().SelectOne(pipelineSelectGitHubURLPrompt, gomock.Any(), gomock.Any()).Return("", errors.New("some error")).Times(1)
 			},
 
@@ -301,31 +220,13 @@ func TestInitPipelineOpts_Ask(t *testing.T) {
 			inGitBranch:         "",
 			buffer:              *bytes.NewBufferString("archer\treallybadGoosegithub.comNotEvenAURL (fetch)\n"),
 
-			mockStore: func(m *mocks.Mockstore) {
-				m.EXPECT().ListEnvironments("my-app").Return([]*config.Environment{
-					{
-						Name:      "test",
-						Region:    "us-west-2",
-						AccountID: "123456789",
-						Prod:      false,
-					},
-					{
-						Name:      "prod",
-						AccountID: "123456789",
-						Region:    "us-west-1",
-						Prod:      true,
-					},
-				}, nil)
+			mockSelector: func(m *mocks.MockpipelineSelector) {
+				m.EXPECT().Environments(pipelineSelectEnvPrompt, gomock.Any(), "my-app", gomock.Any(), gomock.Any()).Return([]string{"test", "prod"}, nil)
 			},
 			mockRunner: func(m *mocks.Mockrunner) {
 				m.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			},
 			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().Confirm(pipelineInitAddEnvPrompt, gomock.Any()).Return(true, nil).Times(1)
-				m.EXPECT().Confirm(pipelineInitAddMoreEnvPrompt, gomock.Any()).Return(true, nil).Times(1)
-				m.EXPECT().SelectOne(pipelineSelectEnvPrompt, gomock.Any(), []string{"test", "prod"}).Return("test", nil).Times(1)
-				m.EXPECT().SelectOne(pipelineSelectEnvPrompt, gomock.Any(), []string{"prod"}).Return("prod", nil).Times(1)
-
 				m.EXPECT().SelectOne(pipelineSelectGitHubURLPrompt, gomock.Any(), []string{githubReallyBadURL}).Return(githubReallyBadURL, nil).Times(1)
 			},
 
@@ -343,31 +244,13 @@ func TestInitPipelineOpts_Ask(t *testing.T) {
 			inGitBranch:         "",
 			buffer:              *bytes.NewBufferString("archer\tgit@github.com:goodGoose/bhaOS (fetch)\narcher\thttps://github.com/badGoose/chaOS (push)\n"),
 
-			mockStore: func(m *mocks.Mockstore) {
-				m.EXPECT().ListEnvironments("my-app").Return([]*config.Environment{
-					{
-						Name:      "test",
-						Region:    "us-west-2",
-						AccountID: "123456789",
-						Prod:      false,
-					},
-					{
-						Name:      "prod",
-						AccountID: "123456789",
-						Region:    "us-west-1",
-						Prod:      true,
-					},
-				}, nil)
+			mockSelector: func(m *mocks.MockpipelineSelector) {
+				m.EXPECT().Environments(pipelineSelectEnvPrompt, gomock.Any(), "my-app", gomock.Any(), gomock.Any()).Return([]string{"test", "prod"}, nil)
 			},
 			mockRunner: func(m *mocks.Mockrunner) {
 				m.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			},
 			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().Confirm(pipelineInitAddEnvPrompt, gomock.Any()).Return(true, nil).Times(1)
-				m.EXPECT().Confirm(pipelineInitAddMoreEnvPrompt, gomock.Any()).Return(true, nil).Times(1)
-				m.EXPECT().SelectOne(pipelineSelectEnvPrompt, gomock.Any(), []string{"test", "prod"}).Return("test", nil).Times(1)
-				m.EXPECT().SelectOne(pipelineSelectEnvPrompt, gomock.Any(), []string{"prod"}).Return("prod", nil).Times(1)
-
 				m.EXPECT().SelectOne(pipelineSelectGitHubURLPrompt, gomock.Any(), gomock.Any()).Return(githubURL, nil).Times(1)
 				m.EXPECT().GetSecret(gomock.Eq("Please enter your GitHub Personal Access Token for your repository chaOS:"), gomock.Any()).Return("", errors.New("some error")).Times(1)
 			},
@@ -388,8 +271,8 @@ func TestInitPipelineOpts_Ask(t *testing.T) {
 			defer ctrl.Finish()
 
 			mockPrompt := mocks.NewMockprompter(ctrl)
-			mockStore := mocks.NewMockstore(ctrl)
 			mockRunner := mocks.NewMockrunner(ctrl)
+			mockSelector := mocks.NewMockpipelineSelector(ctrl)
 
 			opts := &initPipelineOpts{
 				initPipelineVars: initPipelineVars{
@@ -398,16 +281,15 @@ func TestInitPipelineOpts_Ask(t *testing.T) {
 					repoURL:           tc.inRepoURL,
 					githubAccessToken: tc.inGitHubAccessToken,
 				},
-				envs:   []*config.Environment{},
 				prompt: mockPrompt,
-				store:  mockStore,
 				runner: mockRunner,
 				buffer: tc.buffer,
+				sel:    mockSelector,
 			}
 
 			tc.mockPrompt(mockPrompt)
-			tc.mockStore(mockStore)
 			tc.mockRunner(mockRunner)
+			tc.mockSelector(mockSelector)
 
 			// WHEN
 			err := opts.Ask()
@@ -435,7 +317,6 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 		inGitHubRepo   string
 		inGitBranch    string
 		inAppName      string
-		inAppEnvs      []*config.Environment
 
 		mockSecretsManager          func(m *mocks.MocksecretsManager)
 		mockWsWriter                func(m *mocks.MockwsPipelineWriter)
@@ -452,14 +333,6 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 			inGitHubRepo:   "goose",
 			inGitBranch:    "dev",
 			inAppName:      "badgoose",
-			inAppEnvs: []*config.Environment{
-				{
-					Name: "test",
-				},
-				{
-					Name: "prod",
-				},
-			},
 
 			mockSecretsManager: func(m *mocks.MocksecretsManager) {
 				m.EXPECT().CreateSecret("github-token-badgoose-goose", "hunter2").Return("some-arn", nil)
@@ -477,6 +350,9 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 				m.EXPECT().GetApplication("badgoose").Return(&config.Application{
 					Name: "badgoose",
 				}, nil)
+				m.EXPECT().GetEnvironment("badgoose", "test").Return(&config.Environment{
+					Name: "test",
+				}, nil).AnyTimes()
 			},
 			mockRegionalResourcesGetter: func(m *mocks.MockappResourcesGetter) {
 				m.EXPECT().GetRegionalAppResources(&config.Application{
@@ -496,14 +372,6 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 			inGitHubRepo:   "goose",
 			inGitBranch:    "dev",
 			inAppName:      "badgoose",
-			inAppEnvs: []*config.Environment{
-				{
-					Name: "test",
-				},
-				{
-					Name: "prod",
-				},
-			},
 
 			mockSecretsManager: func(m *mocks.MocksecretsManager) {
 				existsErr := &secretsmanager.ErrSecretAlreadyExists{}
@@ -522,6 +390,9 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 				m.EXPECT().GetApplication("badgoose").Return(&config.Application{
 					Name: "badgoose",
 				}, nil)
+				m.EXPECT().GetEnvironment("badgoose", "test").Return(&config.Environment{
+					Name: "test",
+				}, nil).AnyTimes()
 			},
 			mockRegionalResourcesGetter: func(m *mocks.MockappResourcesGetter) {
 				m.EXPECT().GetRegionalAppResources(&config.Application{
@@ -542,14 +413,6 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 			inGitHubRepo:   "goose",
 			inGitBranch:    "dev",
 			inAppName:      "badgoose",
-			inAppEnvs: []*config.Environment{
-				{
-					Name: "test",
-				},
-				{
-					Name: "prod",
-				},
-			},
 
 			mockSecretsManager: func(m *mocks.MocksecretsManager) {
 				m.EXPECT().CreateSecret("github-token-badgoose-goose", "hunter2").Return("some-arn", nil)
@@ -557,8 +420,12 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 			mockWsWriter: func(m *mocks.MockwsPipelineWriter) {
 				m.EXPECT().WritePipelineManifest(gomock.Any()).Return("", errors.New("some error"))
 			},
-			mockParser:                  func(m *templatemocks.MockParser) {},
-			mockStoreSvc:                func(m *mocks.Mockstore) {},
+			mockParser: func(m *templatemocks.MockParser) {},
+			mockStoreSvc: func(m *mocks.Mockstore) {
+				m.EXPECT().GetEnvironment("badgoose", "test").Return(&config.Environment{
+					Name: "test",
+				}, nil).AnyTimes()
+			},
 			mockRegionalResourcesGetter: func(m *mocks.MockappResourcesGetter) {},
 			expectedError:               errors.New("write pipeline manifest to workspace: some error"),
 		},
@@ -568,14 +435,6 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 			inGitHubRepo:   "goose",
 			inGitBranch:    "dev",
 			inAppName:      "badgoose",
-			inAppEnvs: []*config.Environment{
-				{
-					Name: "test",
-				},
-				{
-					Name: "prod",
-				},
-			},
 
 			mockSecretsManager: func(m *mocks.MocksecretsManager) {
 				m.EXPECT().CreateSecret("github-token-badgoose-goose", "hunter2").Return("some-arn", nil)
@@ -586,6 +445,9 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 			mockParser: func(m *templatemocks.MockParser) {},
 			mockStoreSvc: func(m *mocks.Mockstore) {
 				m.EXPECT().GetApplication("badgoose").Return(nil, errors.New("some error"))
+				m.EXPECT().GetEnvironment("badgoose", "test").Return(&config.Environment{
+					Name: "test",
+				}, nil).AnyTimes()
 			},
 			mockRegionalResourcesGetter: func(m *mocks.MockappResourcesGetter) {},
 			expectedError:               errors.New("get application badgoose: some error"),
@@ -596,14 +458,6 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 			inGitHubRepo:   "goose",
 			inGitBranch:    "dev",
 			inAppName:      "badgoose",
-			inAppEnvs: []*config.Environment{
-				{
-					Name: "test",
-				},
-				{
-					Name: "prod",
-				},
-			},
 
 			mockSecretsManager: func(m *mocks.MocksecretsManager) {
 				m.EXPECT().CreateSecret("github-token-badgoose-goose", "hunter2").Return("some-arn", nil)
@@ -616,6 +470,9 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 				m.EXPECT().GetApplication("badgoose").Return(&config.Application{
 					Name: "badgoose",
 				}, nil)
+				m.EXPECT().GetEnvironment("badgoose", "test").Return(&config.Environment{
+					Name: "test",
+				}, nil).AnyTimes()
 			},
 			mockRegionalResourcesGetter: func(m *mocks.MockappResourcesGetter) {
 				m.EXPECT().GetRegionalAppResources(&config.Application{
@@ -630,14 +487,6 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 			inGitHubRepo:   "goose",
 			inGitBranch:    "dev",
 			inAppName:      "badgoose",
-			inAppEnvs: []*config.Environment{
-				{
-					Name: "test",
-				},
-				{
-					Name: "prod",
-				},
-			},
 
 			mockSecretsManager: func(m *mocks.MocksecretsManager) {
 				m.EXPECT().CreateSecret("github-token-badgoose-goose", "hunter2").Return("some-arn", nil)
@@ -653,6 +502,9 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 				m.EXPECT().GetApplication("badgoose").Return(&config.Application{
 					Name: "badgoose",
 				}, nil)
+				m.EXPECT().GetEnvironment("badgoose", "test").Return(&config.Environment{
+					Name: "test",
+				}, nil).AnyTimes()
 			},
 			mockRegionalResourcesGetter: func(m *mocks.MockappResourcesGetter) {
 				m.EXPECT().GetRegionalAppResources(&config.Application{
@@ -672,14 +524,6 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 			inGitHubRepo:   "goose",
 			inGitBranch:    "dev",
 			inAppName:      "badgoose",
-			inAppEnvs: []*config.Environment{
-				{
-					Name: "test",
-				},
-				{
-					Name: "prod",
-				},
-			},
 
 			mockSecretsManager: func(m *mocks.MocksecretsManager) {
 				m.EXPECT().CreateSecret("github-token-badgoose-goose", "hunter2").Return("some-arn", nil)
@@ -697,6 +541,9 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 				m.EXPECT().GetApplication("badgoose").Return(&config.Application{
 					Name: "badgoose",
 				}, nil)
+				m.EXPECT().GetEnvironment("badgoose", "test").Return(&config.Environment{
+					Name: "test",
+				}, nil).AnyTimes()
 			},
 			mockRegionalResourcesGetter: func(m *mocks.MockappResourcesGetter) {
 				m.EXPECT().GetRegionalAppResources(&config.Application{
@@ -716,14 +563,6 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 			inGitHubRepo:   "goose",
 			inGitBranch:    "dev",
 			inAppName:      "badgoose",
-			inAppEnvs: []*config.Environment{
-				{
-					Name: "test",
-				},
-				{
-					Name: "prod",
-				},
-			},
 
 			mockSecretsManager: func(m *mocks.MocksecretsManager) {
 				m.EXPECT().CreateSecret("github-token-badgoose-goose", "hunter2").Return("some-arn", nil)
@@ -741,6 +580,9 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 				m.EXPECT().GetApplication("badgoose").Return(&config.Application{
 					Name: "badgoose",
 				}, nil)
+				m.EXPECT().GetEnvironment("badgoose", "test").Return(&config.Environment{
+					Name: "test",
+				}, nil).AnyTimes()
 			},
 			mockRegionalResourcesGetter: func(m *mocks.MockappResourcesGetter) {
 				m.EXPECT().GetRegionalAppResources(&config.Application{
@@ -790,7 +632,6 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 				workspace:      mockWriter,
 				parser:         mockParser,
 				fs:             memFs,
-				envs:           tc.inAppEnvs,
 			}
 
 			// WHEN
@@ -806,7 +647,7 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 	}
 }
 
-func TestInitPipelineOpts_createPipelineName(t *testing.T) {
+func TestInitPipelineOpts_pipelineName(t *testing.T) {
 	testCases := map[string]struct {
 		inGitHubRepo string
 		inAppName    string
@@ -929,72 +770,6 @@ func TestInitPipelineOpts_parseOwnerRepoName(t *testing.T) {
 			} else {
 				require.Equal(t, tc.expectedOwner, owner)
 				require.Equal(t, tc.expectedRepo, repo)
-			}
-		})
-	}
-}
-
-func TestInitPipelineOpts_getEnvConfig(t *testing.T) {
-	testCases := map[string]struct {
-		inAppName         string
-		inEnvironmentName string
-		inEnvs            []*config.Environment
-
-		expectedEnvironment *config.Environment
-		expectedError       error
-	}{
-		"happy case": {
-			inAppName:         "badgoose",
-			inEnvironmentName: "test",
-			inEnvs: []*config.Environment{
-				{
-					Name: "test",
-				},
-				{
-					Name: "prod",
-				},
-			},
-
-			expectedEnvironment: &config.Environment{
-				Name: "test",
-			},
-			expectedError: nil,
-		},
-		"returns an error if an environment is not found": {
-			inAppName:         "badgoose",
-			inEnvironmentName: "badenv",
-			inEnvs: []*config.Environment{
-				{
-					Name: "test",
-				},
-				{
-					Name: "prod",
-				},
-			},
-
-			expectedEnvironment: nil,
-			expectedError:       fmt.Errorf("environment badenv in application badgoose is not found"),
-		},
-	}
-
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			// GIVEN
-			opts := &initPipelineOpts{
-				initPipelineVars: initPipelineVars{
-					appName: tc.inAppName,
-				},
-				envs: tc.inEnvs,
-			}
-
-			// WHEN
-			env, err := opts.getEnvConfig(tc.inEnvironmentName)
-
-			// THEN
-			if tc.expectedError != nil {
-				require.EqualError(t, err, tc.expectedError.Error())
-			} else {
-				require.Equal(t, tc.expectedEnvironment, env)
 			}
 		})
 	}

--- a/internal/pkg/cli/pipeline_init_test.go
+++ b/internal/pkg/cli/pipeline_init_test.go
@@ -138,7 +138,6 @@ func TestInitPipelineOpts_Ask(t *testing.T) {
 		inGitHubAccessToken string
 		inGitBranch         string
 
-		//mockStore    func(m *mocks.Mockstore)
 		mockPrompt   func(m *mocks.Mockprompter)
 		mockRunner   func(m *mocks.Mockrunner)
 		mockSelector func(m *mocks.MockpipelineSelector)
@@ -160,7 +159,7 @@ func TestInitPipelineOpts_Ask(t *testing.T) {
 			buffer:              *bytes.NewBufferString("archer\tgit@github.com:goodGoose/bhaOS (fetch)\narcher\thttps://github.com/badGoose/chaOS (push)\n"),
 
 			mockSelector: func(m *mocks.MockpipelineSelector) {
-				m.EXPECT().Environments(pipelineSelectEnvPrompt, gomock.Any(), "my-app", gomock.Any(), gomock.Any()).Return([]string{"test", "prod"}, nil)
+				m.EXPECT().Environments(pipelineSelectEnvPrompt, gomock.Any(), "my-app", gomock.Any()).Return([]string{"test", "prod"}, nil)
 			},
 			mockRunner: func(m *mocks.Mockrunner) {
 				m.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
@@ -182,7 +181,7 @@ func TestInitPipelineOpts_Ask(t *testing.T) {
 			inEnvironments: []string{},
 
 			mockSelector: func(m *mocks.MockpipelineSelector) {
-				m.EXPECT().Environments(pipelineSelectEnvPrompt, gomock.Any(), "my-app", gomock.Any(), gomock.Any()).Return(nil, errors.New("some error"))
+				m.EXPECT().Environments(pipelineSelectEnvPrompt, gomock.Any(), "my-app", gomock.Any()).Return(nil, errors.New("some error"))
 			},
 			mockRunner: func(m *mocks.Mockrunner) {},
 			mockPrompt: func(m *mocks.Mockprompter) {},
@@ -197,7 +196,7 @@ func TestInitPipelineOpts_Ask(t *testing.T) {
 			buffer:         *bytes.NewBufferString("archer\tgit@github.com:goodGoose/bhaOS (fetch)\narcher\thttps://github.com/badGoose/chaOS (push)\n"),
 
 			mockSelector: func(m *mocks.MockpipelineSelector) {
-				m.EXPECT().Environments(pipelineSelectEnvPrompt, gomock.Any(), "my-app", gomock.Any(), gomock.Any()).Return([]string{"test", "prod"}, nil)
+				m.EXPECT().Environments(pipelineSelectEnvPrompt, gomock.Any(), "my-app", gomock.Any()).Return([]string{"test", "prod"}, nil)
 			},
 			mockRunner: func(m *mocks.Mockrunner) {
 				m.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
@@ -221,7 +220,7 @@ func TestInitPipelineOpts_Ask(t *testing.T) {
 			buffer:              *bytes.NewBufferString("archer\treallybadGoosegithub.comNotEvenAURL (fetch)\n"),
 
 			mockSelector: func(m *mocks.MockpipelineSelector) {
-				m.EXPECT().Environments(pipelineSelectEnvPrompt, gomock.Any(), "my-app", gomock.Any(), gomock.Any()).Return([]string{"test", "prod"}, nil)
+				m.EXPECT().Environments(pipelineSelectEnvPrompt, gomock.Any(), "my-app", gomock.Any()).Return([]string{"test", "prod"}, nil)
 			},
 			mockRunner: func(m *mocks.Mockrunner) {
 				m.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
@@ -245,7 +244,7 @@ func TestInitPipelineOpts_Ask(t *testing.T) {
 			buffer:              *bytes.NewBufferString("archer\tgit@github.com:goodGoose/bhaOS (fetch)\narcher\thttps://github.com/badGoose/chaOS (push)\n"),
 
 			mockSelector: func(m *mocks.MockpipelineSelector) {
-				m.EXPECT().Environments(pipelineSelectEnvPrompt, gomock.Any(), "my-app", gomock.Any(), gomock.Any()).Return([]string{"test", "prod"}, nil)
+				m.EXPECT().Environments(pipelineSelectEnvPrompt, gomock.Any(), "my-app", gomock.Any()).Return([]string{"test", "prod"}, nil)
 			},
 			mockRunner: func(m *mocks.Mockrunner) {
 				m.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)

--- a/internal/pkg/term/selector/selector.go
+++ b/internal/pkg/term/selector/selector.go
@@ -431,7 +431,7 @@ func (s *Select) Environment(prompt, help, app string, additionalOpts ...string)
 
 // Environments fetches all the environments in an app and prompts the user to select one OR MORE.
 // The List of options decreases as envs are chosen. Chosen envs displayed above with the finalMsg.
-func (s *Select) Environments(prompt, help, app string, finalMsg prompt.Option) ([]string, error) {
+func (s *Select) Environments(prompt, help, app string, finalMsgFunc func(int) prompt.Option) ([]string, error) {
 	envs, err := s.retrieveEnvironments(app)
 	if err != nil {
 		return nil, fmt.Errorf("get environments for app %s from metadata store: %w", app, err)
@@ -447,7 +447,7 @@ func (s *Select) Environments(prompt, help, app string, finalMsg prompt.Option) 
 	var selectedEnvs []string
 	usedEnvs := make(map[string]bool)
 
-	for {
+	for i := 1; i < len(envs); i++ {
 		var availableEnvs []string
 		for _, env := range envs {
 			// Check if environment has already been added to pipeline
@@ -456,7 +456,7 @@ func (s *Select) Environments(prompt, help, app string, finalMsg prompt.Option) 
 			}
 		}
 
-		selectedEnv, err := s.prompt.SelectOne(prompt, help, availableEnvs, finalMsg)
+		selectedEnv, err := s.prompt.SelectOne(prompt, help, availableEnvs, finalMsgFunc(i))
 		if err != nil {
 			return nil, fmt.Errorf("select environments: %w", err)
 		}
@@ -465,10 +465,6 @@ func (s *Select) Environments(prompt, help, app string, finalMsg prompt.Option) 
 		}
 		selectedEnvs = append(selectedEnvs, selectedEnv)
 
-		// If only [No additional environments] is available
-		if len(selectedEnvs) == len(envs)-1 {
-			break
-		}
 		usedEnvs[selectedEnv] = true
 	}
 	return selectedEnvs, nil

--- a/internal/pkg/term/selector/selector.go
+++ b/internal/pkg/term/selector/selector.go
@@ -29,6 +29,8 @@ const (
 	weekly  = "Weekly"
 	monthly = "Monthly"
 	yearly  = "Yearly"
+
+	escapeOpt = "[No additional environments]"
 )
 
 const (
@@ -441,13 +443,11 @@ func (s *Select) Environments(prompt, help, app string, finalMsg prompt.Option) 
 		return nil, fmt.Errorf("no environments found in app %s", app)
 	}
 
-	envs = append(envs, "[No additional environments]")
+	envs = append(envs, escapeOpt)
 	var selectedEnvs []string
 	usedEnvs := make(map[string]bool)
-	// This for-loop ends with one item left to select because when Environments() is used for `pipeline init`,
-	// the "[No additional environments]" option will be the only choice remaining if the user selects all
-	// of their environments for their pipeline.
-	for i := 1; i < len(envs); i++ {
+
+	for {
 		var availableEnvs []string
 		for _, env := range envs {
 			// Check if environment has already been added to pipeline
@@ -460,10 +460,15 @@ func (s *Select) Environments(prompt, help, app string, finalMsg prompt.Option) 
 		if err != nil {
 			return nil, fmt.Errorf("select environments: %w", err)
 		}
-		if selectedEnv == "[No additional environments]" {
+		if selectedEnv == escapeOpt {
 			break
 		}
 		selectedEnvs = append(selectedEnvs, selectedEnv)
+
+		// If only [No additional environments] is available
+		if len(selectedEnvs) == len(envs)-1 {
+			break
+		}
 		usedEnvs[selectedEnv] = true
 	}
 	return selectedEnvs, nil

--- a/internal/pkg/term/selector/selector.go
+++ b/internal/pkg/term/selector/selector.go
@@ -429,7 +429,7 @@ func (s *Select) Environment(prompt, help, app string, additionalOpts ...string)
 
 // Environments fetches all the environments in an app and prompts the user to select one OR MORE.
 // The List of options decreases as envs are chosen. Chosen envs displayed above with the finalMsg.
-func (s *Select) Environments(prompt, help, app string, finalMsg prompt.Option, additionalOpts ...string) ([]string, error) {
+func (s *Select) Environments(prompt, help, app string, finalMsg prompt.Option) ([]string, error) {
 	envs, err := s.retrieveEnvironments(app)
 	if err != nil {
 		return nil, fmt.Errorf("get environments for app %s from metadata store: %w", app, err)
@@ -441,16 +441,12 @@ func (s *Select) Environments(prompt, help, app string, finalMsg prompt.Option, 
 		return nil, fmt.Errorf("no environments found in app %s", app)
 	}
 
-	// This, as below with the for-loop, is currently optimized for `pipeline init`-- additional opts
-	// are not added until after the method errors out because len(envs) == 0.
-	envs = append(envs, additionalOpts...)
+	envs = append(envs, "[No additional environments]")
 	var selectedEnvs []string
 	usedEnvs := make(map[string]bool)
-
-	// This for-loop ends with one item left to select because at the moment,
-	// Environments() is being used only for `pipeline init` and the the 'quit'
-	// option ("[No additional environments]") will be the only choice remaining
-	// if the user selects all of their environments for their pipeline.
+	// This for-loop ends with one item left to select because when Environments() is used for `pipeline init`,
+	// the "[No additional environments]" option will be the only choice remaining if the user selects all
+	// of their environments for their pipeline.
 	for i := 1; i < len(envs); i++ {
 		var availableEnvs []string
 		for _, env := range envs {

--- a/internal/pkg/term/selector/selector.go
+++ b/internal/pkg/term/selector/selector.go
@@ -30,7 +30,7 @@ const (
 	monthly = "Monthly"
 	yearly  = "Yearly"
 
-	escapeOpt = "[No additional environments]"
+	pipelineEscapeOpt = "[No additional environments]"
 )
 
 const (
@@ -443,7 +443,7 @@ func (s *Select) Environments(prompt, help, app string, finalMsgFunc func(int) p
 		return nil, fmt.Errorf("no environments found in app %s", app)
 	}
 
-	envs = append(envs, escapeOpt)
+	envs = append(envs, pipelineEscapeOpt)
 	var selectedEnvs []string
 	usedEnvs := make(map[string]bool)
 
@@ -460,7 +460,7 @@ func (s *Select) Environments(prompt, help, app string, finalMsgFunc func(int) p
 		if err != nil {
 			return nil, fmt.Errorf("select environments: %w", err)
 		}
-		if selectedEnv == escapeOpt {
+		if selectedEnv == pipelineEscapeOpt {
 			break
 		}
 		selectedEnvs = append(selectedEnvs, selectedEnv)

--- a/internal/pkg/term/selector/selector_test.go
+++ b/internal/pkg/term/selector/selector_test.go
@@ -1086,12 +1086,9 @@ func TestSelect_Environment(t *testing.T) {
 
 func TestSelect_Environments(t *testing.T) {
 	appName := "myapp"
-	additionalOpt1 := "[No additional environments]"
-	additionalOpt2 := "opt2"
+	hardcodedOpt := "[No additional environments]"
 
 	testCases := map[string]struct {
-		inAdditionalOpts []string
-
 		setupMocks func(m environmentMocks)
 		wantErr    error
 		want       []string
@@ -1109,11 +1106,32 @@ func TestSelect_Environments(t *testing.T) {
 						SelectOne(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 						Times(0),
 				)
-
 			},
 			wantErr: fmt.Errorf("no environments found in app myapp"),
 		},
-		"with multiple environments": {
+		"with one environment": {
+			setupMocks: func(m environmentMocks) {
+				gomock.InOrder(
+					m.envLister.
+						EXPECT().
+						ListEnvironments(gomock.Eq(appName)).
+						Return([]*config.Environment{
+							{
+								App:  appName,
+								Name: "env1",
+							},
+						}, nil).
+						Times(1),
+					m.prompt.
+						EXPECT().
+						SelectOne(gomock.Any(), gomock.Any(), gomock.Eq([]string{"env1", hardcodedOpt}), gomock.Any()).
+						Return("env1", nil).
+						Times(1),
+				)
+			},
+			want: []string{"env1"},
+		},
+		"with multiple environments (selection list reduces with each iteration, returns envs in order selected)": {
 			setupMocks: func(m environmentMocks) {
 				gomock.InOrder(
 					m.envLister.
@@ -1139,7 +1157,7 @@ func TestSelect_Environments(t *testing.T) {
 						SelectOne(
 							gomock.Eq("Select an environment"),
 							gomock.Eq("Help text"),
-							gomock.Eq([]string{"env1", "env2", "env3"}),
+							gomock.Eq([]string{"env1", "env2", "env3", hardcodedOpt}),
 							gomock.Any()).
 						Return("env2", nil).
 						Times(1),
@@ -1148,9 +1166,70 @@ func TestSelect_Environments(t *testing.T) {
 						SelectOne(
 							gomock.Eq("Select an environment"),
 							gomock.Eq("Help text"),
-							gomock.Eq([]string{"env1", "env3"}),
+							gomock.Eq([]string{"env1", "env3", hardcodedOpt}),
 							gomock.Any()).
 						Return("env1", nil).
+						Times(1),
+					m.prompt.
+						EXPECT().
+						SelectOne(
+							gomock.Eq("Select an environment"),
+							gomock.Eq("Help text"),
+							gomock.Eq([]string{"env3", hardcodedOpt}),
+							gomock.Any()).
+						Return("env3", nil).
+						Times(1),
+				)
+			},
+			want: []string{"env2", "env1", "env3"},
+		},
+		"stops prompting when user selects '[No additional environments]'; quit opt not in env list": {
+			setupMocks: func(m environmentMocks) {
+				gomock.InOrder(
+					m.envLister.
+						EXPECT().
+						ListEnvironments(gomock.Eq(appName)).
+						Return([]*config.Environment{
+							{
+								App:  appName,
+								Name: "env1",
+							},
+							{
+								App:  appName,
+								Name: "env2",
+							},
+							{
+								App:  appName,
+								Name: "env3",
+							},
+						}, nil).
+						Times(1),
+					m.prompt.
+						EXPECT().
+						SelectOne(
+							gomock.Eq("Select an environment"),
+							gomock.Eq("Help text"),
+							gomock.Eq([]string{"env1", "env2", "env3", hardcodedOpt}),
+							gomock.Any()).
+						Return("env2", nil).
+						Times(1),
+					m.prompt.
+						EXPECT().
+						SelectOne(
+							gomock.Eq("Select an environment"),
+							gomock.Eq("Help text"),
+							gomock.Eq([]string{"env1", "env3", hardcodedOpt}),
+							gomock.Any()).
+						Return("env1", nil).
+						Times(1),
+					m.prompt.
+						EXPECT().
+						SelectOne(
+							gomock.Eq("Select an environment"),
+							gomock.Eq("Help text"),
+							gomock.Eq([]string{"env3", hardcodedOpt}),
+							gomock.Any()).
+						Return(hardcodedOpt, nil).
 						Times(1),
 				)
 			},
@@ -1175,85 +1254,12 @@ func TestSelect_Environments(t *testing.T) {
 						Times(1),
 					m.prompt.
 						EXPECT().
-						SelectOne(gomock.Any(), gomock.Any(), gomock.Eq([]string{"env1", "env2"}), gomock.Any()).
+						SelectOne(gomock.Any(), gomock.Any(), gomock.Eq([]string{"env1", "env2", hardcodedOpt}), gomock.Any()).
 						Return("", fmt.Errorf("error selecting")).
 						Times(1),
 				)
 			},
 			wantErr: fmt.Errorf("select environments: error selecting"),
-		},
-		"no environment but with one additional option (prompt.SelectOne never called)": {
-			inAdditionalOpts: []string{additionalOpt1},
-			setupMocks: func(m environmentMocks) {
-				gomock.InOrder(
-					m.envLister.
-						EXPECT().
-						ListEnvironments(gomock.Eq(appName)).
-						Return([]*config.Environment{}, nil).
-						Times(1),
-				)
-			},
-
-			want: nil,
-		},
-		"no environment but with multiple additional options (errors out assuming additional opts are not legitimate envs)": {
-			inAdditionalOpts: []string{additionalOpt1, additionalOpt2},
-			setupMocks: func(m environmentMocks) {
-				gomock.InOrder(
-					m.envLister.
-						EXPECT().
-						ListEnvironments(gomock.Eq(appName)).
-						Return([]*config.Environment{}, nil).
-						Times(1),
-				)
-			},
-
-			wantErr: fmt.Errorf("no environments found in app myapp"),
-		},
-		"with multiple multiple environments and one additional option; selection list reduces with each iteration; stops prompting for more selections if '[No additional environments]' selected; returns envs in order selected": {
-			inAdditionalOpts: []string{additionalOpt1},
-			setupMocks: func(m environmentMocks) {
-				gomock.InOrder(
-					m.envLister.
-						EXPECT().
-						ListEnvironments(gomock.Eq(appName)).
-						Return([]*config.Environment{
-							{
-								App:  appName,
-								Name: "env1",
-							},
-							{
-								App:  appName,
-								Name: "env2",
-							},
-							{
-								App:  appName,
-								Name: "env3",
-							}, {
-								App:  appName,
-								Name: "env4",
-							},
-						}, nil).
-						Times(1),
-					m.prompt.
-						EXPECT().
-						SelectOne(gomock.Any(), gomock.Any(), gomock.Eq([]string{"env1", "env2", "env3", "env4", additionalOpt1}), gomock.Any()).
-						Return("env4", nil).
-						Times(1),
-					m.prompt.
-						EXPECT().
-						SelectOne(gomock.Any(), gomock.Any(), gomock.Eq([]string{"env1", "env2", "env3", additionalOpt1}), gomock.Any()).
-						Return("env3", nil).
-						Times(1),
-					m.prompt.
-						EXPECT().
-						SelectOne(gomock.Any(), gomock.Any(), gomock.Eq([]string{"env1", "env2", additionalOpt1}), gomock.Any()).
-						Return(additionalOpt1, nil).
-						Times(1),
-				)
-			},
-
-			want: []string{"env4", "env3"},
 		},
 	}
 
@@ -1275,7 +1281,7 @@ func TestSelect_Environments(t *testing.T) {
 				config: mockenvLister,
 			}
 
-			got, err := sel.Environments("Select an environment", "Help text", appName, prompt.WithFinalMessage("Final message"), tc.inAdditionalOpts...)
+			got, err := sel.Environments("Select an environment", "Help text", appName, prompt.WithFinalMessage("Final message"))
 			if tc.wantErr != nil {
 				require.EqualError(t, tc.wantErr, err.Error())
 			} else {

--- a/internal/pkg/term/selector/selector_test.go
+++ b/internal/pkg/term/selector/selector_test.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/dustin/go-humanize"
+
 	"github.com/aws/copilot-cli/internal/pkg/config"
 	"github.com/aws/copilot-cli/internal/pkg/term/prompt"
 	"github.com/aws/copilot-cli/internal/pkg/term/selector/mocks"
@@ -1281,7 +1283,9 @@ func TestSelect_Environments(t *testing.T) {
 				config: mockenvLister,
 			}
 
-			got, err := sel.Environments("Select an environment", "Help text", appName, prompt.WithFinalMessage("Final message"))
+			got, err := sel.Environments("Select an environment", "Help text", appName, func(order int) prompt.Option {
+				return prompt.WithFinalMessage(fmt.Sprintf("%s stage:", humanize.Ordinal(order)))
+			})
 			if tc.wantErr != nil {
 				require.EqualError(t, tc.wantErr, err.Error())
 			} else {


### PR DESCRIPTION
-- Moves the selection of pipeline envs out of `cli` and into `selector`.
-- Streamlines the env selection process by: not asking the user if they want to add environments at the get-go, giving a 'quit' option to eliminate extra questioning about whether or not they want to add another env, keeping a record of the envs already chosen above the prompt.
-- Condenses env-related methods and condenses repo-related methods in `pipeline init`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
