### PR TITLE
chore: split manifest layout to "trigger" and "containers" sections

### DIFF
--- a/internal/pkg/manifest/testdata/backend-svc-customhealthcheck.yml
+++ b/internal/pkg/manifest/testdata/backend-svc-customhealthcheck.yml
@@ -4,28 +4,26 @@
 
 # Your service name will be used in naming your resources like log groups, ECS services, etc.
 name: subscribers
-# Your service is reachable at "http://subscribers.${COPILOT_SERVICE_DISCOVERY_ENDPOINT}:8080" but is not public.
 type: Backend Service
 
+# Your service is reachable at "http://subscribers.${COPILOT_SERVICE_DISCOVERY_ENDPOINT}:8080" but is not public.
+
+# Configuration for your containers and service.
 image:
-  # The name of the Docker image.
   location: flask-sample
   # Port exposed through your container to route traffic to it.
   port: 8080
   healthcheck:
-    # The command the container runs to determine if it's healthy.
+    # Container health checks: https://aws.github.io/copilot-cli/docs/manifest/backend-service/#image-healthcheck
     command: ["CMD-SHELL", "curl -f http://localhost:8080 || exit 1"]
-    interval: 6s  # Time period between healthchecks. Default is 10s.
-    retries: 0      # Number of times to retry before container is deemed unhealthy. Default is 2.
-    timeout: 20s     # How long to wait before considering the healthcheck failed. Default is 5s.
-    start_period: 15s # Grace period within which to provide containers time to bootstrap before failed health checks count towards the maximum number of retries. Default is 0s.
+    interval: 6s
+    retries: 0
+    timeout: 20s
+    start_period: 15s
 
-# Number of CPU units for the task.
-cpu: 256
-# Amount of memory in MiB used by the task.
-memory: 512
-# Number of tasks that should be running in your service.
-count: 1
+cpu: 256       # Number of CPU units for the task.
+memory: 512    # Amount of memory in MiB used by the task.
+count: 1       # Number of tasks that should be running in your service.
 
 # Optional fields for more advanced use-cases.
 #
@@ -33,7 +31,7 @@ count: 1
 #  LOG_LEVEL: info
 
 #secrets:                      # Pass secrets from AWS Systems Manager (SSM) Parameter Store.
-#  GITHUB_TOKEN: GITHUB_TOKEN  # The key is the name of the environment variable, the value is the name of the SSM      parameter.
+#  GITHUB_TOKEN: GITHUB_TOKEN  # The key is the name of the environment variable, the value is the name of the SSM parameter.
 
 # You can override any of the values defined above by environment.
 #environments:

--- a/internal/pkg/manifest/testdata/backend-svc-nohealthcheck.yml
+++ b/internal/pkg/manifest/testdata/backend-svc-nohealthcheck.yml
@@ -4,20 +4,18 @@
 
 # Your service name will be used in naming your resources like log groups, ECS services, etc.
 name: subscribers
-# Your service does not allow any traffic.
 type: Backend Service
 
+# Your service does not allow any traffic.
+
+# Configuration for your containers and service.
 image:
-  # Docker build arguments.
-  # For additional overrides: https://aws.github.io/copilot-cli/docs/manifest/backend-service/#image-build
+  # Docker build arguments. For additional overrides: https://aws.github.io/copilot-cli/docs/manifest/backend-service/#image-build
   build: ./subscribers/Dockerfile
 
-# Number of CPU units for the task.
-cpu: 256
-# Amount of memory in MiB used by the task.
-memory: 512
-# Number of tasks that should be running in your service.
-count: 1
+cpu: 256       # Number of CPU units for the task.
+memory: 512    # Amount of memory in MiB used by the task.
+count: 1       # Number of tasks that should be running in your service.
 
 # Optional fields for more advanced use-cases.
 #
@@ -25,7 +23,7 @@ count: 1
 #  LOG_LEVEL: info
 
 #secrets:                      # Pass secrets from AWS Systems Manager (SSM) Parameter Store.
-#  GITHUB_TOKEN: GITHUB_TOKEN  # The key is the name of the environment variable, the value is the name of the SSM      parameter.
+#  GITHUB_TOKEN: GITHUB_TOKEN  # The key is the name of the environment variable, the value is the name of the SSM parameter.
 
 # You can override any of the values defined above by environment.
 #environments:

--- a/internal/pkg/manifest/testdata/scheduled-job-fully-specified.yml
+++ b/internal/pkg/manifest/testdata/scheduled-job-fully-specified.yml
@@ -4,35 +4,29 @@
 
 # Your job name will be used in naming your resources like log groups, ECS Tasks, etc.
 name: cuteness-aggregator
-
-# The "architecture" of the job you're running.
 type: Scheduled Job
 
-image:
-  # Docker build arguments.
-  # For additional overrides: https://aws.github.io/copilot-cli/docs/manifest/scheduled-job/#image-build
-  build: ./cuteness-aggregator/Dockerfile
-
-# Number of CPU units for the task.
-cpu: 256
-# Amount of memory in MiB used by the task.
-memory: 512
-
+# Trigger for your task.
 on:
   # The scheduled trigger for your job. You can specify a Unix cron schedule or keyword (@weekly) or a rate (@every 1h30m)
   # AWS Schedule Expressions are also accepted: https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html
   schedule: "0 */2 * * *"
