### PR TITLE
chore(cli): fix checking if roles are retained in the env template

### DIFF
--- a/internal/pkg/cli/env_delete_test.go
+++ b/internal/pkg/cli/env_delete_test.go
@@ -276,6 +276,7 @@ Resources:
 
 				deployer := mocks.NewMockenvironmentDeployer(ctrl)
 				deployer.EXPECT().EnvironmentTemplate(gomock.Any(), gomock.Any()).Return(`
+Resources:
   CloudformationExecutionRole:
     DeletionPolicy: Retain
   EnvironmentManagerRole:
@@ -311,6 +312,7 @@ Resources:
 
 				deployer := mocks.NewMockenvironmentDeployer(ctrl)
 				deployer.EXPECT().EnvironmentTemplate(gomock.Any(), gomock.Any()).Return(`
+Resources:
   CloudformationExecutionRole:
     DeletionPolicy: Retain
   EnvironmentManagerRole:
@@ -355,11 +357,15 @@ Resources:
 
 				deployer := mocks.NewMockenvironmentDeployer(ctrl)
 				deployer.EXPECT().EnvironmentTemplate("phonetool", "test").Return(`
+Resources:
   CloudformationExecutionRole:
     DeletionPolicy: Retain
+    Type: AWS::IAM::Role
   EnvironmentManagerRole:
     # An IAM Role to manage resources in your environment
-    DeletionPolicy: Retain`, nil)
+    DeletionPolicy: Retain
+    Type: AWS::IAM::Role
+`, nil)
 				deployer.EXPECT().DeleteEnvironment("phonetool", "test", "execARN").Return(nil)
 
 				iam := mocks.NewMockroleDeleter(ctrl)

--- a/templates/environment/partials/environment-manager-role.yml
+++ b/templates/environment/partials/environment-manager-role.yml
@@ -1,5 +1,3 @@
-# The EnvironmentManagerRole definition must be immediately followed with DeletionPolicy: Retain.
-# See #1533.
 EnvironmentManagerRole:
   # An IAM Role to manage resources in your environment
   DeletionPolicy: Retain


### PR DESCRIPTION
Resolves #1533

https://github.com/aws/copilot-cli/pull/1799 did not properly check if the EnvManagerRole and CFNExecRole were retained by the CFN stack :( This change fixes that.

Tested by getting the same error as our e2e test while running `app delete`:
```
execute env delete: update environment stack to retain environment roles: change set with name copilot-9c2696f1-77cd-4fe8-a8ca-28589c86ff36 for stack e2e-addons-1609456780-test has no changes
```
After, this change the deletion is back to being successful:
```
Are you sure you want to delete application e2e-addons-1609456780? Yes
✔ Deleted environment test from application e2e-addons-1609456780.
✔ Cleaned up deployment resources.
✔ Deleted application resources.
✔ Deleted application configuration.
✔ Deleted local .workspace file.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
