### PR TITLE
chore: add Done method to streamers and renderer to exit successfully

### DIFF
--- a/internal/pkg/deploy/cloudformation/cloudformation_test.go
+++ b/internal/pkg/deploy/cloudformation/cloudformation_test.go
@@ -4,7 +4,6 @@
 package cloudformation
 
 import (
-	"context"
 	"errors"
 	"io"
 	"strings"
@@ -83,33 +82,7 @@ func TestCloudFormation_renderStackChanges(t *testing.T) {
 		// THEN
 		require.EqualError(t, err, "TemplateBody error")
 	})
-	t.Run("bubbles up waiter error and cancels streamers and renderer on waiter error", func(t *testing.T) {
-		// GIVEN
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-		m := mocks.NewMockcfnClient(ctrl)
-		m.EXPECT().DescribeChangeSet(gomock.Any(), gomock.Any()).Return(&cloudformation.ChangeSetDescription{}, nil)
-		m.EXPECT().TemplateBody(gomock.Any()).Return("", nil)
-		m.EXPECT().DescribeStackEvents(gomock.Any()).Return(&sdkcloudformation.DescribeStackEventsOutput{}, nil).AnyTimes()
-		client := CloudFormation{cfnClient: m}
-		buf := new(strings.Builder)
-
-		// WHEN
-		in := renderStackChangesInput{
-			w: mockFileWriter{Writer: buf},
-			createChangeSet: func() (string, error) {
-				return "", nil
-			},
-			waitForStack: func(ctx context.Context, s string) error {
-				return errors.New("waiter error")
-			},
-		}
-		err := client.renderStackChanges(in)
-
-		// THEN
-		require.EqualError(t, err, "waiter error")
-	})
-	t.Run("bubbles up streamer error and cancels waiter and renderer on streamer error", func(t *testing.T) {
+	t.Run("bubbles up streamer error and cancels renderer", func(t *testing.T) {
 		// GIVEN
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
@@ -127,21 +100,51 @@ func TestCloudFormation_renderStackChanges(t *testing.T) {
 			createChangeSet: func() (string, error) {
 				return "", nil
 			},
-			waitForStack: func(ctx context.Context, s string) error {
-				select {
-				case <-time.After(10 * time.Second):
-					return errors.New("expected waitForStack to be canceled, instead we waited for a timeout")
-				case <-ctx.Done():
-					return nil
-				}
-			},
 		}
 		err := client.renderStackChanges(in)
 
 		// THEN
 		require.True(t, errors.Is(err, wantedErr), "expected streamer error to be wrapped and returned")
 	})
-	t.Run("renders a resource on success", func(t *testing.T) {
+	t.Run("renders the stack and its resources until stack fails and return an error", func(t *testing.T) {
+		// GIVEN
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		m := mocks.NewMockcfnClient(ctrl)
+		m.EXPECT().DescribeChangeSet(gomock.Any(), gomock.Any()).Return(&cloudformation.ChangeSetDescription{}, nil)
+		m.EXPECT().TemplateBody(gomock.Any()).Return("", nil)
+		m.EXPECT().DescribeStackEvents(gomock.Any()).Return(&sdkcloudformation.DescribeStackEventsOutput{
+			StackEvents: []*sdkcloudformation.StackEvent{
+				{
+					EventId:            aws.String("2"),
+					LogicalResourceId:  aws.String("phonetool-test"),
+					PhysicalResourceId: aws.String("AWS::CloudFormation::Stack"),
+					ResourceStatus:     aws.String("CREATE_FAILED"), // Send failure event for stack.
+					Timestamp:          aws.Time(time.Now()),
+				},
+			},
+		}, nil).AnyTimes()
+		m.EXPECT().Describe("phonetool-test").Return(&cloudformation.StackDescription{
+			StackStatus: aws.String("CREATE_FAILED"),
+		}, nil)
+		client := CloudFormation{cfnClient: m}
+		buf := new(strings.Builder)
+
+		// WHEN
+		in := renderStackChangesInput{
+			w:                mockFileWriter{Writer: buf},
+			stackName:        "phonetool-test",
+			stackDescription: "Creating phonetool-test environment.",
+			createChangeSet: func() (string, error) {
+				return "1234", nil
+			},
+		}
+		err := client.renderStackChanges(in)
+
+		// THEN
+		require.EqualError(t, err, "stack phonetool-test did not complete successfully and exited with status CREATE_FAILED")
+	})
+	t.Run("renders the stack and its resource on success", func(t *testing.T) {
 		// GIVEN
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
@@ -166,14 +169,24 @@ Resources:
 		}).Return(&sdkcloudformation.DescribeStackEventsOutput{
 			StackEvents: []*sdkcloudformation.StackEvent{
 				{
-					EventId:            aws.String("some event id"),
+					EventId:            aws.String("1"),
 					LogicalResourceId:  aws.String("Cluster"),
 					PhysicalResourceId: aws.String("AWS::ECS::Cluster"),
 					ResourceStatus:     aws.String("CREATE_COMPLETE"),
 					Timestamp:          aws.Time(time.Now()),
 				},
+				{
+					EventId:            aws.String("2"),
+					LogicalResourceId:  aws.String("phonetool-test"),
+					PhysicalResourceId: aws.String("AWS::CloudFormation::Stack"),
+					ResourceStatus:     aws.String("CREATE_COMPLETE"),
+					Timestamp:          aws.Time(time.Now()),
+				},
 			},
 		}, nil).AnyTimes()
+		m.EXPECT().Describe("phonetool-test").Return(&cloudformation.StackDescription{
+			StackStatus: aws.String("CREATE_COMPLETE"),
+		}, nil)
 		client := CloudFormation{cfnClient: m}
 		buf := new(strings.Builder)
 
@@ -184,9 +197,6 @@ Resources:
 			stackDescription: "Creating phonetool-test environment.",
 			createChangeSet: func() (string, error) {
 				return "1234", nil
-			},
-			waitForStack: func(ctx context.Context, s string) error {
-				return nil
 			},
 		}
 		err := client.renderStackChanges(in)

--- a/internal/pkg/deploy/cloudformation/env.go
+++ b/internal/pkg/deploy/cloudformation/env.go
@@ -46,7 +46,6 @@ func (cf CloudFormation) DeployAndRenderEnvironment(out progress.FileWriter, env
 			}
 			return changeSetID, nil
 		},
-		waitForStack: cf.cfnClient.WaitForCreate,
 	})
 }
 