+retries: 3    # Optional. The number of times to retry the job before failing.
+timeout: 1h30m    # Optional. The timeout after which to stop the job if it's still running. You can use the units (h, m, s).
 
-# Optional. The number of times to retry the job before failing.
-retries: 3
-# Optional. The timeout after which to stop the job if it's still running. You can use the units (h, m, s).
-timeout: 1h30m
+# Configuration for your container and task.
+image:
+  # Docker build arguments. For additional overrides: https://aws.github.io/copilot-cli/docs/manifest/scheduled-job/#image-build
+  build: ./cuteness-aggregator/Dockerfile
+
+cpu: 256       # Number of CPU units for the task.
+memory: 512    # Amount of memory in MiB used by the task.
 
 # Optional fields for more advanced use-cases.
 #
 #variables:                    # Pass environment variables as key value pairs.
 #  LOG_LEVEL: info
-#
+
 #secrets:                      # Pass secrets from AWS Systems Manager (SSM) Parameter Store.
 #  GITHUB_TOKEN: GITHUB_TOKEN  # The key is the name of the environment variable, the value is the name of the SSM parameter.
 

--- a/internal/pkg/manifest/testdata/scheduled-job-no-retries.yml
+++ b/internal/pkg/manifest/testdata/scheduled-job-no-retries.yml
@@ -4,35 +4,29 @@
 
 # Your job name will be used in naming your resources like log groups, ECS Tasks, etc.
 name: cuteness-aggregator
-
-# The "architecture" of the job you're running.
 type: Scheduled Job
 
-image:
-  # Docker build arguments.
-  # For additional overrides: https://aws.github.io/copilot-cli/docs/manifest/scheduled-job/#image-build
-  build: ./cuteness-aggregator/Dockerfile
-
-# Number of CPU units for the task.
-cpu: 256
-# Amount of memory in MiB used by the task.
-memory: 512
-
+# Trigger for your task.
 on:
   # The scheduled trigger for your job. You can specify a Unix cron schedule or keyword (@weekly) or a rate (@every 1h30m)
   # AWS Schedule Expressions are also accepted: https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html
   schedule: "@every 5h"
+#retries: 3        # Optional. The number of times to retry the job before failing.
+timeout: 3h    # Optional. The timeout after which to stop the job if it's still running. You can use the units (h, m, s).
 
-# Optional. The number of times to retry the job before failing.
-#retries: 3
-# Optional. The timeout after which to stop the job if it's still running. You can use the units (h, m, s).
-timeout: 3h
+# Configuration for your container and task.
+image:
+  # Docker build arguments. For additional overrides: https://aws.github.io/copilot-cli/docs/manifest/scheduled-job/#image-build
+  build: ./cuteness-aggregator/Dockerfile
+
+cpu: 256       # Number of CPU units for the task.
+memory: 512    # Amount of memory in MiB used by the task.
 
 # Optional fields for more advanced use-cases.
 #
 #variables:                    # Pass environment variables as key value pairs.
 #  LOG_LEVEL: info
-#
+
 #secrets:                      # Pass secrets from AWS Systems Manager (SSM) Parameter Store.
 #  GITHUB_TOKEN: GITHUB_TOKEN  # The key is the name of the environment variable, the value is the name of the SSM parameter.
 

--- a/internal/pkg/manifest/testdata/scheduled-job-no-timeout-or-retries.yml
+++ b/internal/pkg/manifest/testdata/scheduled-job-no-timeout-or-retries.yml
@@ -4,34 +4,28 @@
 
 # Your job name will be used in naming your resources like log groups, ECS Tasks, etc.
 name: cuteness-aggregator
-
-# The "architecture" of the job you're running.
 type: Scheduled Job
 
-image:
-  # The name of the Docker image.
-  location: copilot/cuteness-aggregator
-
-# Number of CPU units for the task.
-cpu: 256
-# Amount of memory in MiB used by the task.
-memory: 512
-
+# Trigger for your task.
 on:
   # The scheduled trigger for your job. You can specify a Unix cron schedule or keyword (@weekly) or a rate (@every 1h30m)
   # AWS Schedule Expressions are also accepted: https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html
   schedule: "@weekly"
+#retries: 3        # Optional. The number of times to retry the job before failing.
+#timeout: 1h30m    # Optional. The timeout after which to stop the job if it's still running. You can use the units (h, m, s).
 
-# Optional. The number of times to retry the job before failing.
-#retries: 3
-# Optional. The timeout after which to stop the job if it's still running. You can use the units (h, m, s).
-#timeout: 1h30m
+# Configuration for your container and task.
+image:
+  location: copilot/cuteness-aggregator
+
+cpu: 256       # Number of CPU units for the task.
+memory: 512    # Amount of memory in MiB used by the task.
 
 # Optional fields for more advanced use-cases.
 #
 #variables:                    # Pass environment variables as key value pairs.
 #  LOG_LEVEL: info
-#
+
 #secrets:                      # Pass secrets from AWS Systems Manager (SSM) Parameter Store.
 #  GITHUB_TOKEN: GITHUB_TOKEN  # The key is the name of the environment variable, the value is the name of the SSM parameter.
 

