### PR TITLE
chore: use Metadata instead of comments to parse resource descriptions

### DIFF
--- a/internal/pkg/aws/cloudformation/testdata/parse/env.yaml
+++ b/internal/pkg/aws/cloudformation/testdata/parse/env.yaml
@@ -2,8 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 Resources:
   VPC:
-  # Virtual private cloud on 2 availability zones to control network boundaries.
     Type: AWS::EC2::VPC
+    Metadata:
+      'aws:copilot:description': 'Virtual private cloud on 2 availability zones to control network boundaries.'
     Properties:
       CidrBlock: 10.0.0.0/16
       EnableDnsHostnames: true
@@ -14,8 +15,9 @@ Resources:
           Value: !Sub 'copilot-${AppName}-${EnvironmentName}'
 
   PublicRouteTable:
-  # Routing table for services to talk with each other.
     Type: AWS::EC2::RouteTable
+    Metadata:
+      'aws:copilot:description': 'Routing table for services to talk with each other.'
     Properties:
       VpcId: !Ref VPC
       Tags:
@@ -31,16 +33,18 @@ Resources:
       GatewayId: !Ref InternetGateway
 
   InternetGateway:
-  # Internet gateway to connect the network to the internet.
     Type: AWS::EC2::InternetGateway
+    Metadata:
+      'aws:copilot:description': 'Internet gateway to connect the network to the internet.'
     Properties:
       Tags:
         - Key: Name
           Value: !Sub 'copilot-${AppName}-${EnvironmentName}'
 
   PublicSubnet1:
-  # A public subnet in your first AZ for internet facing services.
     Type: AWS::EC2::Subnet
+    Metadata:
+      'aws:copilot:description': 'A public subnet in your first AZ for internet facing services.'
     Properties:
       CidrBlock: 10.0.0.0/24
       VpcId: !Ref VPC
@@ -51,8 +55,9 @@ Resources:
           Value: !Sub 'copilot-${AppName}-${EnvironmentName}-pub0'
 
   PublicSubnet2:
-  # A public subnet in your second AZ for internet facing services.
     Type: AWS::EC2::Subnet
+    Metadata:
+      'aws:copilot:description': 'A public subnet in your second AZ for internet facing services.'
     Properties:
       CidrBlock: 10.0.1.0/24
       VpcId: !Ref VPC
@@ -71,8 +76,9 @@ Resources:
       Vpc: !Ref VPC
 
   Cluster:
-  # An ECS Cluster to hold your services.
     Type: AWS::ECS::Cluster
+    Metadata:
+      'aws:copilot:description': 'An ECS Cluster to hold your services.'
     Properties:
       CapacityProviders: ['FARGATE', 'FARGATE_SPOT']
 
@@ -87,7 +93,8 @@ Resources:
           Value: !Sub 'copilot-${AppName}-${EnvironmentName}-env'
 
   PublicLoadBalancer:
-  # An application load balancer to distribute traffic to your Load Balanced Web Services.
+    Metadata:
+      'aws:copilot:description': 'An application load balancer to distribute traffic to your Load Balanced Web Services.'
     Condition: CreateALB
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:

--- a/internal/pkg/aws/cloudformation/testdata/parse/lb-web-svc.yaml
+++ b/internal/pkg/aws/cloudformation/testdata/parse/lb-web-svc.yaml
@@ -3,15 +3,17 @@
 
 Resources:
   LogGroup:
-  # A CloudWatch log group to store your logs.
+    Metadata:
+      'aws:copilot:description': 'A CloudWatch log group to store your logs.'
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Join ['', [/copilot/, !Ref AppName, '-', !Ref EnvName, '-', !Ref WorkloadName]]
       RetentionInDays: !Ref LogRetention
 
   TaskDefinition:
-  # An ECS TaskDefinition where your containers are defined.
     Type: AWS::ECS::TaskDefinition
+    Metadata:
+      'aws:copilot:description': 'An ECS TaskDefinition where your containers are defined.'
     DependsOn: LogGroup
     Properties:
       Family: !Join ['', [!Ref AppName, '-', !Ref EnvName, '-', !Ref WorkloadName]]
@@ -50,7 +52,8 @@ Resources:
               awslogs-stream-prefix: copilot
 
   TaskRole:
