### PR TITLE
chore(stack): validate path and root_directory against allowed characters

### DIFF
--- a/internal/pkg/cli/validate.go
+++ b/internal/pkg/cli/validate.go
@@ -355,7 +355,7 @@ func s3BucketNameValidation(val interface{}) error {
 	return nil
 }
 
-// Dynameo table names: 'a-zA-Z0-9.-_'
+// Dynamo table names: 'a-zA-Z0-9.-_'
 func dynamoTableNameValidation(val interface{}) error {
 	// https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html
 	const minDDBTableNameLength = 3

--- a/internal/pkg/deploy/cloudformation/stack/transformers_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/transformers_test.go
@@ -302,7 +302,7 @@ func Test_convertStorageOpts(t *testing.T) {
 					},
 				},
 			},
-			wantErr: errVolNoContainerPath.Error(),
+			wantErr: errNoContainerPath.Error(),
 		},
 		"full specification with access point renders correctly": {
 			inVolumes: map[string]manifest.Volume{
@@ -507,7 +507,7 @@ func Test_convertSidecarMountPoints(t *testing.T) {
 					},
 				},
 			},
-			wantErr: errMPNoContainerPath.Error(),
+			wantErr: errNoContainerPath.Error(),
 		},
 	}
 	for name, tc := range testCases {
@@ -521,4 +521,12 @@ func Test_convertSidecarMountPoints(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_validatePaths(t *testing.T) {
+	t.Run("containerPath should be properly validated", func(t *testing.T) {
+		require.NoError(t, validateContainerPath("/abc/90_"), "contains underscore")
+		require.EqualError(t, validateContainerPath("/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), "path must be less than 242 bytes in length", "too long")
+		require.EqualError(t, validateContainerPath("/etc /bin/sh cat `i'm evil` > /dev/null"), "paths can only contain the characters a-zA-Z0-9.-_/", "invalid characters disallowed")
+	})
 }

--- a/internal/pkg/deploy/cloudformation/stack/workload.go
+++ b/internal/pkg/deploy/cloudformation/stack/workload.go
@@ -6,6 +6,7 @@ package stack
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"strconv"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -33,6 +34,17 @@ const (
 	WorkloadLogRetentionParamKey      = "LogRetention"
 	WorkloadAddonsTemplateURLParamKey = "AddonsTemplateURL"
 )
+
+// Matches alphanumeric characters and -._
+var pathRegexp = regexp.MustCompile(`^[a-zA-Z0-9\-\.\_/]+$`)
+
+// Max path length in EFS is 255 bytes.
+// https://docs.aws.amazon.com/efs/latest/ug/troubleshooting-efs-fileop-errors.html#filenametoolong
+const maxEFSPathLength = 255
+
+// In docker containers, max path length is 242.
+// https://github.com/moby/moby/issues/1413
+const maxDockerContainerPathLength = 242
 
 // RuntimeConfig represents configuration that's defined outside of the manifest file
 // that is needed to create a CloudFormation stack.
@@ -223,4 +235,25 @@ func envVarOutputNames(outputs []addon.Output) []string {
 		}
 	}
 	return envVars
+}
+
+// Validate that paths contain only an approved set of characters to guard against command injection.
+// We can accept 0-9A-Za-z-_.
+func validatePath(input string, maxLength int) error {
+	if len(input) > maxLength {
+		return fmt.Errorf("path must be less than %d bytes in length", maxLength)
+	}
+	m := pathRegexp.FindStringSubmatch(input)
+	if len(m) == 0 {
+		return fmt.Errorf("paths can only contain the characters a-zA-Z0-9.-_/")
+	}
+	return nil
+}
+
+func validateRootDirPath(input string) error {
+	return validatePath(input, maxEFSPathLength)
+}
+
+func validateContainerPath(input string) error {
+	return validatePath(input, maxDockerContainerPathLength)
 }

--- a/internal/pkg/deploy/cloudformation/stack/workload.go
+++ b/internal/pkg/deploy/cloudformation/stack/workload.go
@@ -243,6 +243,9 @@ func validatePath(input string, maxLength int) error {
 	if len(input) > maxLength {
 		return fmt.Errorf("path must be less than %d bytes in length", maxLength)
 	}
+	if len(input) == 0 {
+		return nil
+	}
 	m := pathRegexp.FindStringSubmatch(input)
 	if len(m) == 0 {
 		return fmt.Errorf("paths can only contain the characters a-zA-Z0-9.-_/")


### PR DESCRIPTION
This PR adds limits to the length of input paths corresponding to the limits of docker containers and EFS volumes. It also ensures that paths do not include special characters beyond a small allowlist of common characters and the `/` separator. 

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
