### PR TITLE
refactor(test): refactor job integ test to use marshaled yaml

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/scheduled_job_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/scheduled_job_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"testing"
+	"gopkg.in/yaml.v3"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
@@ -50,9 +51,16 @@ func TestScheduledJob_Template(t *testing.T) {
 	})
 
 	t.Run("CF Template should be equal", func(t *testing.T) {
+		actualBytes := []byte(tpl)
+		mActual := make(map[interface{}]interface{})
+		require.NoError(t, yaml.Unmarshal(actualBytes, mActual))
+
 		expected, err := ioutil.ReadFile(filepath.Join("testdata", "workloads", jobStackPath))
 		require.NoError(t, err, "should be able to read expected bytes")
-		require.Equal(t, string(expected), tpl)
+		expectedBytes := []byte(expected)
+		mExpected := make(map[interface{}]interface{})
+		require.NoError(t, yaml.Unmarshal(expectedBytes, mExpected))
+		require.Equal(t, mExpected, mActual)
 	})
 
 	t.Run("Parameter values should render properly", func(t *testing.T) {


### PR DESCRIPTION
Refactors the scheduled job CF template integ test to be congruent with the [pipeline tests](https://github.com/aws/copilot-cli/blob/67fff31f27422b9e16228ddf4da43bfafce22b79/internal/pkg/deploy/cloudformation/stack/cc_pipeline_integration_test.go#L52-L61). 

Integ tests pass as of Friday evening. 

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