--- a/internal/pkg/manifest/testdata/scheduled-job-no-timeout.yml
+++ b/internal/pkg/manifest/testdata/scheduled-job-no-timeout.yml
@@ -4,35 +4,29 @@
 
 # Your job name will be used in naming your resources like log groups, ECS Tasks, etc.
 name: cuteness-aggregator
-
-# The "architecture" of the job you're running.
 type: Scheduled Job
 
-image:
-  # Docker build arguments.
-  # For additional overrides: https://aws.github.io/copilot-cli/docs/manifest/scheduled-job/#image-build
-  build: ./cuteness-aggregator/Dockerfile
-
-# Number of CPU units for the task.
-cpu: 256
-# Amount of memory in MiB used by the task.
-memory: 512
-
+# Trigger for your task.
 on:
   # The scheduled trigger for your job. You can specify a Unix cron schedule or keyword (@weekly) or a rate (@every 1h30m)
   # AWS Schedule Expressions are also accepted: https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html
   schedule: "@every 5h"
+retries: 5    # Optional. The number of times to retry the job before failing.
+#timeout: 1h30m    # Optional. The timeout after which to stop the job if it's still running. You can use the units (h, m, s).
 
-# Optional. The number of times to retry the job before failing.
-retries: 5
-# Optional. The timeout after which to stop the job if it's still running. You can use the units (h, m, s).
-#timeout: 1h30m
+# Configuration for your container and task.
+image:
+  # Docker build arguments. For additional overrides: https://aws.github.io/copilot-cli/docs/manifest/scheduled-job/#image-build
+  build: ./cuteness-aggregator/Dockerfile
+
+cpu: 256       # Number of CPU units for the task.
+memory: 512    # Amount of memory in MiB used by the task.
 
 # Optional fields for more advanced use-cases.
 #
 #variables:                    # Pass environment variables as key value pairs.
 #  LOG_LEVEL: info
-#
+
 #secrets:                      # Pass secrets from AWS Systems Manager (SSM) Parameter Store.
 #  GITHUB_TOKEN: GITHUB_TOKEN  # The key is the name of the environment variable, the value is the name of the SSM parameter.
 

--- a/site/content/docs/manifest/backend-service.md
+++ b/site/content/docs/manifest/backend-service.md
@@ -1,46 +1,39 @@
 List of all available properties for a `'Backend Service'` manifest.
-```yaml
-# Your service name will be used in naming your resources like log groups, ECS services, etc.
-name: api
 
-# Your service is reachable at "http://{{.Name}}.${COPILOT_SERVICE_DISCOVERY_ENDPOINT}:{{.Image.Port}}" but is not public.
-type: Backend App
+???+ note "Sample manifest for an api service"
 
-image:
-  # Path to your service's Dockerfile.
-  build: ./api/Dockerfile
-  # Or instead of building, you can specify an existing image name.
-  location: aws_account_id.dkr.ecr.region.amazonaws.com/my-svc:tag
-  # Optional. Port exposed through your container to route traffic to it.
-  port: 8080
-
-  #Optional. Configuration for your container healthcheck.
-  healthcheck:
-    # The command the container runs to determine if it's healthy.
-    command: ["CMD-SHELL", "curl -f http://localhost:8080 || exit 1"]
-    interval: 10s     # Time period between healthchecks. Default is 10s if omitted.
-    retries: 2        # Number of times to retry before container is deemed unhealthy. Default is 2 if omitted.
-    timeout: 5s       # How long to wait before considering the healthcheck failed. Default is 5s if omitted.
-    start_period: 0s  # Grace period within which to provide containers time to bootstrap before failed health checks count towards the maximum number of retries. Default is 0s if omitted.
-
-# Number of CPU units for the task.
-cpu: 256
-# Amount of memory in MiB used by the task.
-memory: 512
-# Number of tasks that should be running in your service.
-count: 1
-
-variables:                    # Optional. Pass environment variables as key value pairs.
-  LOG_LEVEL: info
-
-secrets:                      # Optional. Pass secrets from AWS Systems Manager (SSM) Parameter Store.
-  GITHUB_TOKEN: GITHUB_TOKEN  # The key is the name of the environment variable, the value is the name of the SSM      parameter.
-
-# Optional. You can override any of the values defined above by environment.
-environments:
-  prod:
-    count: 2               # Number of tasks to run for the "prod" environment.
-```
+    ```yaml
+    # Your service name will be used in naming your resources like log groups, ECS services, etc.
+    name: api
+    type: Backend Service
+    
+    # Your service is reachable at "http://api.${COPILOT_SERVICE_DISCOVERY_ENDPOINT}:8080" but is not public.
+    
+    # Configuration for your containers and service.
+    image:
+      build: ./api/Dockerfile
+      port: 8080
+      healthcheck:
+        command: ["CMD-SHELL", "curl -f http://localhost:8080 || exit 1"]
+        interval: 10s
+        retries: 2
+        timeout: 5s 
+        start_period: 0s
+    
+    cpu: 256
+    memory: 512
+    count: 1
+    
+    variables: 
+      LOG_LEVEL: info
+    secrets:
+      GITHUB_TOKEN: GITHUB_TOKEN
+    
+    # You can override any of the values defined above by environment.
+    environments:
+      production:
+        count: 2
+    ```
 
 <a id="name" href="#name" class="field">`name`</a> <span class="type">String</span>  
 The name of your service.   

