### PR TITLE
chore(progress): display time elapsed for resource creation

### DIFF
--- a/internal/pkg/term/progress/cloudformation.go
+++ b/internal/pkg/term/progress/cloudformation.go
@@ -6,6 +6,7 @@ package progress
 import (
 	"fmt"
 	"io"
+	"strings"
 	"sync"
 
 	"github.com/aws/copilot-cli/internal/pkg/aws/cloudformation"
@@ -38,6 +39,7 @@ func ListeningStackRenderer(streamer StackSubscriber, stackName, description str
 		logicalID:   stackName,
 		description: description,
 		statuses:    []stackStatus{notStartedStackStatus},
+		stopWatch:   newStopWatch(),
 		children:    children,
 		stream:      make(chan stream.StackEvent),
 		separator:   '\t',
@@ -54,6 +56,7 @@ func listeningResourceRenderer(streamer StackSubscriber, resource StackResourceD
 		logicalID:   resource.LogicalResourceID,
 		description: resource.Description,
 		statuses:    []stackStatus{notStartedStackStatus},
+		stopWatch:   newStopWatch(),
 		stream:      make(chan stream.StackEvent),
 		padding:     padding,
 		separator:   '\t',
@@ -69,6 +72,7 @@ type stackComponent struct {
 	description string        // The human friendly explanation of the purpose of the stack.
 	statuses    []stackStatus // In-order history of the CloudFormation status of the stack throughout the deployment.
 	children    []Renderer    // Resources part of the stack.
+	stopWatch   *stopWatch    // Timer to measure how long the operation takes to complete.
 
 	padding   int  // Leading spaces before rendering the stack.
 	separator rune // Character used to separate columns of text.
@@ -80,7 +84,11 @@ type stackComponent struct {
 // Listen updates the stack's status if a CloudFormation stack event is received.
 func (c *stackComponent) Listen() {
 	for ev := range c.stream {
-		updateComponentStatus(&c.mu, &c.statuses, c.logicalID, ev)
+		if c.logicalID != ev.LogicalResourceID {
+			continue
+		}
+		updateComponentStatus(&c.mu, &c.statuses, ev)
+		updateComponentTimer(&c.mu, c.statuses, c.stopWatch)
 	}
 }
 
@@ -88,7 +96,7 @@ func (c *stackComponent) Listen() {
 // If any sub-component's Render call fails, then writes nothing and returns an error.
 func (c *stackComponent) Render(out io.Writer) (numLines int, err error) {
 	c.mu.Lock()
-	components := stackResourceComponents(c.description, c.separator, c.statuses, c.padding)
+	components := stackResourceComponents(c.description, c.separator, c.statuses, c.stopWatch, c.padding)
 	c.mu.Unlock()
 
 	return renderComponents(out, append(components, c.children...))
@@ -99,6 +107,7 @@ type regularResourceComponent struct {
 	logicalID   string        // The LogicalID defined in the template for the resource.
 	description string        // The human friendly explanation of the resource.
 	statuses    []stackStatus // In-order history of the CloudFormation status of the resource throughout the deployment.
+	stopWatch   *stopWatch    // Timer to measure how long the operation takes to complete.
 
 	padding   int  // Leading spaces before rendering the resource.
 	separator rune // Character used to separate columns of text.
@@ -110,7 +119,11 @@ type regularResourceComponent struct {
 // Listen updates the resource's status if a CloudFormation stack resource event is received.
 func (c *regularResourceComponent) Listen() {
 	for ev := range c.stream {
-		updateComponentStatus(&c.mu, &c.statuses, c.logicalID, ev)
+		if c.logicalID != ev.LogicalResourceID {
+			continue
+		}
+		updateComponentStatus(&c.mu, &c.statuses, ev)
+		updateComponentTimer(&c.mu, c.statuses, c.stopWatch)
 	}
 }
 
@@ -119,26 +132,39 @@ func (c *regularResourceComponent) Render(out io.Writer) (numLines int, err erro
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	components := stackResourceComponents(c.description, c.separator, c.statuses, c.padding)
+	components := stackResourceComponents(c.description, c.separator, c.statuses, c.stopWatch, c.padding)
 	return renderComponents(out, components)
 }
 
-func updateComponentStatus(mu *sync.Mutex, statuses *[]stackStatus, logicalID string, event stream.StackEvent) {
-	if logicalID != event.LogicalResourceID {
-		return
-	}
+func updateComponentStatus(mu *sync.Mutex, statuses *[]stackStatus, event stream.StackEvent) {
 	mu.Lock()
+	defer mu.Unlock()
+
 	*statuses = append(*statuses, stackStatus{
 		value:  cloudformation.StackStatus(event.ResourceStatus),
 		reason: event.ResourceStatusReason,
 	})
-	mu.Unlock()
 }
 
-func stackResourceComponents(description string, separator rune, statuses []stackStatus, padding int) []Renderer {
+func updateComponentTimer(mu *sync.Mutex, statuses []stackStatus, sw *stopWatch) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	latestStatus := statuses[len(statuses)-1]
+	switch {
+	case latestStatus.value.InProgress():
+		sw.reset()
+		sw.start()
+	default:
+		sw.stop()
+	}
+}
+
+func stackResourceComponents(description string, separator rune, statuses []stackStatus, sw *stopWatch, padding int) []Renderer {
+	columns := []string{fmt.Sprintf("- %s", description), prettifyLatestStackStatus(statuses), prettifyElapsedTime(sw)}
 	components := []Renderer{
 		&singleLineComponent{
-			Text:    fmt.Sprintf("- %s%s%s", description, string(separator), prettifyLatestStackStatus(statuses)),
+			Text:    strings.Join(columns, string(separator)),
 			Padding: padding,
 		},
 	}
@@ -146,7 +172,7 @@ func stackResourceComponents(description string, separator rune, statuses []stac
 	for _, failureReason := range failureReasons(statuses) {
 		for _, text := range splitByLength(failureReason, maxCellLength) {
 			components = append(components, &singleLineComponent{
-				Text:    fmt.Sprintf("%s%s", colorFailureReason(text), string(separator)),
+				Text:    strings.Join([]string{colorFailureReason(text), "", ""}, string(separator)),
 				Padding: padding + nestedComponentPadding,
 			})
 		}

--- a/internal/pkg/term/progress/cloudformation.go
+++ b/internal/pkg/term/progress/cloudformation.go
@@ -150,12 +150,18 @@ func updateComponentTimer(mu *sync.Mutex, statuses []stackStatus, sw *stopWatch)
 	mu.Lock()
 	defer mu.Unlock()
 
-	latestStatus := statuses[len(statuses)-1]
+	// There is always at least two elements {notStartedStatus, <new event>}
+	curStatus, nextStatus := statuses[len(statuses)-2], statuses[len(statuses)-1]
 	switch {
-	case latestStatus.value.InProgress():
+	case nextStatus.value.InProgress():
 		sw.reset()
 		sw.start()
 	default:
+		if curStatus == notStartedStackStatus {
+			// The resource went from [not started] to a finished state immediately.
+			// So start the timer and then immediately finish it.
+			sw.start()
+		}
 		sw.stop()
 	}
 }

--- a/internal/pkg/term/progress/cloudformation_test.go
+++ b/internal/pkg/term/progress/cloudformation_test.go
@@ -34,7 +34,7 @@ func TestStackComponent_Listen(t *testing.T) {
 		done := make(chan bool)
 		comp := &stackComponent{
 			logicalID: "phonetool-test",
-			statuses:  []stackStatus{},
+			statuses:  []stackStatus{notStartedStackStatus},
 			stopWatch: &stopWatch{
 				clock: &fakeClock{
 					wantedValues: []time.Time{testDate},
@@ -62,7 +62,7 @@ func TestStackComponent_Listen(t *testing.T) {
 
 		// THEN
 		<-done // Wait for listen to exit.
-		require.Empty(t, comp.statuses)
+		require.ElementsMatch(t, []stackStatus{notStartedStackStatus}, comp.statuses)
 		_, hasStarted := comp.stopWatch.elapsed()
 		require.False(t, hasStarted, "the stopwatch should not have started")
 	})
@@ -72,7 +72,7 @@ func TestStackComponent_Listen(t *testing.T) {
 		done := make(chan bool)
 		comp := &stackComponent{
 			logicalID: "phonetool-test",
-			statuses:  []stackStatus{},
+			statuses:  []stackStatus{notStartedStackStatus},
 			stopWatch: &stopWatch{
 				clock: &fakeClock{
 					wantedValues: []time.Time{testDate},
@@ -101,6 +101,7 @@ func TestStackComponent_Listen(t *testing.T) {
 		// THEN
 		<-done // Wait for listen to exit.
 		require.ElementsMatch(t, []stackStatus{
+			notStartedStackStatus,
 			{
 				value: "CREATE_COMPLETE",
 			},
@@ -117,6 +118,7 @@ func TestStackComponent_Render(t *testing.T) {
 		comp := &stackComponent{
 			description: `The environment stack "phonetool-test" contains your shared resources between services`,
 			statuses: []stackStatus{
+				notStartedStackStatus,
 				{
 					value: "CREATE_COMPLETE",
 				},
@@ -154,6 +156,7 @@ func TestStackComponent_Render(t *testing.T) {
 		comp := &stackComponent{
 			description: `The environment stack "phonetool-test" contains your shared resources between services`,
 			statuses: []stackStatus{
+				notStartedStackStatus,
 				{
 					value: "CREATE_IN_PROGRESS",
 				},
@@ -236,7 +239,7 @@ func TestRegularResourceComponent_Listen(t *testing.T) {
 		done := make(chan bool)
 		comp := &regularResourceComponent{
 			logicalID: "EnvironmentManagerRole",
-			statuses:  []stackStatus{},
+			statuses:  []stackStatus{notStartedStackStatus},
 			stopWatch: &stopWatch{
 				clock: &fakeClock{
 					wantedValues: []time.Time{testDate},
@@ -260,7 +263,7 @@ func TestRegularResourceComponent_Listen(t *testing.T) {
 
 		// THEN
 		<-done // Wait for listen to exit.
-		require.Empty(t, comp.statuses)
+		require.ElementsMatch(t, []stackStatus{notStartedStackStatus}, comp.statuses)
 		_, hasStarted := comp.stopWatch.elapsed()
 		require.False(t, hasStarted, "the stopwatch should not have started")
 	})
@@ -270,7 +273,7 @@ func TestRegularResourceComponent_Listen(t *testing.T) {
 		done := make(chan bool)
 		comp := &regularResourceComponent{
 			logicalID: "EnvironmentManagerRole",
-			statuses:  []stackStatus{},
+			statuses:  []stackStatus{notStartedStackStatus},
 			stopWatch: &stopWatch{
 				clock: &fakeClock{
 					wantedValues: []time.Time{testDate},
@@ -300,6 +303,7 @@ func TestRegularResourceComponent_Listen(t *testing.T) {
 		// THEN
 		<-done // Wait for listen to exit.
 		require.ElementsMatch(t, []stackStatus{
+			notStartedStackStatus,
 			{
 				value:  "CREATE_FAILED",
 				reason: "This IAM role already exists.",
@@ -317,6 +321,7 @@ func TestRegularResourceComponent_Render(t *testing.T) {
 		comp := &regularResourceComponent{
 			description: "An ECS cluster to hold your services",
 			statuses: []stackStatus{
+				notStartedStackStatus,
 				{
 					value: "CREATE_COMPLETE",
 				},
@@ -344,6 +349,7 @@ func TestRegularResourceComponent_Render(t *testing.T) {
 		comp := &regularResourceComponent{
 			description: "An ECS cluster to hold your services",
 			statuses: []stackStatus{
+				notStartedStackStatus,
 				{
 					value: "CREATE_IN_PROGRESS",
 				},

--- a/internal/pkg/term/progress/status.go
+++ b/internal/pkg/term/progress/status.go
@@ -28,6 +28,14 @@ func prettifyLatestStackStatus(statuses []stackStatus) string {
 	return color("[%s]", pretty)
 }
 
+func prettifyElapsedTime(sw *stopWatch) string {
+	elapsed, hasStarted := sw.elapsed()
+	if !hasStarted {
+		return ""
+	}
+	return color.Faint.Sprintf("[%.1fs]", elapsed.Seconds())
+}
+
 func failureReasons(statuses []stackStatus) []string {
 	var reasons []string
 	for _, status := range statuses {

--- a/internal/pkg/term/progress/time.go
+++ b/internal/pkg/term/progress/time.go
@@ -1,0 +1,69 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package progress
+
+import "time"
+
+type clock interface {
+	now() time.Time
+}
+
+type realClock struct{}
+
+func (c realClock) now() time.Time {
+	return time.Now()
+}
+
+type stopWatch struct {
+	startTime time.Time
+	stopTime  time.Time
+
+	started bool
+	stopped bool
+	clock   clock
+}
+
+func newStopWatch() *stopWatch {
+	return &stopWatch{
+		clock: realClock{},
+	}
+}
+
+func (sw *stopWatch) start() {
+	if sw.stopped {
+		sw.reset()
+	}
+
+	sw.startTime = sw.clock.now()
+	sw.started = true
+}
+
+func (sw *stopWatch) stop() {
+	sw.stopTime = sw.clock.now()
+
+	if !sw.started {
+		sw.start()
+		sw.stopTime = sw.startTime
+	}
+	sw.stopped = true
+}
+
+func (sw *stopWatch) reset() {
+	sw.startTime = time.Time{}
+	sw.stopTime = time.Time{}
+	sw.stopped = false
+	sw.started = false
+}
+
+// elapsed returns the time since starting the stopWatch.
+// If the stopWatch never run, then returns false for the boolean.
+func (sw *stopWatch) elapsed() (time.Duration, bool) {
+	if !sw.started { // The stopWatch didn't start, so no time elapsed.
+		return 0, false
+	}
+	if sw.stopped {
+		return sw.stopTime.Sub(sw.startTime), true
+	}
+	return sw.clock.now().Sub(sw.startTime), true
+}

--- a/internal/pkg/term/progress/time.go
+++ b/internal/pkg/term/progress/time.go
@@ -30,25 +30,31 @@ func newStopWatch() *stopWatch {
 	}
 }
 
+// start records the current time when the watch started.
+// If the watch is already in progress, then calling start multiple times does nothing.
 func (sw *stopWatch) start() {
-	if sw.stopped {
-		sw.reset()
+	if sw.started {
+		return
 	}
-
 	sw.startTime = sw.clock.now()
 	sw.started = true
 }
 
+// stop records the current time when the watch stopped.
+// If the watch never started, then calling stop doesn't do anything.
+// If the watch is already stopped, then calling stop another time doesn't do anything.
 func (sw *stopWatch) stop() {
-	sw.stopTime = sw.clock.now()
-
 	if !sw.started {
-		sw.start()
-		sw.stopTime = sw.startTime
+		return
 	}
+	if sw.stopped {
+		return
+	}
+	sw.stopTime = sw.clock.now()
 	sw.stopped = true
 }
 
+// reset should be called before starting a timer always.
 func (sw *stopWatch) reset() {
 	sw.startTime = time.Time{}
 	sw.stopTime = time.Time{}
@@ -57,7 +63,7 @@ func (sw *stopWatch) reset() {
 }
 
 // elapsed returns the time since starting the stopWatch.
-// If the stopWatch never run, then returns false for the boolean.
+// If the stopWatch never started, then returns false for the boolean.
 func (sw *stopWatch) elapsed() (time.Duration, bool) {
 	if !sw.started { // The stopWatch didn't start, so no time elapsed.
 		return 0, false


### PR DESCRIPTION
Next to the status we now display a timer for how long the resource took while it was in progress.
![with-timer](https://user-images.githubusercontent.com/879348/103832336-e970c200-5032-11eb-9dd4-76be77002994.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
