### PR TITLE
chore(progress): keep stopwatch running on multiple inprogress events

### DIFF
--- a/internal/pkg/term/progress/cloudformation.go
+++ b/internal/pkg/term/progress/cloudformation.go
@@ -96,6 +96,11 @@ func updateComponentTimer(mu *sync.Mutex, statuses []stackStatus, sw *stopWatch)
 	curStatus, nextStatus := statuses[len(statuses)-2], statuses[len(statuses)-1]
 	switch {
 	case nextStatus.value.InProgress():
+		// Reset and start only if the status moved to in progress from a static state.
+		// It's possible that CloudFormation sends multiple "CREATE_IN_PROGRESS" events back to back, we don't want to reset the timer then.
+		if !curStatus.value.InProgress() {
+			return
+		}
 		sw.reset()
 		sw.start()
 	default:

--- a/internal/pkg/term/progress/cloudformation.go
+++ b/internal/pkg/term/progress/cloudformation.go
@@ -96,9 +96,9 @@ func updateComponentTimer(mu *sync.Mutex, statuses []stackStatus, sw *stopWatch)
 	curStatus, nextStatus := statuses[len(statuses)-2], statuses[len(statuses)-1]
 	switch {
 	case nextStatus.value.InProgress():
-		// Reset and start only if the status moved to in progress from a static state.
-		// It's possible that CloudFormation sends multiple "CREATE_IN_PROGRESS" events back to back, we don't want to reset the timer then.
-		if !curStatus.value.InProgress() {
+		// It's possible that CloudFormation sends multiple "CREATE_IN_PROGRESS" events back to back,
+		// we don't want to reset the timer then.
+		if curStatus.value.InProgress() {
 			return
 		}
 		sw.reset()


### PR DESCRIPTION
CloudFormation can send multiple IN_PROGRESS events for the same resource:
![events](https://user-images.githubusercontent.com/879348/104360210-90d37600-54c5-11eb-93a8-cc7b48fd6436.png)


In that situation, we don't want to reset the stopwatch for the event while tracking how long it took for it finalize.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
