### PR TITLE
fix(template): Option with value as "on" is converted to true

### DIFF
--- a/templates/workloads/partials/cf/logconfig.yml
+++ b/templates/workloads/partials/cf/logconfig.yml
@@ -2,7 +2,7 @@
   LogDriver: awsfirelens
 {{- if .LogConfig.Destination}}
   Options:{{range $name, $value := .LogConfig.Destination}}
-    {{$name}}: {{$value}}{{end}}
+    {{$name}}: {{$value | printf "%q"}}{{end}}
 {{- end}}
 {{- if .LogConfig.SecretOptions}}
   SecretOptions:{{range $name, $valueFrom := .LogConfig.SecretOptions}}


### PR DESCRIPTION
```
logging:
  image: amazon/aws-for-fluent-bit:latest
  destination:
    Name: datadog
    TLS: on
```
will produce something like `"TLS": "true"`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
