### PR TITLE
chore(templates): output for DiscoveryServiceARN

### DIFF
--- a/templates/workloads/services/backend/cf.yml
+++ b/templates/workloads/services/backend/cf.yml
@@ -116,3 +116,10 @@ Resources:
       ServiceRegistries: !If [ExposePort, [{RegistryArn: !GetAtt DiscoveryService.Arn, Port: !Ref ContainerPort}], !Ref "AWS::NoValue"]
 
 {{include "addons" . | indent 2}}
+
+Outputs:
+  DiscoveryServiceArn:
+    Description: ARN of the Discovery Service.
+    Value: !GetAtt DiscoveryService.Arn
+    Export:
+      Name: !Sub ${AWS::StackName}-DiscoveryServiceArn

--- a/templates/workloads/services/backend/cf.yml
+++ b/templates/workloads/services/backend/cf.yml
@@ -118,8 +118,8 @@ Resources:
 {{include "addons" . | indent 2}}
 
 Outputs:
-  DiscoveryServiceArn:
+  DiscoveryServiceARN:
     Description: ARN of the Discovery Service.
     Value: !GetAtt DiscoveryService.Arn
     Export:
-      Name: !Sub ${AWS::StackName}-DiscoveryServiceArn
+      Name: !Sub ${AWS::StackName}-DiscoveryServiceARN

--- a/templates/workloads/services/lb-web/cf.yml
+++ b/templates/workloads/services/lb-web/cf.yml
@@ -351,3 +351,11 @@ Resources:
       Count: 0
 
 {{include "addons" . | indent 2}}
+
+
+Outputs:
+  DiscoveryServiceARN:
+    Description: ARN of the Discovery Service.
+    Value: !GetAtt DiscoveryService.Arn
+    Export:
+      Name: !Sub ${AWS::StackName}-DiscoveryServiceARN


### PR DESCRIPTION
Added output section in templates/workloads/services/backend/cf.yml to export the DiscoverService.ARN so that can be used by other CF stack.

Resolves #1864

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

