### PR TITLE
chore(progress): add components to render cloudformation stack updates

### DIFF
--- a/internal/pkg/describe/stack.go
+++ b/internal/pkg/describe/stack.go
@@ -11,6 +11,13 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 )
 
+// StackResourceDescription identifies a CloudFormation stack resource with a human-friendly description.
+type StackResourceDescription struct {
+	LogicalResourceID string
+	ResourceType      string
+	Description       string
+}
+
 type cfnStackDescriber interface {
 	DescribeStacks(input *cloudformation.DescribeStacksInput) (*cloudformation.DescribeStacksOutput, error)
 	DescribeStackResources(input *cloudformation.DescribeStackResourcesInput) (*cloudformation.DescribeStackResourcesOutput, error)

--- a/internal/pkg/term/progress/cloudformation.go
+++ b/internal/pkg/term/progress/cloudformation.go
@@ -13,13 +13,13 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/stream"
 )
 
-// StackSubscriber is the interface to subscribe a channel to a CloudFormation stack stream event.
+// StackSubscriber is the interface to subscribe channels to a CloudFormation stack stream event.
 type StackSubscriber interface {
 	Subscribe(channels ...chan stream.StackEvent)
 }
 
 // ListeningStackRenderer returns a component that listens for CloudFormation
-// resource events from a stack until ctx is canceled.
+// resource events from a stack until the ctx is canceled.
 //
 // The component only listens for stack resource events for the provided changes in the stack.
 // The state of changes is updated as events are published from the streamer.

--- a/internal/pkg/term/progress/cloudformation.go
+++ b/internal/pkg/term/progress/cloudformation.go
@@ -1,0 +1,135 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package progress
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/aws/copilot-cli/internal/pkg/describe"
+	"github.com/aws/copilot-cli/internal/pkg/stream"
+)
+
+// StackSubscriber is the interface to subscribe a channel to a CloudFormation stack stream event.
+type StackSubscriber interface {
+	Subscribe(channels ...chan stream.StackEvent)
+}
+
+// ListeningStackRenderer returns a component that listens for CloudFormation
+// resource events from a stack until ctx is canceled.
+//
+// The component only listens for stack resource events for the provided changes in the stack.
+// The state of changes is updated as events are published from the streamer.
+func ListeningStackRenderer(ctx context.Context, stackName, description string, changes []describe.StackResourceDescription, streamer StackSubscriber) Renderer {
+	var children []Renderer
+	for _, change := range changes {
+		children = append(children, listeningResourceRenderer(ctx, change, streamer))
+	}
+	comp := &stackComponent{
+		logicalID:   stackName,
+		description: description,
+		children:    children,
+		stream:      make(chan stream.StackEvent),
+	}
+	streamer.Subscribe(comp.stream)
+	go comp.Listen(ctx)
+	return comp
+}
+
+// listeningResourceRenderer returns a component that listens for CloudFormation stack events for a particular resource.
+func listeningResourceRenderer(ctx context.Context, resource describe.StackResourceDescription, streamer StackSubscriber) Renderer {
+	comp := &regularResourceComponent{
+		logicalID:   resource.LogicalResourceID,
+		description: resource.Description,
+		stream:      make(chan stream.StackEvent),
+	}
+	streamer.Subscribe(comp.stream)
+	go comp.Listen(ctx)
+	return comp
+}
+
+// stackComponent can display a CloudFormation stack and all of its associated resources.
+type stackComponent struct {
+	logicalID   string     // The CloudFormation stack name.
+	description string     // The human friendly explanation of the purpose of the stack.
+	status      string     // The CloudFormation status of the stack.
+	children    []Renderer // Resources part of the stack.
+
+	stream chan stream.StackEvent
+	mu     sync.Mutex
+}
+
+// Listen updates the stack's status if a CloudFormation stack event is received or until ctx is canceled.
+func (c *stackComponent) Listen(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			// TODO(efekarakus): The streamer should close(c.stream) on ctx.Done().
+			// So that we can loop through remaining events `for ev := range c.stream`
+			// and make sure that the latest status for the logical ID is applied.
+			return
+		case ev := <-c.stream:
+			updateComponentStatus(&c.mu, &c.status, c.logicalID, ev)
+		}
+	}
+}
+
+// Render prints the CloudFormation stack's resource components in order and returns the number of lines written.
+// If any sub-component's Render call fails, then writes nothing and returns an error.
+func (c *stackComponent) Render(out io.Writer) (numLines int, err error) {
+	r := new(allOrNothingRenderer)
+	c.mu.Lock()
+	r.Partial(&singleLineComponent{
+		Text: fmt.Sprintf("- %s [%s]", c.description, c.status),
+	})
+	c.mu.Unlock()
+	for _, child := range c.children {
+		r.Partial(child)
+	}
+	return r.Render(out)
+}
+
+// regularResourceComponent can display a simple CloudFormation stack resource event.
+type regularResourceComponent struct {
+	logicalID   string // The LogicalID defined in the template for the resource.
+	status      string // The CloudFormation status of the resource.
+	description string // The human friendly explanation of the resource.
+
+	stream chan stream.StackEvent
+	mu     sync.Mutex
+}
+
+// Listen updates the resource's status if a CloudFormation stack resource event is received or until ctx is canceled.
+func (c *regularResourceComponent) Listen(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case ev := <-c.stream:
+			updateComponentStatus(&c.mu, &c.status, c.logicalID, ev)
+		}
+	}
+}
+
+// Render prints the resource as a singleLineComponent and returns the number of lines written and the error if any.
+func (c *regularResourceComponent) Render(out io.Writer) (numLines int, err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	slc := &singleLineComponent{
+		Text: fmt.Sprintf("- %s [%s]", c.description, c.status),
+	}
+	return slc.Render(out)
+}
+
+func updateComponentStatus(mu *sync.Mutex, status *string, logicalID string, event stream.StackEvent) {
+	if logicalID != event.LogicalResourceID {
+		return
+	}
+	mu.Lock()
+	*status = event.ResourceStatus
+	mu.Unlock()
+}

