### PR TITLE
chore(template): add Network opts to place tasks in private subnets 

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/cc_template.yaml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/cc_template.yaml
@@ -267,7 +267,7 @@ Resources:
                 ChangeSetName: phonetool-test-api
                 ActionMode: CREATE_UPDATE
                 StackName: phonetool-test-api
-                Capabilities: CAPABILITY_NAMED_IAM
+                Capabilities: CAPABILITY_IAM,CAPABILITY_NAMED_IAM,CAPABILITY_AUTO_EXPAND
                 TemplatePath: BuildOutput::infrastructure/api-test.stack.yml
                 TemplateConfiguration: BuildOutput::infrastructure/api-test.params.json
                 # The ARN of the IAM role (in the env account) that

--- a/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/gh_template.yaml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/gh_template.yaml
@@ -273,7 +273,7 @@ Resources:
                 ChangeSetName: phonetool-test-api
                 ActionMode: CREATE_UPDATE
                 StackName: phonetool-test-api
-                Capabilities: CAPABILITY_NAMED_IAM
+                Capabilities: CAPABILITY_IAM,CAPABILITY_NAMED_IAM,CAPABILITY_AUTO_EXPAND
                 TemplatePath: BuildOutput::infrastructure/api-test.stack.yml
                 TemplateConfiguration: BuildOutput::infrastructure/api-test.params.json
                 # The ARN of the IAM role (in the env account) that

