### PR TITLE
chore(selector): add running tasks selector

### DIFF
--- a/internal/pkg/aws/ecs/ecs.go
+++ b/internal/pkg/aws/ecs/ecs.go
@@ -90,6 +90,10 @@ func (e *ECS) RunningTasksInFamily(cluster, family string) ([]*Task, error) {
 	return e.listTasks(cluster, withFamily(family), withRunningTasks())
 }
 
+func (e *ECS) RunningTasks(cluster string) ([]*Task, error) {
+	return e.listTasks(cluster, withRunningTasks())
+}
+
 type listTasksOpts func(*ecs.ListTasksInput)
 
 func withService(svcName string) listTasksOpts {

--- a/internal/pkg/aws/ecs/task.go
+++ b/internal/pkg/aws/ecs/task.go
@@ -34,6 +34,19 @@ type Image struct {
 // Task wraps up ECS Task struct.
 type Task ecs.Task
 
+// String returns the human readable format of an ECS task.
+// For example, a task with ARN arn:aws:ecs:us-west-2:123456789:task/4082490ee6c245e09d2145010aa1ba8d
+// and task definition ARN arn:aws:ecs:us-west-2:123456789012:task-definition/sample-fargate:2
+// becomes "4082490e (sample-fargate:2)"
+func (t Task) String() string {
+	taskID, _ := TaskID(aws.StringValue(t.TaskArn))
+	if len(taskID) >= shortTaskIDLength {
+		taskID = taskID[:shortTaskIDLength]
+	}
+	taskDefName, _ := taskDefinitionName(aws.StringValue(t.TaskDefinitionArn))
+	return fmt.Sprintf("%s (%s)", taskID, taskDefName)
+}
+
 // TaskStatus returns the status of the running task.
 func (t *Task) TaskStatus() (*TaskStatus, error) {
 	taskID, err := TaskID(aws.StringValue(t.TaskArn))
@@ -190,4 +203,16 @@ func taskHealthColor(status string) string {
 // becomes 18f7eb6cff6e63e5f5273fb53f672975fe6044580f66c354f55d2de8dd28aec7.
 func imageDigestValue(digest string) string {
 	return strings.TrimPrefix(digest, imageDigestPrefix)
+}
+
+// taskDefinitionName parses the task definition ARN and returns the task definition name.
+// For example: arn:aws:ecs:us-west-2:123456789012:task-definition/sample-fargate:2
+// returns sample-fargate:2
+func taskDefinitionName(taskDefARN string) (string, error) {
+	parsedARN, err := arn.Parse(taskDefARN)
+	if err != nil {
+		return "", fmt.Errorf("parse ECS task definition ARN: %w", err)
+	}
+	resources := strings.Split(parsedARN.Resource, "/")
+	return resources[len(resources)-1], nil
 }

--- a/internal/pkg/ecs/ecs.go
+++ b/internal/pkg/ecs/ecs.go
@@ -6,7 +6,9 @@ package ecs
 
 import (
 	"fmt"
+	"strings"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/copilot-cli/internal/pkg/aws/ecs"
 	"github.com/aws/copilot-cli/internal/pkg/aws/resourcegroups"
@@ -15,6 +17,7 @@ import (
 
 const (
 	fmtWorkloadTaskDefinitionFamily = "%s-%s-%s"
+	fmtTaskTaskDefinitionFamily     = "copilot-%s"
 	clusterResourceType             = "ecs:cluster"
 	serviceResourceType             = "ecs:service"
 )
@@ -25,7 +28,9 @@ type resourceGetter interface {
 
 type ecsClient interface {
 	RunningTasksInFamily(cluster, family string) ([]*ecs.Task, error)
+	RunningTasks(cluster string) ([]*ecs.Task, error)
 	ServiceTasks(clusterName, serviceName string) ([]*ecs.Task, error)
+	DefaultCluster() (string, error)
 }
 
 // ServiceDesc contains the description of an ECS service.
@@ -131,4 +136,83 @@ func (c Client) ListActiveWorkloadTasks(app, env, workload string) (clusterARN s
 		taskARNs = append(taskARNs, *task.TaskArn)
 	}
 	return
+}
+
+// ListActiveAppEnvTasksOpts contains the parameters for ListActiveAppEnvTasks.
+type ListActiveAppEnvTasksOpts struct {
+	App string
+	Env string
+	ListTasksFilter
+}
+
+// ListTasksFilter contains the filtering parameters for listing Copilot tasks.
+type ListTasksFilter struct {
+	TaskGroup string
+	TaskID    string
+}
+
+type listActiveCopilotTasksOpts struct {
+	Cluster string
+	ListTasksFilter
+}
+
+// ListActiveAppEnvTasks returns the active Copilot tasks in the environment of an application.
+func (c Client) ListActiveAppEnvTasks(opts ListActiveAppEnvTasksOpts) ([]*ecs.Task, error) {
+	clusterARN, err := c.ClusterARN(opts.App, opts.Env)
+	if err != nil {
+		return nil, fmt.Errorf("get cluster for env %s: %w", opts.Env, err)
+	}
+	return c.listActiveCopilotTasks(listActiveCopilotTasksOpts{
+		Cluster:         clusterARN,
+		ListTasksFilter: opts.ListTasksFilter,
+	})
+}
+
+// ListActiveDefaultClusterTasks returns the active Copilot tasks in the default cluster.
+func (c Client) ListActiveDefaultClusterTasks(filter ListTasksFilter) ([]*ecs.Task, error) {
+	defaultCluster, err := c.ecsClient.DefaultCluster()
+	if err != nil {
+		return nil, fmt.Errorf("get default cluster: %w", err)
+	}
+	return c.listActiveCopilotTasks(listActiveCopilotTasksOpts{
+		Cluster:         defaultCluster,
+		ListTasksFilter: filter,
+	})
+}
+
+func (c Client) listActiveCopilotTasks(opts listActiveCopilotTasksOpts) ([]*ecs.Task, error) {
+	var tasks []*ecs.Task
+	if opts.TaskGroup != "" {
+		tdFamilyName := fmt.Sprintf(fmtTaskTaskDefinitionFamily, opts.TaskGroup)
+		resp, err := c.ecsClient.RunningTasksInFamily(opts.Cluster, tdFamilyName)
+		if err != nil {
+			return nil, fmt.Errorf("list running tasks that belong to family %s in cluster %s: %w", tdFamilyName, opts.Cluster, err)
+		}
+		tasks = resp
+	} else {
+		resp, err := c.ecsClient.RunningTasks(opts.Cluster)
+		if err != nil {
+			return nil, fmt.Errorf("list running tasks in cluster %s: %w", opts.Cluster, err)
+		}
+		tasks = resp
+	}
+	return filterCopilotTask(tasks, opts.TaskID), nil
+}
+
+func filterCopilotTask(tasks []*ecs.Task, taskID string) []*ecs.Task {
+	var filteredTasks []*ecs.Task
+	for _, task := range tasks {
+		var copilotTask bool
+		for _, tag := range task.Tags {
+			if aws.StringValue(tag.Key) == deploy.TaskTagKey {
+				copilotTask = true
+				break
+			}
+		}
+		id, _ := ecs.TaskID(aws.StringValue(task.TaskArn))
+		if copilotTask && strings.Contains(id, taskID) {
+			filteredTasks = append(filteredTasks, task)
+		}
+	}
+	return filteredTasks
 }

--- a/internal/pkg/ecs/mocks/mock_ecs.go
+++ b/internal/pkg/ecs/mocks/mock_ecs.go
@@ -87,6 +87,21 @@ func (mr *MockecsClientMockRecorder) RunningTasksInFamily(cluster, family interf
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunningTasksInFamily", reflect.TypeOf((*MockecsClient)(nil).RunningTasksInFamily), cluster, family)
 }
 
+// RunningTasks mocks base method
+func (m *MockecsClient) RunningTasks(cluster string) ([]*ecs.Task, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RunningTasks", cluster)
+	ret0, _ := ret[0].([]*ecs.Task)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RunningTasks indicates an expected call of RunningTasks
+func (mr *MockecsClientMockRecorder) RunningTasks(cluster interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunningTasks", reflect.TypeOf((*MockecsClient)(nil).RunningTasks), cluster)
+}
+
 // ServiceTasks mocks base method
 func (m *MockecsClient) ServiceTasks(clusterName, serviceName string) ([]*ecs.Task, error) {
 	m.ctrl.T.Helper()
@@ -100,4 +115,19 @@ func (m *MockecsClient) ServiceTasks(clusterName, serviceName string) ([]*ecs.Ta
 func (mr *MockecsClientMockRecorder) ServiceTasks(clusterName, serviceName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceTasks", reflect.TypeOf((*MockecsClient)(nil).ServiceTasks), clusterName, serviceName)
+}
+
+// DefaultCluster mocks base method
+func (m *MockecsClient) DefaultCluster() (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DefaultCluster")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DefaultCluster indicates an expected call of DefaultCluster
+func (mr *MockecsClientMockRecorder) DefaultCluster() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DefaultCluster", reflect.TypeOf((*MockecsClient)(nil).DefaultCluster))
 }

--- a/internal/pkg/term/selector/mocks/mock_selector.go
+++ b/internal/pkg/term/selector/mocks/mock_selector.go
@@ -5,7 +5,9 @@
 package mocks
 
 import (
+	ecs "github.com/aws/copilot-cli/internal/pkg/aws/ecs"
 	config "github.com/aws/copilot-cli/internal/pkg/config"
+	ecs0 "github.com/aws/copilot-cli/internal/pkg/ecs"
 	prompt "github.com/aws/copilot-cli/internal/pkg/term/prompt"
 	workspace "github.com/aws/copilot-cli/internal/pkg/workspace"
 	gomock "github.com/golang/mock/gomock"
@@ -551,4 +553,57 @@ func (m *MockDeployStoreClient) IsServiceDeployed(appName, envName, svcName stri
 func (mr *MockDeployStoreClientMockRecorder) IsServiceDeployed(appName, envName, svcName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsServiceDeployed", reflect.TypeOf((*MockDeployStoreClient)(nil).IsServiceDeployed), appName, envName, svcName)
+}
+
+// MockTaskLister is a mock of TaskLister interface
+type MockTaskLister struct {
+	ctrl     *gomock.Controller
+	recorder *MockTaskListerMockRecorder
+}
+
+// MockTaskListerMockRecorder is the mock recorder for MockTaskLister
+type MockTaskListerMockRecorder struct {
+	mock *MockTaskLister
+}
+
+// NewMockTaskLister creates a new mock instance
+func NewMockTaskLister(ctrl *gomock.Controller) *MockTaskLister {
+	mock := &MockTaskLister{ctrl: ctrl}
+	mock.recorder = &MockTaskListerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockTaskLister) EXPECT() *MockTaskListerMockRecorder {
+	return m.recorder
+}
+
+// ListActiveAppEnvTasks mocks base method
+func (m *MockTaskLister) ListActiveAppEnvTasks(opts ecs0.ListActiveAppEnvTasksOpts) ([]*ecs.Task, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListActiveAppEnvTasks", opts)
+	ret0, _ := ret[0].([]*ecs.Task)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListActiveAppEnvTasks indicates an expected call of ListActiveAppEnvTasks
+func (mr *MockTaskListerMockRecorder) ListActiveAppEnvTasks(opts interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListActiveAppEnvTasks", reflect.TypeOf((*MockTaskLister)(nil).ListActiveAppEnvTasks), opts)
+}
+
+// ListActiveDefaultClusterTasks mocks base method
+func (m *MockTaskLister) ListActiveDefaultClusterTasks(filter ecs0.ListTasksFilter) ([]*ecs.Task, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListActiveDefaultClusterTasks", filter)
+	ret0, _ := ret[0].([]*ecs.Task)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListActiveDefaultClusterTasks indicates an expected call of ListActiveDefaultClusterTasks
+func (mr *MockTaskListerMockRecorder) ListActiveDefaultClusterTasks(filter interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListActiveDefaultClusterTasks", reflect.TypeOf((*MockTaskLister)(nil).ListActiveDefaultClusterTasks), filter)
 }


### PR DESCRIPTION
<!-- Provide summary of changes -->
Add `RunningTask()` to `selector` pkg, allowing to select a running copilot task.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