--- a/internal/pkg/term/progress/cloudformation_test.go
+++ b/internal/pkg/term/progress/cloudformation_test.go
@@ -1,0 +1,188 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package progress
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/aws/copilot-cli/internal/pkg/stream"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStackComponent_Listen(t *testing.T) {
+	t.Run("should not update status if no events are received for the logical ID", func(t *testing.T) {
+		// GIVEN
+		ctx, cancel := context.WithCancel(context.Background())
+		ch := make(chan stream.StackEvent)
+		done := make(chan bool)
+		comp := &stackComponent{
+			logicalID: "phonetool-test",
+			status:    "not started",
+			stream:    ch,
+		}
+
+		// WHEN
+		go func() {
+			comp.Listen(ctx)
+			done <- true
+		}()
+		go func() {
+			ch <- stream.StackEvent{
+				LogicalResourceID: "EnvironmentManagerRole",
+				ResourceStatus:    "CREATE_COMPLETE",
+			}
+			ch <- stream.StackEvent{
+				LogicalResourceID: "ServiceDiscoveryNamespace",
+				ResourceStatus:    "CREATE_COMPLETE",
+			}
+			cancel()
+		}()
+
+		// THEN
+		<-done // Block until we are done listening.
+		require.Equal(t, "not started", comp.status)
+	})
+	t.Run("should update status when an event is received for stack", func(t *testing.T) {
+		// GIVEN
+		ctx, cancel := context.WithCancel(context.Background())
+		ch := make(chan stream.StackEvent)
+		done := make(chan bool)
+		comp := &stackComponent{
+			logicalID: "phonetool-test",
+			status:    "not started",
+			stream:    ch,
+		}
+
+		// WHEN
+		go func() {
+			comp.Listen(ctx)
+			done <- true
+		}()
+		go func() {
+			ch <- stream.StackEvent{
+				LogicalResourceID: "EnvironmentManagerRole",
+				ResourceStatus:    "CREATE_COMPLETE",
+			}
+			ch <- stream.StackEvent{
+				LogicalResourceID: "phonetool-test",
+				ResourceStatus:    "CREATE_COMPLETE",
+			}
+			cancel()
+		}()
+
+		// THEN
+		<-done // Block until we are done listening.
+		require.Equal(t, "CREATE_COMPLETE", comp.status)
+	})
+}
+
+func TestStackComponent_Render(t *testing.T) {
+	// GIVEN
+	comp := &stackComponent{
+		description: `The environment stack "phonetool-test" contains your shared resources between services`,
+		status:      "CREATE_COMPLETE",
+		children: []Renderer{
+			&mockRenderer{
+				content: "  - A load balancer to distribute traffic from the internet",
+			},
+			&mockRenderer{
+				content: "  - An ECS cluster to hold your services",
+			},
+		},
+	}
+	buf := new(strings.Builder)
+
+	// WHEN
+	nl, err := comp.Render(buf)
+
+	// THEN
+	require.NoError(t, err)
+	require.Equal(t, 3, nl, "expected 3 entries to be printed to the terminal")
+	require.Equal(t, `- The environment stack "phonetool-test" contains your shared resources between services [CREATE_COMPLETE]
+  - A load balancer to distribute traffic from the internet
+  - An ECS cluster to hold your services
+`, buf.String())
+}
+
+func TestRegularResourceComponent_Listen(t *testing.T) {
+	t.Run("should not update status if no events are received for the logical ID", func(t *testing.T) {
+		// GIVEN
+		ctx, cancel := context.WithCancel(context.Background())
+		ch := make(chan stream.StackEvent)
+		done := make(chan bool)
+		comp := &regularResourceComponent{
+			logicalID: "EnvironmentManagerRole",
+			status:    "not started",
+			stream:    ch,
+		}
+
+		// WHEN
+		go func() {
+			comp.Listen(ctx)
+			done <- true
+		}()
+		go func() {
+			ch <- stream.StackEvent{
+				LogicalResourceID: "ServiceDiscoveryNamespace",
+				ResourceStatus:    "CREATE_COMPLETE",
+			}
+			cancel()
+		}()
+
+		// THEN
+		<-done // Block until we are done listening.
+		require.Equal(t, "not started", comp.status)
+	})
+	t.Run("should update status when an event is received for the resource", func(t *testing.T) {
+		// GIVEN
+		ctx, cancel := context.WithCancel(context.Background())
+		ch := make(chan stream.StackEvent)
+		done := make(chan bool)
+		comp := &regularResourceComponent{
+			logicalID: "EnvironmentManagerRole",
+			status:    "not started",
+			stream:    ch,
+		}
+
+		// WHEN
+		go func() {
+			comp.Listen(ctx)
+			done <- true
+		}()
+		go func() {
+			ch <- stream.StackEvent{
+				LogicalResourceID: "EnvironmentManagerRole",
+				ResourceStatus:    "CREATE_COMPLETE",
+			}
+			ch <- stream.StackEvent{
+				LogicalResourceID: "phonetool-test",
+				ResourceStatus:    "ROLLBACK_COMPLETE",
+			}
+			cancel()
+		}()
+
+		// THEN
+		<-done // Block until we are done listening.
+		require.Equal(t, "CREATE_COMPLETE", comp.status)
+	})
+}
+
+func TestRegularResourceComponent_Render(t *testing.T) {
+	// GIVEN
+	comp := &regularResourceComponent{
+		description: "An ECS cluster to hold your services",
+		status:      "CREATE_COMPLETE",
+	}
+	buf := new(strings.Builder)
+
+	// WHEN
+	nl, err := comp.Render(buf)
+
+	// THEN
+	require.NoError(t, err)
+	require.Equal(t, 1, nl, "expected to be rendered as a single line component")
+	require.Equal(t, "- An ECS cluster to hold your services [CREATE_COMPLETE]\n", buf.String())
+}