--- a/internal/pkg/template/template_functions.go
+++ b/internal/pkg/template/template_functions.go
@@ -101,7 +101,7 @@ func QuotePSliceFunc(elems []*string) []string {
 // generateMountPointJSON turns a list of MountPoint objects into a JSON string:
 // `{"myEFSVolume": "/var/www", "myEBSVolume": "/usr/data"}`
 // This function must be called on an array of correctly constructed MountPoint objects.
-func generateMountPointJSON(mountPoints []MountPoint) string {
+func generateMountPointJSON(mountPoints []*MountPoint) string {
 	volumeMap := make(map[string]string)
 
 	for _, mp := range mountPoints {

--- a/internal/pkg/template/template_functions_test.go
+++ b/internal/pkg/template/template_functions_test.go
@@ -233,7 +233,7 @@ func TestQuotePSliceFunc(t *testing.T) {
 }
 
 func TestGenerateMountPointJSON(t *testing.T) {
-	require.Equal(t, `{"myEFSVolume":"/var/www"}`, generateMountPointJSON([]MountPoint{{ContainerPath: aws.String("/var/www"), SourceVolume: aws.String("myEFSVolume")}}), "JSON should render correctly")
-	require.Equal(t, "{}", generateMountPointJSON([]MountPoint{}), "nil list of arguments should render ")
-	require.Equal(t, "{}", generateMountPointJSON([]MountPoint{{SourceVolume: aws.String("fromEFS")}}), "empty paths should not get injected")
+	require.Equal(t, `{"myEFSVolume":"/var/www"}`, generateMountPointJSON([]*MountPoint{{ContainerPath: aws.String("/var/www"), SourceVolume: aws.String("myEFSVolume")}}), "JSON should render correctly")
+	require.Equal(t, "{}", generateMountPointJSON([]*MountPoint{}), "nil list of arguments should render ")
+	require.Equal(t, "{}", generateMountPointJSON([]*MountPoint{{SourceVolume: aws.String("fromEFS")}}), "empty paths should not get injected")
 }

--- a/internal/pkg/template/template_integration_test.go
+++ b/internal/pkg/template/template_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/aws/sessions"
 	"github.com/aws/copilot-cli/internal/pkg/template"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func TestTemplate_ParseScheduledJob(t *testing.T) {
@@ -178,6 +179,117 @@ func TestTemplate_ParseLoadBalancedWebService(t *testing.T) {
 				TemplateBody: aws.String(content.String()),
 			})
 			require.NoError(t, err, content.String())
+		})
+	}
+}
+
+func TestTemplate_ParseNetwork(t *testing.T) {
+	type cfn struct {
+		Resources struct {
+			Service struct {
+				Properties struct {
+					NetworkConfiguration map[interface{}]interface{} `yaml:"NetworkConfiguration"`
+				} `yaml:"Properties"`
+			} `yaml:"Service"`
+		} `yaml:"Resources"`
+	}
+
+	testCases := map[string]struct {
+		input template.NetworkOpts
+
+		wantedNetworkConfig string
+	}{
+		"should render AWS VPC configuration for public subnets by default": {
+			input: template.NetworkOpts{},
+			wantedNetworkConfig: `
+  AwsvpcConfiguration:
+    AssignPublicIp: ENABLED
+    Subnets:
+    - Fn::Select:
+      - 0
+      - Fn::Split:
+        - ','
+        - Fn::ImportValue: !Sub '${AppName}-${EnvName}-PublicSubnets'
+    - Fn::Select:
+      - 1
+      - Fn::Split:
+        - ','
+        - Fn::ImportValue: !Sub '${AppName}-${EnvName}-PublicSubnets'
+    SecurityGroups:
+      - Fn::ImportValue: !Sub '${AppName}-${EnvName}-EnvironmentSecurityGroup'
+`,
+		},
+		"should render AWS VPC configuration for private subnets if placement is 'private'": {
+			input: template.NetworkOpts{
+				Placement: "private",
+			},
+			wantedNetworkConfig: `
+  AwsvpcConfiguration:
+    AssignPublicIp: DISABLED
+    Subnets:
+    - Fn::Select:
+      - 0
+      - Fn::Split:
+        - ','
+        - Fn::ImportValue: !Sub '${AppName}-${EnvName}-PrivateSubnets'
+    - Fn::Select:
+      - 1
+      - Fn::Split:
+        - ','
+        - Fn::ImportValue: !Sub '${AppName}-${EnvName}-PrivateSubnets'
+    SecurityGroups:
+      - Fn::ImportValue: !Sub '${AppName}-${EnvName}-EnvironmentSecurityGroup'
+`,
+		},
+		"should render AWS VPC configuration for 'isolated' placement": {
+			input: template.NetworkOpts{
+				Placement: "isolated",
+				SecurityGroups: []string{
+					"sg-1bcf1d5b",
+					"sg-asdasdas",
+				},
+			},
+			wantedNetworkConfig: `
+  AwsvpcConfiguration:
+    AssignPublicIp: DISABLED
+    Subnets:
+    - Fn::Select:
+      - 0
+      - Fn::Split:
+        - ','
+        - Fn::ImportValue: !Sub '${AppName}-${EnvName}-PrivateSubnets'
+    - Fn::Select:
+      - 1
+      - Fn::Split:
+        - ','
+        - Fn::ImportValue: !Sub '${AppName}-${EnvName}-PrivateSubnets'
+    SecurityGroups:
+      - Fn::ImportValue: !Sub '${AppName}-${EnvName}-EnvironmentSecurityGroup'
+      - "sg-1bcf1d5b"
+      - "sg-asdasdas"
+`,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// GIVEN
+			tpl := template.New()
+			wanted := make(map[interface{}]interface{})
+			err := yaml.Unmarshal([]byte(tc.wantedNetworkConfig), &wanted)
+			require.NoError(t, err, "unmarshal wanted config")
+
+			// WHEN
+			content, err := tpl.ParseLoadBalancedWebService(template.WorkloadOpts{
+				Network: tc.input,
+			})
+
+			// THEN
+			require.NoError(t, err, "parse load balanced web service")
+			var actual cfn
+			err = yaml.Unmarshal(content.Bytes(), &actual)
+			require.NoError(t, err, "unmarshal actual config")
+			require.Equal(t, wanted, actual.Resources.Service.Properties.NetworkConfiguration)
 		})
 	}
 }

