### PR TITLE
chore: fix cursor movement for windows

### DIFF
--- a/internal/pkg/term/cursor/cursor.go
+++ b/internal/pkg/term/cursor/cursor.go
@@ -62,16 +62,6 @@ func NewWithWriter(out io.Writer) *Cursor {
 	}
 }
 
-// Up moves the cursor n lines.
-func (c *Cursor) Up(n int) {
-	c.c.Up(n)
-}
-
-// Down moves the cursor n lines.
-func (c *Cursor) Down(n int) {
-	c.c.Down(n)
-}
-
 // Hide makes the cursor invisible.
 func (c *Cursor) Hide() {
 	c.c.Hide()
@@ -96,8 +86,10 @@ func EraseLine(fw terminal.FileWriter) {
 
 // EraseLinesAbove erases a line and moves the cursor up from fw, repeated n times.
 func EraseLinesAbove(fw terminal.FileWriter, n int) {
-	c := &terminal.Cursor{
-		Out: fw,
+	c := Cursor{
+		c: &terminal.Cursor{
+			Out: fw,
+		},
 	}
 	for i := 0; i < n; i += 1 {
 		EraseLine(fw)

--- a/internal/pkg/term/cursor/vertical.go
+++ b/internal/pkg/term/cursor/vertical.go
@@ -1,0 +1,16 @@
+// +build !windows
+
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cursor
+
+// Up moves the cursor n lines.
+func (c *Cursor) Up(n int) {
+	c.c.Up(n)
+}
+
+// Down moves the cursor n lines.
+func (c *Cursor) Down(n int) {
+	c.c.Down(n)
+}

--- a/internal/pkg/term/cursor/vertical_windows.go
+++ b/internal/pkg/term/cursor/vertical_windows.go
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cursor
+
+// Up moves the cursor n lines.
+func (c *Cursor) Up(n int) {
+	c.c.Down(n)
+}
+
+// Down moves the cursor n lines.
+func (c *Cursor) Down(n int) {
+	c.c.Up(n)
+}

--- a/internal/pkg/term/progress/render.go
+++ b/internal/pkg/term/progress/render.go
@@ -11,10 +11,6 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/term/cursor"
 )
 
-const (
-	renderInterval = 100 * time.Millisecond // How frequently Render should be invoked.
-)
-
 // Renderer is the interface to print a component to a writer.
 // It returns the number of lines printed and the error if any.
 type Renderer interface {

--- a/internal/pkg/term/progress/render_interval.go
+++ b/internal/pkg/term/progress/render_interval.go
@@ -1,0 +1,12 @@
+// +build !windows
+
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package progress
+
+import "time"
+
+const (
+	renderInterval = 100 * time.Millisecond // How frequently Render should be invoked.
+)

--- a/internal/pkg/term/progress/render_interval_windows.go
+++ b/internal/pkg/term/progress/render_interval_windows.go
@@ -1,0 +1,11 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package progress
+
+import "time"
+
+const (
+	// Windows flickers too frequently if the interval is too short.
+	renderInterval = 500 * time.Millisecond // How frequently Render should be invoked.
+)


### PR DESCRIPTION
Cursor movements are upside down on Windows.
This ensures that progress trackers render updates in place for Windows.

![Screen Shot 2021-01-08 at 11 23 33 AM](https://user-images.githubusercontent.com/879348/104055895-653e4c00-51a4-11eb-9774-26cecf6a8849.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