--- a/internal/pkg/term/progress/component.go
+++ b/internal/pkg/term/progress/component.go
@@ -1,0 +1,25 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package progress
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+// singleLineComponent can display a single line of text.
+type singleLineComponent struct {
+	Text    string // Line of text to print.
+	Padding int    // Number of spaces prior to the text.
+}
+
+// Render prints the component and returns the number of lines printed to the terminal and the error if any.
+func (c *singleLineComponent) Render(out io.Writer) (numLines int, err error) {
+	_, err = fmt.Fprintf(out, "%s%s\n", strings.Repeat(" ", c.Padding), c.Text)
+	if err != nil {
+		return 0, err
+	}
+	return 1, err
+}

--- a/internal/pkg/term/progress/component_test.go
+++ b/internal/pkg/term/progress/component_test.go
@@ -1,0 +1,46 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package progress
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSingleLineComponent_Render(t *testing.T) {
+	testCases := map[string]struct {
+		inText    string
+		inPadding int
+
+		wantedOut string
+	}{
+		"should print padded text with new line": {
+			inText:    "hello world",
+			inPadding: 4,
+
+			wantedOut: "    hello world\n",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// GIVEN
+			comp := &singleLineComponent{
+				Text:    tc.inText,
+				Padding: tc.inPadding,
+			}
+			buf := new(strings.Builder)
+
+			// WHEN
+			nl, err := comp.Render(buf)
+
+			// THEN
+			require.NoError(t, err)
+			require.Equal(t, 1, nl, "expected only a single line to be written by a single line component")
+			require.Equal(t, tc.wantedOut, buf.String())
+		})
+	}
+}

