### PR TITLE
chore(progress): add a suffixWriter to align deployment table

### DIFF
--- a/e2e/multi-svc-app/back-end/Dockerfile
+++ b/e2e/multi-svc-app/back-end/Dockerfile
@@ -20,6 +20,9 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64  go build -o e2e-service ./
 
 # To make our images smaller, use alpine and copy in the service binary.
 FROM alpine:latest
+# curl is need for container healthchecks.
+RUN apk update
+RUN apk add curl
 # Install certs
 RUN apk --no-cache add ca-certificates
 # Copy the binary from the builder image

--- a/e2e/multi-svc-app/back-end/Dockerfile
+++ b/e2e/multi-svc-app/back-end/Dockerfile
@@ -20,7 +20,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64  go build -o e2e-service ./
 
 # To make our images smaller, use alpine and copy in the service binary.
 FROM alpine:latest
-# curl is need for container healthchecks.
+# curl is needed for container healthchecks.
 RUN apk update
 RUN apk add curl
 # Install certs

--- a/internal/pkg/stream/stream.go
+++ b/internal/pkg/stream/stream.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	streamerFetchIntervalDuration = 2 * time.Second // How long to wait until Fetch is called again for a Streamer.
+	streamerFetchIntervalDuration = 3 * time.Second // How long to wait until Fetch is called again for a Streamer.
 )
 
 // Streamer is the interface that groups methods to periodically retrieve events,

--- a/internal/pkg/term/progress/cloudformation.go
+++ b/internal/pkg/term/progress/cloudformation.go
@@ -295,7 +295,11 @@ func (c *ecsServiceResourceComponent) Render(out io.Writer) (numLines int, err e
 		deploymentRenderer = c.deploymentRenderer
 	}
 
-	nl, err = deploymentRenderer.Render(buf)
+	sw := &suffixWriter{
+		buf:    buf,
+		suffix: []byte{'\t', '\t'}, // Add two columns to the deployment renderer so that it aligns with resources.
+	}
+	nl, err = deploymentRenderer.Render(sw)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/pkg/term/progress/cloudformation_test.go
+++ b/internal/pkg/term/progress/cloudformation_test.go
@@ -498,8 +498,7 @@ func TestEcsServiceResourceComponent_Render(t *testing.T) {
 		// THEN
 		require.Nil(t, err)
 		require.Equal(t, 2, nl)
-		require.Equal(t, `resource
-deployment
-`, buf.String())
+		require.Equal(t, "resource\n"+
+			"deployment\t\t\n", buf.String())
 	})
 }

--- a/internal/pkg/term/progress/writer.go
+++ b/internal/pkg/term/progress/writer.go
@@ -47,3 +47,25 @@ func NewTabbedFileWriter(fw FileWriter) *TabbedFileWriter {
 		WriteFlusher: tabwriter.NewWriter(fw, minCellWidth, tabWidth, cellPaddingWidth, paddingChar, noAdditionalFormatting),
 	}
 }
+
+// suffixWriter is an io.Writer that adds the suffix before a new line character.
+type suffixWriter struct {
+	buf    io.Writer
+	suffix []byte
+}
+
+// Write adds a suffix before each new line character in p.
+func (w *suffixWriter) Write(p []byte) (n int, err error) {
+	var withSuffix []byte
+	for _, b := range p {
+		suffix := []byte{b}
+		if b == '\n' {
+			suffix = append(w.suffix, b)
+		}
+		withSuffix = append(withSuffix, suffix...)
+	}
+	if _, err := w.buf.Write(withSuffix); err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}

--- a/internal/pkg/term/progress/writer_test.go
+++ b/internal/pkg/term/progress/writer_test.go
@@ -1,0 +1,50 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package progress
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSuffixWriter_Write(t *testing.T) {
+	testCases := map[string]struct {
+		inText string
+		suffix []byte
+
+		wantedText string
+	}{
+		"should wrap every new line with the suffix": {
+			inText: `The AWS Copilot CLI is a tool for developers to build, release
+and operate production ready containerized applications
+on Amazon ECS and AWS Fargate.
+`,
+			suffix: []byte{'\t', '\t'},
+
+			wantedText: "The AWS Copilot CLI is a tool for developers to build, release\t\t\n" +
+				"and operate production ready containerized applications\t\t\n" +
+				"on Amazon ECS and AWS Fargate.\t\t\n",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// GIVEN
+			buf := new(strings.Builder)
+			sw := &suffixWriter{
+				buf:    buf,
+				suffix: tc.suffix,
+			}
+
+			// WHEN
+			_, err := sw.Write([]byte(tc.inText))
+
+			// THEN
+			require.NoError(t, err)
+			require.Equal(t, tc.wantedText, buf.String())
+		})
+	}
+}


### PR DESCRIPTION
Before:
![before](https://user-images.githubusercontent.com/879348/106534553-38324000-64a9-11eb-809f-954f6e5c33c0.png)

After:
![after](https://user-images.githubusercontent.com/879348/106534565-3ec0b780-64a9-11eb-82de-75a2f677e6b7.png)

You can see that the items under the deployment times have the columns aligned.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
