### PR TITLE
chore(cli): apply underline method to pipeline files

### DIFF
--- a/internal/pkg/describe/pipeline_show.go
+++ b/internal/pkg/describe/pipeline_show.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/aws/copilot-cli/internal/pkg/aws/sessions"
@@ -100,9 +101,9 @@ func (p *Pipeline) HumanString() string {
 	writer.Flush()
 	fmt.Fprint(writer, color.Bold.Sprint("\nStages\n\n"))
 	writer.Flush()
-	fmt.Fprintf(writer, "  %s\t%s\t%s\t%s\n", "Name", "Category", "Provider", "Details")
-	writer.Flush()
-	fmt.Fprintf(writer, "  %s\t%[1]s\t%[1]s\t%[1]s\n", "----")
+	headers := []string{"Name", "Category", "Provider", "Details"}
+	fmt.Fprintf(writer, "  %s\n", strings.Join(headers, "\t"))
+	fmt.Fprintf(writer, "  %s\n", strings.Join(underline(headers), "\t"))
 	for _, stage := range p.Stages {
 		fmt.Fprint(writer, stage.HumanString())
 	}

--- a/internal/pkg/describe/pipeline_show_test.go
+++ b/internal/pkg/describe/pipeline_show_test.go
@@ -215,7 +215,7 @@ func TestPipelineDescriber_String(t *testing.T) {
 Stages
 
   Name              Category            Provider            Details
-  ----              ----                ----                ----
+  ----              --------            --------            -------
   Source            Source              GitHub              Repository: badgoose/repo
   Build             Build               CodeBuild           BuildProject: pipeline-dinder-badgoose-repo-BuildProject
   DeployTo-test     Deploy              CloudFormation      StackName: dinder-test-test
@@ -243,7 +243,7 @@ Resources
 Stages
 
   Name              Category            Provider            Details
-  ----              ----                ----                ----
+  ----              --------            --------            -------
   Source            Source              GitHub              Repository: badgoose/repo
   Build             Build               CodeBuild           BuildProject: pipeline-dinder-badgoose-repo-BuildProject
   DeployTo-test     Deploy              CloudFormation      StackName: dinder-test-test

--- a/internal/pkg/describe/pipeline_status.go
+++ b/internal/pkg/describe/pipeline_status.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/aws/copilot-cli/internal/pkg/aws/codepipeline"
@@ -68,8 +69,9 @@ func (p PipelineStatus) HumanString() string {
 	writer := tabwriter.NewWriter(&b, minCellWidth, tabWidth, cellPaddingWidth, paddingChar, noAdditionalFormatting)
 	fmt.Fprint(writer, color.Bold.Sprint("Pipeline Status\n\n"))
 	writer.Flush()
-	fmt.Fprintf(writer, "%s\t%s\t%s\n", "Stage", "Transition", "Status")
-	fmt.Fprintf(writer, "%s\t%s\t%s\n", "-----", "----------", "------")
+	headers := []string{"Stage", "Transition", "Status"}
+	fmt.Fprintf(writer, "%s\n", strings.Join(headers, "\t"))
+	fmt.Fprintf(writer, "%s\n", strings.Join(underline(headers), "\t"))
 	for _, stage := range p.StageStates {
 		fmt.Fprint(writer, stage.HumanString())
 	}


### PR DESCRIPTION
This creates underlines that are the same length as the column headings. Previously applied to env and app; adding pipeline commands here.

(Also fixed a column flush issue.)

Related: https://github.com/aws/copilot-cli/pull/1705/files

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
