### PR TITLE
fix(templates): fix typo in sidecar template

### DIFF
--- a/templates/workloads/partials/cf/sidecars.yml
+++ b/templates/workloads/partials/cf/sidecars.yml
@@ -23,7 +23,7 @@
   - Name: {{$name}}
     Value: {{$value | printf "%q"}}
   {{- end}}
-  {{- if $.sidecar.MountPoints}}
+  {{- if $sidecar.MountPoints}}
   - Name: COPILOT_MOUNT_POINTS
     Value: '{{jsonMountPoints $sidecar.MountPoints}}'
   {{- end}}


### PR DESCRIPTION
<!-- Provide summary of changes -->
![](https://emojis.slackmojis.com/emojis/images/1566825215/6248/dumpster-fire.gif?1566825215)

One line change. This is a typo in a template which otherwise should execute. Currently waiting on e2es to finish locally. 

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
