### PR TITLE
fix(cicd): limit `env upgrade` in buildspec to environments in pipeline

### DIFF
--- a/templates/cicd/buildspec.yml
+++ b/templates/cicd/buildspec.yml
@@ -22,7 +22,7 @@ phases:
       - export COLOR="false"
       # First, upgrade the cloudformation stack of every environment in the pipeline.
       - pipeline=$(cat $CODEBUILD_SRC_DIR/copilot/pipeline.yml | ruby -ryaml -rjson -e 'puts JSON.pretty_generate(YAML.load(ARGF))')
-        pl_envs=$(echo $pipeline | jq '.stages[].name' | sed 's/"//g')
+      - pl_envs=$(echo $pipeline | jq '.stages[].name' | sed 's/"//g')
       - >
         for pl_env in $pl_envs; do
         ./copilot-linux env upgrade -n $pl_env;

--- a/templates/cicd/buildspec.yml
+++ b/templates/cicd/buildspec.yml
@@ -20,8 +20,13 @@ phases:
     commands:
       - ls -l
       - export COLOR="false"
-      # First, upgrade the cloudformation stack of every environment.
-      - ./copilot-linux env upgrade --all
+      # First, upgrade the cloudformation stack of every environment in the pipeline.
+      - pipeline=$(cat $CODEBUILD_SRC_DIR/copilot/pipeline.yml | ruby -ryaml -rjson -e 'puts JSON.pretty_generate(YAML.load(ARGF))')
+        pl_envs=$(echo $pipeline | jq '.stages[].name' | sed 's/"//g')
+      - >
+        for pl_env in $pl_envs; do
+        ./copilot-linux env upgrade -n $pl_env;
+        done;
       # Find all the local services in the workspace.
       - svcs=$(./copilot-linux svc ls --local --json | jq '.services[].name' | sed 's/"//g')
       # Find all the local jobs in the workspace.


### PR DESCRIPTION
Instead of trying to upgrade all envs in a workspace, now the buildspec reads the pipeline.yml file to find the envs to upgrade.

Fixes https://github.com/aws/copilot-cli/issues/1805

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
