### PR TITLE
chore(cli): Unmarshal template in "env upgrade" to check if roles are retained

### DIFF
--- a/internal/pkg/cli/env_delete.go
+++ b/internal/pkg/cli/env_delete.go
@@ -21,6 +21,7 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/term/prompt"
 	"github.com/aws/copilot-cli/internal/pkg/term/selector"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -242,13 +243,30 @@ func (o *deleteEnvOpts) ensureRolesAreRetained() error {
 		}
 		return fmt.Errorf("get template body for environment %s in application %s: %v", o.name, o.appName, err)
 	}
-	// Check if the roles are already being retained.
-	retainsExecRole := strings.Contains(body, `
-  CloudformationExecutionRole:
-    DeletionPolicy: Retain`)
-	retainsManagerRole := strings.Contains(body, `
-  EnvironmentManagerRole:
-    DeletionPolicy: Retain`)
+
+	// Check if the execution role and the manager role are retained by the stack.
+	const retainPolicy = "Retain"
+	roles := struct {
+		ExecRole    yaml.Node `yaml:"CloudformationExecutionRole"`
+		ManagerRole yaml.Node `yaml:"EnvironmentManagerRole"`
+	}{}
+	if err := yaml.Unmarshal([]byte(body), &roles); err != nil {
+		return fmt.Errorf("unmarshal environment template body %s-%s to environment roles: %w", o.appName, o.name, err)
+	}
+
+	type roleProperties struct {
+		DeletionPolicy string `yaml:"DeletionPolicy"`
+	}
+	var execRoleProps roleProperties
+	if err := roles.ExecRole.Decode(&execRoleProps); err != nil {
+		return fmt.Errorf("decode execution role's deletion policy: %w", err)
+	}
+	var managerRoleProps roleProperties
+	if err := roles.ManagerRole.Decode(&managerRoleProps); err != nil {
+		return fmt.Errorf("decode manager role's deletion policy: %w", err)
+	}
+	retainsExecRole := execRoleProps.DeletionPolicy == retainPolicy
+	retainsManagerRole := managerRoleProps.DeletionPolicy == retainPolicy
 	if retainsExecRole && retainsManagerRole {
 		// Nothing to do, this is **not** a legacy environment stack. Exit successfully.
 		return nil

--- a/internal/pkg/cli/env_delete_test.go
+++ b/internal/pkg/cli/env_delete_test.go
@@ -216,17 +216,35 @@ func TestDeleteEnvOpts_Execute(t *testing.T) {
 
 				deployer := mocks.NewMockenvironmentDeployer(ctrl)
 				deployer.EXPECT().EnvironmentTemplate(gomock.Any(), gomock.Any()).Return(`
+Resources:
+  EnableLongARNFormatAction:
+    Type: Custom::EnableLongARNFormatFunction
+    DependsOn:
+    - EnableLongARNFormatFunction
+    Properties:
+    ServiceToken: !GetAtt EnableLongARNFormatFunction.Arn
   CloudformationExecutionRole:
+    Type: AWS::IAM::Role
   EnvironmentManagerRole:
+    Type: AWS::IAM::Role
 `, nil)
 				deployer.EXPECT().UpdateEnvironmentTemplate(
 					"phonetool",
 					"test",
 					`
+Resources:
+  EnableLongARNFormatAction:
+    Type: Custom::EnableLongARNFormatFunction
+    DependsOn:
+    - EnableLongARNFormatFunction
+    Properties:
+    ServiceToken: !GetAtt EnableLongARNFormatFunction.Arn
   CloudformationExecutionRole:
     DeletionPolicy: Retain
+    Type: AWS::IAM::Role
   EnvironmentManagerRole:
     DeletionPolicy: Retain
+    Type: AWS::IAM::Role
 `, "arn").Return(errors.New("some error"))
 
 				prog.EXPECT().Stop(log.Serror("Failed to delete environment test from application phonetool.\n"))
@@ -261,6 +279,7 @@ func TestDeleteEnvOpts_Execute(t *testing.T) {
   CloudformationExecutionRole:
     DeletionPolicy: Retain
   EnvironmentManagerRole:
+    # An IAM Role to manage resources in your environment
     DeletionPolicy: Retain`, nil)
 				deployer.EXPECT().DeleteEnvironment(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("some error"))
 
@@ -295,6 +314,7 @@ func TestDeleteEnvOpts_Execute(t *testing.T) {
   CloudformationExecutionRole:
     DeletionPolicy: Retain
   EnvironmentManagerRole:
+    # An IAM Role to manage resources in your environment
     DeletionPolicy: Retain`, nil)
 				deployer.EXPECT().DeleteEnvironment(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
@@ -338,6 +358,7 @@ func TestDeleteEnvOpts_Execute(t *testing.T) {
   CloudformationExecutionRole:
     DeletionPolicy: Retain
   EnvironmentManagerRole:
+    # An IAM Role to manage resources in your environment
     DeletionPolicy: Retain`, nil)
 				deployer.EXPECT().DeleteEnvironment("phonetool", "test", "execARN").Return(nil)
 


### PR DESCRIPTION
Previously, we would check if the following string was included in the
template to see if the EnvManagerRole or ExecRole were retained:
```yaml
EnvManagerRole:
    DeletionPolicy: Retain
```
Once, we added a comment under the EnvManagerRole:
```yaml
EnvManagerRole:
    # An IAM role to manage your environments
    DeletionPolicy: Retain`
```
The parsing broke and the CLI thought that the resources were not
retained.

Now, we're using the yaml.Unmarshal library to see if a "DeletionPolicy"
node is present under the roles.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
