### PR TITLE
docs: add task-delete to the menu and fix lb docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ repo_url: 'https://github.com/aws/copilot-cli'
 edit_uri: 'edit/mainline/site/content'
 copyright: 'Copyright &copy; 2020 Amazon'
 docs_dir: 'site/content'
+site_dir: 'docs'
 extra_css:
   - stylesheets/extra.css
 
@@ -63,6 +64,7 @@ nav:
         - svc deploy: docs/commands/svc-deploy.md
         - svc delete: docs/commands/svc-delete.md
         - task run: docs/commands/task-run.md
+        - task delete: docs/commands/task-delete.md
       - Release:
         - pipeline init: docs/commands/pipeline-init.md
         - pipeline update: docs/commands/pipeline-update.md

--- a/site/content/docs/manifest/lb-web-service.md
+++ b/site/content/docs/manifest/lb-web-service.md
@@ -24,6 +24,9 @@ http:
   # You can specify whether to enable sticky sessions.
   # stickiness: true
 
+  # CIDR IP addresses permitted to access your service.
+  # allowed_source_ips: ["192.0.2.0/24", "198.51.100.10/32"]
+
 # Number of CPU units for the task.
 cpu: 256
 # Amount of memory in MiB used by the task.


### PR DESCRIPTION
<!-- Provide summary of changes -->
This PR
1. Add `task delete` to the menu.
2. Add `allowed_source_ips` to the manifest example in LB Web App doc.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
