### PR TITLE
chore(progress): fix showing cursor after rendering

### DIFF
--- a/internal/pkg/term/progress/render.go
+++ b/internal/pkg/term/progress/render.go
@@ -40,6 +40,8 @@ func NestedRenderOptions(opts RenderOptions) RenderOptions {
 // Render stops when there the ctx is canceled or r is done listening to new events.
 // While Render is executing, the terminal cursor is hidden and updates are written in-place.
 func Render(ctx context.Context, out FileWriteFlusher, r DynamicRenderer) error {
+	defer out.Flush() // Make sure every buffered text in out is written before exiting.
+
 	cursor := cursor.NewWithWriter(out)
 	cursor.Hide()
 	defer cursor.Show()


### PR DESCRIPTION
Although we have a `defer cursor.Show()` statement, it wouldn't actually get written to `out` because we never called `Flush()`. 

This change ensures that all buffered writes get written to `out` at the end of the invocation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
