### PR TITLE
chore(cli): prompt to select app if not under a workspace

### DIFF
--- a/internal/pkg/cli/env_init.go
+++ b/internal/pkg/cli/env_init.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	envInitAppNameHelpPrompt = "An environment will be created to the selected application."
+	envInitAppNameHelpPrompt = "An environment will be created in the selected application."
 
 	envInitNamePrompt              = "What is your environment's name?"
 	envInitNameHelpPrompt          = "A unique identifier for an environment (e.g. dev, test, prod)."

--- a/internal/pkg/cli/env_init.go
+++ b/internal/pkg/cli/env_init.go
@@ -68,7 +68,7 @@ https://aws.github.io/copilot-cli/docs/credentials/#environment-credentials`
 )
 
 var (
-	envInitAppNamePrompt = fmt.Sprintf("In which %s would you like to create an environment?", color.Emphasize("application"))
+	envInitAppNamePrompt = fmt.Sprintf("In which %s would you like to create the environment?", color.Emphasize("application"))
 	envInitDefaultConfigSelectOption      = "Yes, use default."
 	envInitAdjustEnvResourcesSelectOption = "Yes, but I'd like configure the default resources (CIDR ranges)."
 	envInitImportEnvResourcesSelectOption = "No, I'd like to import existing resources (VPC, subnets)."

--- a/internal/pkg/cli/env_init.go
+++ b/internal/pkg/cli/env_init.go
@@ -32,6 +32,8 @@ import (
 )
 
 const (
+	envInitAppNameHelpPrompt = "An environment will be created to the selected application."
+
 	envInitNamePrompt              = "What is your environment's name?"
 	envInitNameHelpPrompt          = "A unique identifier for an environment (e.g. dev, test, prod)."
 	envInitDefaultEnvConfirmPrompt = `Would you like to use the default configuration for a new environment?
@@ -66,6 +68,7 @@ https://aws.github.io/copilot-cli/docs/credentials/#environment-credentials`
 )
 
 var (
+	envInitAppNamePrompt = fmt.Sprintf("In which %s would you like to create an environment?", color.Emphasize("application"))
 	envInitDefaultConfigSelectOption      = "Yes, use default."
 	envInitAdjustEnvResourcesSelectOption = "Yes, but I'd like configure the default resources (CIDR ranges)."
 	envInitImportEnvResourcesSelectOption = "No, I'd like to import existing resources (VPC, subnets)."
@@ -138,6 +141,7 @@ type initEnvOpts struct {
 	prompt       prompter
 	selVPC       ec2Selector
 	selCreds     credsSelector
+	selApp 	     appSelector
 
 	sess *session.Session // Session pointing to environment's AWS account and region.
 }
@@ -171,6 +175,7 @@ func newInitEnvOpts(vars initEnvVars) (*initEnvOpts, error) {
 			Profile: cfg,
 			Prompt:  prompter,
 		},
+		selApp: selector.NewSelect(prompt.New(), store),
 	}, nil
 }
 
@@ -181,9 +186,7 @@ func (o *initEnvOpts) Validate() error {
 			return err
 		}
 	}
-	if o.appName == "" {
-		return fmt.Errorf("no application found: run %s or %s into your workspace please", color.HighlightCode("app init"), color.HighlightCode("cd"))
-	}
+
 	if err := o.validateCustomizedResources(); err != nil {
 		return err
 	}
@@ -192,6 +195,12 @@ func (o *initEnvOpts) Validate() error {
 
 // Ask asks for fields that are required but not passed in.
 func (o *initEnvOpts) Ask() error {
+	if o.appName == "" {
+		if err := o.askAppName(); err != nil {
+			return err
+		}
+	}
+
 	if err := o.askEnvName(); err != nil {
 		return err
 	}
@@ -272,6 +281,15 @@ func (o *initEnvOpts) validateCustomizedResources() error {
 	if (o.importVPC.isSet() || o.adjustVPC.isSet()) && o.defaultConfig {
 		return fmt.Errorf("cannot import or configure vpc if --%s is set", defaultConfigFlag)
 	}
+	return nil
+}
+
+func (o *initEnvOpts) askAppName() error {
+	app, err := o.selApp.Application(envInitAppNamePrompt, envInitAppNameHelpPrompt)
+	if err != nil {
+		return fmt.Errorf("ask for application: %w", err)
+	}
+	o.appName = app
 	return nil
 }
 

--- a/internal/pkg/cli/env_init.go
+++ b/internal/pkg/cli/env_init.go
@@ -195,12 +195,9 @@ func (o *initEnvOpts) Validate() error {
 
 // Ask asks for fields that are required but not passed in.
 func (o *initEnvOpts) Ask() error {
-	if o.appName == "" {
-		if err := o.askAppName(); err != nil {
-			return err
-		}
+	if err := o.askAppName(); err != nil {
+		return err
 	}
-
 	if err := o.askEnvName(); err != nil {
 		return err
 	}
@@ -285,6 +282,10 @@ func (o *initEnvOpts) validateCustomizedResources() error {
 }
 
 func (o *initEnvOpts) askAppName() error {
+	if o.appName != "" {
+		return nil
+	}
+
 	app, err := o.selApp.Application(envInitAppNamePrompt, envInitAppNameHelpPrompt)
 	if err != nil {
 		return fmt.Errorf("ask for application: %w", err)

--- a/internal/pkg/cli/env_init_test.go
+++ b/internal/pkg/cli/env_init_test.go
@@ -197,6 +197,17 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 
 			wantedError: nil,
 		},
+		"fail to get app name": {
+			inAppName: "",
+
+			setupMocks: func(m initEnvMocks) {
+				m.selApp.EXPECT().
+					Application(envInitAppNamePrompt, envInitAppNameHelpPrompt).
+					Return("", mockErr)
+			},
+
+			wantedError: fmt.Errorf("get application: some error"),
+		},
 		"fail to get env name": {
 			inAppName: mockApp,
 			setupMocks: func(m initEnvMocks) {

--- a/internal/pkg/cli/env_init_test.go
+++ b/internal/pkg/cli/env_init_test.go
@@ -206,7 +206,7 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 					Return("", mockErr)
 			},
 
-			wantedError: fmt.Errorf("get application: some error"),
+			wantedError: fmt.Errorf("ask for application: some error"),
 		},
 		"fail to get env name": {
 			inAppName: mockApp,


### PR DESCRIPTION
This pull requests changes current cli behavior for `env init`. If the user is not currently in any workspace and no application is specified using `--app` flag, it prompts the user to select from existing applications instead of returning an error. 

Resolves #1238  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
