### PR TITLE
chore(progress): close Done channels only if child renders are done

### DIFF
--- a/internal/pkg/term/progress/component_test.go
+++ b/internal/pkg/term/progress/component_test.go
@@ -133,18 +133,25 @@ func TestDynamicTreeComponent_Render(t *testing.T) {
 func TestDynamicTreeComponent_Done(t *testing.T) {
 	// GIVEN
 	root := &mockDynamicRenderer{
-		content: "hello",
-		done:    make(chan struct{}),
+		done: make(chan struct{}),
+	}
+	child := &mockDynamicRenderer{
+		done: make(chan struct{}),
 	}
 	comp := dynamicTreeComponent{
-		Root: root,
+		Root:     root,
+		Children: []Renderer{child, &noopComponent{}},
 	}
 
 	// WHEN
-	ch := comp.Done()
+	go func() {
+		// Close all nodes in the tree.
+		close(child.done)
+		close(root.done)
+	}()
 
 	// THEN
-	require.Equal(t, root.Done(), ch)
+	<-comp.Done() // Should successfully exit instead of hanging.
 }
 
 func TestTableComponent_Render(t *testing.T) {

--- a/internal/pkg/term/progress/ecs.go
+++ b/internal/pkg/term/progress/ecs.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"sync"
 
+	"github.com/aws/copilot-cli/internal/pkg/aws/ecs"
 	"github.com/aws/copilot-cli/internal/pkg/stream"
 	"github.com/aws/copilot-cli/internal/pkg/term/color"
 )
@@ -157,4 +158,13 @@ func reverseStrings(arr []string) []string {
 		reversed[i], reversed[opp] = reversed[opp], reversed[i]
 	}
 	return reversed
+}
+
+// parseServiceARN returns the cluster name and service name from a service ARN.
+func parseServiceARN(arn string) (cluster, service string) {
+	parsed := ecs.ServiceArn(arn)
+	// Errors can't happen on valid ARNs.
+	cluster, _ = parsed.ClusterName()
+	service, _ = parsed.ServiceName()
+	return cluster, service
 }

--- a/internal/pkg/term/progress/ecs_test.go
+++ b/internal/pkg/term/progress/ecs_test.go
@@ -7,19 +7,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/aws/copilot-cli/internal/pkg/aws/ecs"
 	"github.com/aws/copilot-cli/internal/pkg/stream"
 	"github.com/stretchr/testify/require"
 )
-
-type mockECSDescriber struct {
-	out *ecs.Service
-	err error
-}
-
-func (m *mockECSDescriber) Service(clusterName, serviceName string) (*ecs.Service, error) {
-	return m.out, m.err
-}
 
 func TestRollingUpdateComponent_Listen(t *testing.T) {
 	t.Run("should update deployments to latest event and respect max number of failed msgs", func(t *testing.T) {


### PR DESCRIPTION
Stop rendering a component when all of its children components are done rendering first.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
