### PR TITLE
chore(cicd): enable CodeCommit as repo source for pipeline init

### DIFF
--- a/internal/pkg/cli/flag.go
+++ b/internal/pkg/cli/flag.go
@@ -40,7 +40,7 @@ const (
 	prodEnvFlag           = "prod"
 	deployFlag            = "deploy"
 	resourcesFlag         = "resources"
-	githubURLFlag         = "github-url"
+	repoURLFlag           = "url"
 	githubAccessTokenFlag = "github-access-token"
 	gitBranchFlag         = "git-branch"
 	envsFlag              = "environments"
@@ -100,7 +100,7 @@ const (
 
 	dockerFileFlagShort        = "d"
 	imageFlagShort             = "i"
-	githubURLFlagShort         = "u"
+	repoURLFlagShort           = "u"
 	githubAccessTokenFlagShort = "t"
 	gitBranchFlagShort         = "b"
 	envsFlagShort              = "e"
@@ -164,7 +164,7 @@ Defaults to all logs. Only one of end-time / follow may be used.`
 	tasksLogsFlagDescription = "Optional. Only return logs from specific task IDs."
 
 	deployTestFlagDescription        = `Deploy your service or job to a "test" environment.`
-	githubURLFlagDescription         = "GitHub repository URL for your service."
+	repoURLFlagDescription           = "GitHub or CodeCommit repository URL for your service."
 	githubAccessTokenFlagDescription = "GitHub personal access token for your repository."
 	gitBranchFlagDescription         = "Branch used to trigger your pipeline."
 	pipelineEnvsFlagDescription      = "Environments to add to the pipeline."

--- a/internal/pkg/cli/flag.go
+++ b/internal/pkg/cli/flag.go
@@ -165,8 +165,8 @@ Defaults to all logs. Only one of end-time / follow may be used.`
 	tasksLogsFlagDescription = "Optional. Only return logs from specific task IDs."
 
 	deployTestFlagDescription        = `Deploy your service or job to a "test" environment.`
-	githubURLFlagDescription         = "(Deprecated.) Use --url instead. GitHub repository URL for your service."
-	repoURLFlagDescription           = "GitHub or CodeCommit repository URL for your service."
+	githubURLFlagDescription         = "(Deprecated.) Use --url instead. Repository URL to trigger your pipeline."
+	repoURLFlagDescription           = "The repository URL to trigger your pipeline."
 	githubAccessTokenFlagDescription = "GitHub personal access token for your repository."
 	gitBranchFlagDescription         = "Branch used to trigger your pipeline."
 	pipelineEnvsFlagDescription      = "Environments to add to the pipeline."

--- a/internal/pkg/cli/flag.go
+++ b/internal/pkg/cli/flag.go
@@ -40,6 +40,7 @@ const (
 	prodEnvFlag           = "prod"
 	deployFlag            = "deploy"
 	resourcesFlag         = "resources"
+	githubURLFlag         = "github-url"
 	repoURLFlag           = "url"
 	githubAccessTokenFlag = "github-access-token"
 	gitBranchFlag         = "git-branch"
@@ -100,6 +101,7 @@ const (
 
 	dockerFileFlagShort        = "d"
 	imageFlagShort             = "i"
+	githubURLFlagShort         = "g"
 	repoURLFlagShort           = "u"
 	githubAccessTokenFlagShort = "t"
 	gitBranchFlagShort         = "b"
@@ -164,6 +166,7 @@ Defaults to all logs. Only one of end-time / follow may be used.`
 	tasksLogsFlagDescription = "Optional. Only return logs from specific task IDs."
 
 	deployTestFlagDescription        = `Deploy your service or job to a "test" environment.`
+	githubURLFlagDescription         = "(Deprecated.) Use --url instead. GitHub repository URL for your service."
 	repoURLFlagDescription           = "GitHub or CodeCommit repository URL for your service."
 	githubAccessTokenFlagDescription = "GitHub personal access token for your repository."
 	gitBranchFlagDescription         = "Branch used to trigger your pipeline."

--- a/internal/pkg/cli/flag.go
+++ b/internal/pkg/cli/flag.go
@@ -101,7 +101,6 @@ const (
 
 	dockerFileFlagShort        = "d"
 	imageFlagShort             = "i"
-	githubURLFlagShort         = "g"
 	repoURLFlagShort           = "u"
 	githubAccessTokenFlagShort = "t"
 	gitBranchFlagShort         = "b"

--- a/internal/pkg/cli/pipeline_init.go
+++ b/internal/pkg/cli/pipeline_init.go
@@ -68,13 +68,9 @@ var (
 type initPipelineVars struct {
 	appName           string
 	environments      []string
-	provider          string
 	repoURL           string
-	repoName          string
 	repoBranch        string
-	githubOwner       string
 	githubAccessToken string
-	ccRegion          string
 }
 
 type initPipelineOpts struct {
@@ -90,7 +86,11 @@ type initPipelineOpts struct {
 	sel            pipelineSelector
 
 	// Outputs stored on successful actions.
-	secret string
+	secret      string
+	provider    string
+	repoName    string
+	githubOwner string
+	ccRegion    string
 
 	// Caches variables
 	fs         *afero.Afero

--- a/internal/pkg/cli/pipeline_init.go
+++ b/internal/pkg/cli/pipeline_init.go
@@ -53,10 +53,11 @@ const (
 )
 
 const (
-	fmtSecretName       = "github-token-%s-%s"
-	fmtGHPipelineName   = "pipeline-%s-%s-%s"
-	fmtCCPipelineName   = "pipeline-%s-%s"
-	fmtPipelineProvider = "https://%s/%s/%s"
+	fmtSecretName         = "github-token-%s-%s"
+	fmtGHPipelineName     = "pipeline-%s-%s-%s"
+	fmtCCPipelineName     = "pipeline-%s-%s"
+	fmtGHPipelineProvider = "https://%s/%s/%s"
+	fmtCCPipelineProvider = "https://%s.console.%s/codesuite/codecommit/repositories/%s"
 )
 
 var (
@@ -74,7 +75,6 @@ type initPipelineVars struct {
 	githubOwner       string
 	githubAccessToken string
 	ccRegion          string
-	ccSSHKey          string
 }
 
 type initPipelineOpts struct {
@@ -258,27 +258,6 @@ func (o *initPipelineOpts) askEnvs() error {
 	o.envConfigs = envConfigs
 
 	return nil
-}
-
-func (o *initPipelineOpts) createPipelineProvider() (manifest.Provider, error) {
-	if o.provider == ghProviderName {
-		config := &manifest.GitHubProperties{
-			OwnerAndRepository:    "https://" + githubURL + "/" + o.githubOwner + "/" + o.repoName,
-			Branch:                o.repoBranch,
-			GithubSecretIdKeyName: o.secret,
-		}
-		return manifest.NewProvider(config)
-	}
-	// TODO: double-check this
-	if o.provider == ccProviderName {
-		config := &manifest.CodeCommitProperties{
-			Repository: "https://" + o.ccRegion + ".console." + awsURL + "/codesuite/codecommit/repositories/" + o.repoName,
-			Branch:     o.repoBranch,
-		}
-		return manifest.NewProvider(config)
-	}
-	// Placeholder error, as provider type is currently assigned
-	return nil, fmt.Errorf("unsupported provider: %s", o.provider)
 }
 
 func (o *initPipelineOpts) askRepository() error {
@@ -535,7 +514,7 @@ func (o *initPipelineOpts) pipelineName() (string, error) {
 func (o *initPipelineOpts) pipelineProvider() (manifest.Provider, error) {
 	if o.provider == ghProviderName {
 		config := &manifest.GitHubProperties{
-			OwnerAndRepository:    fmt.Sprintf(fmtPipelineProvider, githubURL, o.githubOwner, o.repoName),
+			OwnerAndRepository:    fmt.Sprintf(fmtGHPipelineProvider, githubURL, o.githubOwner, o.repoName),
 			Branch:                o.repoBranch,
 			GithubSecretIdKeyName: o.secret,
 		}
@@ -543,7 +522,7 @@ func (o *initPipelineOpts) pipelineProvider() (manifest.Provider, error) {
 	}
 	if o.provider == ccProviderName {
 		config := &manifest.CodeCommitProperties{
-			Repository: o.repoName,
+			Repository: fmt.Sprintf(fmtCCPipelineProvider, o.ccRegion, awsURL, o.repoName),
 			Branch:     o.repoBranch,
 		}
 		return manifest.NewProvider(config)

--- a/internal/pkg/cli/pipeline_init.go
+++ b/internal/pkg/cli/pipeline_init.go
@@ -10,6 +10,11 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/aws/copilot-cli/internal/pkg/term/color"
+	"github.com/aws/copilot-cli/internal/pkg/term/log"
+	"github.com/aws/copilot-cli/internal/pkg/version"
+	"github.com/spf13/cobra"
+
 	"github.com/dustin/go-humanize"
 
 	"github.com/aws/copilot-cli/internal/pkg/term/selector"
@@ -20,22 +25,18 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation"
 	"github.com/aws/copilot-cli/internal/pkg/manifest"
 	"github.com/aws/copilot-cli/internal/pkg/template"
-	"github.com/aws/copilot-cli/internal/pkg/term/color"
 	"github.com/aws/copilot-cli/internal/pkg/term/command"
-	"github.com/aws/copilot-cli/internal/pkg/term/log"
 	"github.com/aws/copilot-cli/internal/pkg/term/prompt"
-	"github.com/aws/copilot-cli/internal/pkg/version"
 	"github.com/aws/copilot-cli/internal/pkg/workspace"
 	"github.com/spf13/afero"
-	"github.com/spf13/cobra"
 )
 
 const (
 	pipelineSelectEnvPrompt     = "Which environment would you like to add to your pipeline?"
 	pipelineSelectEnvHelpPrompt = "Adds an environment that corresponds to a deployment stage in your pipeline. Environments are added sequentially."
 
-	pipelineSelectGitHubURLPrompt     = "Which GitHub repository would you like to use for your service?"
-	pipelineSelectGitHubURLHelpPrompt = `The GitHub repository linked to your workspace.
+	pipelineSelectURLPrompt     = "Which repository would you like to use for your service?"
+	pipelineSelectURLHelpPrompt = `The repository linked to your workspace.
 Pushing to this repository will trigger your pipeline build stage.
 Please enter full repository URL, e.g. "https://github.com/myCompany/myRepo", or the owner/rep, e.g. "myCompany/myRepo"`
 )
@@ -43,12 +44,18 @@ Please enter full repository URL, e.g. "https://github.com/myCompany/myRepo", or
 const (
 	buildspecTemplatePath = "cicd/buildspec.yml"
 	githubURL             = "github.com"
-	defaultBranch         = "main"
+	codeCommit            = "codecommit"
+	awsURL                = "aws.amazon.com"
+	ghProviderName        = "GitHub"
+	ccProviderName        = "CodeCommit"
+	defaultGHBranch       = "main"
+	defaultCCBranch       = "master"
 )
 
 const (
 	fmtSecretName       = "github-token-%s-%s"
-	fmtPipelineName     = "pipeline-%s-%s-%s"
+	fmtGHPipelineName   = "pipeline-%s-%s-%s"
+	fmtCCPipelineName   = "pipeline-%s-%s"
 	fmtPipelineProvider = "https://%s/%s/%s"
 )
 
@@ -60,11 +67,14 @@ var (
 type initPipelineVars struct {
 	appName           string
 	environments      []string
+	provider          string
 	repoURL           string
+	repoName          string
+	repoBranch        string
 	githubOwner       string
-	githubRepo        string
 	githubAccessToken string
-	gitBranch         string
+	ccRegion          string
+	ccSSHKey          string
 }
 
 type initPipelineOpts struct {
@@ -83,8 +93,9 @@ type initPipelineOpts struct {
 	secret string
 
 	// Caches variables
-	fs     *afero.Afero
-	buffer bytes.Buffer
+	fs         *afero.Afero
+	buffer     bytes.Buffer
+	envConfigs []*config.Environment
 }
 
 type artifactBucket struct {
@@ -143,12 +154,8 @@ func (o *initPipelineOpts) Validate() error {
 	}
 
 	if o.repoURL != "" {
-		if err := validateDomainName(o.repoURL); err != nil {
+		if err := o.validateURL(o.repoURL); err != nil {
 			return err
-		}
-		// TODO: add "&& !strings.Contains(o.repoURL, ccURL)" to 'if' and "and CodeCommit" to error
-		if !strings.Contains(o.repoURL, githubURL) {
-			return errors.New("Copilot currently accepts only URLs to GitHub repository sources")
 		}
 	}
 
@@ -169,7 +176,6 @@ func (o *initPipelineOpts) Ask() error {
 	if err := o.askEnvs(); err != nil {
 		return err
 	}
-	// TODO: Do a switch/case here after adding more repo providers.
 	if err := o.askRepository(); err != nil {
 		return err
 	}
@@ -178,44 +184,36 @@ func (o *initPipelineOpts) Ask() error {
 
 // Execute writes the pipeline manifest file.
 func (o *initPipelineOpts) Execute() error {
-	secretName := o.secretName()
-	_, err := o.secretsmanager.CreateSecret(secretName, o.githubAccessToken)
+	if o.provider == ghProviderName {
+		secretName := o.secretName()
+		_, err := o.secretsmanager.CreateSecret(secretName, o.githubAccessToken)
 
-	if err != nil {
-		var existsErr *secretsmanager.ErrSecretAlreadyExists
-		if !errors.As(err, &existsErr) {
-			return err
-		}
-		log.Successf("Secret already exists for %s! Do nothing.\n", color.HighlightUserInput(o.githubRepo))
-	} else {
-		log.Successf("Created the secret %s for pipeline source stage!\n", color.HighlightUserInput(secretName))
-	}
-	o.secret = secretName
-
-	var envConfigs []*config.Environment
-	for _, environment := range o.environments {
-		envConfig, err := o.store.GetEnvironment(o.appName, environment)
 		if err != nil {
-			return fmt.Errorf("get config of environment: %w", err)
+			var existsErr *secretsmanager.ErrSecretAlreadyExists
+			if !errors.As(err, &existsErr) {
+				return err
+			}
+			log.Successf("Secret already exists for %s! Do nothing.\n", color.HighlightUserInput(o.repoName))
+		} else {
+			log.Successf("Created the secret %s for pipeline source stage!\n", color.HighlightUserInput(secretName))
 		}
-		envConfigs = append(envConfigs, envConfig)
+		o.secret = secretName
 	}
 
 	// write pipeline.yml file, populate with:
-	//   - github repo as source
+	//   - git repo as source
 	//   - stage names (environments)
 	//   - enable/disable transition to prod envs
-
-	err = o.createPipelineManifest(envConfigs)
+	var err error
+	err = o.createPipelineManifest()
 	if err != nil {
 		return err
 	}
 
-	err = o.createBuildspec(envConfigs)
+	err = o.createBuildspec()
 	if err != nil {
 		return err
 	}
-
 	return nil
 }
 
@@ -229,6 +227,15 @@ func (o *initPipelineOpts) RecommendedActions() []string {
 	}
 }
 
+func (o *initPipelineOpts) validateURL(url string) error {
+	// Note: no longer calling `validateDomainName` because if users use git-remote-codecommit
+	// (the HTTPS (GRC) protocol) to connect to CodeCommit, the url does not have any periods.
+	if !strings.Contains(url, githubURL) && !strings.Contains(url, codeCommit) {
+		return errors.New("Copilot currently accepts only URLs to GitHub and CodeCommit repository sources")
+	}
+	return nil
+}
+
 func (o *initPipelineOpts) askEnvs() error {
 	if len(o.environments) == 0 {
 		envs, err := o.sel.Environments(pipelineSelectEnvPrompt, pipelineSelectEnvHelpPrompt, o.appName, func(order int) prompt.Option {
@@ -239,31 +246,86 @@ func (o *initPipelineOpts) askEnvs() error {
 		}
 		o.environments = envs
 	}
+
+	var envConfigs []*config.Environment
+	for _, environment := range o.environments {
+		envConfig, err := o.store.GetEnvironment(o.appName, environment)
+		if err != nil {
+			return fmt.Errorf("get config of environment: %w", err)
+		}
+		envConfigs = append(envConfigs, envConfig)
+	}
+	o.envConfigs = envConfigs
+
 	return nil
+}
+
+func (o *initPipelineOpts) createPipelineProvider() (manifest.Provider, error) {
+	if o.provider == ghProviderName {
+		config := &manifest.GitHubProperties{
+			OwnerAndRepository:    "https://" + githubURL + "/" + o.githubOwner + "/" + o.repoName,
+			Branch:                o.repoBranch,
+			GithubSecretIdKeyName: o.secret,
+		}
+		return manifest.NewProvider(config)
+	}
+	// TODO: double-check this
+	if o.provider == ccProviderName {
+		config := &manifest.CodeCommitProperties{
+			Repository: "https://" + o.ccRegion + ".console." + awsURL + "/codesuite/codecommit/repositories/" + o.repoName,
+			Branch:     o.repoBranch,
+		}
+		return manifest.NewProvider(config)
+	}
+	// Placeholder error, as provider type is currently assigned
+	return nil, fmt.Errorf("unsupported provider: %s", o.provider)
 }
 
 func (o *initPipelineOpts) askRepository() error {
 	var err error
 	if o.repoURL == "" {
-		if err = o.selectGitHubURL(); err != nil {
+		if err = o.selectURL(); err != nil {
 			return err
 		}
 	}
-	if o.githubOwner, o.githubRepo, err = o.parseOwnerRepoName(o.repoURL); err != nil {
-		return err
-	}
-	if o.githubAccessToken == "" {
-		if err = o.getGitHubAccessToken(); err != nil {
+
+	if strings.Contains(o.repoURL, githubURL) {
+		o.provider = ghProviderName
+		if o.githubOwner, o.repoName, err = o.parseOwnerRepoName(o.repoURL); err != nil {
 			return err
 		}
+		if o.githubAccessToken == "" {
+			if err = o.getGitHubAccessToken(); err != nil {
+				return err
+			}
+		}
+		if o.repoBranch == "" {
+			o.repoBranch = defaultGHBranch
+		}
 	}
-	if o.gitBranch == "" {
-		o.gitBranch = defaultBranch
+	if strings.Contains(o.repoURL, codeCommit) {
+		o.provider = ccProviderName
+		if o.repoName, err = o.parseRepoName(o.repoURL); err != nil {
+			return err
+		}
+		if o.ccRegion, err = o.parseRegion(o.repoURL); err != nil {
+			return err
+		}
+
+		// If any one of the chosen environments is in a region besides that of the CodeCommit repo, pipeline init errors out.
+		for _, env := range o.envConfigs {
+			if env.Region != o.ccRegion {
+				return fmt.Errorf("repository %s is in %s, but environment %s is in %s; they must be in the same region", o.repoName, o.ccRegion, env.Name, env.Region)
+			}
+		}
+		if o.repoBranch == "" {
+			o.repoBranch = defaultCCBranch
+		}
 	}
 	return nil
 }
 
-func (o *initPipelineOpts) selectGitHubURL() error {
+func (o *initPipelineOpts) selectURL() error {
 	// Fetches and parses all remote repositories.
 	err := o.runner.Run("git", []string{"remote", "-v"}, command.Stdout(&o.buffer))
 	if err != nil {
@@ -277,16 +339,20 @@ func (o *initPipelineOpts) selectGitHubURL() error {
 
 	// Prompts user to select a repo URL.
 	url, err := o.prompt.SelectOne(
-		pipelineSelectGitHubURLPrompt,
-		pipelineSelectGitHubURLHelpPrompt,
+		pipelineSelectURLPrompt,
+		pipelineSelectURLHelpPrompt,
 		urls,
 	)
 	if err != nil {
-		return fmt.Errorf("select GitHub URL: %w", err)
+		return fmt.Errorf("select URL: %w", err)
+	}
+	if err := o.validateURL(url); err != nil {
+		return err
 	}
 	o.repoURL = url
 
 	return nil
+
 }
 
 func (o *initPipelineOpts) parseOwnerRepoName(url string) (string, string, error) {
@@ -295,9 +361,29 @@ func (o *initPipelineOpts) parseOwnerRepoName(url string) (string, string, error
 	parsedURL = strings.TrimSuffix(parsedURL, ".git")
 	ownerRepo := strings.Split(parsedURL, "/")
 	if len(ownerRepo) != 2 {
-		return "", "", fmt.Errorf("unable to parse the GitHub repository owner and name from %s: please pass the repository URL with the format `--github-url https://github.com/{owner}/{repositoryName}`", url)
+		return "", "", fmt.Errorf("unable to parse the GitHub repository owner and name from %s: please pass the repository URL with the format `--url https://github.com/{owner}/{repositoryName}`", url)
 	}
 	return ownerRepo[0], ownerRepo[1], nil
+}
+
+func (o *initPipelineOpts) parseRepoName(url string) (string, error) {
+	parsedForRepo := strings.Split(url, "/")
+	if len(parsedForRepo) < 2 {
+		return "", fmt.Errorf("unable to parse the CodeCommit repository name from %s", url)
+	}
+	return parsedForRepo[len(parsedForRepo)-1], nil
+}
+
+func (o *initPipelineOpts) parseRegion(url string) (string, error) {
+	regexPattern := regexp.MustCompile(`(codecommit)(::|.)`)
+	region := regexPattern.Split(url, 2)
+	region = strings.Split(region[1], ".")
+	region = strings.Split(region[0], ":")
+	match, _ := regexp.MatchString(`(us(-gov)?|ap|ca|cn|eu|sa)-(central|(north|south)?(east|west)?)-\d`, region[0])
+	if !match {
+		return "", fmt.Errorf("unable to parse the AWS region from %s", url)
+	}
+	return region[0], nil
 }
 
 // examples:
@@ -305,12 +391,16 @@ func (o *initPipelineOpts) parseOwnerRepoName(url string) (string, string, error
 // efekarakus	https://github.com/karakuse/grit.git (fetch)
 // origin	    https://github.com/koke/grit (fetch)
 // koke         git://github.com/koke/grit.git (push)
+
+// https	https://git-codecommit.us-west-2.amazonaws.com/v1/repos/aws-sample (fetch)
+// fed		codecommit::us-west-2://aws-sample (fetch)
+// ssh		ssh://git-codecommit.us-west-2.amazonaws.com/v1/repos/aws-sample (push)
 func (o *initPipelineOpts) parseGitRemoteResult(s string) ([]string, error) {
 	var urls []string
 	urlSet := make(map[string]bool)
 	items := strings.Split(s, "\n")
 	for _, item := range items {
-		if !strings.Contains(item, githubURL) {
+		if !strings.Contains(item, githubURL) && !strings.Contains(item, codeCommit) {
 			continue
 		}
 		cols := strings.Split(item, "\t")
@@ -325,7 +415,7 @@ func (o *initPipelineOpts) parseGitRemoteResult(s string) ([]string, error) {
 
 func (o *initPipelineOpts) getGitHubAccessToken() error {
 	token, err := o.prompt.GetSecret(
-		fmt.Sprintf("Please enter your GitHub Personal Access Token for your repository %s:", color.HighlightUserInput(o.githubRepo)),
+		fmt.Sprintf("Please enter your GitHub Personal Access Token for your repository %s:", color.HighlightUserInput(o.repoName)),
 		`The personal access token for the GitHub repository linked to your workspace. 
 For more information, please refer to: https://git.io/JfDFD.`,
 	)
@@ -337,15 +427,19 @@ For more information, please refer to: https://git.io/JfDFD.`,
 	return nil
 }
 
-func (o *initPipelineOpts) createPipelineManifest(envs []*config.Environment) error {
-	pipelineName := o.pipelineName()
+func (o *initPipelineOpts) createPipelineManifest() error {
+	pipelineName, err := o.pipelineName()
+	if err != nil {
+		return err
+	}
 	provider, err := o.pipelineProvider()
 	if err != nil {
-		return fmt.Errorf("create pipeline provider: %w", err)
+		return err
 	}
 
 	var stages []manifest.PipelineStage
-	for _, env := range envs {
+	for _, env := range o.envConfigs {
+
 		stage := manifest.PipelineStage{
 			Name:             env.Name,
 			RequiresApproval: env.Prod,
@@ -378,13 +472,13 @@ func (o *initPipelineOpts) createPipelineManifest(envs []*config.Environment) er
 	if manifestExists {
 		manifestMsgFmt = "Pipeline manifest file for %s already exists at %s, skipping writing it.\n"
 	}
-	log.Successf(manifestMsgFmt, color.HighlightUserInput(o.githubRepo), color.HighlightResource(manifestPath))
+	log.Successf(manifestMsgFmt, color.HighlightUserInput(o.repoName), color.HighlightResource(manifestPath))
 	log.Infoln("The manifest contains configurations for your CodePipeline resources, such as your pipeline stages and build steps.")
 	return nil
 }
 
-func (o *initPipelineOpts) createBuildspec(envs []*config.Environment) error {
-	artifactBuckets, err := o.artifactBuckets(envs)
+func (o *initPipelineOpts) createBuildspec() error {
+	artifactBuckets, err := o.artifactBuckets()
 	if err != nil {
 		return err
 	}
@@ -425,23 +519,39 @@ func (o *initPipelineOpts) createBuildspec(envs []*config.Environment) error {
 }
 
 func (o *initPipelineOpts) secretName() string {
-	return fmt.Sprintf(fmtSecretName, o.appName, o.githubRepo)
+	return fmt.Sprintf(fmtSecretName, o.appName, o.repoName)
 }
 
-func (o *initPipelineOpts) pipelineName() string {
-	return fmt.Sprintf(fmtPipelineName, o.appName, o.githubOwner, o.githubRepo)
+func (o *initPipelineOpts) pipelineName() (string, error) {
+	if o.provider == ghProviderName {
+		return fmt.Sprintf(fmtGHPipelineName, o.appName, o.githubOwner, o.repoName), nil
+	}
+	if o.provider == ccProviderName {
+		return fmt.Sprintf(fmtCCPipelineName, o.appName, o.repoName), nil
+	}
+	return "", fmt.Errorf("unable to create pipeline name for repo %s from provider %s", o.repoName, o.provider)
 }
 
 func (o *initPipelineOpts) pipelineProvider() (manifest.Provider, error) {
-	config := &manifest.GitHubProperties{
-		OwnerAndRepository:    fmt.Sprintf(fmtPipelineProvider, githubURL, o.githubOwner, o.githubRepo),
-		Branch:                o.gitBranch,
-		GithubSecretIdKeyName: o.secret,
+	if o.provider == ghProviderName {
+		config := &manifest.GitHubProperties{
+			OwnerAndRepository:    fmt.Sprintf(fmtPipelineProvider, githubURL, o.githubOwner, o.repoName),
+			Branch:                o.repoBranch,
+			GithubSecretIdKeyName: o.secret,
+		}
+		return manifest.NewProvider(config)
 	}
-	return manifest.NewProvider(config)
+	if o.provider == ccProviderName {
+		config := &manifest.CodeCommitProperties{
+			Repository: o.repoName,
+			Branch:     o.repoBranch,
+		}
+		return manifest.NewProvider(config)
+	}
+	return nil, fmt.Errorf("unable to create pipeline source provider for %s", o.repoName)
 }
 
-func (o *initPipelineOpts) artifactBuckets(envs []*config.Environment) ([]artifactBucket, error) {
+func (o *initPipelineOpts) artifactBuckets() ([]artifactBucket, error) {
 	app, err := o.store.GetApplication(o.appName)
 	if err != nil {
 		return nil, fmt.Errorf("get application %s: %w", o.appName, err)
@@ -454,7 +564,7 @@ func (o *initPipelineOpts) artifactBuckets(envs []*config.Environment) ([]artifa
 	var buckets []artifactBucket
 	for _, resource := range regionalResources {
 		var envNames []string
-		for _, env := range envs {
+		for _, env := range o.envConfigs {
 			if env.Region == resource.Region {
 				envNames = append(envNames, env.Name)
 			}
@@ -479,7 +589,7 @@ func buildPipelineInitCmd() *cobra.Command {
 		Example: `
   Create a pipeline for the services in your workspace.
   /code $ copilot pipeline init \
-  /code  --github-url https://github.com/gitHubUserName/myFrontendApp.git \
+  /code  --url https://github.com/gitHubUserName/myFrontendApp.git \
   /code  --github-access-token file://myGitHubToken \
   /code  --environments "stage,prod"`,
 		RunE: runCmdE(func(cmd *cobra.Command, args []string) error {
@@ -505,9 +615,9 @@ func buildPipelineInitCmd() *cobra.Command {
 		}),
 	}
 	cmd.Flags().StringVarP(&vars.appName, appFlag, appFlagShort, tryReadingAppName(), appFlagDescription)
-	cmd.Flags().StringVarP(&vars.repoURL, githubURLFlag, githubURLFlagShort, "", githubURLFlagDescription)
+	cmd.Flags().StringVarP(&vars.repoURL, repoURLFlag, repoURLFlagShort, "", repoURLFlagDescription)
 	cmd.Flags().StringVarP(&vars.githubAccessToken, githubAccessTokenFlag, githubAccessTokenFlagShort, "", githubAccessTokenFlagDescription)
-	cmd.Flags().StringVarP(&vars.gitBranch, gitBranchFlag, gitBranchFlagShort, "", gitBranchFlagDescription)
+	cmd.Flags().StringVarP(&vars.repoBranch, gitBranchFlag, gitBranchFlagShort, "", gitBranchFlagDescription)
 	cmd.Flags().StringSliceVarP(&vars.environments, envsFlag, envsFlagShort, []string{}, pipelineEnvsFlagDescription)
 
 	return cmd

--- a/internal/pkg/cli/pipeline_init.go
+++ b/internal/pkg/cli/pipeline_init.go
@@ -594,8 +594,8 @@ func buildPipelineInitCmd() *cobra.Command {
 		}),
 	}
 	cmd.Flags().StringVarP(&vars.appName, appFlag, appFlagShort, tryReadingAppName(), appFlagDescription)
-	cmd.Flags().StringVarP(&vars.repoURL, githubURLFlag, githubURLFlagShort, "", githubURLFlagDescription)
-	cmd.Flags().MarkHidden(githubURLFlag)
+	cmd.Flags().StringVar(&vars.repoURL, githubURLFlag, "", githubURLFlagDescription)
+	_ = cmd.Flags().MarkHidden(githubURLFlag)
 	cmd.Flags().StringVarP(&vars.repoURL, repoURLFlag, repoURLFlagShort, "", repoURLFlagDescription)
 	cmd.Flags().StringVarP(&vars.githubAccessToken, githubAccessTokenFlag, githubAccessTokenFlagShort, "", githubAccessTokenFlagDescription)
 	cmd.Flags().StringVarP(&vars.repoBranch, gitBranchFlag, gitBranchFlagShort, "", gitBranchFlagDescription)

--- a/internal/pkg/cli/pipeline_init.go
+++ b/internal/pkg/cli/pipeline_init.go
@@ -594,6 +594,8 @@ func buildPipelineInitCmd() *cobra.Command {
 		}),
 	}
 	cmd.Flags().StringVarP(&vars.appName, appFlag, appFlagShort, tryReadingAppName(), appFlagDescription)
+	cmd.Flags().StringVarP(&vars.repoURL, githubURLFlag, githubURLFlagShort, "", githubURLFlagDescription)
+	cmd.Flags().MarkHidden(githubURLFlag)
 	cmd.Flags().StringVarP(&vars.repoURL, repoURLFlag, repoURLFlagShort, "", repoURLFlagDescription)
 	cmd.Flags().StringVarP(&vars.githubAccessToken, githubAccessTokenFlag, githubAccessTokenFlagShort, "", githubAccessTokenFlagDescription)
 	cmd.Flags().StringVarP(&vars.repoBranch, gitBranchFlag, gitBranchFlagShort, "", gitBranchFlagDescription)

--- a/internal/pkg/cli/pipeline_init_test.go
+++ b/internal/pkg/cli/pipeline_init_test.go
@@ -39,25 +39,18 @@ func TestInitPipelineOpts_Validate(t *testing.T) {
 			setupMocks: func(m *mocks.Mockstore) {
 				m.EXPECT().GetApplication("ghost-app").Return(nil, fmt.Errorf("get application ghost-app: some error"))
 			},
+
 			expectedError: fmt.Errorf("get application ghost-app: some error"),
 		},
-		"invalid URL": {
-			inAppName: "my-app",
-			inrepoURL: "somethingdotcom",
-			inEnvs:    []string{"test"},
-			setupMocks: func(m *mocks.Mockstore) {
-				m.EXPECT().GetApplication("my-app").Return(&config.Application{Name: "my-app"}, nil)
-			},
-			expectedError: errDomainInvalid,
-		},
-		"non-GH repo provider": {
+		"URL to unsupported repo provider": {
 			inAppName: "my-app",
 			inrepoURL: "bitbucket.org/repositories/repoName",
 			inEnvs:    []string{"test"},
 			setupMocks: func(m *mocks.Mockstore) {
 				m.EXPECT().GetApplication("my-app").Return(&config.Application{Name: "my-app"}, nil)
 			},
-			expectedError: errors.New("Copilot currently accepts only URLs to GitHub repository sources"),
+
+			expectedError: errors.New("Copilot currently accepts only URLs to GitHub and CodeCommit repository sources"),
 		},
 		"invalid environments": {
 			inAppName: "my-app",
@@ -71,10 +64,29 @@ func TestInitPipelineOpts_Validate(t *testing.T) {
 
 			expectedError: errors.New("some error"),
 		},
-		"success": {
+		"success with GH repo": {
 			inAppName: "my-app",
 			inEnvs:    []string{"test", "prod"},
 			inrepoURL: "https://github.com/badGoose/chaOS",
+
+			setupMocks: func(m *mocks.Mockstore) {
+				m.EXPECT().GetApplication("my-app").Return(&config.Application{Name: "my-app"}, nil)
+				m.EXPECT().GetEnvironment("my-app", "test").Return(
+					&config.Environment{
+						Name: "test",
+					}, nil)
+				m.EXPECT().GetEnvironment("my-app", "prod").Return(
+					&config.Environment{
+						Name: "prod",
+					}, nil)
+			},
+
+			expectedError: nil,
+		},
+		"success with CC repo": {
+			inAppName: "my-app",
+			inEnvs:    []string{"test", "prod"},
+			inrepoURL: "https://git-codecommit.us-west-2.amazonaws.com/v1/repos/repo-man",
 
 			setupMocks: func(m *mocks.Mockstore) {
 				m.EXPECT().GetApplication("my-app").Return(&config.Application{Name: "my-app"}, nil)
@@ -123,6 +135,7 @@ func TestInitPipelineOpts_Validate(t *testing.T) {
 		})
 	}
 }
+
 func TestInitPipelineOpts_Ask(t *testing.T) {
 	githubOwner := "badGoose"
 	githubRepoName := "chaOS"
@@ -132,6 +145,14 @@ func TestInitPipelineOpts_Ask(t *testing.T) {
 	githubAnotherURL := "git@github.com:goodGoose/bhaOS.git"
 	githubReallyBadURL := "reallybadGoosegithub.comNotEvenAURL"
 	githubToken := "hunter2"
+	codecommitRepoName := "repo-man"
+	codecommitAnotherRepoName := "repo-woman"
+	codecommitHTTPSURL := "https://git-codecommit.us-west-2.amazonaws.com/v1/repos/repo-man"
+	codecommitSSHURL := "ssh://git-codecommit.us-west-2.amazonaws.com/v1/repos/repo-woman"
+	codecommitFedURL := "codecommit::us-west-2://repo-man"
+	codecommitBadURL := "git-codecommitus-west-2amazonaws.com"
+	codecommitBadRegion := "codecommit::us-mess-2://repo-man"
+	codecommitRegion := "us-west-2"
 	testCases := map[string]struct {
 		inEnvironments      []string
 		inRepoURL           string
@@ -141,41 +162,87 @@ func TestInitPipelineOpts_Ask(t *testing.T) {
 		mockPrompt   func(m *mocks.Mockprompter)
 		mockRunner   func(m *mocks.Mockrunner)
 		mockSelector func(m *mocks.MockpipelineSelector)
+		mockStore    func(m *mocks.Mockstore)
 		buffer       bytes.Buffer
 
 		expectedEnvironments      []string
 		expectedRepoURL           string
+		expectedRepoName          string
+		expectedRepoBranch        string
 		expectedGitHubOwner       string
-		expectedGitHubRepo        string
 		expectedGitHubAccessToken string
-		expectedGitBranch         string
+		expectedCodeCommitRegion  string
 		expectedError             error
 	}{
-		"no flags, prompts for all input": {
+		"no flags, prompts for all input, success case for GitHub": {
 			inEnvironments:      []string{},
 			inRepoURL:           "",
 			inGitHubAccessToken: "",
 			inGitBranch:         "",
-			buffer:              *bytes.NewBufferString("archer\tgit@github.com:goodGoose/bhaOS (fetch)\narcher\thttps://github.com/badGoose/chaOS (push)\n"),
+			buffer:              *bytes.NewBufferString("archer\tgit@github.com:goodGoose/bhaOS (fetch)\narcher\thttps://github.com/badGoose/chaOS (push)\narcher\tcodecommit::us-west-2://repo-man (fetch)\n"),
 
 			mockSelector: func(m *mocks.MockpipelineSelector) {
 				m.EXPECT().Environments(pipelineSelectEnvPrompt, gomock.Any(), "my-app", gomock.Any()).Return([]string{"test", "prod"}, nil)
+			},
+			mockStore: func(m *mocks.Mockstore) {
+				m.EXPECT().GetEnvironment("my-app", "test").Return(&config.Environment{
+					Name:   "test",
+					Region: "us-west-2",
+				}, nil)
+				m.EXPECT().GetEnvironment("my-app", "prod").Return(&config.Environment{
+					Name:   "prod",
+					Region: "us-west-2",
+				}, nil)
 			},
 			mockRunner: func(m *mocks.Mockrunner) {
 				m.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			},
 			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().SelectOne(pipelineSelectGitHubURLPrompt, gomock.Any(), gomock.Any()).Return(githubAnotherURL, nil).Times(1)
+				m.EXPECT().SelectOne(pipelineSelectURLPrompt, gomock.Any(), gomock.Any()).Return(githubAnotherURL, nil).Times(1)
 				m.EXPECT().GetSecret(gomock.Eq("Please enter your GitHub Personal Access Token for your repository bhaOS:"), gomock.Any()).Return(githubToken, nil).Times(1)
 			},
 
 			expectedRepoURL:           githubAnotherURL,
 			expectedGitHubOwner:       githubAnotherOwner,
-			expectedGitHubRepo:        githubAnotherRepoName,
+			expectedRepoName:          githubAnotherRepoName,
 			expectedGitHubAccessToken: githubToken,
-			expectedGitBranch:         "main",
+			expectedRepoBranch:        "main",
 			expectedEnvironments:      []string{"test", "prod"},
 			expectedError:             nil,
+		},
+		"no flags, success case for CodeCommit": {
+			inEnvironments:      []string{},
+			inRepoURL:           "",
+			inGitHubAccessToken: "",
+			inGitBranch:         "",
+			buffer:              *bytes.NewBufferString("archer\tgit@github.com:goodGoose/bhaOS (fetch)\narcher\thttps://github.com/badGoose/chaOS (push)\narcher\thttps://git-codecommit.us-west-2.amazonaws.com/v1/repos/repo-man (fetch)\narcher\tssh://git-codecommit.us-west-2.amazonaws.com/v1/repos/repo-woman (push)\narcher\tcodecommit::us-west-2://repo-man (fetch)\n"),
+
+			mockSelector: func(m *mocks.MockpipelineSelector) {
+				m.EXPECT().Environments(pipelineSelectEnvPrompt, gomock.Any(), "my-app", gomock.Any()).Return([]string{"test", "prod"}, nil)
+			},
+			mockStore: func(m *mocks.Mockstore) {
+				m.EXPECT().GetEnvironment("my-app", "test").Return(&config.Environment{
+					Name:   "test",
+					Region: "us-west-2",
+				}, nil)
+				m.EXPECT().GetEnvironment("my-app", "prod").Return(&config.Environment{
+					Name:   "prod",
+					Region: "us-west-2",
+				}, nil)
+			},
+			mockRunner: func(m *mocks.Mockrunner) {
+				m.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			},
+			mockPrompt: func(m *mocks.Mockprompter) {
+				m.EXPECT().SelectOne(pipelineSelectURLPrompt, gomock.Any(), gomock.Any()).Return(codecommitSSHURL, nil).Times(1)
+			},
+
+			expectedRepoURL:          codecommitSSHURL,
+			expectedRepoName:         codecommitAnotherRepoName,
+			expectedRepoBranch:       "master",
+			expectedCodeCommitRegion: codecommitRegion,
+			expectedEnvironments:     []string{"test", "prod"},
+			expectedError:            nil,
 		},
 		"returns error if fail to list environments": {
 			inEnvironments: []string{},
@@ -183,6 +250,7 @@ func TestInitPipelineOpts_Ask(t *testing.T) {
 			mockSelector: func(m *mocks.MockpipelineSelector) {
 				m.EXPECT().Environments(pipelineSelectEnvPrompt, gomock.Any(), "my-app", gomock.Any()).Return(nil, errors.New("some error"))
 			},
+			mockStore:  func(m *mocks.Mockstore) {},
 			mockRunner: func(m *mocks.Mockrunner) {},
 			mockPrompt: func(m *mocks.Mockprompter) {},
 
@@ -190,7 +258,7 @@ func TestInitPipelineOpts_Ask(t *testing.T) {
 			expectedError:        fmt.Errorf("select environments: some error"),
 		},
 
-		"returns error if fail to select GitHub URL": {
+		"returns error if fail to select URL": {
 			inRepoURL:      "",
 			inEnvironments: []string{},
 			buffer:         *bytes.NewBufferString("archer\tgit@github.com:goodGoose/bhaOS (fetch)\narcher\thttps://github.com/badGoose/chaOS (push)\n"),
@@ -198,19 +266,55 @@ func TestInitPipelineOpts_Ask(t *testing.T) {
 			mockSelector: func(m *mocks.MockpipelineSelector) {
 				m.EXPECT().Environments(pipelineSelectEnvPrompt, gomock.Any(), "my-app", gomock.Any()).Return([]string{"test", "prod"}, nil)
 			},
+			mockStore: func(m *mocks.Mockstore) {
+				m.EXPECT().GetEnvironment("my-app", "test").Return(&config.Environment{
+					Name:   "test",
+					Region: "us-west-2",
+				}, nil)
+				m.EXPECT().GetEnvironment("my-app", "prod").Return(&config.Environment{
+					Name:   "prod",
+					Region: "us-west-2",
+				}, nil)
+			},
 			mockRunner: func(m *mocks.Mockrunner) {
 				m.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			},
 			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().SelectOne(pipelineSelectGitHubURLPrompt, gomock.Any(), gomock.Any()).Return("", errors.New("some error")).Times(1)
+				m.EXPECT().SelectOne(pipelineSelectURLPrompt, gomock.Any(), gomock.Any()).Return("", errors.New("some error")).Times(1)
 			},
 
 			expectedGitHubOwner:       "",
-			expectedGitHubRepo:        "",
+			expectedRepoName:          "",
 			expectedGitHubAccessToken: "",
-			expectedGitBranch:         "",
+			expectedRepoBranch:        "",
 			expectedEnvironments:      []string{"test", "prod"},
-			expectedError:             fmt.Errorf("select GitHub URL: some error"),
+			expectedError:             fmt.Errorf("select URL: some error"),
+		},
+		"returns error if select invalid URL": {
+			inRepoURL:      "",
+			inEnvironments: []string{},
+			buffer:         *bytes.NewBufferString("archer\tgit@github.com:goodGoose/bhaOS (fetch)\narcher\thttps://bitbub.com/badGoose/chaOS (push)\n"),
+			mockSelector: func(m *mocks.MockpipelineSelector) {
+				m.EXPECT().Environments(pipelineSelectEnvPrompt, gomock.Any(), "my-app", gomock.Any()).Return([]string{"test", "prod"}, nil)
+			},
+			mockStore: func(m *mocks.Mockstore) {
+				m.EXPECT().GetEnvironment("my-app", "test").Return(&config.Environment{
+					Name:   "test",
+					Region: "us-west-2",
+				}, nil)
+				m.EXPECT().GetEnvironment("my-app", "prod").Return(&config.Environment{
+					Name:   "prod",
+					Region: "us-west-2",
+				}, nil)
+			},
+			mockRunner: func(m *mocks.Mockrunner) {
+				m.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			},
+			mockPrompt: func(m *mocks.Mockprompter) {
+				m.EXPECT().SelectOne(pipelineSelectURLPrompt, gomock.Any(), gomock.Any()).Return("https://bitbub.com/badGoose/chaOS", nil).Times(1)
+			},
+
+			expectedError: fmt.Errorf("Copilot currently accepts only URLs to GitHub and CodeCommit repository sources"),
 		},
 		"returns error if fail to parse GitHub URL": {
 			inEnvironments:      []string{},
@@ -222,19 +326,29 @@ func TestInitPipelineOpts_Ask(t *testing.T) {
 			mockSelector: func(m *mocks.MockpipelineSelector) {
 				m.EXPECT().Environments(pipelineSelectEnvPrompt, gomock.Any(), "my-app", gomock.Any()).Return([]string{"test", "prod"}, nil)
 			},
+			mockStore: func(m *mocks.Mockstore) {
+				m.EXPECT().GetEnvironment("my-app", "test").Return(&config.Environment{
+					Name:   "test",
+					Region: "us-west-2",
+				}, nil)
+				m.EXPECT().GetEnvironment("my-app", "prod").Return(&config.Environment{
+					Name:   "prod",
+					Region: "us-west-2",
+				}, nil)
+			},
 			mockRunner: func(m *mocks.Mockrunner) {
 				m.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			},
 			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().SelectOne(pipelineSelectGitHubURLPrompt, gomock.Any(), []string{githubReallyBadURL}).Return(githubReallyBadURL, nil).Times(1)
+				m.EXPECT().SelectOne(pipelineSelectURLPrompt, gomock.Any(), []string{githubReallyBadURL}).Return(githubReallyBadURL, nil).Times(1)
 			},
 
 			expectedGitHubOwner:       "",
-			expectedGitHubRepo:        "",
+			expectedRepoName:          "",
 			expectedGitHubAccessToken: "",
-			expectedGitBranch:         "",
+			expectedRepoBranch:        "",
 			expectedEnvironments:      []string{"test", "prod"},
-			expectedError:             fmt.Errorf("unable to parse the GitHub repository owner and name from reallybadGoosegithub.comNotEvenAURL: please pass the repository URL with the format `--github-url https://github.com/{owner}/{repositoryName}`"),
+			expectedError:             fmt.Errorf("unable to parse the GitHub repository owner and name from reallybadGoosegithub.comNotEvenAURL: please pass the repository URL with the format `--url https://github.com/{owner}/{repositoryName}`"),
 		},
 		"returns error if fail to get GitHub access token": {
 			inEnvironments:      []string{},
@@ -246,20 +360,116 @@ func TestInitPipelineOpts_Ask(t *testing.T) {
 			mockSelector: func(m *mocks.MockpipelineSelector) {
 				m.EXPECT().Environments(pipelineSelectEnvPrompt, gomock.Any(), "my-app", gomock.Any()).Return([]string{"test", "prod"}, nil)
 			},
+			mockStore: func(m *mocks.Mockstore) {
+				m.EXPECT().GetEnvironment("my-app", "test").Return(&config.Environment{
+					Name:   "test",
+					Region: "us-west-2",
+				}, nil)
+				m.EXPECT().GetEnvironment("my-app", "prod").Return(&config.Environment{
+					Name:   "prod",
+					Region: "us-west-2",
+				}, nil)
+			},
 			mockRunner: func(m *mocks.Mockrunner) {
 				m.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			},
 			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().SelectOne(pipelineSelectGitHubURLPrompt, gomock.Any(), gomock.Any()).Return(githubURL, nil).Times(1)
+				m.EXPECT().SelectOne(pipelineSelectURLPrompt, gomock.Any(), gomock.Any()).Return(githubURL, nil).Times(1)
 				m.EXPECT().GetSecret(gomock.Eq("Please enter your GitHub Personal Access Token for your repository chaOS:"), gomock.Any()).Return("", errors.New("some error")).Times(1)
 			},
 
 			expectedGitHubOwner:       githubOwner,
-			expectedGitHubRepo:        githubRepoName,
+			expectedRepoName:          githubRepoName,
 			expectedGitHubAccessToken: "",
-			expectedGitBranch:         "main",
+			expectedRepoBranch:        "main",
 			expectedEnvironments:      []string{"test", "prod"},
 			expectedError:             fmt.Errorf("get GitHub access token: some error"),
+		},
+		"returns error if fail to parse repo name out of CodeCommit URL": {
+			inEnvironments:      []string{},
+			inGitHubAccessToken: "",
+			buffer:              *bytes.NewBufferString(""),
+
+			mockSelector: func(m *mocks.MockpipelineSelector) {
+				m.EXPECT().Environments(pipelineSelectEnvPrompt, gomock.Any(), "my-app", gomock.Any()).Return([]string{"test", "prod"}, nil)
+			},
+			mockStore: func(m *mocks.Mockstore) {
+				m.EXPECT().GetEnvironment("my-app", "test").Return(&config.Environment{
+					Name:   "test",
+					Region: "us-west-2",
+				}, nil)
+				m.EXPECT().GetEnvironment("my-app", "prod").Return(&config.Environment{
+					Name:   "prod",
+					Region: "us-west-2",
+				}, nil)
+			},
+			mockRunner: func(m *mocks.Mockrunner) {
+				m.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			},
+			mockPrompt: func(m *mocks.Mockprompter) {
+				m.EXPECT().SelectOne(pipelineSelectURLPrompt, gomock.Any(), gomock.Any()).Return(codecommitBadURL, nil).Times(1)
+			},
+
+			expectedRepoName:     "",
+			expectedEnvironments: []string{"test", "prod"},
+			expectedError:        fmt.Errorf("unable to parse the CodeCommit repository name from git-codecommitus-west-2amazonaws.com"),
+		},
+		"returns error if fail to parse region out of CodeCommit URL": {
+			buffer: *bytes.NewBufferString(""),
+
+			mockSelector: func(m *mocks.MockpipelineSelector) {
+				m.EXPECT().Environments(pipelineSelectEnvPrompt, gomock.Any(), "my-app", gomock.Any()).Return([]string{"test", "prod"}, nil)
+			},
+			mockStore: func(m *mocks.Mockstore) {
+				m.EXPECT().GetEnvironment("my-app", "test").Return(&config.Environment{
+					Name:   "test",
+					Region: "us-west-2",
+				}, nil)
+				m.EXPECT().GetEnvironment("my-app", "prod").Return(&config.Environment{
+					Name:   "prod",
+					Region: "us-west-2",
+				}, nil)
+			},
+			mockRunner: func(m *mocks.Mockrunner) {
+				m.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			},
+			mockPrompt: func(m *mocks.Mockprompter) {
+				m.EXPECT().SelectOne(pipelineSelectURLPrompt, gomock.Any(), gomock.Any()).Return(codecommitBadRegion, nil).Times(1)
+			},
+
+			expectedRepoURL:          codecommitHTTPSURL,
+			expectedRepoName:         codecommitRepoName,
+			expectedRepoBranch:       "",
+			expectedCodeCommitRegion: "",
+			expectedEnvironments:     []string{"test", "prod"},
+			expectedError:            fmt.Errorf("unable to parse the AWS region from %s", codecommitBadRegion),
+		},
+		"returns error if repo region is not an environment's region": {
+			buffer: *bytes.NewBufferString(""),
+
+			mockSelector: func(m *mocks.MockpipelineSelector) {
+				m.EXPECT().Environments(pipelineSelectEnvPrompt, gomock.Any(), "my-app", gomock.Any()).Return([]string{"test", "prod"}, nil)
+			},
+			mockStore: func(m *mocks.Mockstore) {
+				m.EXPECT().GetEnvironment("my-app", "test").Return(&config.Environment{
+					Name:   "test",
+					Region: "us-west-2",
+				}, nil)
+				m.EXPECT().GetEnvironment("my-app", "prod").Return(&config.Environment{
+					Name:   "prod",
+					Region: "us-east-1",
+				}, nil)
+			},
+			mockRunner: func(m *mocks.Mockrunner) {
+				m.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			},
+			mockPrompt: func(m *mocks.Mockprompter) {
+				m.EXPECT().SelectOne(pipelineSelectURLPrompt, gomock.Any(), gomock.Any()).Return(codecommitFedURL, nil).Times(1)
+			},
+
+			expectedRepoName:     "",
+			expectedEnvironments: []string{},
+			expectedError:        fmt.Errorf("repository repo-man is in us-west-2, but environment prod is in us-east-1; they must be in the same region"),
 		},
 	}
 
@@ -272,6 +482,7 @@ func TestInitPipelineOpts_Ask(t *testing.T) {
 			mockPrompt := mocks.NewMockprompter(ctrl)
 			mockRunner := mocks.NewMockrunner(ctrl)
 			mockSelector := mocks.NewMockpipelineSelector(ctrl)
+			mockStore := mocks.NewMockstore(ctrl)
 
 			opts := &initPipelineOpts{
 				initPipelineVars: initPipelineVars{
@@ -284,11 +495,13 @@ func TestInitPipelineOpts_Ask(t *testing.T) {
 				runner: mockRunner,
 				buffer: tc.buffer,
 				sel:    mockSelector,
+				store:  mockStore,
 			}
 
 			tc.mockPrompt(mockPrompt)
 			tc.mockRunner(mockRunner)
 			tc.mockSelector(mockSelector)
+			tc.mockStore(mockStore)
 
 			// WHEN
 			err := opts.Ask()
@@ -298,9 +511,10 @@ func TestInitPipelineOpts_Ask(t *testing.T) {
 				require.EqualError(t, err, tc.expectedError.Error())
 			} else {
 				require.NoError(t, err)
+				require.Equal(t, tc.expectedRepoName, opts.repoName)
 				require.Equal(t, tc.expectedGitHubOwner, opts.githubOwner)
-				require.Equal(t, tc.expectedGitHubRepo, opts.githubRepo)
 				require.Equal(t, tc.expectedGitHubAccessToken, opts.githubAccessToken)
+				require.Equal(t, tc.expectedCodeCommitRegion, opts.ccRegion)
 				require.ElementsMatch(t, tc.expectedEnvironments, opts.environments)
 			}
 		})
@@ -311,10 +525,12 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 	buildspecExistsErr := &workspace.ErrFileExists{FileName: "/buildspec.yml"}
 	manifestExistsErr := &workspace.ErrFileExists{FileName: "/pipeline.yml"}
 	testCases := map[string]struct {
+		inProvider     string
 		inEnvironments []string
+		inEnvConfigs   []*config.Environment
 		inGitHubToken  string
-		inGitHubRepo   string
-		inGitBranch    string
+		inRepoName     string
+		inBranch       string
 		inAppName      string
 
 		mockSecretsManager          func(m *mocks.MocksecretsManager)
@@ -326,12 +542,18 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 
 		expectedError error
 	}{
-		"creates secret and writes manifest and buildspecs": {
-			inEnvironments: []string{"test"},
-			inGitHubToken:  "hunter2",
-			inGitHubRepo:   "goose",
-			inGitBranch:    "dev",
-			inAppName:      "badgoose",
+		"creates secret and writes manifest and buildspecs for GH provider": {
+			inProvider: "GitHub",
+			inEnvConfigs: []*config.Environment{
+				{
+					Name: "test",
+					Prod: false,
+				},
+			},
+			inGitHubToken: "hunter2",
+			inRepoName:    "goose",
+			inBranch:      "dev",
+			inAppName:     "badgoose",
 
 			mockSecretsManager: func(m *mocks.MocksecretsManager) {
 				m.EXPECT().CreateSecret("github-token-badgoose-goose", "hunter2").Return("some-arn", nil)
@@ -349,9 +571,46 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 				m.EXPECT().GetApplication("badgoose").Return(&config.Application{
 					Name: "badgoose",
 				}, nil)
-				m.EXPECT().GetEnvironment("badgoose", "test").Return(&config.Environment{
+			},
+			mockRegionalResourcesGetter: func(m *mocks.MockappResourcesGetter) {
+				m.EXPECT().GetRegionalAppResources(&config.Application{
+					Name: "badgoose",
+				}).Return([]*stack.AppRegionalResources{
+					{
+						Region:   "us-west-2",
+						S3Bucket: "gooseBucket",
+					},
+				}, nil)
+			},
+			expectedError: nil,
+		},
+		"creates secret and writes manifest and buildspecs for CC provider": {
+			inProvider: "CodeCommit",
+			inEnvConfigs: []*config.Environment{
+				{
 					Name: "test",
-				}, nil).AnyTimes()
+					Prod: false,
+				},
+			},
+			inRepoName:    "goose",
+			inBranch:      "main",
+			inAppName:     "badgoose",
+			inGitHubToken: "",
+
+			mockSecretsManager: func(m *mocks.MocksecretsManager) {},
+			mockWsWriter: func(m *mocks.MockwsPipelineWriter) {
+				m.EXPECT().WritePipelineManifest(gomock.Any()).Return("/pipeline.yml", nil)
+				m.EXPECT().WritePipelineBuildspec(gomock.Any()).Return("/buildspec.yml", nil)
+			},
+			mockParser: func(m *templatemocks.MockParser) {
+				m.EXPECT().Parse(buildspecTemplatePath, gomock.Any()).Return(&template.Content{
+					Buffer: bytes.NewBufferString("hello"),
+				}, nil)
+			},
+			mockStoreSvc: func(m *mocks.Mockstore) {
+				m.EXPECT().GetApplication("badgoose").Return(&config.Application{
+					Name: "badgoose",
+				}, nil)
 			},
 			mockRegionalResourcesGetter: func(m *mocks.MockappResourcesGetter) {
 				m.EXPECT().GetRegionalAppResources(&config.Application{
@@ -366,11 +625,17 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 			expectedError: nil,
 		},
 		"does not return an error if secret already exists": {
-			inEnvironments: []string{"test"},
-			inGitHubToken:  "hunter2",
-			inGitHubRepo:   "goose",
-			inGitBranch:    "dev",
-			inAppName:      "badgoose",
+			inProvider: "GitHub",
+			inEnvConfigs: []*config.Environment{
+				{
+					Name: "test",
+					Prod: false,
+				},
+			},
+			inGitHubToken: "hunter2",
+			inRepoName:    "goose",
+			inBranch:      "dev",
+			inAppName:     "badgoose",
 
 			mockSecretsManager: func(m *mocks.MocksecretsManager) {
 				existsErr := &secretsmanager.ErrSecretAlreadyExists{}
@@ -389,9 +654,6 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 				m.EXPECT().GetApplication("badgoose").Return(&config.Application{
 					Name: "badgoose",
 				}, nil)
-				m.EXPECT().GetEnvironment("badgoose", "test").Return(&config.Environment{
-					Name: "test",
-				}, nil).AnyTimes()
 			},
 			mockRegionalResourcesGetter: func(m *mocks.MockappResourcesGetter) {
 				m.EXPECT().GetRegionalAppResources(&config.Application{
@@ -407,11 +669,17 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 			expectedError: nil,
 		},
 		"returns an error if can't write manifest": {
-			inEnvironments: []string{"test"},
-			inGitHubToken:  "hunter2",
-			inGitHubRepo:   "goose",
-			inGitBranch:    "dev",
-			inAppName:      "badgoose",
+			inProvider: "GitHub",
+			inEnvConfigs: []*config.Environment{
+				{
+					Name: "test",
+					Prod: false,
+				},
+			},
+			inGitHubToken: "hunter2",
+			inRepoName:    "goose",
+			inBranch:      "dev",
+			inAppName:     "badgoose",
 
 			mockSecretsManager: func(m *mocks.MocksecretsManager) {
 				m.EXPECT().CreateSecret("github-token-badgoose-goose", "hunter2").Return("some-arn", nil)
@@ -419,21 +687,23 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 			mockWsWriter: func(m *mocks.MockwsPipelineWriter) {
 				m.EXPECT().WritePipelineManifest(gomock.Any()).Return("", errors.New("some error"))
 			},
-			mockParser: func(m *templatemocks.MockParser) {},
-			mockStoreSvc: func(m *mocks.Mockstore) {
-				m.EXPECT().GetEnvironment("badgoose", "test").Return(&config.Environment{
-					Name: "test",
-				}, nil).AnyTimes()
-			},
+			mockParser:                  func(m *templatemocks.MockParser) {},
+			mockStoreSvc:                func(m *mocks.Mockstore) {},
 			mockRegionalResourcesGetter: func(m *mocks.MockappResourcesGetter) {},
 			expectedError:               errors.New("write pipeline manifest to workspace: some error"),
 		},
 		"returns an error if application cannot be retrieved": {
-			inEnvironments: []string{"test"},
-			inGitHubToken:  "hunter2",
-			inGitHubRepo:   "goose",
-			inGitBranch:    "dev",
-			inAppName:      "badgoose",
+			inProvider: "GitHub",
+			inEnvConfigs: []*config.Environment{
+				{
+					Name: "test",
+					Prod: false,
+				},
+			},
+			inGitHubToken: "hunter2",
+			inRepoName:    "goose",
+			inBranch:      "dev",
+			inAppName:     "badgoose",
 
 			mockSecretsManager: func(m *mocks.MocksecretsManager) {
 				m.EXPECT().CreateSecret("github-token-badgoose-goose", "hunter2").Return("some-arn", nil)
@@ -444,19 +714,22 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 			mockParser: func(m *templatemocks.MockParser) {},
 			mockStoreSvc: func(m *mocks.Mockstore) {
 				m.EXPECT().GetApplication("badgoose").Return(nil, errors.New("some error"))
-				m.EXPECT().GetEnvironment("badgoose", "test").Return(&config.Environment{
-					Name: "test",
-				}, nil).AnyTimes()
 			},
 			mockRegionalResourcesGetter: func(m *mocks.MockappResourcesGetter) {},
 			expectedError:               errors.New("get application badgoose: some error"),
 		},
 		"returns an error if can't get regional application resources": {
-			inEnvironments: []string{"test"},
-			inGitHubToken:  "hunter2",
-			inGitHubRepo:   "goose",
-			inGitBranch:    "dev",
-			inAppName:      "badgoose",
+			inProvider: "GitHub",
+			inEnvConfigs: []*config.Environment{
+				{
+					Name: "test",
+					Prod: false,
+				},
+			},
+			inGitHubToken: "hunter2",
+			inRepoName:    "goose",
+			inBranch:      "dev",
+			inAppName:     "badgoose",
 
 			mockSecretsManager: func(m *mocks.MocksecretsManager) {
 				m.EXPECT().CreateSecret("github-token-badgoose-goose", "hunter2").Return("some-arn", nil)
@@ -469,9 +742,6 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 				m.EXPECT().GetApplication("badgoose").Return(&config.Application{
 					Name: "badgoose",
 				}, nil)
-				m.EXPECT().GetEnvironment("badgoose", "test").Return(&config.Environment{
-					Name: "test",
-				}, nil).AnyTimes()
 			},
 			mockRegionalResourcesGetter: func(m *mocks.MockappResourcesGetter) {
 				m.EXPECT().GetRegionalAppResources(&config.Application{
@@ -481,11 +751,17 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 			expectedError: fmt.Errorf("get regional application resources: some error"),
 		},
 		"returns an error if buildspec cannot be parsed": {
-			inEnvironments: []string{"test"},
-			inGitHubToken:  "hunter2",
-			inGitHubRepo:   "goose",
-			inGitBranch:    "dev",
-			inAppName:      "badgoose",
+			inProvider: "GitHub",
+			inEnvConfigs: []*config.Environment{
+				{
+					Name: "test",
+					Prod: false,
+				},
+			},
+			inGitHubToken: "hunter2",
+			inRepoName:    "goose",
+			inBranch:      "dev",
+			inAppName:     "badgoose",
 
 			mockSecretsManager: func(m *mocks.MocksecretsManager) {
 				m.EXPECT().CreateSecret("github-token-badgoose-goose", "hunter2").Return("some-arn", nil)
@@ -501,9 +777,6 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 				m.EXPECT().GetApplication("badgoose").Return(&config.Application{
 					Name: "badgoose",
 				}, nil)
-				m.EXPECT().GetEnvironment("badgoose", "test").Return(&config.Environment{
-					Name: "test",
-				}, nil).AnyTimes()
 			},
 			mockRegionalResourcesGetter: func(m *mocks.MockappResourcesGetter) {
 				m.EXPECT().GetRegionalAppResources(&config.Application{
@@ -518,11 +791,17 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 			expectedError: errors.New("some error"),
 		},
 		"does not return an error if buildspec and manifest already exists": {
-			inEnvironments: []string{"test"},
-			inGitHubToken:  "hunter2",
-			inGitHubRepo:   "goose",
-			inGitBranch:    "dev",
-			inAppName:      "badgoose",
+			inProvider: "GitHub",
+			inEnvConfigs: []*config.Environment{
+				{
+					Name: "test",
+					Prod: false,
+				},
+			},
+			inGitHubToken: "hunter2",
+			inRepoName:    "goose",
+			inBranch:      "dev",
+			inAppName:     "badgoose",
 
 			mockSecretsManager: func(m *mocks.MocksecretsManager) {
 				m.EXPECT().CreateSecret("github-token-badgoose-goose", "hunter2").Return("some-arn", nil)
@@ -540,9 +819,6 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 				m.EXPECT().GetApplication("badgoose").Return(&config.Application{
 					Name: "badgoose",
 				}, nil)
-				m.EXPECT().GetEnvironment("badgoose", "test").Return(&config.Environment{
-					Name: "test",
-				}, nil).AnyTimes()
 			},
 			mockRegionalResourcesGetter: func(m *mocks.MockappResourcesGetter) {
 				m.EXPECT().GetRegionalAppResources(&config.Application{
@@ -557,11 +833,17 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 			expectedError: nil,
 		},
 		"returns an error if can't write buildspec": {
-			inEnvironments: []string{"test"},
-			inGitHubToken:  "hunter2",
-			inGitHubRepo:   "goose",
-			inGitBranch:    "dev",
-			inAppName:      "badgoose",
+			inProvider: "GitHub",
+			inEnvConfigs: []*config.Environment{
+				{
+					Name: "test",
+					Prod: false,
+				},
+			},
+			inGitHubToken: "hunter2",
+			inRepoName:    "goose",
+			inBranch:      "dev",
+			inAppName:     "badgoose",
 
 			mockSecretsManager: func(m *mocks.MocksecretsManager) {
 				m.EXPECT().CreateSecret("github-token-badgoose-goose", "hunter2").Return("some-arn", nil)
@@ -579,9 +861,6 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 				m.EXPECT().GetApplication("badgoose").Return(&config.Application{
 					Name: "badgoose",
 				}, nil)
-				m.EXPECT().GetEnvironment("badgoose", "test").Return(&config.Environment{
-					Name: "test",
-				}, nil).AnyTimes()
 			},
 			mockRegionalResourcesGetter: func(m *mocks.MockappResourcesGetter) {
 				m.EXPECT().GetRegionalAppResources(&config.Application{
@@ -618,10 +897,9 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 
 			opts := &initPipelineOpts{
 				initPipelineVars: initPipelineVars{
-					environments:      tc.inEnvironments,
-					githubRepo:        tc.inGitHubRepo,
+					provider:          tc.inProvider,
+					repoName:          tc.inRepoName,
 					githubAccessToken: tc.inGitHubToken,
-					gitBranch:         tc.inGitBranch,
 					appName:           tc.inAppName,
 				},
 
@@ -631,6 +909,7 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 				workspace:      mockWriter,
 				parser:         mockParser,
 				fs:             memFs,
+				envConfigs:     tc.inEnvConfigs,
 			}
 
 			// WHEN
@@ -648,18 +927,34 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 
 func TestInitPipelineOpts_pipelineName(t *testing.T) {
 	testCases := map[string]struct {
-		inGitHubRepo string
-		inAppName    string
-		inAppOwner   string
+		inRepoName     string
+		inAppName      string
+		inAppOwner     string
+		inProviderName string
 
-		expected string
+		expected    string
+		expectedErr error
 	}{
-		"matches repo name": {
-			inGitHubRepo: "goose",
-			inAppName:    "badgoose",
-			inAppOwner:   "david",
+		"pipeline name from GH repo": {
+			inRepoName:     "goose",
+			inAppName:      "badgoose",
+			inAppOwner:     "david",
+			inProviderName: "GitHub",
 
 			expected: "pipeline-badgoose-david-goose",
+		},
+		"pipeline name from CC repo": {
+			inRepoName:     "repo-man",
+			inAppName:      "goodmoose",
+			inProviderName: "CodeCommit",
+
+			expected: "pipeline-goodmoose-repo-man",
+		},
+		"cannot piece together pipeline name bc unidentified provider": {
+			inRepoName:     "repo-man",
+			inProviderName: "BadProvider",
+
+			expectedErr: errors.New("unable to create pipeline name for repo repo-man from provider BadProvider"),
 		},
 	}
 
@@ -668,17 +963,22 @@ func TestInitPipelineOpts_pipelineName(t *testing.T) {
 			// GIVEN
 			opts := &initPipelineOpts{
 				initPipelineVars: initPipelineVars{
-					githubRepo:  tc.inGitHubRepo,
+					repoName:    tc.inRepoName,
 					appName:     tc.inAppName,
 					githubOwner: tc.inAppOwner,
+					provider:    tc.inProviderName,
 				},
 			}
 
 			// WHEN
-			actual := opts.pipelineName()
+			actual, err := opts.pipelineName()
 
 			// THEN
-			require.Equal(t, tc.expected, actual)
+			if tc.expectedErr != nil {
+				require.EqualError(t, err, tc.expectedErr.Error())
+			} else {
+				require.Equal(t, tc.expected, actual)
+			}
 		})
 	}
 }
@@ -694,12 +994,15 @@ func TestInitPipelineOpts_parseGitRemoteResult(t *testing.T) {
 			inRemoteResult: `badgoose	git@github.com:badgoose/grit.git (fetch)
 badgoose	https://github.com/badgoose/cli.git (fetch)
 origin	https://github.com/koke/grit (fetch)
-koke	git://github.com/koke/grit.git (push)`,
+koke	git://github.com/koke/grit.git (push)
+https	https://git-codecommit.us-west-2.amazonaws.com/v1/repos/aws-sample (fetch)
+fed	codecommit::us-west-2://aws-sample (fetch)
+ssh	ssh://git-codecommit.us-west-2.amazonaws.com/v1/repos/aws-sample (push)`,
 
-			expectedURLs:  []string{"git@github.com:badgoose/grit", "https://github.com/badgoose/cli", "https://github.com/koke/grit", "git://github.com/koke/grit"},
+			expectedURLs:  []string{"git@github.com:badgoose/grit", "https://github.com/badgoose/cli", "https://github.com/koke/grit", "git://github.com/koke/grit", "https://git-codecommit.us-west-2.amazonaws.com/v1/repos/aws-sample", "codecommit::us-west-2://aws-sample", "ssh://git-codecommit.us-west-2.amazonaws.com/v1/repos/aws-sample"},
 			expectedError: nil,
 		},
-		"don't add to URL list if it is not a github URL": {
+		"don't add to URL list if it is not a GitHub or CodeCommit URL": {
 			inRemoteResult: `badgoose	verybad@gitlab.com/whatever (fetch)`,
 
 			expectedURLs:  []string{},
@@ -751,7 +1054,7 @@ func TestInitPipelineOpts_parseOwnerRepoName(t *testing.T) {
 
 			expectedOwner: "",
 			expectedRepo:  "",
-			expectedError: fmt.Errorf("unable to parse the GitHub repository owner and name from https://git-codecommit.us-east-1.amazonaws.com/v1/repos/whatever: please pass the repository URL with the format `--github-url https://github.com/{owner}/{repositoryName}`"),
+			expectedError: fmt.Errorf("unable to parse the GitHub repository owner and name from https://git-codecommit.us-east-1.amazonaws.com/v1/repos/whatever: please pass the repository URL with the format `--url https://github.com/{owner}/{repositoryName}`"),
 		},
 	}
 
@@ -769,6 +1072,96 @@ func TestInitPipelineOpts_parseOwnerRepoName(t *testing.T) {
 			} else {
 				require.Equal(t, tc.expectedOwner, owner)
 				require.Equal(t, tc.expectedRepo, repo)
+			}
+		})
+	}
+}
+
+func TestInitPipelineOpts_parseRepoName(t *testing.T) {
+	testCases := map[string]struct {
+		inRepoURL string
+
+		expectedRepo  string
+		expectedError error
+	}{
+		"matches repo name with https url": {
+			inRepoURL: "https://git-codecommit.us-west-2.amazonaws.com/v1/repos/aws-sample",
+
+			expectedRepo:  "aws-sample",
+			expectedError: nil,
+		},
+		"matches repo name with ssh url": {
+			inRepoURL: "ssh://git-codecommit.us-west-2.amazonaws.com/v1/repos/aws-sample",
+
+			expectedRepo:  "aws-sample",
+			expectedError: nil,
+		},
+		"matches repo name with federated (GRC) url": {
+			inRepoURL: "codecommit::us-west-2://aws-sample",
+
+			expectedRepo:  "aws-sample",
+			expectedError: nil,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// GIVEN
+			opts := &initPipelineOpts{}
+
+			// WHEN
+			repo, err := opts.parseRepoName(tc.inRepoURL)
+
+			// THEN
+			if tc.expectedError != nil {
+				require.EqualError(t, err, tc.expectedError.Error())
+			} else {
+				require.Equal(t, tc.expectedRepo, repo)
+			}
+		})
+	}
+}
+
+func TestInitPipelineOpts_parseRegion(t *testing.T) {
+	testCases := map[string]struct {
+		inRepoURL string
+
+		expectedRegion string
+		expectedError  error
+	}{
+		"matches region with https url": {
+			inRepoURL: "https://git-codecommit.sa-east-1.amazonaws.com/v1/repos/aws-sample",
+
+			expectedRegion: "sa-east-1",
+			expectedError:  nil,
+		},
+		"matches repo name with ssh url": {
+			inRepoURL: "ssh://git-codecommit.us-east-2.amazonaws.com/v1/repos/aws-sample",
+
+			expectedRegion: "us-east-2",
+			expectedError:  nil,
+		},
+		"matches repo name with federated (GRC) url": {
+			inRepoURL: "codecommit::us-gov-west-1://aws-sample",
+
+			expectedRegion: "us-gov-west-1",
+			expectedError:  nil,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// GIVEN
+			opts := &initPipelineOpts{}
+
+			// WHEN
+			region, err := opts.parseRegion(tc.inRepoURL)
+
+			// THEN
+			if tc.expectedError != nil {
+				require.EqualError(t, err, tc.expectedError.Error())
+			} else {
+				require.Equal(t, tc.expectedRegion, region)
 			}
 		})
 	}

--- a/internal/pkg/cli/pipeline_init_test.go
+++ b/internal/pkg/cli/pipeline_init_test.go
@@ -897,8 +897,6 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 
 			opts := &initPipelineOpts{
 				initPipelineVars: initPipelineVars{
-					provider:          tc.inProvider,
-					repoName:          tc.inRepoName,
 					githubAccessToken: tc.inGitHubToken,
 					appName:           tc.inAppName,
 				},
@@ -910,6 +908,8 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 				parser:         mockParser,
 				fs:             memFs,
 				envConfigs:     tc.inEnvConfigs,
+				provider:       tc.inProvider,
+				repoName:       tc.inRepoName,
 			}
 
 			// WHEN
@@ -963,11 +963,11 @@ func TestInitPipelineOpts_pipelineName(t *testing.T) {
 			// GIVEN
 			opts := &initPipelineOpts{
 				initPipelineVars: initPipelineVars{
-					repoName:    tc.inRepoName,
-					appName:     tc.inAppName,
-					githubOwner: tc.inAppOwner,
-					provider:    tc.inProviderName,
+					appName: tc.inAppName,
 				},
+				githubOwner: tc.inAppOwner,
+				provider:    tc.inProviderName,
+				repoName:    tc.inRepoName,
 			}
 
 			// WHEN

--- a/internal/pkg/deploy/pipeline.go
+++ b/internal/pkg/deploy/pipeline.go
@@ -80,7 +80,7 @@ type Source struct {
 
 // GitHubPersonalAccessTokenSecretID returns the ID of the secret in the
 // Secrets manager, which stores the GitHub Personal Access token if the
-// provider is "GitHub". Otherwise, it returns an error.
+// provider is "GitHub". Otherwise, it returns the detected provider.
 func (s *Source) GitHubPersonalAccessTokenSecretID() (string, error) {
 	// TODO type check if properties are GitHubProperties?
 	secretID, exists := s.Properties[manifest.GithubSecretIdKeyName]
@@ -94,7 +94,7 @@ func (s *Source) GitHubPersonalAccessTokenSecretID() (string, error) {
 	}
 
 	if s.ProviderName != manifest.GithubProviderName {
-		return "", fmt.Errorf("failed attempt to retrieve GitHub token from a non-GitHub provider")
+		return fmt.Sprintf("Non-GitHub provider detected: %s", s.ProviderName), nil
 	}
 
 	return id, nil

--- a/internal/pkg/manifest/pipeline.go
+++ b/internal/pkg/manifest/pipeline.go
@@ -13,8 +13,9 @@ import (
 )
 
 const (
-	GithubProviderName    = "GitHub"
-	GithubSecretIdKeyName = "access_token_secret"
+	GithubProviderName     = "GitHub"
+	CodeCommitProviderName = "CodeCommit"
+	GithubSecretIdKeyName  = "access_token_secret"
 
 	pipelineManifestPath = "cicd/pipeline.yml"
 )
@@ -43,6 +44,22 @@ func (p *githubProvider) Properties() map[string]interface{} {
 	return structs.Map(p.properties)
 }
 
+type codecommitProvider struct {
+	properties *CodeCommitProperties
+}
+
+func (p *codecommitProvider) Name() string {
+	return CodeCommitProviderName
+}
+
+func (p *codecommitProvider) String() string {
+	return CodeCommitProviderName
+}
+
+func (p *codecommitProvider) Properties() map[string]interface{} {
+	return structs.Map(p.properties)
+}
+
 // GitHubProperties contain information for configuring a Github
 // source provider.
 type GitHubProperties struct {
@@ -55,12 +72,23 @@ type GitHubProperties struct {
 	GithubSecretIdKeyName string `structs:"access_token_secret" yaml:"access_token_secret"`
 }
 
+// CodeCommitProperties contains information for configuring a CodeCommit
+// source provider.
+type CodeCommitProperties struct {
+	Repository string `structs:"repository" yaml:"repository"`
+	Branch     string `structs:"branch" yaml:"branch"`
+}
+
 // NewProvider creates a source provider based on the type of
 // the provided provider-specific configurations
 func NewProvider(configs interface{}) (Provider, error) {
 	switch props := configs.(type) {
 	case *GitHubProperties:
 		return &githubProvider{
+			properties: props,
+		}, nil
+	case *CodeCommitProperties:
+		return &codecommitProvider{
 			properties: props,
 		}, nil
 	default:


### PR DESCRIPTION
These changes enable users who are connected to a CodeConnect repo to use it as a pipeline source through pipeline.yml and buildspec.yml creation.

CFN template generation/update will come in the next PR.

Related #781, #1339.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
