### PR TITLE
Export DiscoverServiceARN

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ We're distributing binaries from our GitHub releases. Instructions for installin
 
 | Platform | Command to install |
 |---------|---------
-| macOS | `curl -Lo /usr/local/bin/copilot https://github.com/aws/copilot-cli/releases/download/v0.2.0/copilot-darwin-v0.2.0 && chmod +x /usr/local/bin/copilot && copilot --help` |
-| Linux | `curl -Lo /usr/local/bin/copilot https://github.com/aws/copilot-cli/releases/download/v0.2.0/copilot-linux-v0.2.0 && chmod +x /usr/local/bin/copilot && copilot --help` |
+| macOS | `curl -Lo /usr/local/bin/copilot https://github.com/aws/copilot-cli/releases/download/v0.3.0/copilot-darwin-v0.3.0 && chmod +x /usr/local/bin/copilot && copilot --help` |
+| Linux | `curl -Lo /usr/local/bin/copilot https://github.com/aws/copilot-cli/releases/download/v0.3.0/copilot-linux-v0.3.0 && chmod +x /usr/local/bin/copilot && copilot --help` |
 
 </details>
 

--- a/templates/services/backend/cf.yml
+++ b/templates/services/backend/cf.yml
@@ -71,3 +71,10 @@ Resources:
           Port: !Ref ContainerPort
 
 {{include "addons" . | indent 2}}
+
+Outputs:
+  DiscoveryServiceArn:
+    Description: ARN of the Discovery Service.
+    Value: !GetAtt DiscoveryService.Arn
+    Export:
+      Name: !Sub ${AWS::StackName}-DiscoveryServiceArn


### PR DESCRIPTION
Added output section in services/backend/cf.yaml to export the DiscoverService.ARN so that can be used by other CF stack.

Issue number #1864 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
