### PR TITLE
refactor(progress): spinner constructor accepts an io.Writer

### DIFF
--- a/internal/pkg/cli/app_delete.go
+++ b/internal/pkg/cli/app_delete.go
@@ -81,7 +81,7 @@ func newDeleteAppOpts(vars deleteAppVars) (*deleteAppOpts, error) {
 
 	return &deleteAppOpts{
 		deleteAppVars: vars,
-		spinner:       termprogress.NewSpinner(),
+		spinner:       termprogress.NewSpinner(log.DiagnosticWriter),
 		store:         store,
 		ws:            ws,
 		sessProvider:  provider,

--- a/internal/pkg/cli/app_init.go
+++ b/internal/pkg/cli/app_init.go
@@ -72,7 +72,7 @@ func newInitAppOpts(vars initAppVars) (*initAppOpts, error) {
 		ws:          ws,
 		cfn:         cloudformation.New(sess),
 		prompt:      prompt.New(),
-		prog:        termprogress.NewSpinner(),
+		prog:        termprogress.NewSpinner(log.DiagnosticWriter),
 	}, nil
 }
 

--- a/internal/pkg/cli/deploy.go
+++ b/internal/pkg/cli/deploy.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/config"
 	"github.com/aws/copilot-cli/internal/pkg/manifest"
 	"github.com/aws/copilot-cli/internal/pkg/term/command"
+	"github.com/aws/copilot-cli/internal/pkg/term/log"
 	termprogress "github.com/aws/copilot-cli/internal/pkg/term/progress"
 	"github.com/aws/copilot-cli/internal/pkg/term/prompt"
 	"github.com/aws/copilot-cli/internal/pkg/term/selector"
@@ -67,7 +68,7 @@ func newDeployOpts(vars deployWkldVars) (*deployOpts, error) {
 					store:        o.store,
 					ws:           o.ws,
 					unmarshal:    manifest.UnmarshalWorkload,
-					spinner:      termprogress.NewSpinner(),
+					spinner:      termprogress.NewSpinner(log.DiagnosticWriter),
 					sel:          selector.NewWorkspaceSelect(o.prompt, o.store, o.ws),
 					prompt:       o.prompt,
 					cmd:          command.New(),
@@ -80,7 +81,7 @@ func newDeployOpts(vars deployWkldVars) (*deployOpts, error) {
 					store:        o.store,
 					ws:           o.ws,
 					unmarshal:    manifest.UnmarshalWorkload,
-					spinner:      termprogress.NewSpinner(),
+					spinner:      termprogress.NewSpinner(log.DiagnosticWriter),
 					sel:          selector.NewWorkspaceSelect(o.prompt, o.store, o.ws),
 					prompt:       o.prompt,
 					cmd:          command.New(),

--- a/internal/pkg/cli/env_delete.go
+++ b/internal/pkg/cli/env_delete.go
@@ -79,7 +79,7 @@ func newDeleteEnvOpts(vars deleteEnvVars) (*deleteEnvOpts, error) {
 		deleteEnvVars: vars,
 
 		store:  store,
-		prog:   termprogress.NewSpinner(),
+		prog:   termprogress.NewSpinner(log.DiagnosticWriter),
 		sel:    selector.NewConfigSelect(prompter, store),
 		prompt: prompter,
 

--- a/internal/pkg/cli/env_init.go
+++ b/internal/pkg/cli/env_init.go
@@ -169,7 +169,7 @@ func newInitEnvOpts(vars initEnvVars) (*initEnvOpts, error) {
 		store:        store,
 		appDeployer:  deploycfn.New(defaultSession),
 		identity:     identity.New(defaultSession),
-		prog:         termprogress.NewSpinner(),
+		prog:         termprogress.NewSpinner(log.DiagnosticWriter),
 		prompt:       prompter,
 		selCreds: &selector.CredsSelect{
 			Session: sessProvider,

--- a/internal/pkg/cli/env_upgrade.go
+++ b/internal/pkg/cli/env_upgrade.go
@@ -71,7 +71,7 @@ func newEnvUpgradeOpts(vars envUpgradeVars) (*envUpgradeOpts, error) {
 		legacyEnvTemplater: stack.NewEnvStackConfig(&deploy.CreateEnvironmentInput{
 			Version: deploy.LegacyEnvTemplateVersion,
 		}),
-		prog: termprogress.NewSpinner(),
+		prog: termprogress.NewSpinner(log.DiagnosticWriter),
 
 		newEnvVersionGetter: func(app, env string) (versionGetter, error) {
 			d, err := describe.NewEnvDescriber(describe.NewEnvDescriberConfig{

--- a/internal/pkg/cli/init.go
+++ b/internal/pkg/cli/init.go
@@ -99,7 +99,7 @@ func newInitOpts(vars initVars) (*initOpts, error) {
 	}
 	prompt := prompt.New()
 	sel := selector.NewWorkspaceSelect(prompt, ssm, ws)
-	spin := termprogress.NewSpinner()
+	spin := termprogress.NewSpinner(log.DiagnosticWriter)
 	id := identity.New(defaultSess)
 	deployer := cloudformation.New(defaultSess)
 	if err != nil {

--- a/internal/pkg/cli/job_delete.go
+++ b/internal/pkg/cli/job_delete.go
@@ -97,7 +97,7 @@ func newDeleteJobOpts(vars deleteJobVars) (*deleteJobOpts, error) {
 		deleteJobVars: vars,
 
 		store:   store,
-		spinner: termprogress.NewSpinner(),
+		spinner: termprogress.NewSpinner(log.DiagnosticWriter),
 		prompt:  prompt.New(),
 		sel:     selector.NewWorkspaceSelect(prompter, store, ws),
 		sess:    provider,

--- a/internal/pkg/cli/job_deploy.go
+++ b/internal/pkg/cli/job_deploy.go
@@ -78,7 +78,7 @@ func newJobDeployOpts(vars deployWkldVars) (*deployJobOpts, error) {
 		store:        store,
 		ws:           ws,
 		unmarshal:    manifest.UnmarshalWorkload,
-		spinner:      termprogress.NewSpinner(),
+		spinner:      termprogress.NewSpinner(log.DiagnosticWriter),
 		sel:          selector.NewWorkspaceSelect(prompter, store, ws),
 		prompt:       prompter,
 		cmd:          command.New(),

--- a/internal/pkg/cli/job_init.go
+++ b/internal/pkg/cli/job_init.go
@@ -79,7 +79,7 @@ func newInitJobOpts(vars initJobVars) (*initJobOpts, error) {
 	jobInitter := &initialize.WorkloadInitializer{
 		Store:    store,
 		Ws:       ws,
-		Prog:     termprogress.NewSpinner(),
+		Prog:     termprogress.NewSpinner(log.DiagnosticWriter),
 		Deployer: cloudformation.New(sess),
 	}
 

--- a/internal/pkg/cli/pipeline_delete.go
+++ b/internal/pkg/cli/pipeline_delete.go
@@ -72,7 +72,7 @@ func newDeletePipelineOpts(vars deletePipelineVars) (*deletePipelineOpts, error)
 
 	opts := &deletePipelineOpts{
 		deletePipelineVars: vars,
-		prog:               termprogress.NewSpinner(),
+		prog:               termprogress.NewSpinner(log.DiagnosticWriter),
 		prompt:             prompt.New(),
 		secretsmanager:     secretsmanager,
 		pipelineDeployer:   cloudformation.New(defaultSess),

--- a/internal/pkg/cli/pipeline_update.go
+++ b/internal/pkg/cli/pipeline_update.go
@@ -86,7 +86,7 @@ func newUpdatePipelineOpts(vars updatePipelineVars) (*updatePipelineOpts, error)
 		updatePipelineVars: vars,
 		envStore:           store,
 		ws:                 ws,
-		prog:               termprogress.NewSpinner(),
+		prog:               termprogress.NewSpinner(log.DiagnosticWriter),
 		prompt:             prompt.New(),
 	}, nil
 }

--- a/internal/pkg/cli/svc_delete.go
+++ b/internal/pkg/cli/svc_delete.go
@@ -89,7 +89,7 @@ func newDeleteSvcOpts(vars deleteSvcVars) (*deleteSvcOpts, error) {
 		deleteSvcVars: vars,
 
 		store:   store,
-		spinner: termprogress.NewSpinner(),
+		spinner: termprogress.NewSpinner(log.DiagnosticWriter),
 		prompt:  prompter,
 		sess:    provider,
 		sel:     selector.NewWorkspaceSelect(prompter, store, ws),

--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -87,7 +87,7 @@ func newSvcDeployOpts(vars deployWkldVars) (*deploySvcOpts, error) {
 		store:        store,
 		ws:           ws,
 		unmarshal:    manifest.UnmarshalWorkload,
-		spinner:      termprogress.NewSpinner(),
+		spinner:      termprogress.NewSpinner(log.DiagnosticWriter),
 		sel:          selector.NewWorkspaceSelect(prompter, store, ws),
 		prompt:       prompter,
 		cmd:          command.New(),

--- a/internal/pkg/cli/svc_init.go
+++ b/internal/pkg/cli/svc_init.go
@@ -112,7 +112,7 @@ func newInitSvcOpts(vars initSvcVars) (*initSvcOpts, error) {
 	initSvc := &initialize.WorkloadInitializer{
 		Store:    store,
 		Ws:       ws,
-		Prog:     termprogress.NewSpinner(),
+		Prog:     termprogress.NewSpinner(log.DiagnosticWriter),
 		Deployer: cloudformation.New(sess),
 	}
 	return &initSvcOpts{

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -131,7 +131,7 @@ func newTaskRunOpts(vars runTaskVars) (*runTaskOpts, error) {
 		fs:      &afero.Afero{Fs: afero.NewOsFs()},
 		store:   store,
 		sel:     selector.NewSelect(prompt.New(), store),
-		spinner: termprogress.NewSpinner(),
+		spinner: termprogress.NewSpinner(log.DiagnosticWriter),
 	}
 
 	opts.configureRuntimeOpts = func() error {

--- a/internal/pkg/term/progress/spinner.go
+++ b/internal/pkg/term/progress/spinner.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/aws/copilot-cli/internal/pkg/term/cursor"
-	"github.com/aws/copilot-cli/internal/pkg/term/log"
 	"github.com/briandowns/spinner"
 )
 
@@ -59,10 +58,10 @@ type Spinner struct {
 	eventsWriter writeFlusher // Writer to pretty format events in a table.
 }
 
-// NewSpinner returns a spinner that outputs to stderr.
-func NewSpinner() *Spinner {
+// NewSpinner returns a spinner that outputs to w.
+func NewSpinner(w io.Writer) *Spinner {
 	s := spinner.New(charset, 125*time.Millisecond, spinner.WithHiddenCursor(true))
-	s.Writer = log.DiagnosticWriter
+	s.Writer = w
 	return &Spinner{
 		spin:         s,
 		cur:          cursor.New(),

--- a/internal/pkg/term/progress/spinner_test.go
+++ b/internal/pkg/term/progress/spinner_test.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -49,12 +49,13 @@ func (m *mockCursor) EraseLine() {
 
 func TestNew(t *testing.T) {
 	t.Run("it should initialize the spin spinner", func(t *testing.T) {
-		got := NewSpinner()
+		buf := new(strings.Builder)
+		got := NewSpinner(buf)
 
 		v, ok := got.spin.(*spin.Spinner)
 		require.True(t, ok)
 
-		require.Equal(t, os.Stderr, v.Writer)
+		require.Equal(t, buf, v.Writer)
 		require.Equal(t, 125*time.Millisecond, v.Delay)
 	})
 }

--- a/internal/pkg/term/progress/spinner_windows.go
+++ b/internal/pkg/term/progress/spinner_windows.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/aws/copilot-cli/internal/pkg/term/cursor"
-	"github.com/aws/copilot-cli/internal/pkg/term/log"
 	"github.com/briandowns/spinner"
 )
 
@@ -58,9 +57,9 @@ type Spinner struct {
 }
 
 // NewSpinner returns a spinner that outputs to stderr.
-func NewSpinner() *Spinner {
+func NewSpinner(w io.Writer) *Spinner {
 	s := spinner.New(charset, 500*time.Millisecond, spinner.WithHiddenCursor(true))
-	s.Writer = log.DiagnosticWriter
+	s.Writer = w
 	return &Spinner{
 		spin:         s,
 		cur:          cursor.New(),


### PR DESCRIPTION
Previously, the writer was hard-coded to be os.Stderr.
This change allows us to pass any writer that we want to the spinner.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
