### PR TITLE
refactor(progress): initialize renderers in the deploy pkg

### DIFF
--- a/internal/pkg/term/progress/cloudformation.go
+++ b/internal/pkg/term/progress/cloudformation.go
@@ -18,88 +18,30 @@ type StackSubscriber interface {
 	Subscribe(channels ...chan stream.StackEvent)
 }
 
-// StackResourceDescription identifies a CloudFormation stack resource annotated with a human-friendly description.
-type StackResourceDescription struct {
-	LogicalResourceID string
-	ResourceType      string
-	Description       string
+// ListeningStackRenderer returns a tree component that listens for CloudFormation
+// resource events from a stack mutated with a changeSet until the streamer stops.
+func ListeningStackRenderer(streamer StackSubscriber, stackName, description string, changes []Renderer, opts RenderOptions) Renderer {
+	return &treeComponent{
+		Root:     ListeningResourceRenderer(streamer, stackName, description, opts),
+		Children: changes,
+	}
 }
 
-// ListeningStackRenderer returns a tab-separated component that listens for CloudFormation
-// resource events from a stack until the streamer stops.
-//
-// The component only listens for stack resource events for the provided changes in the stack.
-// The state of changes is updated as events are published from the streamer.
-func ListeningStackRenderer(streamer StackSubscriber, stackName, description string, changes []StackResourceDescription) Renderer {
-	var children []Renderer
-	for _, change := range changes {
-		children = append(children, listeningResourceRenderer(streamer, change, nestedComponentPadding))
-	}
-	comp := &stackComponent{
-		logicalID:   stackName,
+// ListeningResourceRenderer returns a tab-separated component that listens for
+// CloudFormation stack events for a particular resource.
+func ListeningResourceRenderer(streamer StackSubscriber, logicalID, description string, opts RenderOptions) Renderer {
+	comp := &regularResourceComponent{
+		logicalID:   logicalID,
 		description: description,
 		statuses:    []stackStatus{notStartedStackStatus},
 		stopWatch:   newStopWatch(),
-		children:    children,
 		stream:      make(chan stream.StackEvent),
+		padding:     opts.Padding,
 		separator:   '\t',
 	}
 	streamer.Subscribe(comp.stream)
 	go comp.Listen()
 	return comp
-}
-
-// listeningResourceRenderer returns a tab-separated component that listens for
-// CloudFormation stack events for a particular resource.
-func listeningResourceRenderer(streamer StackSubscriber, resource StackResourceDescription, padding int) Renderer {
-	comp := &regularResourceComponent{
-		logicalID:   resource.LogicalResourceID,
-		description: resource.Description,
-		statuses:    []stackStatus{notStartedStackStatus},
-		stopWatch:   newStopWatch(),
-		stream:      make(chan stream.StackEvent),
-		padding:     padding,
-		separator:   '\t',
-	}
-	streamer.Subscribe(comp.stream)
-	go comp.Listen()
-	return comp
-}
-
-// stackComponent can display a CloudFormation stack and all of its associated resources.
-type stackComponent struct {
-	logicalID   string        // The CloudFormation stack name.
-	description string        // The human friendly explanation of the purpose of the stack.
-	statuses    []stackStatus // In-order history of the CloudFormation status of the stack throughout the deployment.
-	children    []Renderer    // Resources part of the stack.
-	stopWatch   *stopWatch    // Timer to measure how long the operation takes to complete.
-
-	padding   int  // Leading spaces before rendering the stack.
-	separator rune // Character used to separate columns of text.
-
-	stream chan stream.StackEvent
-	mu     sync.Mutex
-}
-
-// Listen updates the stack's status if a CloudFormation stack event is received.
-func (c *stackComponent) Listen() {
-	for ev := range c.stream {
-		if c.logicalID != ev.LogicalResourceID {
-			continue
-		}
-		updateComponentStatus(&c.mu, &c.statuses, ev)
-		updateComponentTimer(&c.mu, c.statuses, c.stopWatch)
-	}
-}
-
-// Render prints the CloudFormation stack's resource components in order and returns the number of lines written.
-// If any sub-component's Render call fails, then writes nothing and returns an error.
-func (c *stackComponent) Render(out io.Writer) (numLines int, err error) {
-	c.mu.Lock()
-	components := stackResourceComponents(c.description, c.separator, c.statuses, c.stopWatch, c.padding)
-	c.mu.Unlock()
-
-	return renderComponents(out, append(components, c.children...))
 }
 
 // regularResourceComponent can display a simple CloudFormation stack resource event.
@@ -184,15 +126,4 @@ func stackResourceComponents(description string, separator rune, statuses []stac
 		}
 	}
 	return components
-}
-
-func renderComponents(out io.Writer, components []Renderer) (numLines int, err error) {
-	for _, comp := range components {
-		nl, err := comp.Render(out)
-		if err != nil {
-			return 0, err
-		}
-		numLines += nl
-	}
-	return numLines, nil
 }

--- a/internal/pkg/term/progress/cloudformation_test.go
+++ b/internal/pkg/term/progress/cloudformation_test.go
@@ -27,211 +27,6 @@ func (c *fakeClock) now() time.Time {
 	return t
 }
 
-func TestStackComponent_Listen(t *testing.T) {
-	t.Run("should not add status if no events are received for the logical ID", func(t *testing.T) {
-		// GIVEN
-		ch := make(chan stream.StackEvent)
-		done := make(chan bool)
-		comp := &stackComponent{
-			logicalID: "phonetool-test",
-			statuses:  []stackStatus{notStartedStackStatus},
-			stopWatch: &stopWatch{
-				clock: &fakeClock{
-					wantedValues: []time.Time{testDate},
-				},
-			},
-			stream: ch,
-		}
-
-		// WHEN
-		go func() {
-			comp.Listen()
-			done <- true
-		}()
-		go func() {
-			ch <- stream.StackEvent{
-				LogicalResourceID: "EnvironmentManagerRole",
-				ResourceStatus:    "CREATE_COMPLETE",
-			}
-			ch <- stream.StackEvent{
-				LogicalResourceID: "ServiceDiscoveryNamespace",
-				ResourceStatus:    "CREATE_COMPLETE",
-			}
-			close(ch) // Close to notify that no more events will be sent.
-		}()
-
-		// THEN
-		<-done // Wait for listen to exit.
-		require.ElementsMatch(t, []stackStatus{notStartedStackStatus}, comp.statuses)
-		_, hasStarted := comp.stopWatch.elapsed()
-		require.False(t, hasStarted, "the stopwatch should not have started")
-	})
-	t.Run("should add status when an event is received for stack", func(t *testing.T) {
-		// GIVEN
-		ch := make(chan stream.StackEvent)
-		done := make(chan bool)
-		comp := &stackComponent{
-			logicalID: "phonetool-test",
-			statuses:  []stackStatus{notStartedStackStatus},
-			stopWatch: &stopWatch{
-				clock: &fakeClock{
-					wantedValues: []time.Time{testDate},
-				},
-			},
-			stream: ch,
-		}
-
-		// WHEN
-		go func() {
-			comp.Listen()
-			done <- true
-		}()
-		go func() {
-			ch <- stream.StackEvent{
-				LogicalResourceID: "EnvironmentManagerRole",
-				ResourceStatus:    "CREATE_COMPLETE",
-			}
-			ch <- stream.StackEvent{
-				LogicalResourceID: "phonetool-test",
-				ResourceStatus:    "CREATE_COMPLETE",
-			}
-			close(ch) // Close to notify that no more events will be sent.
-		}()
-
-		// THEN
-		<-done // Wait for listen to exit.
-		require.ElementsMatch(t, []stackStatus{
-			notStartedStackStatus,
-			{
-				value: "CREATE_COMPLETE",
-			},
-		}, comp.statuses)
-		elapsed, hasStarted := comp.stopWatch.elapsed()
-		require.True(t, hasStarted, "the stopwatch should have started when an event was received")
-		require.Equal(t, time.Duration(0), elapsed)
-	})
-}
-
-func TestStackComponent_Render(t *testing.T) {
-	t.Run("renders the stack description and children renderers", func(t *testing.T) {
-		// GIVEN
-		comp := &stackComponent{
-			description: `The environment stack "phonetool-test" contains your shared resources between services`,
-			statuses: []stackStatus{
-				notStartedStackStatus,
-				{
-					value: "CREATE_COMPLETE",
-				},
-			},
-			stopWatch: &stopWatch{
-				startTime: testDate,
-				stopTime:  testDate,
-				started:   true,
-				stopped:   true,
-			},
-			children: []Renderer{
-				&mockRenderer{
-					content: "  - A load balancer to distribute traffic from the internet\n",
-				},
-				&mockRenderer{
-					content: "  - An ECS cluster to hold your services\n",
-				},
-			},
-			separator: '\t',
-		}
-		buf := new(strings.Builder)
-
-		// WHEN
-		nl, err := comp.Render(buf)
-
-		// THEN
-		require.NoError(t, err)
-		require.Equal(t, 3, nl, "expected 3 entries to be printed to the terminal")
-		require.Equal(t, "- The environment stack \"phonetool-test\" contains your shared resources between services\t[create complete]\t[0.0s]\n"+
-			"  - A load balancer to distribute traffic from the internet\n"+
-			"  - An ECS cluster to hold your services\n", buf.String())
-	})
-	t.Run("splits long failure reason into multiple lines", func(t *testing.T) {
-		// GIVEN
-		comp := &stackComponent{
-			description: `The environment stack "phonetool-test" contains your shared resources between services`,
-			statuses: []stackStatus{
-				notStartedStackStatus,
-				{
-					value: "CREATE_IN_PROGRESS",
-				},
-				{
-					value: "CREATE_FAILED",
-					reason: "The following resource(s) failed to create: [PublicSubnet2, CloudformationExecutionRole, " +
-						"PrivateSubnet1, InternetGatewayAttachment, PublicSubnet1, ServiceDiscoveryNamespace," +
-						" PrivateSubnet2], EnvironmentSecurityGroup, PublicRouteTable]. Rollback requested by user.",
-				},
-				{
-					value: "DELETE_COMPLETE",
-				},
-			},
-			stopWatch: &stopWatch{
-				startTime: testDate,
-				stopTime:  testDate,
-				started:   true,
-				stopped:   true,
-			},
-			separator: '\t',
-		}
-		buf := new(strings.Builder)
-
-		// WHEN
-		nl, err := comp.Render(buf)
-
-		// THEN
-		require.NoError(t, err)
-		require.Equal(t, 5, nl, "expected 3 entries to be printed to the terminal")
-		require.Equal(t, "- The environment stack \"phonetool-test\" contains your shared resources between services\t[delete complete]\t[0.0s]\n"+
-			"  The following resource(s) failed to create: [PublicSubnet2, Cloudforma\t\t\n"+
-			"  tionExecutionRole, PrivateSubnet1, InternetGatewayAttachment, PublicSu\t\t\n"+
-			"  bnet1, ServiceDiscoveryNamespace, PrivateSubnet2], EnvironmentSecurity\t\t\n"+
-			"  Group, PublicRouteTable]. Rollback requested by user.\t\t\n", buf.String())
-	})
-	t.Run("renders multiple failure reasons", func(t *testing.T) {
-		// GIVEN
-		comp := &stackComponent{
-			description: `The environment stack "phonetool-test" contains your shared resources between services`,
-			statuses: []stackStatus{
-				notStartedStackStatus,
-				{
-					value: "CREATE_IN_PROGRESS",
-				},
-				{
-					value:  "CREATE_FAILED",
-					reason: "Resource creation cancelled",
-				},
-				{
-					value:  "DELETE_FAILED",
-					reason: "Resource cannot be deleted",
-				},
-			},
-			stopWatch: &stopWatch{
-				startTime: testDate,
-				stopTime:  testDate,
-				started:   true,
-				stopped:   true,
-			},
-			separator: '\t',
-		}
-		buf := new(strings.Builder)
-
-		// WHEN
-		nl, err := comp.Render(buf)
-
-		// THEN
-		require.NoError(t, err)
-		require.Equal(t, 3, nl, "expected 3 entries to be printed to the terminal")
-		require.Equal(t, "- The environment stack \"phonetool-test\" contains your shared resources between services\t[delete failed]\t[0.0s]\n"+
-			"  Resource creation cancelled\t\t\n"+
-			"  Resource cannot be deleted\t\t\n", buf.String())
-	})
-}
-
 func TestRegularResourceComponent_Listen(t *testing.T) {
 	t.Run("should not add status if no events are received for the logical ID", func(t *testing.T) {
 		// GIVEN
@@ -372,5 +167,84 @@ func TestRegularResourceComponent_Render(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 1, nl, "expected to be rendered as a single line component")
 		require.Equal(t, "- An ECS cluster to hold your services\t[create in progress]\t[10.0s]\n", buf.String())
+	})
+	t.Run("splits long failure reason into multiple lines", func(t *testing.T) {
+		// GIVEN
+		comp := &regularResourceComponent{
+			description: `The environment stack "phonetool-test" contains your shared resources between services`,
+			statuses: []stackStatus{
+				notStartedStackStatus,
+				{
+					value: "CREATE_IN_PROGRESS",
+				},
+				{
+					value: "CREATE_FAILED",
+					reason: "The following resource(s) failed to create: [PublicSubnet2, CloudformationExecutionRole, " +
+						"PrivateSubnet1, InternetGatewayAttachment, PublicSubnet1, ServiceDiscoveryNamespace," +
+						" PrivateSubnet2], EnvironmentSecurityGroup, PublicRouteTable]. Rollback requested by user.",
+				},
+				{
+					value: "DELETE_COMPLETE",
+				},
+			},
+			stopWatch: &stopWatch{
+				startTime: testDate,
+				stopTime:  testDate,
+				started:   true,
+				stopped:   true,
+			},
+			separator: '\t',
+		}
+		buf := new(strings.Builder)
+
+		// WHEN
+		nl, err := comp.Render(buf)
+
+		// THEN
+		require.NoError(t, err)
+		require.Equal(t, 5, nl, "expected 3 entries to be printed to the terminal")
+		require.Equal(t, "- The environment stack \"phonetool-test\" contains your shared resources between services\t[delete complete]\t[0.0s]\n"+
+			"  The following resource(s) failed to create: [PublicSubnet2, Cloudforma\t\t\n"+
+			"  tionExecutionRole, PrivateSubnet1, InternetGatewayAttachment, PublicSu\t\t\n"+
+			"  bnet1, ServiceDiscoveryNamespace, PrivateSubnet2], EnvironmentSecurity\t\t\n"+
+			"  Group, PublicRouteTable]. Rollback requested by user.\t\t\n", buf.String())
+	})
+	t.Run("renders multiple failure reasons", func(t *testing.T) {
+		// GIVEN
+		comp := &regularResourceComponent{
+			description: `The environment stack "phonetool-test" contains your shared resources between services`,
+			statuses: []stackStatus{
+				notStartedStackStatus,
+				{
+					value: "CREATE_IN_PROGRESS",
+				},
+				{
+					value:  "CREATE_FAILED",
+					reason: "Resource creation cancelled",
+				},
+				{
+					value:  "DELETE_FAILED",
+					reason: "Resource cannot be deleted",
+				},
+			},
+			stopWatch: &stopWatch{
+				startTime: testDate,
+				stopTime:  testDate,
+				started:   true,
+				stopped:   true,
+			},
+			separator: '\t',
+		}
+		buf := new(strings.Builder)
+
+		// WHEN
+		nl, err := comp.Render(buf)
+
+		// THEN
+		require.NoError(t, err)
+		require.Equal(t, 3, nl, "expected 3 entries to be printed to the terminal")
+		require.Equal(t, "- The environment stack \"phonetool-test\" contains your shared resources between services\t[delete failed]\t[0.0s]\n"+
+			"  Resource creation cancelled\t\t\n"+
+			"  Resource cannot be deleted\t\t\n", buf.String())
 	})
 }

--- a/internal/pkg/term/progress/component.go
+++ b/internal/pkg/term/progress/component.go
@@ -19,11 +19,35 @@ type singleLineComponent struct {
 	Padding int    // Number of spaces prior to the text.
 }
 
-// Render prints the component and returns the number of lines printed to the terminal and the error if any.
+// Render writes the Text with a newline to out and returns 1 for the number of lines written.
+// In case of an error, returns 0 and the error.
 func (c *singleLineComponent) Render(out io.Writer) (numLines int, err error) {
 	_, err = fmt.Fprintf(out, "%s%s\n", strings.Repeat(" ", c.Padding), c.Text)
 	if err != nil {
 		return 0, err
 	}
 	return 1, err
+}
+
+// treeComponent can display a node and its children.
+type treeComponent struct {
+	Root     Renderer
+	Children []Renderer
+}
+
+// Render writes the Root and its children in order to out. Returns the total number of lines written.
+// In case of an error, returns 0 and the error.
+func (c *treeComponent) Render(out io.Writer) (numLines int, err error) {
+	return renderComponents(out, append([]Renderer{c.Root}, c.Children...))
+}
+
+func renderComponents(out io.Writer, components []Renderer) (numLines int, err error) {
+	for _, comp := range components {
+		nl, err := comp.Render(out)
+		if err != nil {
+			return 0, err
+		}
+		numLines += nl
+	}
+	return numLines, nil
 }

--- a/internal/pkg/term/progress/component_test.go
+++ b/internal/pkg/term/progress/component_test.go
@@ -44,3 +44,52 @@ func TestSingleLineComponent_Render(t *testing.T) {
 		})
 	}
 }
