### PR TITLE
test(integ): change Source to new GitHubSource in integration tests

### DIFF
--- a/internal/pkg/deploy/cloudformation/pipeline_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/pipeline_integration_test.go
@@ -169,13 +169,11 @@ func TestPipelineCreation(t *testing.T) {
 		pipelineInput := &deploy.CreatePipelineInput{
 			AppName: app.Name,
 			Name:    pipelineStackName,
-			Source: &deploy.Source{
-				ProviderName: manifest.GithubProviderName,
-				Properties: map[string]interface{}{
-					"repository":                   "chicken/wings",
-					"branch":                       "main",
-					manifest.GithubSecretIdKeyName: secretId,
-				},
+			Source: &deploy.GitHubSource{
+				ProviderName:                manifest.GithubProviderName,
+				Branch:                      "main",
+				RepositoryURL:               "https://github.com/chicken/wings",
+				PersonalAccessTokenSecretID: secretId,
 			},
 			Stages: []deploy.PipelineStage{
 				{

--- a/internal/pkg/deploy/cloudformation/stack/pipeline_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/pipeline_integration_test.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/aws/copilot-cli/internal/pkg/manifest"
+
 	"github.com/aws/copilot-cli/internal/pkg/deploy"
 	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation/stack"
 	"github.com/stretchr/testify/require"
@@ -20,13 +22,11 @@ func TestPipeline_Template(t *testing.T) {
 	ps := stack.NewPipelineStackConfig(&deploy.CreatePipelineInput{
 		AppName: "phonetool",
 		Name:    "phonetool-pipeline",
-		Source: &deploy.Source{
-			ProviderName: "GitHub",
-			Properties: map[string]interface{}{
-				"repository":          "https://github.com/aws/phonetool",
-				"branch":              "mainline",
-				"access_token_secret": "mysecret",
-			},
+		Source: &deploy.GitHubSource{
+			ProviderName:                manifest.GithubProviderName,
+			RepositoryURL:               "https://github.com/aws/phonetool",
+			Branch:                      "mainline",
+			PersonalAccessTokenSecretID: "my secret",
 		},
 		Stages: []deploy.PipelineStage{
 			{


### PR DESCRIPTION
Changing deploy.Source to the more specific deploy.GitHubSource and deploy.CodeCommitSource broke a couple integ tests; this updates the sources in those tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
