### PR TITLE
chore(templates): remove incorrect use of 'and' in env-vars

### DIFF
--- a/templates/workloads/partials/cf/envvars.yml
+++ b/templates/workloads/partials/cf/envvars.yml
@@ -15,7 +15,7 @@ Environment:
 - Name: {{toSnakeCase $var}}
   Value:
     Fn::GetAtt: [{{$stackName}}, Outputs.{{$var}}]{{end}}{{end}}
-{{- if and .Storage .Storage.MountPoints}}
+{{- if .Storage}}{{if .Storage.MountPoints}}
 - Name: COPILOT_MOUNT_POINTS
   Value: '{{jsonMountPoints .Storage.MountPoints}}'
-{{- end}}
+{{- end}}{{end}}


### PR DESCRIPTION
<!-- Provide summary of changes -->
The "and" intrinsic function in golang templates [evaluates both arguments](https://golang.org/pkg/text/template/#hdr-Functions). This caused a nil pointer dereference in the env vars partial template when storage objects were not provided:

```go
{{if and .Storage .Storage.MountPoints}}
```
evaluates the same as "if .Storage then .Storage.MountPoints else .Storage". 

This PR fixes that by using two conditionals. 
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
