### PR TITLE
fix(sessions): FromStaticCreds should render creds correctly

### DIFF
--- a/internal/pkg/aws/sessions/sessions.go
+++ b/internal/pkg/aws/sessions/sessions.go
@@ -115,7 +115,7 @@ func (p *Provider) FromStaticCreds(accessKeyID, secretAccessKey, sessionToken st
 	conf := newConfig()
 	conf.Credentials = credentials.NewStaticCredentials(accessKeyID, secretAccessKey, sessionToken)
 	sess, err := session.NewSessionWithOptions(session.Options{
-		Config: *newConfig(),
+		Config: *conf,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create session from static credentials: %w", err)


### PR DESCRIPTION
<!-- Provide summary of changes -->
FromStaticCreds should render creds correctly. Right now FromStaticCreds doesn't pick up the temp creds users put in `env init`.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