--- a/internal/pkg/template/template_integration_test.go
+++ b/internal/pkg/template/template_integration_test.go
@@ -195,12 +195,12 @@ func TestTemplate_ParseNetwork(t *testing.T) {
 	}
 
 	testCases := map[string]struct {
-		input template.NetworkOpts
+		input *template.NetworkOpts
 
 		wantedNetworkConfig string
 	}{
 		"should render AWS VPC configuration for public subnets by default": {
-			input: template.NetworkOpts{},
+			input: nil,
 			wantedNetworkConfig: `
   AwsvpcConfiguration:
     AssignPublicIp: ENABLED
@@ -219,9 +219,10 @@ func TestTemplate_ParseNetwork(t *testing.T) {
       - Fn::ImportValue: !Sub '${AppName}-${EnvName}-EnvironmentSecurityGroup'
 `,
 		},
-		"should render AWS VPC configuration for private subnets if placement is 'private'": {
-			input: template.NetworkOpts{
-				Placement: "private",
+		"should render AWS VPC configuration for private subnets": {
+			input: &template.NetworkOpts{
+				AssignPublicIP: "DISABLED",
+				SubnetsType:    "PrivateSubnets",
 			},
 			wantedNetworkConfig: `
   AwsvpcConfiguration:
@@ -241,9 +242,10 @@ func TestTemplate_ParseNetwork(t *testing.T) {
       - Fn::ImportValue: !Sub '${AppName}-${EnvName}-EnvironmentSecurityGroup'
 `,
 		},
-		"should render AWS VPC configuration for 'isolated' placement": {
-			input: template.NetworkOpts{
-				Placement: "isolated",
+		"should render AWS VPC configuration for private subnets with security groups": {
+			input: &template.NetworkOpts{
+				AssignPublicIP: "DISABLED",
+				SubnetsType:    "PrivateSubnets",
 				SecurityGroups: []string{
 					"sg-1bcf1d5b",
 					"sg-asdasdas",

--- a/internal/pkg/template/workload.go
+++ b/internal/pkg/template/workload.go
@@ -144,6 +144,12 @@ type StateMachineOpts struct {
 	Retries *int
 }
 
+// NetworkOpts holds AWS networking configuration for the workloads.
+type NetworkOpts struct {
+	Placement      string
+	SecurityGroups []string
+}
+
 // WorkloadOpts holds optional data that can be provided to enable features in a workload stack template.
 type WorkloadOpts struct {
 	// Additional options that are common between **all** workload templates.
@@ -154,6 +160,7 @@ type WorkloadOpts struct {
 	LogConfig   *LogConfigOpts
 	Autoscaling *AutoscalingOpts
 	Storage     *StorageOpts
+	Network     NetworkOpts
 
 	// Additional options for service templates.
 	HealthCheck         *ecs.HealthCheck

--- a/templates/workloads/partials/cf/service-base-properties.yml
+++ b/templates/workloads/partials/cf/service-base-properties.yml
@@ -20,17 +20,26 @@ PropagateTags: SERVICE
 LaunchType: FARGATE
 NetworkConfiguration:
   AwsvpcConfiguration:
-    AssignPublicIp: ENABLED
+    {{- $assignPublicIP := "DISABLED" }}
+    {{- $subnets := "PrivateSubnets" }}
+    {{- if or (eq .Network.Placement "") (eq .Network.Placement "public") }}
+      {{- $assignPublicIP = "ENABLED" }}
+      {{- $subnets = "PublicSubnets" }}
+    {{- end }}
+    AssignPublicIp: {{$assignPublicIP}}
     Subnets:
       - Fn::Select:
         - 0
         - Fn::Split:
           - ','
-          - Fn::ImportValue: !Sub '${AppName}-${EnvName}-PublicSubnets'
+          - Fn::ImportValue: !Sub '${AppName}-${EnvName}-{{$subnets}}'
       - Fn::Select:
         - 1
         - Fn::Split:
           - ','
-          - Fn::ImportValue: !Sub '${AppName}-${EnvName}-PublicSubnets'
+          - Fn::ImportValue: !Sub '${AppName}-${EnvName}-{{$subnets}}'
     SecurityGroups:
       - Fn::ImportValue: !Sub '${AppName}-${EnvName}-EnvironmentSecurityGroup'
+      {{- range $sg := .Network.SecurityGroups}}
+      - {{$sg}}
+      {{- end}}

--- a/templates/workloads/partials/cf/service-base-properties.yml
+++ b/templates/workloads/partials/cf/service-base-properties.yml
@@ -20,24 +20,18 @@ PropagateTags: SERVICE
 LaunchType: FARGATE
 NetworkConfiguration:
   AwsvpcConfiguration:
-    {{- $assignPublicIP := "DISABLED" }}
-    {{- $subnets := "PrivateSubnets" }}
-    {{- if or (eq .Network.Placement "") (eq .Network.Placement "public") }}
-      {{- $assignPublicIP = "ENABLED" }}
-      {{- $subnets = "PublicSubnets" }}
-    {{- end }}
-    AssignPublicIp: {{$assignPublicIP}}
+    AssignPublicIp: {{.Network.AssignPublicIP}}
     Subnets:
       - Fn::Select:
         - 0
         - Fn::Split:
           - ','
-          - Fn::ImportValue: !Sub '${AppName}-${EnvName}-{{$subnets}}'
+          - Fn::ImportValue: !Sub '${AppName}-${EnvName}-{{.Network.SubnetsType}}'
       - Fn::Select:
         - 1
         - Fn::Split:
           - ','
-          - Fn::ImportValue: !Sub '${AppName}-${EnvName}-{{$subnets}}'
+          - Fn::ImportValue: !Sub '${AppName}-${EnvName}-{{.Network.SubnetsType}}'
     SecurityGroups:
       - Fn::ImportValue: !Sub '${AppName}-${EnvName}-EnvironmentSecurityGroup'
       {{- range $sg := .Network.SecurityGroups}}

--- a/templates/workloads/partials/cf/state-machine.yml
+++ b/templates/workloads/partials/cf/state-machine.yml
@@ -24,16 +24,18 @@ StateMachine:
               - 0
               - Fn::Split:
                 - ','
-                - Fn::ImportValue: !Sub '${AppName}-${EnvName}-PublicSubnets'
+                - Fn::ImportValue: !Sub '${AppName}-${EnvName}-{{.Network.SubnetsType}}'
             - Fn::Select:
               - 1
               - Fn::Split:
                 - ','
-                - Fn::ImportValue: !Sub '${AppName}-${EnvName}-PublicSubnets'
-      AssignPublicIp: ENABLED # Should be DISABLED if we use private subnets
+                - Fn::ImportValue: !Sub '${AppName}-${EnvName}-{{.Network.SubnetsType}}'
+      AssignPublicIp: {{.Network.AssignPublicIP}}
       SecurityGroups:
-        Fn::ImportValue:
-          !Sub "${AppName}-${EnvName}-EnvironmentSecurityGroup"
+      - Fn::ImportValue: !Sub "${AppName}-${EnvName}-EnvironmentSecurityGroup"
+      {{- range $sg := .Network.SecurityGroups }}
+      - {{$sg}}
+      {{- end }}
     DefinitionString: |-
 {{include "state-machine-definition.json" . | indent 6}}      
       


### PR DESCRIPTION
Add the `NetworkOpts` type to the `template` pkg so that we can pass placement information from manifests:
```go
type NetworkOpts struct {
	AssignPublicIP   string
	SubnetsType      string
	SecurityGroups []string
}
```
Also fix our integ tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
