### PR TITLE
chore(template): fix statemachine and sidecar so e2e tests pass

### DIFF
--- a/templates/workloads/partials/cf/sidecars.yml
+++ b/templates/workloads/partials/cf/sidecars.yml
@@ -1,4 +1,5 @@
-{{if .LogConfig}}- Name: firelens_log_router
+{{if .LogConfig}}
+- Name: firelens_log_router
   Image: {{ .LogConfig.Image }}
   FirelensConfiguration:
     Type: fluentbit
@@ -11,8 +12,10 @@
     Options:
       awslogs-region: !Ref AWS::Region
       awslogs-group: !Ref LogGroup
-      awslogs-stream-prefix: copilot{{end}}
-{{range $sidecar := .Sidecars}}- Name: {{$sidecar.Name}}
+      awslogs-stream-prefix: copilot
+{{- end}}
+{{- range $sidecar := .Sidecars}}
+- Name: {{$sidecar.Name}}
   Image: {{$sidecar.Image}}{{if $sidecar.Port}}
   PortMappings:
     - ContainerPort: {{$sidecar.Port}}{{if $sidecar.Protocol}}

--- a/templates/workloads/partials/cf/state-machine.yml
+++ b/templates/workloads/partials/cf/state-machine.yml
@@ -32,10 +32,12 @@ StateMachine:
                 - Fn::ImportValue: !Sub '${AppName}-${EnvName}-{{.Network.SubnetsType}}'
       AssignPublicIp: {{.Network.AssignPublicIP}}
       SecurityGroups:
-      - Fn::ImportValue: !Sub "${AppName}-${EnvName}-EnvironmentSecurityGroup"
-      {{- range $sg := .Network.SecurityGroups }}
-      - {{$sg}}
-      {{- end }}
+        Fn::Join:
+          - '","'
+          - - Fn::ImportValue: !Sub "${AppName}-${EnvName}-EnvironmentSecurityGroup"
+            {{- range $sg := .Network.SecurityGroups }}
+            - {{$sg}}
+            {{- end }}
     DefinitionString: |-
 {{include "state-machine-definition.json" . | indent 6}}      
       


### PR DESCRIPTION
The statemachine's `DefinitionSubstitutions` sections expects strings as values. In #1968, we updated them to be a list  and broke the template.  
We also added `"-}}"` in our service templates above the sidecar template which removed extra whitespaces resulting in the template for sidecars to be malformed, this change adds the new lines back.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