-  # A task role to manage permissions for your containers.
+    Metadata:
+      'aws:copilot:description': 'A task role to manage permissions for your containers.'
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
@@ -77,8 +80,9 @@ Resources:
                     'iam:ResourceTag/copilot-environment': !Sub '${EnvName}'
 
   DiscoveryService:
-  # Service discovery to communicate with other services in your VPC.
     Type: AWS::ServiceDiscovery::Service
+    Metadata:
+      'aws:copilot:description': 'Service discovery to communicate with other services in your VPC.'
     Properties:
       Description: Discovery Service for the Copilot services
       DnsConfig:
@@ -97,8 +101,9 @@ Resources:
 
 
   EnvControllerAction:
-  # Updating your environment to enable load balancers.
     Type: Custom::EnvControllerFunction
+    Metadata:
+      'aws:copilot:description': 'Updating your environment to enable load balancers.'
     Properties:
       ServiceToken: !GetAtt EnvControllerFunction.Arn
       Workload: !Ref WorkloadName
@@ -109,8 +114,9 @@ Resources:
       UpdateID: c31b2422-5c1f-48cb-9a58-f0f418984d27
 
   Service:
-  # An ECS service to run and maintain your tasks.
     Type: AWS::ECS::Service
+    Metadata:
+      'aws:copilot:description': 'An ECS service to run and maintain your tasks.'
     DependsOn: WaitUntilListenerRuleIsCreated
     Properties:
       Cluster:
@@ -150,8 +156,9 @@ Resources:
           Port: !Ref ContainerPort
 
   TargetGroup:
-        # A target group to connect your service to the load balancer.
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Metadata:
+      'aws:copilot:description': 'A target group to connect your service to the load balancer.'
     Properties:
       HealthCheckPath: /_healthcheck # Default is '/'.
       Port: !Ref ContainerPort
@@ -188,7 +195,8 @@ Resources:
       Count: 0
 
   AddonsStack:
-  # An addons stack for your additional AWS resources.
+    Metadata:
+      'aws:copilot:description': 'An addons stack for your additional AWS resources.'
     Type: AWS::CloudFormation::Stack
     Condition: HasAddons
     Properties:

--- a/internal/pkg/deploy/cloudformation/cloudformation_test.go
+++ b/internal/pkg/deploy/cloudformation/cloudformation_test.go
@@ -172,10 +172,12 @@ func TestCloudFormation_renderStackChanges(t *testing.T) {
 		m.EXPECT().TemplateBodyFromChangeSet("1234", "phonetool-test").Return(`
 Resources:
   Cluster:
-    # An ECS cluster
+    Metadata:
+      'aws:copilot:description': 'An ECS cluster'
     Type: AWS::ECS::Cluster
   AddonsStack:
-    # An Addons CloudFormation Stack for your additional AWS resources
+    Metadata:
+      'aws:copilot:description': 'An Addons CloudFormation Stack for your additional AWS resources'
     Type: AWS::CloudFormation::Stack
 `, nil)
 
@@ -226,7 +228,8 @@ Resources:
 		m.EXPECT().TemplateBodyFromChangeSet("5678", "my-nested-stack").Return(`
 Resources:
   MyTable:
-    # A DynamoDB table to store data
+    Metadata:
+      'aws:copilot:description': 'A DynamoDB table to store data'
     Type: AWS::DynamoDB::Table`, nil)
 
 		m.EXPECT().DescribeStackEvents(&sdkcloudformation.DescribeStackEventsInput{

--- a/internal/pkg/deploy/cloudformation/stack/testdata/autoscaling/autoscaling-svc-cf.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/autoscaling/autoscaling-svc-cf.yml
@@ -11,7 +11,8 @@
         - 'arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceAutoscaleRole'
   
   AutoScalingTarget:
-    # An AutoScaling target to scale your service's desired count.
+    Metadata:
+      'aws:copilot:description': "An AutoScaling target to scale your service's desired count"
     Type: AWS::ApplicationAutoScaling::ScalableTarget
     Properties:
       MinCapacity: 1

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/job-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/job-test.stack.yml
@@ -30,14 +30,16 @@ Conditions:
     !Not [!Equals [!Ref AddonsTemplateURL, ""]]
 Resources: 
   LogGroup:
-    # A CloudWatch log group to hold your service logs
+    Metadata:
+      'aws:copilot:description': 'A CloudWatch log group to hold your service logs'
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Join ['', [/copilot/, !Ref AppName, '-', !Ref EnvName, '-', !Ref WorkloadName]]
       RetentionInDays: !Ref LogRetention
 
   TaskDefinition:
-    # An ECS task definition to group your containers and run them on ECS
+    Metadata:
+      'aws:copilot:description': 'An ECS task definition to group your containers and run them on ECS'
     Type: AWS::ECS::TaskDefinition
     DependsOn: LogGroup
     Properties:
@@ -74,7 +76,8 @@ Resources:
         
         
   ExecutionRole:
-    # An IAM Role for the Fargate agent to make AWS API calls on your behalf
+    Metadata:
+      'aws:copilot:description': 'An IAM Role for the Fargate agent to make AWS API calls on your behalf'
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
@@ -116,7 +119,8 @@ Resources:
   
 
   TaskRole:
-    # An IAM role to control permissions for the containers in your tasks
+    Metadata:
+      'aws:copilot:description': 'An IAM role to control permissions for the containers in your tasks'
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
@@ -144,7 +148,8 @@ Resources:
   
 
   Rule:
-    # A CloudWatch event rule to trigger the job's state machine
+    Metadata:
+      'aws:copilot:description': "A CloudWatch event rule to trigger the job's state machine"
     Type: AWS::Events::Rule
     Properties:
       ScheduleExpression: !Ref Schedule
@@ -171,7 +176,8 @@ Resources:
             Resource: !Ref StateMachine
 
   StateMachine:
-    # A state machine to invoke your job and handle retry and timeout logic
+    Metadata:
+      'aws:copilot:description': 'A state machine to invoke your job and handle retry and timeout logic'
     Type: AWS::StepFunctions::StateMachine
     Properties:
       StateMachineName: !Sub '${AppName}-${EnvName}-${WorkloadName}'
@@ -308,7 +314,8 @@ Resources:
   
 
   AddonsStack:
-    # An Addons CloudFormation Stack for your additional AWS resources
+    Metadata:
+      'aws:copilot:description': 'An Addons CloudFormation Stack for your additional AWS resources'
     Type: AWS::CloudFormation::Stack
     Condition: HasAddons
     Properties:

--- a/templates/addons/ddb/cf.yml
+++ b/templates/addons/ddb/cf.yml
@@ -10,7 +10,8 @@ Parameters:
     Description: The name of the service, job, or workflow being deployed.
 Resources:
   {{logicalIDSafe .Name}}:
-    # An Amazon DynamoDB table for {{.Name}}
+    Metadata:
+      'aws:copilot:description': 'An Amazon DynamoDB table for {{.Name}}'
     Type: AWS::DynamoDB::Table
     DeletionPolicy: Retain
     Properties:
@@ -35,7 +36,8 @@ Resources:
             ProjectionType: ALL{{end}}{{end}}
 
   {{logicalIDSafe .Name}}AccessPolicy:
-    # An IAM ManagedPolicy for your service to access the {{.Name}} db
+    Metadata:
+      'aws:copilot:description': 'An IAM ManagedPolicy for your service to access the {{.Name}} db'
     Type: AWS::IAM::ManagedPolicy
     Properties:
       Description: !Sub

--- a/templates/addons/s3/cf.yml
+++ b/templates/addons/s3/cf.yml
@@ -10,7 +10,8 @@ Parameters:
     Description: The name of the service, job, or workflow being deployed.
 Resources:
   {{logicalIDSafe .Name}}:
-    # An Amazon S3 bucket to store and retrieve objects for {{.Name}}
+    Metadata:
+      'aws:copilot:description': 'An Amazon S3 bucket to store and retrieve objects for {{.Name}}'
     Type: AWS::S3::Bucket
     DeletionPolicy: Retain
     Properties:
@@ -25,7 +26,8 @@ Resources:
         BlockPublicPolicy: true
 
   {{logicalIDSafe .Name}}BucketPolicy:
-      # A bucket policy to deny unencrypted access to the bucket and its contents
+    Metadata:
+      'aws:copilot:description': 'A bucket policy to deny unencrypted access to the bucket and its contents'
     Type: AWS::S3::BucketPolicy
     DeletionPolicy: Retain
     Properties:
@@ -45,7 +47,8 @@ Resources:
       Bucket: !Ref {{logicalIDSafe .Name}}
 
   {{logicalIDSafe .Name}}AccessPolicy:
-    # An IAM ManagedPolicy for your service to access the {{.Name}} bucket
+    Metadata:
+      'aws:copilot:description': 'An IAM ManagedPolicy for your service to access the {{.Name}} bucket'
     Type: AWS::IAM::ManagedPolicy
     Properties:
       Description: !Sub

--- a/templates/environment/partials/cfn-execution-role.yml
+++ b/templates/environment/partials/cfn-execution-role.yml
@@ -1,7 +1,8 @@
 # The CloudformationExecutionRole definition must be immediately followed with DeletionPolicy: Retain.
 # See #1533.
 CloudformationExecutionRole:
-  # An IAM Role for AWS CloudFormation to manage resources
+  Metadata:
+    'aws:copilot:description': 'An IAM Role for AWS CloudFormation to manage resources'
   DeletionPolicy: Retain
   Type: AWS::IAM::Role
 {{- if not .ImportVPC}}

--- a/templates/environment/partials/environment-manager-role.yml
+++ b/templates/environment/partials/environment-manager-role.yml
@@ -1,5 +1,6 @@
 EnvironmentManagerRole:
-  # An IAM Role to describe resources in your environment
+  Metadata:
+    'aws:copilot:description': 'An IAM Role to describe resources in your environment'
   DeletionPolicy: Retain
   Type: AWS::IAM::Role
   DependsOn: CloudformationExecutionRole

--- a/templates/environment/partials/vpc-resources.yml
+++ b/templates/environment/partials/vpc-resources.yml
@@ -1,5 +1,6 @@
 VPC:
-  # A Virtual Private Cloud to control networking of your AWS resources
+  Metadata:
+    'aws:copilot:description': 'A Virtual Private Cloud to control networking of your AWS resources'
   Type: AWS::EC2::VPC
   Properties:
     CidrBlock: {{.CIDR}}
@@ -27,7 +28,8 @@ DefaultPublicRoute:
     GatewayId: !Ref InternetGateway
 
 InternetGateway:
-  # An Internet Gateway to connect to the public internet
+  Metadata:
+    'aws:copilot:description': 'An Internet Gateway to connect to the public internet'
   Type: AWS::EC2::InternetGateway
   Properties:
     Tags:
@@ -41,7 +43,8 @@ InternetGatewayAttachment:
     VpcId: !Ref VPC
 {{range $ind, $cidr := .PublicSubnetCIDRs}}
 PublicSubnet{{inc $ind}}:
-  # Public subnet {{inc $ind}} for resources that can access the internet
+  Metadata:
+    'aws:copilot:description': 'Public subnet {{inc $ind}} for resources that can access the internet'
   Type: AWS::EC2::Subnet
   Properties:
     CidrBlock: {{$cidr}}
@@ -53,7 +56,8 @@ PublicSubnet{{inc $ind}}:
         Value: !Sub 'copilot-${AppName}-${EnvironmentName}-pub{{$ind}}'
 {{end}}{{range $ind, $cidr := .PrivateSubnetCIDRs}}
 PrivateSubnet{{inc $ind}}:
-  # Private subnet {{inc $ind}} for resources with no internet access
+  Metadata:
+    'aws:copilot:description': 'Private subnet {{inc $ind}} for resources with no internet access'
   Type: AWS::EC2::Subnet
   Properties:
     CidrBlock: {{$cidr}}

--- a/templates/environment/versions/cf-v1.1.0.yml
+++ b/templates/environment/versions/cf-v1.1.0.yml
@@ -52,13 +52,15 @@ Resources:
 {{- end}}
 
   Cluster:
-    # An ECS cluster to group your services.
+    Metadata:
+      'aws:copilot:description': 'An ECS cluster to group your services'
     Type: AWS::ECS::Cluster
     Properties:
       CapacityProviders: ['FARGATE', 'FARGATE_SPOT']
 
   PublicLoadBalancerSecurityGroup:
-    # A security group for your load balancer allowing HTTP and HTTPS traffic
+    Metadata:
+      'aws:copilot:description': 'A security group for your load balancer allowing HTTP and HTTPS traffic'
     Condition: CreateALB
     Type: AWS::EC2::SecurityGroup
     Properties:
@@ -85,7 +87,8 @@ Resources:
 
   # Only accept requests coming from the public ALB or other containers in the same security group.
   EnvironmentSecurityGroup:
-    # A security group to allow your containers to talk to each other
+    Metadata:
+      'aws:copilot:description': 'A security group to allow your containers to talk to each other'
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupDescription: !Join ['', [!Ref AppName, '-', !Ref EnvironmentName, EnvironmentSecurityGroup]]
@@ -116,7 +119,8 @@ Resources:
       SourceSecurityGroupId: !Ref EnvironmentSecurityGroup
 
   PublicLoadBalancer:
-    # An Application Load Balancer to distribute public traffic to your services
+    Metadata:
+      'aws:copilot:description': 'An Application Load Balancer to distribute public traffic to your services'
     Condition: CreateALB
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:

--- a/templates/workloads/jobs/scheduled-job/cf.yml
+++ b/templates/workloads/jobs/scheduled-job/cf.yml
@@ -32,7 +32,8 @@ Resources:
 {{include "loggroup" . | indent 2}}
 
   TaskDefinition:
-    # An ECS task definition to group your containers and run them on ECS
+    Metadata:
+      'aws:copilot:description': 'An ECS task definition to group your containers and run them on ECS'
     Type: AWS::ECS::TaskDefinition
     DependsOn: LogGroup
     Properties:

--- a/templates/workloads/partials/cf/addons.yml
+++ b/templates/workloads/partials/cf/addons.yml
@@ -1,5 +1,6 @@
 AddonsStack:
-  # An Addons CloudFormation Stack for your additional AWS resources
+  Metadata:
+    'aws:copilot:description': 'An Addons CloudFormation Stack for your additional AWS resources'
   Type: AWS::CloudFormation::Stack
   Condition: HasAddons
   Properties:

--- a/templates/workloads/partials/cf/autoscaling.yml
+++ b/templates/workloads/partials/cf/autoscaling.yml
@@ -37,7 +37,8 @@ AutoScalingRole:
       - 'arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceAutoscaleRole'
 
 AutoScalingTarget:
-  # An AutoScaling target to scale your service's desired count.
+  Metadata:
+    'aws:copilot:description': "An AutoScaling target to scale your service's desired count"
   Type: AWS::ApplicationAutoScaling::ScalableTarget
   Properties:
     MinCapacity: {{.Autoscaling.MinCapacity}}

--- a/templates/workloads/partials/cf/env-controller.yml
+++ b/templates/workloads/partials/cf/env-controller.yml
@@ -1,5 +1,6 @@
 EnvControllerAction:
-  # Update your environment's shared resources
+  Metadata:
+    'aws:copilot:description': "Update your environment's shared resources"
   Type: Custom::EnvControllerFunction
   Properties:
     ServiceToken: !GetAtt EnvControllerFunction.Arn

--- a/templates/workloads/partials/cf/eventrule.yml
+++ b/templates/workloads/partials/cf/eventrule.yml
@@ -1,5 +1,6 @@
 Rule:
-  # A CloudWatch event rule to trigger the job's state machine
+  Metadata:
+    'aws:copilot:description': "A CloudWatch event rule to trigger the job's state machine"
   Type: AWS::Events::Rule
   Properties:
     ScheduleExpression: !Ref Schedule

--- a/templates/workloads/partials/cf/executionrole.yml
+++ b/templates/workloads/partials/cf/executionrole.yml
@@ -1,5 +1,6 @@
 ExecutionRole:
-  # An IAM Role for the Fargate agent to make AWS API calls on your behalf
+  Metadata:
+    'aws:copilot:description': 'An IAM Role for the Fargate agent to make AWS API calls on your behalf'
   Type: AWS::IAM::Role
   Properties:
     AssumeRolePolicyDocument:

--- a/templates/workloads/partials/cf/loggroup.yml
+++ b/templates/workloads/partials/cf/loggroup.yml
@@ -1,5 +1,6 @@
 LogGroup:
-  # A CloudWatch log group to hold your service logs
+  Metadata:
+    'aws:copilot:description': 'A CloudWatch log group to hold your service logs'
   Type: AWS::Logs::LogGroup
   Properties:
     LogGroupName: !Join ['', [/copilot/, !Ref AppName, '-', !Ref EnvName, '-', !Ref WorkloadName]]

--- a/templates/workloads/partials/cf/servicediscovery.yml
+++ b/templates/workloads/partials/cf/servicediscovery.yml
@@ -1,5 +1,6 @@
 DiscoveryService:
-  # Service discovery for your services to communicate within the VPC
+  Metadata:
+    'aws:copilot:description': 'Service discovery for your services to communicate within the VPC'
   Type: AWS::ServiceDiscovery::Service
   Properties:
     Description: Discovery Service for the Copilot services

--- a/templates/workloads/partials/cf/state-machine.yml
+++ b/templates/workloads/partials/cf/state-machine.yml
@@ -1,5 +1,6 @@
 StateMachine:
-  # A state machine to invoke your job and handle retry and timeout logic
+  Metadata:
+    'aws:copilot:description': 'A state machine to invoke your job and handle retry and timeout logic'
   Type: AWS::StepFunctions::StateMachine
   Properties:
     StateMachineName: !Sub '${AppName}-${EnvName}-${WorkloadName}'

--- a/templates/workloads/partials/cf/taskrole.yml
+++ b/templates/workloads/partials/cf/taskrole.yml
@@ -1,5 +1,6 @@
 TaskRole:
-  # An IAM role to control permissions for the containers in your tasks
+  Metadata:
+    'aws:copilot:description': 'An IAM role to control permissions for the containers in your tasks'
   Type: AWS::IAM::Role
   Properties:{{if .NestedStack}}{{$stackName := .NestedStack.StackName}}{{if gt (len .NestedStack.PolicyOutputs) 0}}
     ManagedPolicyArns:{{range $managedPolicy := .NestedStack.PolicyOutputs}}

--- a/templates/workloads/services/backend/cf.yml
+++ b/templates/workloads/services/backend/cf.yml
@@ -35,7 +35,8 @@ Resources:
 {{include "loggroup" . | indent 2}}
 
   TaskDefinition:
-    # An ECS task definition to group your containers and run them on ECS
+    Metadata:
+      'aws:copilot:description': 'An ECS task definition to group your containers and run them on ECS'
     Type: AWS::ECS::TaskDefinition
     DependsOn: LogGroup
     Properties:
@@ -107,7 +108,8 @@ Resources:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
 {{- end }}
   Service:
-    # An ECS service to run and maintain your tasks in the environment cluster
+    Metadata:
+      'aws:copilot:description': 'An ECS service to run and maintain your tasks in the environment cluster'
     Type: AWS::ECS::Service
     Properties:
 {{include "service-base-properties" . | indent 6}}

--- a/templates/workloads/services/lb-web/cf.yml
+++ b/templates/workloads/services/lb-web/cf.yml
@@ -51,7 +51,8 @@ Resources:
 {{include "loggroup" . | indent 2}}
 
   TaskDefinition:
-    # An ECS task definition to group your containers and run them on ECS
+    Metadata:
+      'aws:copilot:description': 'An ECS task definition to group your containers and run them on ECS'
     Type: AWS::ECS::TaskDefinition
     DependsOn: LogGroup
     Properties:
@@ -119,7 +120,8 @@ Resources:
 {{include "env-controller" . | indent 2}}
 
   Service:
-    # An ECS service to run and maintain your tasks in the environment cluster
+    Metadata:
+      'aws:copilot:description': 'An ECS service to run and maintain your tasks in the environment cluster'
     Type: AWS::ECS::Service
     DependsOn: WaitUntilListenerRuleIsCreated
     Properties:
@@ -135,7 +137,8 @@ Resources:
           Port: !Ref ContainerPort
 
   TargetGroup:
-    # A target group to connect the load balancer to your service
+    Metadata:
+      'aws:copilot:description': 'A target group to connect the load balancer to your service'
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
       HealthCheckPath: {{.HTTPHealthCheck.HealthCheckPath}} # Default is '/'.


### PR DESCRIPTION
Instead of comments to add description to resources:
```yaml
  VPC:
  # Virtual private cloud on 2 availability zones to control network boundaries.
    Type: AWS::EC2::VPC
```
We're switching it to use the Metadata attribute:
```yaml
  VPC:
    Metadata:
      'aws:copilot:description': 'Virtual private cloud on 2 availability zones to control network boundaries.'
```
Makes for more robust parsing and we can add additional metadata over time

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