--- a/site/content/docs/manifest/lb-web-service.md
+++ b/site/content/docs/manifest/lb-web-service.md
@@ -1,51 +1,51 @@
 List of all available properties for a `'Load Balanced Web Service'` manifest.
-```yaml
-# Your service name will be used in naming your resources like log groups, ECS services, etc.
-name: frontend
-# The "architecture" of the service you're running.
-type: Load Balanced Web Service
 
-image:
-  # Path to your service's Dockerfile.
-  build: ./Dockerfile
-  # Or instead of building, you can specify an existing image name.
-  location: aws_account_id.dkr.ecr.region.amazonaws.com/my-svc:tag
-  # Port exposed through your container to route traffic to it.
-  port: 80
+???+ note "Sample manifest for a frontend service"
 
-http:
-  # Requests to this path will be forwarded to your service.
-  # To match all requests you can use the "/" path.
-  path: '/'
-
-  # You can specify a custom health check path. The default is "/"
-  # healthcheck: "/"
-
-  # You can specify whether to enable sticky sessions.
-  # stickiness: true
-
-  # CIDR IP addresses permitted to access your service.
-  # allowed_source_ips: ["192.0.2.0/24", "198.51.100.10/32"]
-
-# Number of CPU units for the task.
-cpu: 256
-# Amount of memory in MiB used by the task.
-memory: 512
-# Number of tasks that should be running in your service. You can also specify a map for autoscaling.
-count: 1
-
-variables:                    # Optional. Pass environment variables as key value pairs.
-  LOG_LEVEL: info
-
-secrets:                      # Optional. Pass secrets from AWS Systems Manager (SSM) Parameter Store.
-  GITHUB_TOKEN: GITHUB_TOKEN  # The key is the name of the environment variable, the value is the name of the SSM parameter.
-
-
-# Optional. You can override any of the values defined above by environment.
-environments:
-  test:
-    count: 2               # Number of tasks to run for the "test" environment.
-```
+    ```yaml
+    # Your service name will be used in naming your resources like log groups, ECS services, etc.
+    name: frontend
+    type: Load Balanced Web Service
+    
+    # Trigger for your service.
+    http:
+      path: '/'
+      healthcheck:
+        path: '/_healthcheck'
+        healthy_threshold: 3
+        unhealthy_threshold: 2
+        interval: 15s
+        timeout: 10s
+      stickiness: false
+      allowed_source_ips: ["10.24.34.0/23"]
+    
+    # Configuration for your containers and service.
+    image:
+      build:
+        dockerfile: ./frontend/Dockerfile
+        context: ./frontend
+      port: 80
+    
+    cpu: 256
+    memory: 512
+    count:
+      range: 1-10
+      cpu_percentage: 70
+      memory_percentage: 80
+      requests: 10000
+      response_time: 2s
+    
+    variables:
+      LOG_LEVEL: info
+    secrets:
+      GITHUB_TOKEN: GITHUB_TOKEN
+    
+    
+    # You can override any of the values defined above by environment.
+    environments:
+      production:
+        count: 2
+    ```
 
 <a id="name" href="#name" class="field">`name`</a> <span class="type">String</span>  
 The name of your service.   
