### PR TITLE
test(integ): change testdata template to match new cfn template

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/template.yaml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/template.yaml
@@ -7,12 +7,6 @@
 # limitations under the License.
 AWSTemplateFormatVersion: '2010-09-09'
 Description: CodePipeline for phonetool
-Parameters:
-  # TODO: #273 make this source-provider-agnostic
-  GitHubAccessTokenSecretId:
-    Description: The secretId of the GitHub Personal Access token stored in the Secrets Manager
-    Type: String
-    Default: mysecret
 Resources:
   BuildProjectRole:
     Type: AWS::IAM::Role
@@ -145,6 +139,11 @@ Resources:
           - Effect: Allow
             Action:
               - codepipeline:*
+              - codecommit:GetBranch
+              - codecommit:GetCommit
+              - codecommit:UploadArchive
+              - codecommit:GetUploadArchiveStatus
+              - codecommit:CancelUploadArchive
               - iam:ListRoles
               - cloudformation:Describe*
               - cloudFormation:List*
@@ -230,21 +229,18 @@ Resources:
             - Name: SourceCodeFor-phonetool
               ActionTypeId:
                 Category: Source
-                # TODO: #273 For CodeCommit, this needs to be AWS. Let's do that later
                 Owner: ThirdParty
                 Version: 1
                 Provider: GitHub
               Configuration:
-                # TODO: #273 For now this set of configurations is GitHub-specific,
-                # change it to be more generic
                 Owner: aws
                 Repo: phonetool
                 Branch: mainline
                 # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/dynamic-references.html#dynamic-references-secretsmanager
                 # Use the *entire* SecretString with version AWSCURRENT
                 OAuthToken: !Sub
-                    - '{{resolve:secretsmanager:${SecretId}}}'
-                    - { SecretId: !Ref GitHubAccessTokenSecretId }
+                  - '{{resolve:secretsmanager:${SecretId}}}'
+                  - SecretId: my secret
               OutputArtifacts:
                 - Name: SCCheckoutArtifact
               RunOrder: 1

--- a/templates/cicd/pipeline_cfn.yml
+++ b/templates/cicd/pipeline_cfn.yml
@@ -249,7 +249,7 @@ Resources:
                 # Use the *entire* SecretString with version AWSCURRENT
                 OAuthToken: !Sub
                   - '{{"{{"}}resolve:secretsmanager:${SecretId}{{"}}"}}'
-                  - SecretId: {{$.Source.PersonalAccessTokenSecretID}}
+                  - SecretId: {{$.Source.GitHubPersonalAccessTokenSecretID}}
               OutputArtifacts:
                 - Name: SCCheckoutArtifact
               RunOrder: 1


### PR DESCRIPTION
The expected cfn template for pipeline integ tests is now up to date with the changes introduced when CodeCommit was added as a source option.

Also snuck in a couple fixes to the template itself: calling the method for GH token rather than the struct field, newline at end of file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
