### PR TITLE
fix(cicd): add capabilities to cfn template to enable pipeline deployment w addons

### DIFF
--- a/templates/cicd/pipeline_cfn.yml
+++ b/templates/cicd/pipeline_cfn.yml
@@ -306,7 +306,7 @@ Resources:
                 ChangeSetName: {{$.AppName}}-{{$stage.Name}}-{{$workload}}
                 ActionMode: CREATE_UPDATE
                 StackName: {{$.AppName}}-{{$stage.Name}}-{{$workload}}
-                Capabilities: CAPABILITY_NAMED_IAM
+                Capabilities: CAPABILITY_IAM,CAPABILITY_NAMED_IAM,CAPABILITY_AUTO_EXPAND
                 TemplatePath: BuildOutput::infrastructure/{{$stage.WorkloadTemplatePath $workload}}
                 TemplateConfiguration: BuildOutput::infrastructure/{{$stage.WorkloadTemplateConfigurationPath $workload}}
                 # The ARN of the IAM role (in the env account) that


### PR DESCRIPTION
Adds necessary CloudFormation capabilities for pipeline deployment when addons stack is present.

Fixes #1825, #1954.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
