### PR TITLE
chore(deploy): add DeployAndRenderEnvironment method

### DIFF
--- a/internal/pkg/aws/cloudformation/changeset.go
+++ b/internal/pkg/aws/cloudformation/changeset.go
@@ -6,6 +6,7 @@ package cloudformation
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
@@ -26,6 +27,7 @@ const (
 type ChangeSetDescription struct {
 	ExecutionStatus string
 	StatusReason    string
+	CreationTime    time.Time
 	Changes         []*cloudformation.Change
 }
 
@@ -123,6 +125,7 @@ func (cs *changeSet) create(conf *stackConfig) error {
 // describe collects all the changes and statuses that the change set will apply and returns them.
 func (cs *changeSet) describe() (*ChangeSetDescription, error) {
 	var executionStatus, statusReason string
+	var creationTime time.Time
 	var changes []*cloudformation.Change
 	var nextToken *string
 	for {
@@ -136,6 +139,7 @@ func (cs *changeSet) describe() (*ChangeSetDescription, error) {
 		}
 		executionStatus = aws.StringValue(out.ExecutionStatus)
 		statusReason = aws.StringValue(out.StatusReason)
+		creationTime = aws.TimeValue(out.CreationTime)
 		changes = append(changes, out.Changes...)
 		nextToken = out.NextToken
 
@@ -146,6 +150,7 @@ func (cs *changeSet) describe() (*ChangeSetDescription, error) {
 	return &ChangeSetDescription{
 		ExecutionStatus: executionStatus,
 		StatusReason:    statusReason,
+		CreationTime:    creationTime,
 		Changes:         changes,
 	}, nil
 }

--- a/internal/pkg/aws/cloudformation/cloudformation.go
+++ b/internal/pkg/aws/cloudformation/cloudformation.go
@@ -79,7 +79,7 @@ func (c *CloudFormation) CreateAndWait(stack *Stack) error {
 	if _, err := c.Create(stack); err != nil {
 		return err
 	}
-	return c.WaitForCreate(stack.Name)
+	return c.WaitForCreate(context.Background(), stack.Name)
 }
 
 // DescribeChangeSet gathers and returns all changes for a change set.
@@ -93,8 +93,8 @@ func (c *CloudFormation) DescribeChangeSet(changeSetID string) (*ChangeSetDescri
 }
 
 // WaitForCreate blocks until the stack is created or until the max attempt window expires.
-func (c *CloudFormation) WaitForCreate(stackName string) error {
-	err := c.client.WaitUntilStackCreateCompleteWithContext(context.Background(), &cloudformation.DescribeStacksInput{
+func (c *CloudFormation) WaitForCreate(ctx context.Context, stackName string) error {
+	err := c.client.WaitUntilStackCreateCompleteWithContext(ctx, &cloudformation.DescribeStacksInput{
 		StackName: aws.String(stackName),
 	}, waiters...)
 	if err != nil {
@@ -124,12 +124,12 @@ func (c *CloudFormation) UpdateAndWait(stack *Stack) error {
 	if err := c.Update(stack); err != nil {
 		return err
 	}
-	return c.WaitForUpdate(stack.Name)
+	return c.WaitForUpdate(context.Background(), stack.Name)
 }
 
 // WaitForUpdate blocks until the stack is updated or until the max attempt window expires.
-func (c *CloudFormation) WaitForUpdate(stackName string) error {
-	err := c.client.WaitUntilStackUpdateCompleteWithContext(context.Background(), &cloudformation.DescribeStacksInput{
+func (c *CloudFormation) WaitForUpdate(ctx context.Context, stackName string) error {
+	err := c.client.WaitUntilStackUpdateCompleteWithContext(ctx, &cloudformation.DescribeStacksInput{
 		StackName: aws.String(stackName),
 	}, waiters...)
 	if err != nil {

--- a/internal/pkg/aws/cloudformation/cloudformation.go
+++ b/internal/pkg/aws/cloudformation/cloudformation.go
@@ -33,13 +33,13 @@ var waiters = []request.WaiterOption{
 
 // CloudFormation represents a client to make requests to AWS CloudFormation.
 type CloudFormation struct {
-	client api
+	client
 }
 
 // New creates a new CloudFormation client.
 func New(s *session.Session) *CloudFormation {
 	return &CloudFormation{
-		client: cloudformation.New(s),
+		cloudformation.New(s),
 	}
 }
 

--- a/internal/pkg/aws/cloudformation/cloudformation.go
+++ b/internal/pkg/aws/cloudformation/cloudformation.go
@@ -59,7 +59,7 @@ func (c *CloudFormation) Create(stack *Stack) (changeSetID string, err error) {
 	if status.requiresCleanup() {
 		// If the stack exists, but failed to create, we'll clean it up and then re-create it.
 		if err := c.Delete(stack.Name); err != nil {
-			return "", fmt.Errorf("cleanup previously failed stack %s: %w", stack.Name, err)
+			return "", fmt.Errorf("clean up previously failed stack %s: %w", stack.Name, err)
 		}
 		return c.create(stack)
 	}

--- a/internal/pkg/aws/cloudformation/cloudformation_test.go
+++ b/internal/pkg/aws/cloudformation/cloudformation_test.go
@@ -5,6 +5,7 @@ package cloudformation
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -233,7 +234,7 @@ func TestCloudFormation_WaitForCreate(t *testing.T) {
 			}
 
 			// WHEN
-			err := c.WaitForCreate(mockStack.Name)
+			err := c.WaitForCreate(context.Background(), mockStack.Name)
 
 			// THEN
 			require.Equal(t, tc.wantedErr, err)

--- a/internal/pkg/aws/cloudformation/cloudformation_test.go
+++ b/internal/pkg/aws/cloudformation/cloudformation_test.go
@@ -37,7 +37,7 @@ func TestCloudFormation_Create(t *testing.T) {
 	}{
 		"fail if checking the stack description fails": {
 			createMock: func(ctrl *gomock.Controller) client {
-				m := mocks.NewMockapi(ctrl)
+				m := mocks.NewMockclient(ctrl)
 				m.EXPECT().DescribeStacks(&cloudformation.DescribeStacksInput{
 					StackName: aws.String(mockStack.Name),
 				}).Return(nil, errors.New("some unexpected error"))
@@ -47,7 +47,7 @@ func TestCloudFormation_Create(t *testing.T) {
 		},
 		"fail if a stack exists that's already in progress": {
 			createMock: func(ctrl *gomock.Controller) client {
-				m := mocks.NewMockapi(ctrl)
+				m := mocks.NewMockclient(ctrl)
 				m.EXPECT().DescribeStacks(gomock.Any()).Return(&cloudformation.DescribeStacksOutput{
 					Stacks: []*cloudformation.Stack{
 						{
@@ -63,7 +63,7 @@ func TestCloudFormation_Create(t *testing.T) {
 		},
 		"fail if a successfully created stack already exists": {
 			createMock: func(ctrl *gomock.Controller) client {
-				m := mocks.NewMockapi(ctrl)
+				m := mocks.NewMockclient(ctrl)
 				m.EXPECT().DescribeStacks(gomock.Any()).Return(&cloudformation.DescribeStacksOutput{
 					Stacks: []*cloudformation.Stack{
 						{
@@ -82,7 +82,7 @@ func TestCloudFormation_Create(t *testing.T) {
 		},
 		"creates the stack if it doesn't exist": {
 			createMock: func(ctrl *gomock.Controller) client {
-				m := mocks.NewMockapi(ctrl)
+				m := mocks.NewMockclient(ctrl)
 				m.EXPECT().DescribeStacks(gomock.Any()).Return(nil, errDoesNotExist)
 				addCreateDeployCalls(m)
 				return m
@@ -90,7 +90,7 @@ func TestCloudFormation_Create(t *testing.T) {
 		},
 		"creates the stack after cleaning the previously failed execution": {
 			createMock: func(ctrl *gomock.Controller) client {
-				m := mocks.NewMockapi(ctrl)
+				m := mocks.NewMockclient(ctrl)
 				m.EXPECT().DescribeStacks(gomock.Any()).Return(&cloudformation.DescribeStacksOutput{
 					Stacks: []*cloudformation.Stack{
 						{
@@ -140,7 +140,7 @@ func TestCloudFormation_DescribeChangeSet(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		m := mocks.NewMockapi(ctrl)
+		m := mocks.NewMockclient(ctrl)
 		m.EXPECT().DescribeChangeSet(gomock.Any()).Return(nil, errors.New("some error"))
 		cfn := CloudFormation{
 			client: m,
@@ -159,7 +159,7 @@ func TestCloudFormation_DescribeChangeSet(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		m := mocks.NewMockapi(ctrl)
+		m := mocks.NewMockclient(ctrl)
 		wantedChanges := []*cloudformation.Change{
 			{
 				ResourceChange: &cloudformation.ResourceChange{
@@ -214,7 +214,7 @@ func TestCloudFormation_WaitForCreate(t *testing.T) {
 	}{
 		"wraps error on failure": {
 			createMock: func(ctrl *gomock.Controller) client {
-				m := mocks.NewMockapi(ctrl)
+				m := mocks.NewMockclient(ctrl)
 				m.EXPECT().WaitUntilStackCreateCompleteWithContext(gomock.Any(), &cloudformation.DescribeStacksInput{
 					StackName: aws.String(mockStack.Name),
 				}, gomock.Any()).Return(errors.New("some error"))
@@ -249,7 +249,7 @@ func TestCloudFormation_Update(t *testing.T) {
 	}{
 		"fail if the stack is already in progress": {
 			createMock: func(ctrl *gomock.Controller) client {
-				m := mocks.NewMockapi(ctrl)
+				m := mocks.NewMockclient(ctrl)
 				m.EXPECT().DescribeStacks(gomock.Any()).Return(&cloudformation.DescribeStacksOutput{
 					Stacks: []*cloudformation.Stack{
 						{
@@ -265,7 +265,7 @@ func TestCloudFormation_Update(t *testing.T) {
 		},
 		"update a previously existing stack": {
 			createMock: func(ctrl *gomock.Controller) client {
-				m := mocks.NewMockapi(ctrl)
+				m := mocks.NewMockclient(ctrl)
 				m.EXPECT().DescribeStacks(gomock.Any()).Return(&cloudformation.DescribeStacksOutput{
 					Stacks: []*cloudformation.Stack{
 						{
@@ -308,7 +308,7 @@ func TestCloudFormation_UpdateAndWait(t *testing.T) {
 	}{
 		"waits until the stack is created": {
 			createMock: func(ctrl *gomock.Controller) client {
-				m := mocks.NewMockapi(ctrl)
+				m := mocks.NewMockclient(ctrl)
 				m.EXPECT().DescribeStacks(gomock.Any()).Return(&cloudformation.DescribeStacksOutput{
 					Stacks: []*cloudformation.Stack{
 						{
@@ -354,7 +354,7 @@ func TestCloudFormation_Delete(t *testing.T) {
 	}{
 		"fails on unexpected error": {
 			createMock: func(ctrl *gomock.Controller) client {
-				m := mocks.NewMockapi(ctrl)
+				m := mocks.NewMockclient(ctrl)
 				m.EXPECT().DeleteStack(gomock.Any()).Return(nil, errors.New("some error"))
 				return m
 			},
@@ -362,7 +362,7 @@ func TestCloudFormation_Delete(t *testing.T) {
 		},
 		"exits successfully if stack does not exist": {
 			createMock: func(ctrl *gomock.Controller) client {
-				m := mocks.NewMockapi(ctrl)
+				m := mocks.NewMockclient(ctrl)
 				m.EXPECT().DeleteStack(&cloudformation.DeleteStackInput{
 					StackName: aws.String(mockStack.Name),
 				}).Return(nil, errDoesNotExist)
@@ -371,7 +371,7 @@ func TestCloudFormation_Delete(t *testing.T) {
 		},
 		"exits successfully if stack can be deleted": {
 			createMock: func(ctrl *gomock.Controller) client {
-				m := mocks.NewMockapi(ctrl)
+				m := mocks.NewMockclient(ctrl)
 				m.EXPECT().DeleteStack(&cloudformation.DeleteStackInput{
 					StackName: aws.String(mockStack.Name),
 				}).Return(nil, nil)
@@ -405,7 +405,7 @@ func TestCloudFormation_DeleteAndWait(t *testing.T) {
 	}{
 		"skip waiting if stack does not exist": {
 			createMock: func(ctrl *gomock.Controller) client {
-				m := mocks.NewMockapi(ctrl)
+				m := mocks.NewMockclient(ctrl)
 				m.EXPECT().DeleteStack(gomock.Any()).Return(nil, errDoesNotExist)
 				m.EXPECT().WaitUntilStackDeleteCompleteWithContext(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 				return m
@@ -413,7 +413,7 @@ func TestCloudFormation_DeleteAndWait(t *testing.T) {
 		},
 		"wait for stack deletion if stack is being deleted": {
 			createMock: func(ctrl *gomock.Controller) client {
-				m := mocks.NewMockapi(ctrl)
+				m := mocks.NewMockclient(ctrl)
 				m.EXPECT().DeleteStack(&cloudformation.DeleteStackInput{
 					StackName: aws.String(mockStack.Name),
 				}).Return(nil, nil)
@@ -451,7 +451,7 @@ func TestCloudFormation_Describe(t *testing.T) {
 	}{
 		"return ErrStackNotFound if stack does not exist": {
 			createMock: func(ctrl *gomock.Controller) client {
-				m := mocks.NewMockapi(ctrl)
+				m := mocks.NewMockclient(ctrl)
 				m.EXPECT().DescribeStacks(gomock.Any()).Return(nil, errDoesNotExist)
 				return m
 			},
@@ -459,7 +459,7 @@ func TestCloudFormation_Describe(t *testing.T) {
 		},
 		"returns ErrStackNotFound if the list returned is empty": {
 			createMock: func(ctrl *gomock.Controller) client {
-				m := mocks.NewMockapi(ctrl)
+				m := mocks.NewMockclient(ctrl)
 				m.EXPECT().DescribeStacks(gomock.Any()).Return(&cloudformation.DescribeStacksOutput{
 					Stacks: []*cloudformation.Stack{},
 				}, nil)
@@ -469,7 +469,7 @@ func TestCloudFormation_Describe(t *testing.T) {
 		},
 		"returns a StackDescription if stack exists": {
 			createMock: func(ctrl *gomock.Controller) client {
-				m := mocks.NewMockapi(ctrl)
+				m := mocks.NewMockclient(ctrl)
 				m.EXPECT().DescribeStacks(gomock.Any()).Return(&cloudformation.DescribeStacksOutput{
 					Stacks: []*cloudformation.Stack{
 						{
@@ -512,7 +512,7 @@ func TestCloudFormation_TemplateBody(t *testing.T) {
 	}{
 		"return ErrStackNotFound if stack does not exist": {
 			createMock: func(ctrl *gomock.Controller) client {
-				m := mocks.NewMockapi(ctrl)
+				m := mocks.NewMockclient(ctrl)
 				m.EXPECT().GetTemplate(gomock.Any()).Return(nil, errDoesNotExist)
 				return m
 			},
@@ -520,7 +520,7 @@ func TestCloudFormation_TemplateBody(t *testing.T) {
 		},
 		"returns the template body if the stack exists": {
 			createMock: func(ctrl *gomock.Controller) client {
-				m := mocks.NewMockapi(ctrl)
+				m := mocks.NewMockclient(ctrl)
 				m.EXPECT().GetTemplate(&cloudformation.GetTemplateInput{
 					StackName: aws.String(mockStack.Name),
 				}).Return(&cloudformation.GetTemplateOutput{
@@ -567,12 +567,12 @@ func TestCloudFormation_ErrorEvents(t *testing.T) {
 		},
 	}
 	testCases := map[string]struct {
-		mockCf       func(*mocks.Mockapi)
+		mockCf       func(mockclient *mocks.Mockclient)
 		wantedErr    string
 		wantedEvents []StackEvent
 	}{
 		"completes successfully": {
-			mockCf: func(m *mocks.Mockapi) {
+			mockCf: func(m *mocks.Mockclient) {
 				m.EXPECT().DescribeStackEvents(&cloudformation.DescribeStackEventsInput{
 					StackName: aws.String(mockStack.Name),
 				}).Return(&cloudformation.DescribeStackEventsOutput{
@@ -589,7 +589,7 @@ func TestCloudFormation_ErrorEvents(t *testing.T) {
 			},
 		},
 		"error retrieving events": {
-			mockCf: func(m *mocks.Mockapi) {
+			mockCf: func(m *mocks.Mockclient) {
 				m.EXPECT().DescribeStackEvents(gomock.Any()).Return(nil, errors.New("some error"))
 			},
 			wantedErr: "describe stack events for stack id: some error",
@@ -601,7 +601,7 @@ func TestCloudFormation_ErrorEvents(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
-			mockCf := mocks.NewMockapi(ctrl)
+			mockCf := mocks.NewMockclient(ctrl)
 			tc.mockCf(mockCf)
 
 			c := CloudFormation{
@@ -627,7 +627,7 @@ func TestCloudFormation_Events(t *testing.T) {
 	}{
 		"return events in chronological order": {
 			createMock: func(ctrl *gomock.Controller) client {
-				m := mocks.NewMockapi(ctrl)
+				m := mocks.NewMockclient(ctrl)
 				m.EXPECT().DescribeStackEvents(&cloudformation.DescribeStackEventsInput{
 					StackName: aws.String(mockStack.Name),
 				}).Return(&cloudformation.DescribeStackEventsOutput{
@@ -672,15 +672,15 @@ func TestCloudFormation_Events(t *testing.T) {
 	}
 }
 
-func addCreateDeployCalls(m *mocks.Mockapi) {
+func addCreateDeployCalls(m *mocks.Mockclient) {
 	addDeployCalls(m, cloudformation.ChangeSetTypeCreate)
 }
 
-func addUpdateDeployCalls(m *mocks.Mockapi) {
+func addUpdateDeployCalls(m *mocks.Mockclient) {
 	addDeployCalls(m, cloudformation.ChangeSetTypeUpdate)
 }
 
-func addDeployCalls(m *mocks.Mockapi, changeSetType string) {
+func addDeployCalls(m *mocks.Mockclient, changeSetType string) {
 	m.EXPECT().CreateChangeSet(&cloudformation.CreateChangeSetInput{
 		ChangeSetName: aws.String(mockChangeSetName),
 		StackName:     aws.String(mockStack.Name),

--- a/internal/pkg/aws/cloudformation/errors.go
+++ b/internal/pkg/aws/cloudformation/errors.go
@@ -41,11 +41,11 @@ func (e *ErrStackNotFound) Error() string {
 // ErrChangeSetNotExecutable occurs when the change set cannot be executed.
 type ErrChangeSetNotExecutable struct {
 	cs    *changeSet
-	descr *changeSetDescription
+	descr *ChangeSetDescription
 }
 
 func (e *ErrChangeSetNotExecutable) Error() string {
-	return fmt.Sprintf("execute change set %s for stack %s because status is %s with reason %s", e.cs.name, e.cs.stackName, e.descr.executionStatus, e.descr.statusReason)
+	return fmt.Sprintf("execute change set %s for stack %s because status is %s with reason %s", e.cs.name, e.cs.stackName, e.descr.ExecutionStatus, e.descr.StatusReason)
 }
 
 // ErrStackUpdateInProgress occurs when we try to update a stack that's already being updated.

--- a/internal/pkg/aws/cloudformation/interfaces.go
+++ b/internal/pkg/aws/cloudformation/interfaces.go
@@ -17,7 +17,7 @@ type changeSetAPI interface {
 	DeleteChangeSet(*cloudformation.DeleteChangeSetInput) (*cloudformation.DeleteChangeSetOutput, error)
 }
 
-type api interface {
+type client interface {
 	changeSetAPI
 
 	DescribeStacks(*cloudformation.DescribeStacksInput) (*cloudformation.DescribeStacksOutput, error)

--- a/internal/pkg/aws/cloudformation/mocks/mock_cloudformation.go
+++ b/internal/pkg/aws/cloudformation/mocks/mock_cloudformation.go
@@ -114,31 +114,31 @@ func (mr *MockchangeSetAPIMockRecorder) DeleteChangeSet(arg0 interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteChangeSet", reflect.TypeOf((*MockchangeSetAPI)(nil).DeleteChangeSet), arg0)
 }
 
-// Mockapi is a mock of api interface
-type Mockapi struct {
+// Mockclient is a mock of client interface
+type Mockclient struct {
 	ctrl     *gomock.Controller
-	recorder *MockapiMockRecorder
+	recorder *MockclientMockRecorder
 }
 
-// MockapiMockRecorder is the mock recorder for Mockapi
-type MockapiMockRecorder struct {
-	mock *Mockapi
+// MockclientMockRecorder is the mock recorder for Mockclient
+type MockclientMockRecorder struct {
+	mock *Mockclient
 }
 
-// NewMockapi creates a new mock instance
-func NewMockapi(ctrl *gomock.Controller) *Mockapi {
-	mock := &Mockapi{ctrl: ctrl}
-	mock.recorder = &MockapiMockRecorder{mock}
+// NewMockclient creates a new mock instance
+func NewMockclient(ctrl *gomock.Controller) *Mockclient {
+	mock := &Mockclient{ctrl: ctrl}
+	mock.recorder = &MockclientMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use
-func (m *Mockapi) EXPECT() *MockapiMockRecorder {
+func (m *Mockclient) EXPECT() *MockclientMockRecorder {
 	return m.recorder
 }
 
 // CreateChangeSet mocks base method
-func (m *Mockapi) CreateChangeSet(arg0 *cloudformation.CreateChangeSetInput) (*cloudformation.CreateChangeSetOutput, error) {
+func (m *Mockclient) CreateChangeSet(arg0 *cloudformation.CreateChangeSetInput) (*cloudformation.CreateChangeSetOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateChangeSet", arg0)
 	ret0, _ := ret[0].(*cloudformation.CreateChangeSetOutput)
@@ -147,13 +147,13 @@ func (m *Mockapi) CreateChangeSet(arg0 *cloudformation.CreateChangeSetInput) (*c
 }
 
 // CreateChangeSet indicates an expected call of CreateChangeSet
-func (mr *MockapiMockRecorder) CreateChangeSet(arg0 interface{}) *gomock.Call {
+func (mr *MockclientMockRecorder) CreateChangeSet(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateChangeSet", reflect.TypeOf((*Mockapi)(nil).CreateChangeSet), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateChangeSet", reflect.TypeOf((*Mockclient)(nil).CreateChangeSet), arg0)
 }
 
 // WaitUntilChangeSetCreateCompleteWithContext mocks base method
-func (m *Mockapi) WaitUntilChangeSetCreateCompleteWithContext(arg0 aws.Context, arg1 *cloudformation.DescribeChangeSetInput, arg2 ...request.WaiterOption) error {
+func (m *Mockclient) WaitUntilChangeSetCreateCompleteWithContext(arg0 aws.Context, arg1 *cloudformation.DescribeChangeSetInput, arg2 ...request.WaiterOption) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
@@ -165,14 +165,14 @@ func (m *Mockapi) WaitUntilChangeSetCreateCompleteWithContext(arg0 aws.Context, 
 }
 
 // WaitUntilChangeSetCreateCompleteWithContext indicates an expected call of WaitUntilChangeSetCreateCompleteWithContext
-func (mr *MockapiMockRecorder) WaitUntilChangeSetCreateCompleteWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+func (mr *MockclientMockRecorder) WaitUntilChangeSetCreateCompleteWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilChangeSetCreateCompleteWithContext", reflect.TypeOf((*Mockapi)(nil).WaitUntilChangeSetCreateCompleteWithContext), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilChangeSetCreateCompleteWithContext", reflect.TypeOf((*Mockclient)(nil).WaitUntilChangeSetCreateCompleteWithContext), varargs...)
 }
 
 // DescribeChangeSet mocks base method
-func (m *Mockapi) DescribeChangeSet(arg0 *cloudformation.DescribeChangeSetInput) (*cloudformation.DescribeChangeSetOutput, error) {
+func (m *Mockclient) DescribeChangeSet(arg0 *cloudformation.DescribeChangeSetInput) (*cloudformation.DescribeChangeSetOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeChangeSet", arg0)
 	ret0, _ := ret[0].(*cloudformation.DescribeChangeSetOutput)
@@ -181,13 +181,13 @@ func (m *Mockapi) DescribeChangeSet(arg0 *cloudformation.DescribeChangeSetInput)
 }
 
 // DescribeChangeSet indicates an expected call of DescribeChangeSet
-func (mr *MockapiMockRecorder) DescribeChangeSet(arg0 interface{}) *gomock.Call {
+func (mr *MockclientMockRecorder) DescribeChangeSet(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeChangeSet", reflect.TypeOf((*Mockapi)(nil).DescribeChangeSet), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeChangeSet", reflect.TypeOf((*Mockclient)(nil).DescribeChangeSet), arg0)
 }
 
 // ExecuteChangeSet mocks base method
-func (m *Mockapi) ExecuteChangeSet(arg0 *cloudformation.ExecuteChangeSetInput) (*cloudformation.ExecuteChangeSetOutput, error) {
+func (m *Mockclient) ExecuteChangeSet(arg0 *cloudformation.ExecuteChangeSetInput) (*cloudformation.ExecuteChangeSetOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ExecuteChangeSet", arg0)
 	ret0, _ := ret[0].(*cloudformation.ExecuteChangeSetOutput)
@@ -196,13 +196,13 @@ func (m *Mockapi) ExecuteChangeSet(arg0 *cloudformation.ExecuteChangeSetInput) (
 }
 
 // ExecuteChangeSet indicates an expected call of ExecuteChangeSet
-func (mr *MockapiMockRecorder) ExecuteChangeSet(arg0 interface{}) *gomock.Call {
+func (mr *MockclientMockRecorder) ExecuteChangeSet(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecuteChangeSet", reflect.TypeOf((*Mockapi)(nil).ExecuteChangeSet), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecuteChangeSet", reflect.TypeOf((*Mockclient)(nil).ExecuteChangeSet), arg0)
 }
 
 // DeleteChangeSet mocks base method
-func (m *Mockapi) DeleteChangeSet(arg0 *cloudformation.DeleteChangeSetInput) (*cloudformation.DeleteChangeSetOutput, error) {
+func (m *Mockclient) DeleteChangeSet(arg0 *cloudformation.DeleteChangeSetInput) (*cloudformation.DeleteChangeSetOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteChangeSet", arg0)
 	ret0, _ := ret[0].(*cloudformation.DeleteChangeSetOutput)
@@ -211,13 +211,13 @@ func (m *Mockapi) DeleteChangeSet(arg0 *cloudformation.DeleteChangeSetInput) (*c
 }
 
 // DeleteChangeSet indicates an expected call of DeleteChangeSet
-func (mr *MockapiMockRecorder) DeleteChangeSet(arg0 interface{}) *gomock.Call {
+func (mr *MockclientMockRecorder) DeleteChangeSet(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteChangeSet", reflect.TypeOf((*Mockapi)(nil).DeleteChangeSet), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteChangeSet", reflect.TypeOf((*Mockclient)(nil).DeleteChangeSet), arg0)
 }
 
 // DescribeStacks mocks base method
-func (m *Mockapi) DescribeStacks(arg0 *cloudformation.DescribeStacksInput) (*cloudformation.DescribeStacksOutput, error) {
+func (m *Mockclient) DescribeStacks(arg0 *cloudformation.DescribeStacksInput) (*cloudformation.DescribeStacksOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeStacks", arg0)
 	ret0, _ := ret[0].(*cloudformation.DescribeStacksOutput)
@@ -226,13 +226,13 @@ func (m *Mockapi) DescribeStacks(arg0 *cloudformation.DescribeStacksInput) (*clo
 }
 
 // DescribeStacks indicates an expected call of DescribeStacks
-func (mr *MockapiMockRecorder) DescribeStacks(arg0 interface{}) *gomock.Call {
+func (mr *MockclientMockRecorder) DescribeStacks(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeStacks", reflect.TypeOf((*Mockapi)(nil).DescribeStacks), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeStacks", reflect.TypeOf((*Mockclient)(nil).DescribeStacks), arg0)
 }
 
 // DescribeStackEvents mocks base method
-func (m *Mockapi) DescribeStackEvents(arg0 *cloudformation.DescribeStackEventsInput) (*cloudformation.DescribeStackEventsOutput, error) {
+func (m *Mockclient) DescribeStackEvents(arg0 *cloudformation.DescribeStackEventsInput) (*cloudformation.DescribeStackEventsOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeStackEvents", arg0)
 	ret0, _ := ret[0].(*cloudformation.DescribeStackEventsOutput)
@@ -241,13 +241,13 @@ func (m *Mockapi) DescribeStackEvents(arg0 *cloudformation.DescribeStackEventsIn
 }
 
 // DescribeStackEvents indicates an expected call of DescribeStackEvents
-func (mr *MockapiMockRecorder) DescribeStackEvents(arg0 interface{}) *gomock.Call {
+func (mr *MockclientMockRecorder) DescribeStackEvents(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeStackEvents", reflect.TypeOf((*Mockapi)(nil).DescribeStackEvents), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeStackEvents", reflect.TypeOf((*Mockclient)(nil).DescribeStackEvents), arg0)
 }
 
 // GetTemplate mocks base method
-func (m *Mockapi) GetTemplate(input *cloudformation.GetTemplateInput) (*cloudformation.GetTemplateOutput, error) {
+func (m *Mockclient) GetTemplate(input *cloudformation.GetTemplateInput) (*cloudformation.GetTemplateOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTemplate", input)
 	ret0, _ := ret[0].(*cloudformation.GetTemplateOutput)
@@ -256,13 +256,13 @@ func (m *Mockapi) GetTemplate(input *cloudformation.GetTemplateInput) (*cloudfor
 }
 
 // GetTemplate indicates an expected call of GetTemplate
-func (mr *MockapiMockRecorder) GetTemplate(input interface{}) *gomock.Call {
+func (mr *MockclientMockRecorder) GetTemplate(input interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTemplate", reflect.TypeOf((*Mockapi)(nil).GetTemplate), input)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTemplate", reflect.TypeOf((*Mockclient)(nil).GetTemplate), input)
 }
 
 // DeleteStack mocks base method
-func (m *Mockapi) DeleteStack(arg0 *cloudformation.DeleteStackInput) (*cloudformation.DeleteStackOutput, error) {
+func (m *Mockclient) DeleteStack(arg0 *cloudformation.DeleteStackInput) (*cloudformation.DeleteStackOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteStack", arg0)
 	ret0, _ := ret[0].(*cloudformation.DeleteStackOutput)
@@ -271,13 +271,13 @@ func (m *Mockapi) DeleteStack(arg0 *cloudformation.DeleteStackInput) (*cloudform
 }
 
 // DeleteStack indicates an expected call of DeleteStack
-func (mr *MockapiMockRecorder) DeleteStack(arg0 interface{}) *gomock.Call {
+func (mr *MockclientMockRecorder) DeleteStack(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteStack", reflect.TypeOf((*Mockapi)(nil).DeleteStack), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteStack", reflect.TypeOf((*Mockclient)(nil).DeleteStack), arg0)
 }
 
 // WaitUntilStackCreateCompleteWithContext mocks base method
-func (m *Mockapi) WaitUntilStackCreateCompleteWithContext(arg0 aws.Context, arg1 *cloudformation.DescribeStacksInput, arg2 ...request.WaiterOption) error {
+func (m *Mockclient) WaitUntilStackCreateCompleteWithContext(arg0 aws.Context, arg1 *cloudformation.DescribeStacksInput, arg2 ...request.WaiterOption) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
@@ -289,14 +289,14 @@ func (m *Mockapi) WaitUntilStackCreateCompleteWithContext(arg0 aws.Context, arg1
 }
 
 // WaitUntilStackCreateCompleteWithContext indicates an expected call of WaitUntilStackCreateCompleteWithContext
-func (mr *MockapiMockRecorder) WaitUntilStackCreateCompleteWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+func (mr *MockclientMockRecorder) WaitUntilStackCreateCompleteWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilStackCreateCompleteWithContext", reflect.TypeOf((*Mockapi)(nil).WaitUntilStackCreateCompleteWithContext), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilStackCreateCompleteWithContext", reflect.TypeOf((*Mockclient)(nil).WaitUntilStackCreateCompleteWithContext), varargs...)
 }
 
 // WaitUntilStackUpdateCompleteWithContext mocks base method
-func (m *Mockapi) WaitUntilStackUpdateCompleteWithContext(arg0 aws.Context, arg1 *cloudformation.DescribeStacksInput, arg2 ...request.WaiterOption) error {
+func (m *Mockclient) WaitUntilStackUpdateCompleteWithContext(arg0 aws.Context, arg1 *cloudformation.DescribeStacksInput, arg2 ...request.WaiterOption) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
@@ -308,14 +308,14 @@ func (m *Mockapi) WaitUntilStackUpdateCompleteWithContext(arg0 aws.Context, arg1
 }
 
 // WaitUntilStackUpdateCompleteWithContext indicates an expected call of WaitUntilStackUpdateCompleteWithContext
-func (mr *MockapiMockRecorder) WaitUntilStackUpdateCompleteWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+func (mr *MockclientMockRecorder) WaitUntilStackUpdateCompleteWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilStackUpdateCompleteWithContext", reflect.TypeOf((*Mockapi)(nil).WaitUntilStackUpdateCompleteWithContext), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilStackUpdateCompleteWithContext", reflect.TypeOf((*Mockclient)(nil).WaitUntilStackUpdateCompleteWithContext), varargs...)
 }
 
 // WaitUntilStackDeleteCompleteWithContext mocks base method
-func (m *Mockapi) WaitUntilStackDeleteCompleteWithContext(arg0 aws.Context, arg1 *cloudformation.DescribeStacksInput, arg2 ...request.WaiterOption) error {
+func (m *Mockclient) WaitUntilStackDeleteCompleteWithContext(arg0 aws.Context, arg1 *cloudformation.DescribeStacksInput, arg2 ...request.WaiterOption) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
@@ -327,8 +327,8 @@ func (m *Mockapi) WaitUntilStackDeleteCompleteWithContext(arg0 aws.Context, arg1
 }
 
 // WaitUntilStackDeleteCompleteWithContext indicates an expected call of WaitUntilStackDeleteCompleteWithContext
-func (mr *MockapiMockRecorder) WaitUntilStackDeleteCompleteWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+func (mr *MockclientMockRecorder) WaitUntilStackDeleteCompleteWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilStackDeleteCompleteWithContext", reflect.TypeOf((*Mockapi)(nil).WaitUntilStackDeleteCompleteWithContext), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilStackDeleteCompleteWithContext", reflect.TypeOf((*Mockclient)(nil).WaitUntilStackDeleteCompleteWithContext), varargs...)
 }

--- a/internal/pkg/deploy/cloudformation/cloudformation.go
+++ b/internal/pkg/deploy/cloudformation/cloudformation.go
@@ -5,6 +5,9 @@
 package cloudformation
 
 import (
+	"context"
+	"fmt"
+	"io"
 	"strings"
 	"time"
 
@@ -14,8 +17,11 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/aws/cloudformation"
 	"github.com/aws/copilot-cli/internal/pkg/aws/cloudformation/stackset"
 	"github.com/aws/copilot-cli/internal/pkg/deploy"
+	"github.com/aws/copilot-cli/internal/pkg/stream"
+	"github.com/aws/copilot-cli/internal/pkg/term/progress"
 	"github.com/aws/copilot-cli/templates"
 	"github.com/gobuffalo/packd"
+	"golang.org/x/sync/errgroup"
 )
 
 // StackConfiguration represents the set of methods needed to deploy a cloudformation stack.
@@ -27,19 +33,24 @@ type StackConfiguration interface {
 }
 
 type cfnClient interface {
-	Create(*cloudformation.Stack) error
+	// Methods augmented by the aws wrapper struct.
+	Create(*cloudformation.Stack) (string, error)
 	CreateAndWait(*cloudformation.Stack) error
-	WaitForCreate(stackName string) error
+	WaitForCreate(ctx context.Context, stackName string) error
 	Update(*cloudformation.Stack) error
 	UpdateAndWait(*cloudformation.Stack) error
-	WaitForUpdate(stackName string) error
+	WaitForUpdate(ctx context.Context, stackName string) error
 	Delete(stackName string) error
 	DeleteAndWait(stackName string) error
 	DeleteAndWaitWithRoleARN(stackName, roleARN string) error
 	Describe(stackName string) (*cloudformation.StackDescription, error)
+	DescribeChangeSet(changeSetID string) (*cloudformation.ChangeSetDescription, error)
 	TemplateBody(stackName string) (string, error)
 	Events(stackName string) ([]cloudformation.StackEvent, error)
 	ErrorEvents(stackName string) ([]cloudformation.StackEvent, error)
+
+	// Methods vended by the aws sdk struct.
+	DescribeStackEvents(*sdkcloudformation.DescribeStackEventsInput) (*sdkcloudformation.DescribeStackEventsOutput, error)
 }
 
 type stackSetClient interface {
@@ -73,6 +84,19 @@ func New(sess *session.Session) CloudFormation {
 	}
 }
 
+// ErrorEvents returns the list of Cloudformation Resource Events, filtered by failures and erros.
+func (cf CloudFormation) ErrorEvents(conf StackConfiguration) ([]deploy.ResourceEvent, error) {
+	events, err := cf.cfnClient.ErrorEvents(conf.StackName())
+	if err != nil {
+		return nil, err
+	}
+	var transformedEvents []deploy.ResourceEvent
+	for _, cfEvent := range events {
+		transformedEvents = append(transformedEvents, transformEvent(cfEvent))
+	}
+	return transformedEvents, nil
+}
+
 // streamResourceEvents sends a list of ResourceEvent every 3 seconds to the events channel.
 // The events channel is closed only when the done channel receives a message.
 // If an error occurs while describing stack events, it is ignored so that the stream is not interrupted.
@@ -100,6 +124,54 @@ func (cf CloudFormation) streamResourceEvents(done <-chan struct{}, events chan 
 			return              // Exit for-loop.
 		}
 	}
+}
+
+type renderStackChangesInput struct {
+	w                io.Writer
+	stackName        string
+	stackDescription string
+	createChangeSet  func() (string, error)
+	waitForStack     func(context.Context, string) error
+}
+
+func (cf CloudFormation) renderStackChanges(in renderStackChangesInput) error {
+	changeSetID, err := in.createChangeSet()
+	if err != nil {
+		return err
+	}
+	changeSet, err := cf.cfnClient.DescribeChangeSet(changeSetID)
+	if err != nil {
+		return err
+	}
+	body, err := cf.cfnClient.TemplateBody(in.stackName)
+	if err != nil {
+		return err
+	}
+	descriptions, err := cloudformation.ParseTemplateDescriptions(body)
+	if err != nil {
+		return fmt.Errorf("parse cloudformation template for resource descriptions: %w", err)
+	}
+
+	waitCtx, cancelWait := context.WithCancel(context.Background())
+	streamer := stream.NewStackStreamer(cf.cfnClient, in.stackName, changeSet.CreationTime)
+	renderer := progress.ListeningStackRenderer(streamer, in.stackName, in.stackDescription, resourcesToRender(changeSet.Changes, descriptions))
+
+	// Run the streamer, renderer, and waiter all concurrently until they all exit successfully or one of them errors.
+	// When the waiter exits, the waitCtx is canceled which results in the streamer and renderer to exit.
+	// When the streamer exits, the group ctx is canceled resulting in the waiter to exit and canceling the renderer.
+	// When the renderer exits, it's the same flow as the streamer.
+	g, ctx := errgroup.WithContext(waitCtx)
+	g.Go(func() error {
+		defer cancelWait()
+		return in.waitForStack(ctx, in.stackName)
+	})
+	g.Go(func() error {
+		return stream.Stream(waitCtx, streamer)
+	})
+	g.Go(func() error {
+		return progress.Render(waitCtx, in.w, renderer)
+	})
+	return g.Wait()
 }
 
 func transformEvent(input cloudformation.StackEvent) deploy.ResourceEvent {
@@ -136,15 +208,20 @@ func toMap(tags []*sdkcloudformation.Tag) map[string]string {
 	return m
 }
 
-// ErrorEvents returns the list of Cloudformation Resource Events, filtered by failures and erros.
-func (cf CloudFormation) ErrorEvents(conf StackConfiguration) ([]deploy.ResourceEvent, error) {
-	events, err := cf.cfnClient.ErrorEvents(conf.StackName())
-	if err != nil {
-		return nil, err
+// resourcesToRender filters changes by resources that have a description.
+func resourcesToRender(changes []*sdkcloudformation.Change, descriptions map[string]string) []progress.StackResourceDescription {
+	var resources []progress.StackResourceDescription
+	for _, change := range changes {
+		logicalID := aws.StringValue(change.ResourceChange.LogicalResourceId)
+		description, ok := descriptions[logicalID]
+		if !ok {
+			continue
+		}
+		resources = append(resources, progress.StackResourceDescription{
+			LogicalResourceID: logicalID,
+			ResourceType:      aws.StringValue(change.ResourceChange.PhysicalResourceId),
+			Description:       description,
+		})
 	}
-	var transformedEvents []deploy.ResourceEvent
-	for _, cfEvent := range events {
-		transformedEvents = append(transformedEvents, transformEvent(cfEvent))
-	}
-	return transformedEvents, nil
+	return resources
 }

--- a/internal/pkg/deploy/cloudformation/cloudformation.go
+++ b/internal/pkg/deploy/cloudformation/cloudformation.go
@@ -84,7 +84,7 @@ func New(sess *session.Session) CloudFormation {
 	}
 }
 
-// ErrorEvents returns the list of Cloudformation Resource Events, filtered by failures and erros.
+// ErrorEvents returns the list of CloudFormation Resource Events, filtered by failures and errors.
 func (cf CloudFormation) ErrorEvents(conf StackConfiguration) ([]deploy.ResourceEvent, error) {
 	events, err := cf.cfnClient.ErrorEvents(conf.StackName())
 	if err != nil {

--- a/internal/pkg/deploy/cloudformation/cloudformation_test.go
+++ b/internal/pkg/deploy/cloudformation/cloudformation_test.go
@@ -1,0 +1,189 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudformation
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	sdkcloudformation "github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/aws/copilot-cli/internal/pkg/aws/cloudformation"
+	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation/mocks"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCloudFormation_renderStackChanges(t *testing.T) {
+	t.Run("bubbles up create change set error", func(t *testing.T) {
+		// GIVEN
+		client := CloudFormation{}
+
+		// WHEN
+		in := renderStackChangesInput{
+			createChangeSet: func() (string, error) {
+				return "", errors.New("createChangeSet error")
+			},
+		}
+		err := client.renderStackChanges(in)
+
+		// THEN
+		require.EqualError(t, err, "createChangeSet error")
+	})
+	t.Run("bubbles up DescribeChangeSet error", func(t *testing.T) {
+		// GIVEN
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		m := mocks.NewMockcfnClient(ctrl)
+		m.EXPECT().DescribeChangeSet(gomock.Any()).Return(nil, errors.New("DescribeChangeSet error"))
+		client := CloudFormation{cfnClient: m}
+
+		// WHEN
+		in := renderStackChangesInput{
+			createChangeSet: func() (string, error) {
+				return "", nil
+			},
+		}
+		err := client.renderStackChanges(in)
+
+		// THEN
+		require.EqualError(t, err, "DescribeChangeSet error")
+	})
+	t.Run("bubbles up TemplateBody error", func(t *testing.T) {
+		// GIVEN
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		m := mocks.NewMockcfnClient(ctrl)
+		m.EXPECT().DescribeChangeSet(gomock.Any()).Return(&cloudformation.ChangeSetDescription{}, nil)
+		m.EXPECT().TemplateBody(gomock.Any()).Return("", errors.New("TemplateBody error"))
+		client := CloudFormation{cfnClient: m}
+
+		// WHEN
+		in := renderStackChangesInput{
+			createChangeSet: func() (string, error) {
+				return "", nil
+			},
+		}
+		err := client.renderStackChanges(in)
+
+		// THEN
+		require.EqualError(t, err, "TemplateBody error")
+	})
+	t.Run("bubbles up waiter error and cancels streamers and renderer on waiter error", func(t *testing.T) {
+		// GIVEN
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		m := mocks.NewMockcfnClient(ctrl)
+		m.EXPECT().DescribeChangeSet(gomock.Any()).Return(&cloudformation.ChangeSetDescription{}, nil)
+		m.EXPECT().TemplateBody(gomock.Any()).Return("", nil)
+		m.EXPECT().DescribeStackEvents(gomock.Any()).Return(&sdkcloudformation.DescribeStackEventsOutput{}, nil).AnyTimes()
+		client := CloudFormation{cfnClient: m}
+		buf := new(strings.Builder)
+
+		// WHEN
+		in := renderStackChangesInput{
+			w: buf,
+			createChangeSet: func() (string, error) {
+				return "", nil
+			},
+			waitForStack: func(ctx context.Context, s string) error {
+				return errors.New("waiter error")
+			},
+		}
+		err := client.renderStackChanges(in)
+
+		// THEN
+		require.EqualError(t, err, "waiter error")
+	})
+	t.Run("bubbles up streamer error and cancels waiter and renderer on streamer error", func(t *testing.T) {
+		// GIVEN
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		wantedErr := errors.New("streamer error")
+		m := mocks.NewMockcfnClient(ctrl)
+		m.EXPECT().DescribeChangeSet(gomock.Any()).Return(&cloudformation.ChangeSetDescription{}, nil)
+		m.EXPECT().TemplateBody(gomock.Any()).Return("", nil)
+		m.EXPECT().DescribeStackEvents(gomock.Any()).Return(nil, wantedErr)
+		client := CloudFormation{cfnClient: m}
+		buf := new(strings.Builder)
+
+		// WHEN
+		in := renderStackChangesInput{
+			w: buf,
+			createChangeSet: func() (string, error) {
+				return "", nil
+			},
+			waitForStack: func(ctx context.Context, s string) error {
+				select {
+				case <-time.After(10 * time.Second):
+					return errors.New("expected waitForStack to be canceled, instead we waited for a timeout")
+				case <-ctx.Done():
+					return nil
+				}
+			},
+		}
+		err := client.renderStackChanges(in)
+
+		// THEN
+		require.True(t, errors.Is(err, wantedErr), "expected streamer error to be wrapped and returned")
+	})
+	t.Run("renders a resource on success", func(t *testing.T) {
+		// GIVEN
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		m := mocks.NewMockcfnClient(ctrl)
+		m.EXPECT().DescribeChangeSet("1234").Return(&cloudformation.ChangeSetDescription{
+			Changes: []*sdkcloudformation.Change{
+				{
+					ResourceChange: &sdkcloudformation.ResourceChange{
+						LogicalResourceId:  aws.String("Cluster"),
+						PhysicalResourceId: aws.String("AWS::ECS::Cluster"),
+					},
+				},
+			},
+		}, nil)
+		m.EXPECT().TemplateBody("phonetool-test").Return(`
+Resources:
+  Cluster:
+    # An ECS cluster
+    Type: AWS::ECS::Cluster`, nil)
+		m.EXPECT().DescribeStackEvents(&sdkcloudformation.DescribeStackEventsInput{
+			StackName: aws.String("phonetool-test"),
+		}).Return(&sdkcloudformation.DescribeStackEventsOutput{
+			StackEvents: []*sdkcloudformation.StackEvent{
+				{
+					EventId:            aws.String("some event id"),
+					LogicalResourceId:  aws.String("Cluster"),
+					PhysicalResourceId: aws.String("AWS::ECS::Cluster"),
+					ResourceStatus:     aws.String("CREATE_COMPLETE"),
+					Timestamp:          aws.Time(time.Now()),
+				},
+			},
+		}, nil)
+		client := CloudFormation{cfnClient: m}
+		buf := new(strings.Builder)
+
+		// WHEN
+		in := renderStackChangesInput{
+			w:                buf,
+			stackName:        "phonetool-test",
+			stackDescription: "Creating phonetool-test environment.",
+			createChangeSet: func() (string, error) {
+				return "1234", nil
+			},
+			waitForStack: func(ctx context.Context, s string) error {
+				return nil
+			},
+		}
+		err := client.renderStackChanges(in)
+
+		// THEN
+		require.NoError(t, err)
+		require.Contains(t, buf.String(), in.stackDescription)
+		require.Contains(t, buf.String(), "An ECS cluster")
+	})
+}

--- a/internal/pkg/deploy/cloudformation/env.go
+++ b/internal/pkg/deploy/cloudformation/env.go
@@ -5,8 +5,10 @@
 package cloudformation
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -34,7 +36,31 @@ func (cf CloudFormation) DeployEnvironment(env *deploy.CreateEnvironmentInput) e
 	if err != nil {
 		return err
 	}
-	return cf.cfnClient.Create(s)
+	if _, err := cf.cfnClient.Create(s); err != nil {
+		return err
+	}
+	return nil
+}
+
+// DeployAndRenderEnvironment creates the CloudFormation stack for an environment, and render the stack creation to out.
+func (cf CloudFormation) DeployAndRenderEnvironment(out io.Writer, env *deploy.CreateEnvironmentInput) error {
+	s, err := toStack(stack.NewEnvStackConfig(env))
+	if err != nil {
+		return err
+	}
+	return cf.renderStackChanges(renderStackChangesInput{
+		w:                out,
+		stackName:        s.Name,
+		stackDescription: fmt.Sprintf("Creating the infrastructure for the %s environment.", s.Name),
+		createChangeSet: func() (string, error) {
+			changeSetID, err := cf.cfnClient.Create(s)
+			if err != nil {
+				return "", err
+			}
+			return changeSetID, nil
+		},
+		waitForStack: cf.cfnClient.WaitForCreate,
+	})
 }
 
 // StreamEnvironmentCreation streams resource update events while a deployment is taking place.
@@ -65,7 +91,7 @@ func (cf CloudFormation) DeleteEnvironment(appName, envName, cfnExecRoleARN stri
 // The done channel is closed once this method exits to notify other streams that they should stop working.
 func (cf CloudFormation) streamEnvironmentResponse(done chan struct{}, resp chan deploy.CreateEnvironmentResponse, stack *stack.EnvStackConfig) {
 	defer close(done)
-	if err := cf.cfnClient.WaitForCreate(stack.StackName()); err != nil {
+	if err := cf.cfnClient.WaitForCreate(context.Background(), stack.StackName()); err != nil {
 		resp <- deploy.CreateEnvironmentResponse{Err: err}
 		return
 	}
@@ -162,7 +188,7 @@ func (cf CloudFormation) upgradeEnvironment(in *deploy.CreateEnvironmentInput, t
 		if cloudformation.StackStatus(aws.StringValue(descr.StackStatus)).InProgress() {
 			// There is already an update happening to the environment stack.
 			// Best-effort try to wait for the existing update to be over before retrying.
-			_ = cf.cfnClient.WaitForUpdate(s.Name)
+			_ = cf.cfnClient.WaitForUpdate(context.Background(), s.Name)
 			continue
 		}
 

--- a/internal/pkg/deploy/cloudformation/env_test.go
+++ b/internal/pkg/deploy/cloudformation/env_test.go
@@ -71,7 +71,7 @@ func TestCloudFormation_UpgradeEnvironment(t *testing.T) {
 					m.EXPECT().Describe(gomock.Any()).Return(&cloudformation.StackDescription{
 						StackStatus: aws.String("UPDATE_IN_PROGRESS"),
 					}, nil).AnyTimes(),
-					m.EXPECT().WaitForUpdate("phonetool-test").Return(nil).AnyTimes(),
+					m.EXPECT().WaitForUpdate(gomock.Any(), "phonetool-test").Return(nil).AnyTimes(),
 					m.EXPECT().Describe(gomock.Any()).Return(&cloudformation.StackDescription{}, nil).AnyTimes(),
 					m.EXPECT().UpdateAndWait(gomock.Any()).Return(nil),
 				)

--- a/internal/pkg/deploy/cloudformation/mocks/mock_cloudformation.go
+++ b/internal/pkg/deploy/cloudformation/mocks/mock_cloudformation.go
@@ -5,6 +5,7 @@
 package mocks
 
 import (
+	context "context"
 	cloudformation "github.com/aws/aws-sdk-go/service/cloudformation"
 	cloudformation0 "github.com/aws/copilot-cli/internal/pkg/aws/cloudformation"
 	stackset "github.com/aws/copilot-cli/internal/pkg/aws/cloudformation/stackset"
@@ -117,11 +118,12 @@ func (m *MockcfnClient) EXPECT() *MockcfnClientMockRecorder {
 }
 
 // Create mocks base method
-func (m *MockcfnClient) Create(arg0 *cloudformation0.Stack) error {
+func (m *MockcfnClient) Create(arg0 *cloudformation0.Stack) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Create indicates an expected call of Create
@@ -145,17 +147,17 @@ func (mr *MockcfnClientMockRecorder) CreateAndWait(arg0 interface{}) *gomock.Cal
 }
 
 // WaitForCreate mocks base method
-func (m *MockcfnClient) WaitForCreate(stackName string) error {
+func (m *MockcfnClient) WaitForCreate(ctx context.Context, stackName string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WaitForCreate", stackName)
+	ret := m.ctrl.Call(m, "WaitForCreate", ctx, stackName)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // WaitForCreate indicates an expected call of WaitForCreate
-func (mr *MockcfnClientMockRecorder) WaitForCreate(stackName interface{}) *gomock.Call {
+func (mr *MockcfnClientMockRecorder) WaitForCreate(ctx, stackName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForCreate", reflect.TypeOf((*MockcfnClient)(nil).WaitForCreate), stackName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForCreate", reflect.TypeOf((*MockcfnClient)(nil).WaitForCreate), ctx, stackName)
 }
 
 // Update mocks base method
@@ -187,17 +189,17 @@ func (mr *MockcfnClientMockRecorder) UpdateAndWait(arg0 interface{}) *gomock.Cal
 }
 
 // WaitForUpdate mocks base method
-func (m *MockcfnClient) WaitForUpdate(stackName string) error {
+func (m *MockcfnClient) WaitForUpdate(ctx context.Context, stackName string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WaitForUpdate", stackName)
+	ret := m.ctrl.Call(m, "WaitForUpdate", ctx, stackName)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // WaitForUpdate indicates an expected call of WaitForUpdate
-func (mr *MockcfnClientMockRecorder) WaitForUpdate(stackName interface{}) *gomock.Call {
+func (mr *MockcfnClientMockRecorder) WaitForUpdate(ctx, stackName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForUpdate", reflect.TypeOf((*MockcfnClient)(nil).WaitForUpdate), stackName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForUpdate", reflect.TypeOf((*MockcfnClient)(nil).WaitForUpdate), ctx, stackName)
 }
 
 // Delete mocks base method
@@ -257,6 +259,21 @@ func (mr *MockcfnClientMockRecorder) Describe(stackName interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Describe", reflect.TypeOf((*MockcfnClient)(nil).Describe), stackName)
 }
 
+// DescribeChangeSet mocks base method
+func (m *MockcfnClient) DescribeChangeSet(changeSetID string) (*cloudformation0.ChangeSetDescription, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeChangeSet", changeSetID)
+	ret0, _ := ret[0].(*cloudformation0.ChangeSetDescription)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeChangeSet indicates an expected call of DescribeChangeSet
+func (mr *MockcfnClientMockRecorder) DescribeChangeSet(changeSetID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeChangeSet", reflect.TypeOf((*MockcfnClient)(nil).DescribeChangeSet), changeSetID)
+}
+
 // TemplateBody mocks base method
 func (m *MockcfnClient) TemplateBody(stackName string) (string, error) {
 	m.ctrl.T.Helper()
@@ -300,6 +317,21 @@ func (m *MockcfnClient) ErrorEvents(stackName string) ([]cloudformation0.StackEv
 func (mr *MockcfnClientMockRecorder) ErrorEvents(stackName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ErrorEvents", reflect.TypeOf((*MockcfnClient)(nil).ErrorEvents), stackName)
+}
+
+// DescribeStackEvents mocks base method
+func (m *MockcfnClient) DescribeStackEvents(arg0 *cloudformation.DescribeStackEventsInput) (*cloudformation.DescribeStackEventsOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeStackEvents", arg0)
+	ret0, _ := ret[0].(*cloudformation.DescribeStackEventsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeStackEvents indicates an expected call of DescribeStackEvents
+func (mr *MockcfnClientMockRecorder) DescribeStackEvents(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeStackEvents", reflect.TypeOf((*MockcfnClient)(nil).DescribeStackEvents), arg0)
 }
 
 // MockstackSetClient is a mock of stackSetClient interface

--- a/internal/pkg/describe/stack.go
+++ b/internal/pkg/describe/stack.go
@@ -11,13 +11,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 )
 
-// StackResourceDescription identifies a CloudFormation stack resource with a human-friendly description.
-type StackResourceDescription struct {
-	LogicalResourceID string
-	ResourceType      string
-	Description       string
-}
-
 type cfnStackDescriber interface {
 	DescribeStacks(input *cloudformation.DescribeStacksInput) (*cloudformation.DescribeStacksOutput, error)
 	DescribeStackResources(input *cloudformation.DescribeStackResourcesInput) (*cloudformation.DescribeStackResourcesOutput, error)

--- a/internal/pkg/stream/cloudformation.go
+++ b/internal/pkg/stream/cloudformation.go
@@ -24,7 +24,7 @@ type StackEvent struct {
 	ResourceStatus    string
 }
 
-// StackStreamer is a FetchNotifier for StackEvent events started by a change set.
+// StackStreamer is a FetchNotifyStopper for StackEvent events started by a change set.
 type StackStreamer struct {
 	client                StackEventsDescriber
 	stackName             string
@@ -106,6 +106,13 @@ func (s *StackStreamer) Notify() {
 		}
 	}
 	s.eventsToFlush = nil // reset after flushing all events.
+}
+
+// Stop closes all subscribed channels notifying them that no more events will be sent.
+func (s *StackStreamer) Stop() {
+	for _, sub := range s.subscribers {
+		close(sub)
+	}
 }
 
 // Taken from https://github.com/golang/go/wiki/SliceTricks#reversing

--- a/internal/pkg/stream/cloudformation_test.go
+++ b/internal/pkg/stream/cloudformation_test.go
@@ -93,11 +93,7 @@ func testStackStreamer_Fetch_Success(t *testing.T) {
 			},
 		},
 	}
-	streamer := &StackStreamer{
-		Client:                client,
-		StackName:             "phonetool-test",
-		ChangeSetCreationTime: time.Date(2020, time.November, 23, 16, 0, 0, 0, time.UTC),
-	}
+	streamer := NewStackStreamer(client, "phonetool-test", time.Date(2020, time.November, 23, 16, 0, 0, 0, time.UTC))
 
 	// WHEN
 	_, err := streamer.Fetch()
@@ -131,9 +127,9 @@ func testStackStreamer_Fetch_PostChangeSet(t *testing.T) {
 		},
 	}
 	streamer := &StackStreamer{
-		Client:                client,
-		StackName:             "phonetool-test",
-		ChangeSetCreationTime: time.Date(2020, time.November, 23, 19, 0, 0, 0, time.UTC), // An hour after the last event.
+		client:                client,
+		stackName:             "phonetool-test",
+		changeSetCreationTime: time.Date(2020, time.November, 23, 19, 0, 0, 0, time.UTC), // An hour after the last event.
 	}
 
 	// WHEN
@@ -165,9 +161,9 @@ func testStackStreamer_Fetch_WithSeenEvents(t *testing.T) {
 		},
 	}
 	streamer := &StackStreamer{
-		Client:                client,
-		StackName:             "phonetool-test",
-		ChangeSetCreationTime: time.Date(2020, time.November, 23, 16, 0, 0, 0, time.UTC),
+		client:                client,
+		stackName:             "phonetool-test",
+		changeSetCreationTime: time.Date(2020, time.November, 23, 16, 0, 0, 0, time.UTC),
 		pastEventIDs: map[string]bool{
 			"def": true,
 		},
@@ -192,9 +188,9 @@ func testStackStreamer_Fetch_WithError(t *testing.T) {
 		err: errors.New("some error"),
 	}
 	streamer := &StackStreamer{
-		Client:                client,
-		StackName:             "phonetool-test",
-		ChangeSetCreationTime: time.Date(2020, time.November, 23, 16, 0, 0, 0, time.UTC),
+		client:                client,
+		stackName:             "phonetool-test",
+		changeSetCreationTime: time.Date(2020, time.November, 23, 16, 0, 0, 0, time.UTC),
 	}
 
 	// WHEN

--- a/internal/pkg/stream/stream.go
+++ b/internal/pkg/stream/stream.go
@@ -7,26 +7,35 @@ import (
 	"time"
 )
 
+// Fetcher is the interface that wraps the Fetch method.
 // Fetcher fetches events, updates its internal state with new events and returns the next time
 // the Fetch call should be attempted. On failure, Fetch returns an error.
 type Fetcher interface {
 	Fetch() (next time.Time, err error)
 }
 
-// Notifier notifies all of its subscribers of any new event updates.
+// Notifier is the interface that wraps the Notify method.
+// Notify publishes all new event updates to subscribers..
 type Notifier interface {
 	Notify()
 }
 
-// FetchNotifier is the interface that groups the Fetch and a Notify methods.
-type FetchNotifier interface {
+// Stopper is the interface that wraps the Stop method.
+// Stop notifies all subscribers that no more events will be sent.
+type Stopper interface {
+	Stop()
+}
+
+// FetchNotifyStopper is the interface that groups a Fetcher, Notifier, and Stopper.
+type FetchNotifyStopper interface {
 	Fetcher
-	Notifier
+	Notify()
+	Stop()
 }
 
 // Stream streams event updates by calling Fetch followed with Notify until the context is canceled or Fetch errors.
-// Once the context is canceled, a best effort Fetch and Notify is called one last time.
-func Stream(ctx context.Context, fn FetchNotifier) error {
+// Once the context is canceled, a best effort Fetch and Notify is called followed with stopping the streamer.
+func Stream(ctx context.Context, streamer FetchNotifyStopper) error {
 	var next time.Time
 	var err error
 	for {
@@ -37,16 +46,18 @@ func Stream(ctx context.Context, fn FetchNotifier) error {
 
 		select {
 		case <-ctx.Done():
-			// The parent context is canceled. Try Fetch and Notify one last time and exit successfully.
-			_, _ = fn.Fetch()
-			fn.Notify()
+			// The parent context is canceled.
+			// Best-effort publish latest events and then notify subscribers no more events will be sent.
+			_, _ = streamer.Fetch()
+			streamer.Notify()
+			streamer.Stop()
 			return nil
 		case <-time.After(fetchDelay):
-			next, err = fn.Fetch()
+			next, err = streamer.Fetch()
 			if err != nil {
 				return err
 			}
-			fn.Notify()
+			streamer.Notify()
 		}
 	}
 }

--- a/internal/pkg/stream/stream.go
+++ b/internal/pkg/stream/stream.go
@@ -29,8 +29,8 @@ type Stopper interface {
 // FetchNotifyStopper is the interface that groups a Fetcher, Notifier, and Stopper.
 type FetchNotifyStopper interface {
 	Fetcher
-	Notify()
-	Stop()
+	Notifier
+	Stopper
 }
 
 // Stream streams event updates by calling Fetch followed with Notify until the context is canceled or Fetch errors.

--- a/internal/pkg/stream/stream_test.go
+++ b/internal/pkg/stream/stream_test.go
@@ -26,6 +26,8 @@ func (s *counterStreamer) Notify() {
 	s.notifyCount += 1
 }
 
+func (s *counterStreamer) Stop() {}
+
 // errStreamer returns an error when Fetch is invoked.
 type errStreamer struct {
 	err error
@@ -36,6 +38,8 @@ func (s *errStreamer) Fetch() (time.Time, error) {
 }
 
 func (s *errStreamer) Notify() {}
+
+func (s *errStreamer) Stop() {}
 
 func TestStream(t *testing.T) {
 	t.Run("calls Fetch and Notify if context is canceled", func(t *testing.T) {

--- a/internal/pkg/term/progress/cloudformation.go
+++ b/internal/pkg/term/progress/cloudformation.go
@@ -28,7 +28,7 @@ type StackResourceDescription struct {
 //
 // The component only listens for stack resource events for the provided changes in the stack.
 // The state of changes is updated as events are published from the streamer.
-func ListeningStackRenderer(stackName, description string, changes []StackResourceDescription, streamer StackSubscriber) Renderer {
+func ListeningStackRenderer(streamer StackSubscriber, stackName, description string, changes []StackResourceDescription) Renderer {
 	var children []Renderer
 	for _, change := range changes {
 		children = append(children, listeningResourceRenderer(change, streamer))

--- a/internal/pkg/term/progress/cloudformation.go
+++ b/internal/pkg/term/progress/cloudformation.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"sync"
 
-	"github.com/aws/copilot-cli/internal/pkg/describe"
 	"github.com/aws/copilot-cli/internal/pkg/stream"
 )
 
@@ -18,12 +17,19 @@ type StackSubscriber interface {
 	Subscribe(channels ...chan stream.StackEvent)
 }
 
+// StackResourceDescription identifies a CloudFormation stack resource annotated with a human-friendly description.
+type StackResourceDescription struct {
+	LogicalResourceID string
+	ResourceType      string
+	Description       string
+}
+
 // ListeningStackRenderer returns a component that listens for CloudFormation
 // resource events from a stack until the ctx is canceled.
 //
 // The component only listens for stack resource events for the provided changes in the stack.
 // The state of changes is updated as events are published from the streamer.
-func ListeningStackRenderer(ctx context.Context, stackName, description string, changes []describe.StackResourceDescription, streamer StackSubscriber) Renderer {
+func ListeningStackRenderer(ctx context.Context, stackName, description string, changes []StackResourceDescription, streamer StackSubscriber) Renderer {
 	var children []Renderer
 	for _, change := range changes {
 		children = append(children, listeningResourceRenderer(ctx, change, streamer))
@@ -40,7 +46,7 @@ func ListeningStackRenderer(ctx context.Context, stackName, description string, 
 }
 
 // listeningResourceRenderer returns a component that listens for CloudFormation stack events for a particular resource.
-func listeningResourceRenderer(ctx context.Context, resource describe.StackResourceDescription, streamer StackSubscriber) Renderer {
+func listeningResourceRenderer(ctx context.Context, resource StackResourceDescription, streamer StackSubscriber) Renderer {
 	comp := &regularResourceComponent{
 		logicalID:   resource.LogicalResourceID,
 		description: resource.Description,

--- a/internal/pkg/term/progress/cloudformation_test.go
+++ b/internal/pkg/term/progress/cloudformation_test.go
@@ -4,7 +4,6 @@
 package progress
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -15,7 +14,6 @@ import (
 func TestStackComponent_Listen(t *testing.T) {
 	t.Run("should not update status if no events are received for the logical ID", func(t *testing.T) {
 		// GIVEN
-		ctx, cancel := context.WithCancel(context.Background())
 		ch := make(chan stream.StackEvent)
 		done := make(chan bool)
 		comp := &stackComponent{
@@ -26,7 +24,7 @@ func TestStackComponent_Listen(t *testing.T) {
 
 		// WHEN
 		go func() {
-			comp.Listen(ctx)
+			comp.Listen()
 			done <- true
 		}()
 		go func() {
@@ -38,16 +36,15 @@ func TestStackComponent_Listen(t *testing.T) {
 				LogicalResourceID: "ServiceDiscoveryNamespace",
 				ResourceStatus:    "CREATE_COMPLETE",
 			}
-			cancel()
+			close(ch) // Close to notify that no more events will be sent.
 		}()
 
 		// THEN
-		<-done // Block until we are done listening.
+		<-done // Wait for listen to exit.
 		require.Equal(t, "not started", comp.status)
 	})
 	t.Run("should update status when an event is received for stack", func(t *testing.T) {
 		// GIVEN
-		ctx, cancel := context.WithCancel(context.Background())
 		ch := make(chan stream.StackEvent)
 		done := make(chan bool)
 		comp := &stackComponent{
@@ -58,7 +55,7 @@ func TestStackComponent_Listen(t *testing.T) {
 
 		// WHEN
 		go func() {
-			comp.Listen(ctx)
+			comp.Listen()
 			done <- true
 		}()
 		go func() {
@@ -70,11 +67,11 @@ func TestStackComponent_Listen(t *testing.T) {
 				LogicalResourceID: "phonetool-test",
 				ResourceStatus:    "CREATE_COMPLETE",
 			}
-			cancel()
+			close(ch) // Close to notify that no more events will be sent.
 		}()
 
 		// THEN
-		<-done // Block until we are done listening.
+		<-done // Wait for listen to exit.
 		require.Equal(t, "CREATE_COMPLETE", comp.status)
 	})
 }
@@ -110,7 +107,6 @@ func TestStackComponent_Render(t *testing.T) {
 func TestRegularResourceComponent_Listen(t *testing.T) {
 	t.Run("should not update status if no events are received for the logical ID", func(t *testing.T) {
 		// GIVEN
-		ctx, cancel := context.WithCancel(context.Background())
 		ch := make(chan stream.StackEvent)
 		done := make(chan bool)
 		comp := &regularResourceComponent{
@@ -121,7 +117,7 @@ func TestRegularResourceComponent_Listen(t *testing.T) {
 
 		// WHEN
 		go func() {
-			comp.Listen(ctx)
+			comp.Listen()
 			done <- true
 		}()
 		go func() {
@@ -129,16 +125,15 @@ func TestRegularResourceComponent_Listen(t *testing.T) {
 				LogicalResourceID: "ServiceDiscoveryNamespace",
 				ResourceStatus:    "CREATE_COMPLETE",
 			}
-			cancel()
+			close(ch) // Close to notify that no more events will be sent.
 		}()
 
 		// THEN
-		<-done // Block until we are done listening.
+		<-done // Wait for listen to exit.
 		require.Equal(t, "not started", comp.status)
 	})
 	t.Run("should update status when an event is received for the resource", func(t *testing.T) {
 		// GIVEN
-		ctx, cancel := context.WithCancel(context.Background())
 		ch := make(chan stream.StackEvent)
 		done := make(chan bool)
 		comp := &regularResourceComponent{
@@ -149,7 +144,7 @@ func TestRegularResourceComponent_Listen(t *testing.T) {
 
 		// WHEN
 		go func() {
-			comp.Listen(ctx)
+			comp.Listen()
 			done <- true
 		}()
 		go func() {
@@ -161,11 +156,11 @@ func TestRegularResourceComponent_Listen(t *testing.T) {
 				LogicalResourceID: "phonetool-test",
 				ResourceStatus:    "ROLLBACK_COMPLETE",
 			}
-			cancel()
+			close(ch) // Close to notify that no more events will be sent.
 		}()
 
 		// THEN
-		<-done // Block until we are done listening.
+		<-done // Wait for listen to exit.
 		require.Equal(t, "CREATE_COMPLETE", comp.status)
 	})
 }


### PR DESCRIPTION
The "deploy" pkg can now create an environment stack and render the
stack updates to an io.Writer concurrently.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