--- a/internal/pkg/term/progress/render.go
+++ b/internal/pkg/term/progress/render.go
@@ -1,0 +1,44 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package progress
+
+import (
+	"bytes"
+	"io"
+)
+
+// Renderer is the interface to print a component to a writer.
+// It returns the number of lines printed and the error if any.
+type Renderer interface {
+	Render(out io.Writer) (numLines int, err error)
+}
+
+// allOrNothingRenderer renders all partial renders or none of them.
+type allOrNothingRenderer struct {
+	err      error
+	numLines int
+	buf      bytes.Buffer
+}
+
+func (r *allOrNothingRenderer) Partial(renderer Renderer) {
+	if r.err != nil {
+		return
+	}
+	nl, err := renderer.Render(&r.buf)
+	if err != nil {
+		r.err = err
+		return
+	}
+	r.numLines += nl
+}
+
+func (r *allOrNothingRenderer) Render(w io.Writer) (numLines int, err error) {
+	if r.err != nil {
+		return 0, r.err
+	}
+	if _, err := r.buf.WriteTo(w); err != nil {
+		return 0, err
+	}
+	return r.numLines, nil
+}

--- a/internal/pkg/term/progress/render_test.go
+++ b/internal/pkg/term/progress/render_test.go
@@ -1,0 +1,90 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package progress
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type mockRenderer struct {
+	content string
+	err     error
+}
+
+func (m *mockRenderer) Render(out io.Writer) (int, error) {
+	if m.err != nil {
+		return 0, m.err
+	}
+	out.Write([]byte(m.content + "\n"))
+	return 1, nil
+}
+
+func TestAllOrNothingRenderer(t *testing.T) {
+	t.Run("should render all partials when no partial fails", func(t *testing.T) {
+		// GIVEN
+		r := new(allOrNothingRenderer)
+		buf := new(strings.Builder)
+
+		// WHEN
+		r.Partial(&mockRenderer{
+			content: "hello",
+		})
+		r.Partial(&mockRenderer{
+			content: "world",
+		})
+		numLines, err := r.Render(buf)
+
+		// THEN
+		require.NoError(t, err)
+		require.Equal(t, "hello\nworld\n", buf.String())
+		require.Equal(t, 2, numLines, "expected two entries to be rendered")
+	})
+	t.Run("should not render any partials if one of them fails", func(t *testing.T) {
+		// GIVEN
+		r := new(allOrNothingRenderer)
+		buf := new(strings.Builder)
+		wantedErr := errors.New("some error")
+
+		// WHEN
+		r.Partial(&mockRenderer{
+			content: "hello",
+		})
+		r.Partial(&mockRenderer{
+			err: wantedErr,
+		})
+		r.Partial(&mockRenderer{
+			content: "world",
+		})
+		numLines, err := r.Render(buf)
+
+		// THEN
+		require.EqualError(t, err, wantedErr.Error(), "expected partial error to be surfaced")
+		require.Equal(t, 0, numLines, "expected no lines to be rendered")
+	})
+	t.Run("should surface first partial error", func(t *testing.T) {
+		// GIVEN
+		r := new(allOrNothingRenderer)
+		buf := new(strings.Builder)
+		firstErr := errors.New("error1")
+		secondErr := errors.New("error2")
+
+		// WHEN
+		r.Partial(&mockRenderer{
+			err: firstErr,
+		})
+		r.Partial(&mockRenderer{
+			err: secondErr,
+		})
+		numLines, err := r.Render(buf)
+
+		// THEN
+		require.EqualError(t, err, firstErr.Error(), "expected only first error to be returned")
+		require.Equal(t, 0, numLines, "expected no lines to be rendered")
+	})
+}


### PR DESCRIPTION
Components are objects that can be rendered on the terminal 
as they all implement the `Renderer` interface:
```go
type Renderer interface {
    Render(io.Writer) (numLines int, err error)
}
```

In this change, we are adding the following components to the `progress` pkg:
- `singleLineComponent` can print a line of text.
- `regularResourceComponent` can print a CloudFormation resource.
- `stackComponent` can print a CloudFormation stack.

The `regularResourceComponent` and `stackComponent` are *high-level
components*. High-level components:
1. Render themselves by calling low-level components like
`singleLineComponent`.
2. Listen to events to update their internal state. This is achieved
through the `Listen(context.Context)` method.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