+
+func TestTreeComponent_Render(t *testing.T) {
+	testCases := map[string]struct {
+		inNode     Renderer
+		inChildren []Renderer
+
+		wantedNumLines int
+		wantedOut      string
+	}{
+		"should render all the nodes": {
+			inNode: &singleLineComponent{
+				Text: "is",
+			},
+			inChildren: []Renderer{
+				&singleLineComponent{
+					Text: "this",
+				},
+				&singleLineComponent{
+					Text: "working?",
+				},
+			},
+
+			wantedNumLines: 3,
+			wantedOut: `is
+this
+working?
+`,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// GIVEN
+			comp := &treeComponent{
+				Root:     tc.inNode,
+				Children: tc.inChildren,
+			}
+			buf := new(strings.Builder)
+
+			// WHEN
+			nl, err := comp.Render(buf)
+
+			// THEN
+			require.NoError(t, err)
+			require.Equal(t, tc.wantedNumLines, nl)
+			require.Equal(t, tc.wantedOut, buf.String())
+		})
+	}
+}

--- a/internal/pkg/term/progress/render.go
+++ b/internal/pkg/term/progress/render.go
@@ -17,6 +17,18 @@ type Renderer interface {
 	Render(out io.Writer) (numLines int, err error)
 }
 
+// RenderOptions holds optional style configuration for renderers.
+type RenderOptions struct {
+	Padding int // Leading spaces before rendering the component.
+}
+
+// NestedRenderOptions takes a RenderOptions and returns the same RenderOptions but with additional padding.
+func NestedRenderOptions(opts RenderOptions) RenderOptions {
+	return RenderOptions{
+		Padding: opts.Padding + nestedComponentPadding,
+	}
+}
+
 // Render renders r periodically to out until the ctx is canceled or an error occurs.
 // While Render is executing, the terminal cursor is hidden and updates are written in-place.
 func Render(ctx context.Context, out FileWriteFlusher, r Renderer) error {

--- a/internal/pkg/term/progress/render_test.go
+++ b/internal/pkg/term/progress/render_test.go
@@ -79,3 +79,16 @@ func TestRender(t *testing.T) {
 
 	require.Equal(t, wanted.String(), actual.String(), "expected the content printed to match")
 }
+
+func TestNestedRenderOptions(t *testing.T) {
+	// GIVEN
+	opts := RenderOptions{}
+
+	// WHEN
+	actual := NestedRenderOptions(opts)
+
+	// THEN
+	require.Equal(t, RenderOptions{
+		Padding: 2,
+	}, actual)
+}


### PR DESCRIPTION
Removes duplicate code between the `stackComponent` and `regularResourceComponent` by deleting the `stackComponent` and replacing it with a `treeComponent`. 
Finally, initializing which renderer should be used for which component is the responsibility of the "deploy" pkg now instead of the "progress" pkg.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