--- a/internal/pkg/stream/cloudformation.go
+++ b/internal/pkg/stream/cloudformation.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
+	cfn "github.com/aws/copilot-cli/internal/pkg/aws/cloudformation"
 )
 
 const (
@@ -28,13 +29,14 @@ type StackEvent struct {
 	ResourceStatusReason string
 }
 
-// StackStreamer is a FetchNotifyStopper for StackEvent events started by a change set.
+// StackStreamer is a Streamer for StackEvent events started by a change set.
 type StackStreamer struct {
 	client                StackEventsDescriber
 	stackName             string
 	changeSetCreationTime time.Time
 
 	subscribers   []chan StackEvent
+	done          chan struct{}
 	pastEventIDs  map[string]bool
 	eventsToFlush []StackEvent
 }
@@ -46,12 +48,15 @@ func NewStackStreamer(cfn StackEventsDescriber, stackName string, csCreationTime
 		stackName:             stackName,
 		changeSetCreationTime: csCreationTime,
 		pastEventIDs:          make(map[string]bool),
+		done:                  make(chan struct{}),
 	}
 }
 
-// Subscribe registers the channels to receive notifications from the streamer.
-func (s *StackStreamer) Subscribe(channels ...chan StackEvent) {
-	s.subscribers = append(s.subscribers, channels...)
+// Subscribe returns a read-only channel that will receive stack events from the StackStreamer.
+func (s *StackStreamer) Subscribe() <-chan StackEvent {
+	c := make(chan StackEvent)
+	s.subscribers = append(s.subscribers, c)
+	return c
 }
 
 // Fetch retrieves and stores any new CloudFormation stack events since the ChangeSetCreationTime in chronological order.
@@ -83,10 +88,16 @@ func (s *StackStreamer) Fetch() (next time.Time, err error) {
 				finished = true
 				break
 			}
+
+			logicalID, resourceStatus := aws.StringValue(event.LogicalResourceId), aws.StringValue(event.ResourceStatus)
+			if logicalID == s.stackName && !cfn.StackStatus(resourceStatus).InProgress() {
+				// The stack is done, notify that there is no need for another Fetch call beyond this point.
+				close(s.done)
+			}
 			events = append(events, StackEvent{
-				LogicalResourceID:    aws.StringValue(event.LogicalResourceId),
+				LogicalResourceID:    logicalID,
 				ResourceType:         aws.StringValue(event.ResourceType),
-				ResourceStatus:       aws.StringValue(event.ResourceStatus),
+				ResourceStatus:       resourceStatus,
 				ResourceStatusReason: aws.StringValue(event.ResourceStatusReason),
 			})
 			s.pastEventIDs[aws.StringValue(event.EventId)] = true
@@ -113,11 +124,16 @@ func (s *StackStreamer) Notify() {
 	s.eventsToFlush = nil // reset after flushing all events.
 }
 
-// Stop closes all subscribed channels notifying them that no more events will be sent.
-func (s *StackStreamer) Stop() {
+// Close closes all subscribed channels notifying them that no more events will be sent.
+func (s *StackStreamer) Close() {
 	for _, sub := range s.subscribers {
 		close(sub)
 	}
+}
+
+// Done returns a channel that's closed when there are no more events that can be fetched.
+func (s *StackStreamer) Done() <-chan struct{} {
+	return s.done
 }
 
 // Taken from https://github.com/golang/go/wiki/SliceTricks#reversing

--- a/internal/pkg/stream/stream.go
+++ b/internal/pkg/stream/stream.go
@@ -10,36 +10,27 @@ import (
 	"time"
 )
 
-// Fetcher is the interface that wraps the Fetch method.
-// Fetcher fetches events, updates its internal state with new events and returns the next time
-// the Fetch call should be attempted. On failure, Fetch returns an error.
-type Fetcher interface {
+// Streamer is the interface that groups methods to periodically retrieve events,
+// publish them to subscribers, and stop publishing once there are no more events left.
+type Streamer interface {
+	// Fetcher fetches events, updates the internal state of the Streamer with new events and returns the next time
+	// the Fetch call should be attempted. On failure, Fetch returns an error.
 	Fetch() (next time.Time, err error)
-}
 
-// Notifier is the interface that wraps the Notify method.
-// Notify publishes all new event updates to subscribers..
-type Notifier interface {
+	// Notify publishes all new event updates to subscribers.
 	Notify()
+
+	// Close notifies all subscribers that no more events will be sent.
+	Close()
+
+	// Done returns a channel that's closed when there are no more events to Fetch.
+	Done() <-chan struct{}
 }
 
-// Stopper is the interface that wraps the Stop method.
-// Stop notifies all subscribers that no more events will be sent.
-type Stopper interface {
-	Stop()
-}
-
-// FetchNotifyStopper is the interface that groups a Fetcher, Notifier, and Stopper.
-type FetchNotifyStopper interface {
-	Fetcher
-	Notifier
-	Stopper
-}
-
-// Stream streams event updates by calling Fetch followed with Notify until the context is canceled or Fetch errors.
-// Once the context is canceled, a best effort Fetch and Notify is called followed with stopping the streamer.
-func Stream(ctx context.Context, streamer FetchNotifyStopper) error {
-	defer streamer.Stop()
+// Stream streams event updates by calling Fetch followed with Notify until there are no more events left.
+// If the context is canceled or Fetch errors, then Stream short-circuits and returns the error.
+func Stream(ctx context.Context, streamer Streamer) error {
+	defer streamer.Close()
 
 	var next time.Time
 	var err error
@@ -51,8 +42,9 @@ func Stream(ctx context.Context, streamer FetchNotifyStopper) error {
 
 		select {
 		case <-ctx.Done():
-			// The parent context is canceled. Best-effort publish latest events.
-			_, _ = streamer.Fetch()
+			return ctx.Err()
+		case <-streamer.Done():
+			// No more events to Fetch, flush and exit successfully.
 			streamer.Notify()
 			return nil
 		case <-time.After(fetchDelay):

--- a/internal/pkg/term/progress/cloudformation_test.go
+++ b/internal/pkg/term/progress/cloudformation_test.go
@@ -33,7 +33,7 @@ func TestRegularResourceComponent_Listen(t *testing.T) {
 	t.Run("should not add status if no events are received for the logical ID", func(t *testing.T) {
 		// GIVEN
 		ch := make(chan stream.StackEvent)
-		done := make(chan bool)
+		done := make(chan struct{})
 		comp := &regularResourceComponent{
 			logicalID: "EnvironmentManagerRole",
 			statuses:  []stackStatus{notStartedStackStatus},
@@ -43,12 +43,12 @@ func TestRegularResourceComponent_Listen(t *testing.T) {
 				},
 			},
 			stream: ch,
+			done:   done,
 		}
 
 		// WHEN
 		go func() {
 			comp.Listen()
-			done <- true
 		}()
 		go func() {
 			ch <- stream.StackEvent{
@@ -67,7 +67,7 @@ func TestRegularResourceComponent_Listen(t *testing.T) {
 	t.Run("should add status when an event is received for the resource", func(t *testing.T) {
 		// GIVEN
 		ch := make(chan stream.StackEvent)
-		done := make(chan bool)
+		done := make(chan struct{})
 		comp := &regularResourceComponent{
 			logicalID: "EnvironmentManagerRole",
 			statuses:  []stackStatus{notStartedStackStatus},
@@ -77,12 +77,12 @@ func TestRegularResourceComponent_Listen(t *testing.T) {
 				},
 			},
 			stream: ch,
+			done:   done,
 		}
 
 		// WHEN
 		go func() {
 			comp.Listen()
-			done <- true
 		}()
 		go func() {
 			ch <- stream.StackEvent{

--- a/internal/pkg/term/progress/cloudformation_test.go
+++ b/internal/pkg/term/progress/cloudformation_test.go
@@ -47,9 +47,7 @@ func TestRegularResourceComponent_Listen(t *testing.T) {
 		}
 
 		// WHEN
-		go func() {
-			comp.Listen()
-		}()
+		go comp.Listen()
 		go func() {
 			ch <- stream.StackEvent{
 				LogicalResourceID: "ServiceDiscoveryNamespace",
@@ -81,9 +79,7 @@ func TestRegularResourceComponent_Listen(t *testing.T) {
 		}
 
 		// WHEN
-		go func() {
-			comp.Listen()
-		}()
+		go comp.Listen()
 		go func() {
 			ch <- stream.StackEvent{
 				LogicalResourceID:    "EnvironmentManagerRole",
@@ -113,7 +109,7 @@ func TestRegularResourceComponent_Listen(t *testing.T) {
 	t.Run("should keep timer running if multiple in progress events are received", func(t *testing.T) {
 		// GIVEN
 		ch := make(chan stream.StackEvent)
-		done := make(chan bool)
+		done := make(chan struct{})
 		fc := &fakeClock{
 			wantedValues: []time.Time{testDate, testDate.Add(10 * time.Second)},
 		}
@@ -124,13 +120,11 @@ func TestRegularResourceComponent_Listen(t *testing.T) {
 				clock: fc,
 			},
 			stream: ch,
+			done:   done,
 		}
 
 		// WHEN
-		go func() {
-			comp.Listen()
-			done <- true
-		}()
+		go comp.Listen()
 		go func() {
 			ch <- stream.StackEvent{
 				LogicalResourceID: "EnvironmentManagerRole",

--- a/internal/pkg/term/progress/component.go
+++ b/internal/pkg/term/progress/component.go
@@ -29,16 +29,36 @@ func (c *singleLineComponent) Render(out io.Writer) (numLines int, err error) {
 	return 1, err
 }
 
-// treeComponent can display a node and its children.
+// treeComponent can display a node and its Children.
 type treeComponent struct {
 	Root     Renderer
 	Children []Renderer
 }
 
-// Render writes the Root and its children in order to out. Returns the total number of lines written.
+// Render writes the Root and its Children in order to out. Returns the total number of lines written.
 // In case of an error, returns 0 and the error.
 func (c *treeComponent) Render(out io.Writer) (numLines int, err error) {
 	return renderComponents(out, append([]Renderer{c.Root}, c.Children...))
+}
+
+// dynamicTreeComponent is a treeComponent that can notify that it's done updating once the Root node is done.
+type dynamicTreeComponent struct {
+	Root     DynamicRenderer
+	Children []Renderer
+}
+
+// Render creates a treeComponent and renders it.
+func (c *dynamicTreeComponent) Render(out io.Writer) (numLines int, err error) {
+	comp := &treeComponent{
+		Root:     c.Root,
+		Children: c.Children,
+	}
+	return comp.Render(out)
+}
+
+// Done delegates to Root's Done.
+func (c *dynamicTreeComponent) Done() <-chan struct{} {
+	return c.Root.Done()
 }
 
 func renderComponents(out io.Writer, components []Renderer) (numLines int, err error) {

--- a/internal/pkg/term/progress/component_test.go
+++ b/internal/pkg/term/progress/component_test.go
@@ -93,3 +93,42 @@ working?
 		})
 	}
 }
+
+func TestDynamicTreeComponent_Render(t *testing.T) {
+	// GIVEN
+	comp := dynamicTreeComponent{
+		Root: &mockDynamicRenderer{
+			content: "hello",
+		},
+		Children: []Renderer{
+			&mockDynamicRenderer{
+				content: " world",
+			},
+		},
+	}
+	buf := new(strings.Builder)
+
+	// WHEN
+	_, err := comp.Render(buf)
+
+	// THEN
+	require.NoError(t, err)
+	require.Equal(t, "hello world", buf.String())
+}
+
+func TestDynamicTreeComponent_Done(t *testing.T) {
+	// GIVEN
+	root := &mockDynamicRenderer{
+		content: "hello",
+		done:    make(chan struct{}),
+	}
+	comp := dynamicTreeComponent{
+		Root: root,
+	}
+
+	// WHEN
+	ch := comp.Done()
+
+	// THEN
+	require.Equal(t, root.Done(), ch)
+}


### PR DESCRIPTION
Previously, streamers and components from the `stream` and `progress`
packages respectively only exited if a `ctx` was canceled.

This PR enables `StackStreamer` to exit successfully on its own without
waiting for a context to cancel it when the stack is no longer in
progress.

Similarly, components that can both `Render` and `Listen` on events now
have a `Done` method to indicate that there are no more events to
`Listen` and we can exit successfully.


_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