@@ -54,45 +54,6 @@ The name of your service.
 
 <a id="type" href="#type" class="field">`type`</a> <span class="type">String</span>  
 The architecture type for your service. A [Load Balanced Web Service](../concepts/services.md#load-balanced-web-service) is an internet-facing service that's behind a load balancer, orchestrated by Amazon ECS on AWS Fargate.  
-
-<div class="separator"></div>
-
-<a id="image" href="#image" class="field">`image`</a> <span class="type">Map</span>  
-The image section contains parameters relating to the Docker build configuration and exposed port.  
-
-<span class="parent-field">image.</span><a id="image-build" href="#image-build" class="field">`build`</a> <span class="type">String or Map</span>  
-If you specify a string, Copilot interprets it as the path to your Dockerfile. It will assume that the dirname of the string you specify should be the build context. The manifest:
-```yaml
-image:
-  build: path/to/dockerfile
-```
-will result in the following call to docker build: `$ docker build --file path/to/dockerfile path/to`
-
-You can also specify build as a map:
-```yaml
-image:
-  build:
-    dockerfile: path/to/dockerfile
-    context: context/dir
-    target: build-stage
-    cache_from:
-      - image:tag
-    args:
-      key: value
-```
-In this case, Copilot will use the context directory you specified and convert the key-value pairs under args to --build-arg overrides. The equivalent docker build call will be:  
-`$ docker build --file path/to/dockerfile --target build-stage --cache-from image:tag --build-arg key=value context/dir`.
-
-You can omit fields and Copilot will do its best to understand what you mean. For example, if you specify `context` but not `dockerfile`, Copilot will run Docker in the context directory and assume that your Dockerfile is named "Dockerfile." If you specify `dockerfile` but no `context`, Copilot assumes you want to run Docker in the directory that contains `dockerfile`.
-
-All paths are relative to your workspace root.
-
-<span class="parent-field">image.</span><a id="image-location" href="#image-location" class="field">`location`</a> <span class="type">String</span>  
-Instead of building a container from a Dockerfile, you can specify an existing image name. Mutually exclusive with [`image.build`](#image-build).    
-The `location` field follows the same definition as the [`image` parameter](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#container_definition_image) in the Amazon ECS task definition.
-
-<span class="parent-field">image.</span><a id="image-port" href="#image-port" class="field">`port`</a> <span class="type">Integer</span>  
-The port exposed in your Dockerfile. Copilot should parse this value for you from your `EXPOSE` instruction.
 
 <div class="separator"></div>
 
@@ -143,6 +104,45 @@ CIDR IP addresses permitted to access your service.
 http:
   allowed_source_ips: ["192.0.2.0/24", "198.51.100.10/32"]
 ```
+
+<div class="separator"></div>
+
+<a id="image" href="#image" class="field">`image`</a> <span class="type">Map</span>  
+The image section contains parameters relating to the Docker build configuration and exposed port.  
+
+<span class="parent-field">image.</span><a id="image-build" href="#image-build" class="field">`build`</a> <span class="type">String or Map</span>  
+If you specify a string, Copilot interprets it as the path to your Dockerfile. It will assume that the dirname of the string you specify should be the build context. The manifest:
+```yaml
+image:
+  build: path/to/dockerfile
+```
+will result in the following call to docker build: `$ docker build --file path/to/dockerfile path/to`
+
+You can also specify build as a map:
+```yaml
+image:
+  build:
+    dockerfile: path/to/dockerfile
+    context: context/dir
+    target: build-stage
+    cache_from:
+      - image:tag
+    args:
+      key: value
+```
+In this case, Copilot will use the context directory you specified and convert the key-value pairs under args to --build-arg overrides. The equivalent docker build call will be:  
+`$ docker build --file path/to/dockerfile --target build-stage --cache-from image:tag --build-arg key=value context/dir`.
+
+You can omit fields and Copilot will do its best to understand what you mean. For example, if you specify `context` but not `dockerfile`, Copilot will run Docker in the context directory and assume that your Dockerfile is named "Dockerfile." If you specify `dockerfile` but no `context`, Copilot assumes you want to run Docker in the directory that contains `dockerfile`.
+
+All paths are relative to your workspace root.
+
+<span class="parent-field">image.</span><a id="image-location" href="#image-location" class="field">`location`</a> <span class="type">String</span>  
+Instead of building a container from a Dockerfile, you can specify an existing image name. Mutually exclusive with [`image.build`](#image-build).    
+The `location` field follows the same definition as the [`image` parameter](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#container_definition_image) in the Amazon ECS task definition.
+
+<span class="parent-field">image.</span><a id="image-port" href="#image-port" class="field">`port`</a> <span class="type">Integer</span>  
+The port exposed in your Dockerfile. Copilot should parse this value for you from your `EXPOSE` instruction.
 
 <div class="separator"></div>
 

--- a/site/content/docs/manifest/lb-web-service.md
+++ b/site/content/docs/manifest/lb-web-service.md
@@ -7,7 +7,7 @@ List of all available properties for a `'Load Balanced Web Service'` manifest.
     name: frontend
     type: Load Balanced Web Service
     
-    # Trigger for your service.
+    # Distribute traffic to your service.
     http:
       path: '/'
       healthcheck:

--- a/site/content/docs/manifest/pipeline.md
+++ b/site/content/docs/manifest/pipeline.md
@@ -1,39 +1,29 @@
 List of all available properties for a Copilot pipeline manifest.
-```yaml
-# This YAML file defines the relationship and deployment ordering of your environments.
 
-# The name of the pipeline
-name: pipeline-sample-app-frontend
+???+ note "Sample manifest for a pipeline triggered from a GitHub repo"
 
-# The version of the schema used in this template
-version: 1
+    ```yaml
+    name: pipeline-sample-app-frontend
+    version: 1
 
-# This section defines the source artifacts.
-source:
-  # The name of the provider that is used to store the source artifacts.
-  provider: GitHub
-  # Additional properties that further specifies the exact location
-  # the artifacts should be sourced from. For example, the GitHub provider
-  # has the following properties: repository, branch.
-  properties:
-    access_token_secret: github-token-sample-app
-    branch: main
-    repository: https://github.com/<user>/sample-app-frontend
+    source:
+      provider: GitHub
+      properties:
+        access_token_secret: github-token-sample-app
+        branch: main
+        repository: https://github.com/<user>/sample-app-frontend
+    
+    stages:
+        - 
+          name: test
+          test_commands:
+            - make test
+            - echo "woo! Tests passed"
+        - 
+          name: prod
+          requires_approval: true
+    ```
 
-# The deployment section defines the order the pipeline will deploy
-# to your environments.
-stages:
-    - # The name of the environment to deploy to.
-      name: test
-      # Use test commands to validate your stage's deployment.
-      test_commands:
-        - make test
-        - echo "woo! Tests passed"
-    - # The name of the environment to deploy to.
-      name: prod
-      # Require a manual approval step before deployment.
-      requires_approval: true
-```
 <a id="name" href="#name" class="field">`name`</a> <span class="type">String</span>  
 The name of your pipeline.   
 

--- a/site/content/docs/manifest/scheduled-job.md
+++ b/site/content/docs/manifest/scheduled-job.md
@@ -1,37 +1,28 @@
 List of all available properties for a `'Scheduled Job'` manifest.
-```yaml
-# Your job name will be used in naming your resources like log groups, ECS Tasks, etc.
-name: report-generator
-# The type of job that you're running.
-type: Scheduled Job
 
-image:
-  # Path to your service's Dockerfile.
-  build: ./Dockerfile
-  # Or instead of building, you can specify an existing image name.
-  location: aws_account_id.dkr.ecr.region.amazonaws.com/my-svc:tag
+???+ note "Sample manifest for a report generator cronjob"
 
-on:
-  # The scheduled trigger for your job. You can specify a Unix cron schedule or keyword (@weekly) or a rate (@every 1h30m)
-
-  # AWS Schedule Expressions are also accepted: https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html
-  schedule: @daily
-
-cpu: 256    # Number of CPU units for the task.
-memory: 512 # Amount of memory in MiB used by the task.
-retries: 3  # Optional. The number of times to retry the job before failing.
-timeout: 1h # Optional. The timeout after which to stop the job if it's still running. You can use the units (h, m, s).
-
-variables:                    # Optional. Pass environment variables as key value pairs.
-  LOG_LEVEL: info
-
-secrets:                      # Optional. Pass secrets from AWS Systems Manager (SSM) Parameter Store.
-  GITHUB_TOKEN: GITHUB_TOKEN  # The key is the name of the environment variable, the value is the name of the SSM parameter.
-
-environments:                 # Optional. You can override any of the values defined above by environment.
-  prod:
-    cpu: 512
-```
+    ```yaml
+    # Your job name will be used in naming your resources like log groups, ECS Tasks, etc.
+    name: report-generator
+    type: Scheduled Job
+    
+    on:
+      schedule: @daily
+    cpu: 256
+    memory: 512
+    retries: 3
+    timeout: 1h
+    
+    image:
+      # Path to your service's Dockerfile.
+      build: ./Dockerfile
+    
+    variables:
+      LOG_LEVEL: info
+    secrets:
+      GITHUB_TOKEN: GITHUB_TOKEN
+    ```
 
 <a id="name" href="#name" class="field">`name`</a> <span class="type">String</span>  
 The name of your job.   
@@ -41,6 +32,27 @@ The name of your job.
 <a id="type" href="#type" class="field">`type`</a> <span class="type">String</span>  
 The architecture type for your job.  
 Currently, Copilot only supports the "Scheduled Job" type for tasks that are triggered either on a fixed schedule or periodically.
+
+<div class="separator"></div>
+
+<a id="on" href="#on" class="field">`on`</a> <span class="type">Map</span>  
+The configuration for the event that triggers your job.
+
+<span class="parent-field">on.</span><a id="on-schedule" href="#on-schedule" class="field">`schedule`</a> <span class="type">String</span>  
+You can specify a rate to periodically trigger your job. Supported rates:
+
+* `"@yearly"`
+* `"@monthly"`
+* `"@weekly"`
+* `"@daily"`
+* `"@hourly"`
+* `"@every {duration}"` (For example, "1m", "5m")
+* `"rate({duration})"` based on CloudWatch's [rate expressions](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html#RateExpressions)
+
+Alternatively, you can specify a cron schedule if you'd like to trigger the job at a specific time:
+
+* `"* * * * *"` based on the standard [cron format](https://en.wikipedia.org/wiki/Cron#Overview).
+* `"cron({fields})"` based on CloudWatch's [cron expressions](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html#CronExpressions) with six fields.
 
 <div class="separator"></div>
 
@@ -77,27 +89,6 @@ All paths are relative to your workspace root.
 <span class="parent-field">image.</span><a id="image-location" href="#image-location" class="field">`location`</a> <span class="type">String</span>  
 Instead of building a container from a Dockerfile, you can specify an existing image name. Mutually exclusive with [`image.build`](#image-build).    
 The `location` field follows the same definition as the [`image` parameter](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#container_definition_image) in the Amazon ECS task definition.
-
-<div class="separator"></div>
-
-<a id="on" href="#on" class="field">`on`</a> <span class="type">Map</span>  
-The configuration for the event that triggers your job.
-
-<span class="parent-field">on.</span><a id="on-schedule" href="#on-schedule" class="field">`schedule`</a> <span class="type">String</span>  
-You can specify a rate to periodically trigger your job. Supported rates:
-
-* `"@yearly"`
-* `"@monthly"`
-* `"@weekly"`
-* `"@daily"`
-* `"@hourly"`
-* `"@every {duration}"` (For example, "1m", "5m") 
-* `"rate({duration})"` based on CloudWatch's [rate expressions](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html#RateExpressions) 
-
-Alternatively, you can specify a cron schedule if you'd like to trigger the job at a specific time:  
-
-* `"* * * * *"` based on the standard [cron format](https://en.wikipedia.org/wiki/Cron#Overview).
-* `"cron({fields})"` based on CloudWatch's [cron expressions](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html#CronExpressions) with six fields.
 
 <div class="separator"></div>
 

--- a/templates/workloads/jobs/scheduled-job/manifest.yml
+++ b/templates/workloads/jobs/scheduled-job/manifest.yml
@@ -4,49 +4,42 @@
 
 # Your job name will be used in naming your resources like log groups, ECS Tasks, etc.
 name: {{.Name}}
-
-# The "architecture" of the job you're running.
 type: {{.Type}}
 
-image:
-{{- if .ImageConfig.Build.BuildArgs.Dockerfile}}
-  # Docker build arguments.
-  # For additional overrides: https://aws.github.io/copilot-cli/docs/manifest/scheduled-job/#image-build
-  build: {{.ImageConfig.Build.BuildArgs.Dockerfile}}
-{{- end}}
-{{- if .ImageConfig.Location}}
-  # The name of the Docker image.
-  location: {{.ImageConfig.Location}}
-{{- end}}
-
-# Number of CPU units for the task.
-cpu: {{.CPU}}
-# Amount of memory in MiB used by the task.
-memory: {{.Memory}}
-
+# Trigger for your task.
 on:
   # The scheduled trigger for your job. You can specify a Unix cron schedule or keyword (@weekly) or a rate (@every 1h30m)
   # AWS Schedule Expressions are also accepted: https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html
   schedule: "{{.On.Schedule}}"
-
-# Optional. The number of times to retry the job before failing.
 {{- if .Retries}}
-retries: {{.Retries}}
+retries: {{.Retries}}    # Optional. The number of times to retry the job before failing.
 {{- else}}
-#retries: 3
+#retries: 3        # Optional. The number of times to retry the job before failing.
 {{- end}}
-# Optional. The timeout after which to stop the job if it's still running. You can use the units (h, m, s).
 {{- if .Timeout}}
-timeout: {{.Timeout}}
+timeout: {{.Timeout}}    # Optional. The timeout after which to stop the job if it's still running. You can use the units (h, m, s).
 {{- else}}
-#timeout: 1h30m
+#timeout: 1h30m    # Optional. The timeout after which to stop the job if it's still running. You can use the units (h, m, s).
 {{- end}}
+
+# Configuration for your container and task.
+image:
+{{- if .ImageConfig.Build.BuildArgs.Dockerfile}}
+  # Docker build arguments. For additional overrides: https://aws.github.io/copilot-cli/docs/manifest/scheduled-job/#image-build
+  build: {{.ImageConfig.Build.BuildArgs.Dockerfile}}
+{{- end}}
+{{- if .ImageConfig.Location}}
+  location: {{.ImageConfig.Location}}
+{{- end}}
+
+cpu: {{.CPU}}       # Number of CPU units for the task.
+memory: {{.Memory}}    # Amount of memory in MiB used by the task.
 
 # Optional fields for more advanced use-cases.
 #
 #variables:                    # Pass environment variables as key value pairs.
 #  LOG_LEVEL: info
-#
+
 #secrets:                      # Pass secrets from AWS Systems Manager (SSM) Parameter Store.
 #  GITHUB_TOKEN: GITHUB_TOKEN  # The key is the name of the environment variable, the value is the name of the SSM parameter.
 

--- a/templates/workloads/services/backend/manifest.yml
+++ b/templates/workloads/services/backend/manifest.yml
@@ -4,21 +4,20 @@
 
 # Your service name will be used in naming your resources like log groups, ECS services, etc.
 name: {{.Name}}
-{{- if .ImageConfig.Port}}
+type: {{.Type}}
+{{if .ImageConfig.Port}}
 # Your service is reachable at "http://{{.Name}}.${COPILOT_SERVICE_DISCOVERY_ENDPOINT}:{{.ImageConfig.Port}}" but is not public.
 {{- else}}
 # Your service does not allow any traffic.
 {{- end}}
-type: {{.Type}}
 
+# Configuration for your containers and service.
 image:
 {{- if .ImageConfig.Build.BuildArgs.Dockerfile}}
-  # Docker build arguments.
-  # For additional overrides: https://aws.github.io/copilot-cli/docs/manifest/backend-service/#image-build
+  # Docker build arguments. For additional overrides: https://aws.github.io/copilot-cli/docs/manifest/backend-service/#image-build
   build: {{.ImageConfig.Build.BuildArgs.Dockerfile}}
 {{- end}}
 {{- if .ImageConfig.Image.Location}}
-  # The name of the Docker image.
   location: {{.ImageConfig.Image.Location}}
 {{- end}}
 {{- if .ImageConfig.Port}}
@@ -27,20 +26,17 @@ image:
 {{- end}}
 {{- if .ImageConfig.HealthCheck}}
   healthcheck:
-    # The command the container runs to determine if it's healthy.
+    # Container health checks: https://aws.github.io/copilot-cli/docs/manifest/backend-service/#image-healthcheck
     command: {{fmtSlice (quoteSlice .ImageConfig.HealthCheck.Command)}}
-    interval: {{.ImageConfig.HealthCheck.Interval}}  # Time period between healthchecks. Default is 10s.
-    retries: {{.ImageConfig.HealthCheck.Retries}}      # Number of times to retry before container is deemed unhealthy. Default is 2.
-    timeout: {{.ImageConfig.HealthCheck.Timeout}}     # How long to wait before considering the healthcheck failed. Default is 5s.
-    start_period: {{.ImageConfig.HealthCheck.StartPeriod}} # Grace period within which to provide containers time to bootstrap before failed health checks count towards the maximum number of retries. Default is 0s.
+    interval: {{.ImageConfig.HealthCheck.Interval}}
+    retries: {{.ImageConfig.HealthCheck.Retries}}
+    timeout: {{.ImageConfig.HealthCheck.Timeout}}
+    start_period: {{.ImageConfig.HealthCheck.StartPeriod}}
 {{- end}}
 
-# Number of CPU units for the task.
-cpu: {{.CPU}}
-# Amount of memory in MiB used by the task.
-memory: {{.Memory}}
-# Number of tasks that should be running in your service.
-count: {{.Count.Value}}
+cpu: {{.CPU}}       # Number of CPU units for the task.
+memory: {{.Memory}}    # Amount of memory in MiB used by the task.
+count: {{.Count.Value}}       # Number of tasks that should be running in your service.
 
 # Optional fields for more advanced use-cases.
 #
@@ -48,7 +44,7 @@ count: {{.Count.Value}}
 #  LOG_LEVEL: info
 
 #secrets:                      # Pass secrets from AWS Systems Manager (SSM) Parameter Store.
-#  GITHUB_TOKEN: GITHUB_TOKEN  # The key is the name of the environment variable, the value is the name of the SSM      parameter.
+#  GITHUB_TOKEN: GITHUB_TOKEN  # The key is the name of the environment variable, the value is the name of the SSM parameter.
 
 # You can override any of the values defined above by environment.
 #environments:

--- a/templates/workloads/services/lb-web/manifest.yml
+++ b/templates/workloads/services/lb-web/manifest.yml
@@ -6,7 +6,7 @@
 name: {{.Name}}
 type: {{.Type}}
 
-# Trigger for your service.
+# Distribute traffic to your service.
 http:
   # Requests to this path will be forwarded to your service.
   # To match all requests you can use the "/" path.

--- a/templates/workloads/services/lb-web/manifest.yml
+++ b/templates/workloads/services/lb-web/manifest.yml
@@ -4,44 +4,37 @@
 
 # Your service name will be used in naming your resources like log groups, ECS services, etc.
 name: {{.Name}}
-# The "architecture" of the service you're running.
 type: {{.Type}}
 
+# Trigger for your service.
+http:
+  # Requests to this path will be forwarded to your service.
+  # To match all requests you can use the "/" path.
+  path: '{{.Path}}'
+  # You can specify a custom health check path. The default is "/".
+  # healthcheck: '{{.HealthCheck.HealthCheckPath}}'
+
+# Configuration for your containers and service.
 image:
 {{- if .ImageConfig.Build.BuildArgs.Dockerfile}}
-  # Docker build arguments.
-  # For additional overrides: https://aws.github.io/copilot-cli/docs/manifest/lb-web-service/#image-build
+  # Docker build arguments. For additional overrides: https://aws.github.io/copilot-cli/docs/manifest/lb-web-service/#image-build
   build: {{.ImageConfig.Build.BuildArgs.Dockerfile}}
 {{- end}}
 {{- if .ImageConfig.Image.Location}}
-  # The name of the Docker image.
   location: {{.ImageConfig.Image.Location}}
 {{- end}}
   # Port exposed through your container to route traffic to it.
   port: {{.ImageConfig.Port}}
 
-http:
-  # Requests to this path will be forwarded to your service. 
-  # To match all requests you can use the "/" path. 
-  path: '{{.Path}}'
-  # You can specify a custom health check path. The default is "/".
-  # For additional configuration: https://aws.github.io/copilot-cli/docs/manifest/lb-web-service/#http-healthcheck
-  # healthcheck: '{{.HealthCheck.HealthCheckPath}}'
-  # You can enable sticky sessions.
-  # stickiness: true
-
-# Number of CPU units for the task.
-cpu: {{.CPU}}
-# Amount of memory in MiB used by the task.
-memory: {{.Memory}}
-# Number of tasks that should be running in your service.
-count: {{.Count.Value}}
+cpu: {{.CPU}}       # Number of CPU units for the task.
+memory: {{.Memory}}    # Amount of memory in MiB used by the task.
+count: {{.Count.Value}}       # Number of tasks that should be running in your service.
 
 # Optional fields for more advanced use-cases.
 #
 #variables:                    # Pass environment variables as key value pairs.
 #  LOG_LEVEL: info
-#
+
 #secrets:                      # Pass secrets from AWS Systems Manager (SSM) Parameter Store.
 #  GITHUB_TOKEN: GITHUB_TOKEN  # The key is the name of the environment variable, the value is the name of the SSM parameter.
 


### PR DESCRIPTION
To group related fields together, we updated the manifest layout to the following format:
```yaml
# Trigger for your service/task.
http: ...
on: ...

# Configuration for your containers and service.
image: ...
cpu:
memory:
count:
network:
volumes:
```

This PR also prettifies our manifest pages on the website by updating the examples with the layout above and moving them into a collapsible section:
![Screen Shot 2021-02-19 at 8 47 41 AM](https://user-images.githubusercontent.com/879348/108534599-2e715080-728f-11eb-8ffb-3d56b29e5eb2.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
