### PR TITLE
 feat(manifest): enable "network" field to specify subnets and sec groups

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/backend_svc.go
+++ b/internal/pkg/deploy/cloudformation/stack/backend_svc.go
@@ -97,6 +97,7 @@ func (s *BackendService) Template() (string, error) {
 		LogConfig:          convertLogging(s.manifest.Logging),
 		DesiredCountLambda: desiredCountLambda.String(),
 		Storage:            storage,
+		Network:            convertNetworkConfig(s.manifest.Network),
 	})
 	if err != nil {
 		return "", fmt.Errorf("parse backend service template: %w", err)

--- a/internal/pkg/deploy/cloudformation/stack/backend_svc_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/backend_svc_test.go
@@ -161,6 +161,11 @@ Outputs:
 						StackName:       addon.StackName,
 						VariableOutputs: []string{"MyTable"},
 					},
+					Network: &template.NetworkOpts{
+						AssignPublicIP: template.DisablePublicIP,
+						SubnetsType:    template.PrivateSubnetsPlacement,
+						SecurityGroups: []string{"sg-1234"},
+					},
 				}).Return(&template.Content{Buffer: bytes.NewBufferString("template")}, nil)
 				svc.parser = m
 				svc.addons = mockTemplater{
@@ -195,6 +200,10 @@ Outputs:
 					},
 				},
 				manifest: tc.manifest,
+			}
+			if tc.manifest != nil {
+				conf.manifest.Network.VPC.Placement = aws.String(manifest.PrivateSubnetPlacement)
+				conf.manifest.Network.VPC.SecurityGroups = []string{"sg-1234"}
 			}
 			tc.mockDependencies(t, ctrl, conf)
 

--- a/internal/pkg/deploy/cloudformation/stack/lb_web_svc.go
+++ b/internal/pkg/deploy/cloudformation/stack/lb_web_svc.go
@@ -131,6 +131,7 @@ func (s *LoadBalancedWebService) Template() (string, error) {
 		DesiredCountLambda:  desiredCountLambda.String(),
 		EnvControllerLambda: envControllerLambda.String(),
 		Storage:             storage,
+		Network:             convertNetworkConfig(s.manifest.Network),
 	})
 	if err != nil {
 		return "", err

--- a/internal/pkg/deploy/cloudformation/stack/lb_web_svc_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/lb_web_svc_test.go
@@ -177,6 +177,10 @@ Outputs:
 					RulePriorityLambda:  "lambda",
 					DesiredCountLambda:  "something",
 					EnvControllerLambda: "something",
+					Network: &template.NetworkOpts{
+						AssignPublicIP: template.EnablePublicIP,
+						SubnetsType:    template.PublicSubnetsPlacement,
+					},
 				}).Return(&template.Content{Buffer: bytes.NewBufferString("template")}, nil)
 
 				addons := mockTemplater{err: &addon.ErrAddonsDirNotExist{}}
@@ -205,6 +209,10 @@ Outputs:
 					RulePriorityLambda:  "lambda",
 					DesiredCountLambda:  "something",
 					EnvControllerLambda: "something",
+					Network: &template.NetworkOpts{
+						AssignPublicIP: template.EnablePublicIP,
+						SubnetsType:    template.PublicSubnetsPlacement,
+					},
 				}).Return(&template.Content{Buffer: bytes.NewBufferString("template")}, nil)
 				addons := mockTemplater{
 					tpl: `Resources:

--- a/internal/pkg/deploy/cloudformation/stack/scheduled_job.go
+++ b/internal/pkg/deploy/cloudformation/stack/scheduled_job.go
@@ -151,6 +151,7 @@ func (j *ScheduledJob) Template() (string, error) {
 		StateMachine:       stateMachine,
 		LogConfig:          convertLogging(j.manifest.Logging),
 		Storage:            storage,
+		Network:            convertNetworkConfig(j.manifest.Network),
 	})
 	if err != nil {
 		return "", fmt.Errorf("parse scheduled job template: %w", err)

--- a/internal/pkg/deploy/cloudformation/stack/scheduled_job_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/scheduled_job_test.go
@@ -53,6 +53,10 @@ func TestScheduledJob_Template(t *testing.T) {
 						Timeout: aws.Int(5400),
 						Retries: aws.Int(3),
 					},
+					Network: &template.NetworkOpts{
+						AssignPublicIP: template.EnablePublicIP,
+						SubnetsType:    template.PublicSubnetsPlacement,
+					},
 				})).Return(&template.Content{Buffer: bytes.NewBufferString("template")}, nil)
 				addons := mockTemplater{err: &addon.ErrAddonsDirNotExist{}}
 				j.parser = m
@@ -74,6 +78,10 @@ func TestScheduledJob_Template(t *testing.T) {
 					StateMachine: &template.StateMachineOpts{
 						Timeout: aws.Int(5400),
 						Retries: aws.Int(3),
+					},
+					Network: &template.NetworkOpts{
+						AssignPublicIP: template.EnablePublicIP,
+						SubnetsType:    template.PublicSubnetsPlacement,
 					},
 				})).Return(&template.Content{Buffer: bytes.NewBufferString("template")}, nil)
 				addons := mockTemplater{

--- a/internal/pkg/deploy/cloudformation/stack/transformers.go
+++ b/internal/pkg/deploy/cloudformation/stack/transformers.go
@@ -53,7 +53,7 @@ func convertSidecar(s map[string]*manifest.SidecarConfig) ([]*template.SidecarOp
 		if err != nil {
 			return nil, err
 		}
-		mp, err := renderSidecarMountPoints(config.MountPoints)
+		mp, err := convertSidecarMountPoints(config.MountPoints)
 		if err != nil {
 			return nil, err
 		}
@@ -161,15 +161,15 @@ func convertStorageOpts(in *manifest.Storage) (*template.StorageOpts, error) {
 	if in == nil {
 		return nil, nil
 	}
-	v, err := renderVolumes(in.Volumes)
+	v, err := convertVolumes(in.Volumes)
 	if err != nil {
 		return nil, err
 	}
-	mp, err := renderMountPoints(in.Volumes)
+	mp, err := convertMountPoints(in.Volumes)
 	if err != nil {
 		return nil, err
 	}
-	perms, err := renderStoragePermissions(in.Volumes)
+	perms, err := convertEFSPermissions(in.Volumes)
 	if err != nil {
 		return nil, err
 	}
@@ -180,14 +180,14 @@ func convertStorageOpts(in *manifest.Storage) (*template.StorageOpts, error) {
 	}, nil
 }
 
-// renderSidecarMountPoints is used to convert from manifest to template objects.
-func renderSidecarMountPoints(in []manifest.SidecarMountPoint) ([]*template.MountPoint, error) {
+// convertSidecarMountPoints is used to convert from manifest to template objects.
+func convertSidecarMountPoints(in []manifest.SidecarMountPoint) ([]*template.MountPoint, error) {
 	if len(in) == 0 {
 		return nil, nil
 	}
 	var output []*template.MountPoint
 	for _, smp := range in {
-		mp, err := renderMountPoint(smp.SourceVolume, smp.ContainerPath, smp.ReadOnly)
+		mp, err := convertMountPoint(smp.SourceVolume, smp.ContainerPath, smp.ReadOnly)
 		if err != nil {
 			return nil, err
 		}
@@ -196,7 +196,7 @@ func renderSidecarMountPoints(in []manifest.SidecarMountPoint) ([]*template.Moun
 	return output, nil
 }
 
-func renderMountPoint(sourceVolume, containerPath *string, readOnly *bool) (*template.MountPoint, error) {
+func convertMountPoint(sourceVolume, containerPath *string, readOnly *bool) (*template.MountPoint, error) {
 	// containerPath must be specified.
 	if aws.StringValue(containerPath) == "" {
 		return nil, errNoContainerPath
@@ -221,13 +221,13 @@ func renderMountPoint(sourceVolume, containerPath *string, readOnly *bool) (*tem
 	}, nil
 }
 
-func renderMountPoints(input map[string]manifest.Volume) ([]*template.MountPoint, error) {
+func convertMountPoints(input map[string]manifest.Volume) ([]*template.MountPoint, error) {
 	if len(input) == 0 {
 		return nil, nil
 	}
 	var output []*template.MountPoint
 	for name, volume := range input {
-		mp, err := renderMountPoint(aws.String(name), volume.ContainerPath, volume.ReadOnly)
+		mp, err := convertMountPoint(aws.String(name), volume.ContainerPath, volume.ReadOnly)
 		if err != nil {
 			return nil, err
 		}
@@ -236,7 +236,7 @@ func renderMountPoints(input map[string]manifest.Volume) ([]*template.MountPoint
 	return output, nil
 }
 
-func renderStoragePermissions(input map[string]manifest.Volume) ([]*template.EFSPermission, error) {
+func convertEFSPermissions(input map[string]manifest.Volume) ([]*template.EFSPermission, error) {
 	if len(input) == 0 {
 		return nil, nil
 	}
@@ -260,7 +260,7 @@ func renderStoragePermissions(input map[string]manifest.Volume) ([]*template.EFS
 	return output, nil
 }
 
-func renderVolumes(input map[string]manifest.Volume) ([]*template.Volume, error) {
+func convertVolumes(input map[string]manifest.Volume) ([]*template.Volume, error) {
 	if len(input) == 0 {
 		return nil, nil
 	}

--- a/internal/pkg/deploy/cloudformation/stack/transformers.go
+++ b/internal/pkg/deploy/cloudformation/stack/transformers.go
@@ -317,3 +317,16 @@ func convertVolumes(input map[string]manifest.Volume) ([]*template.Volume, error
 	}
 	return output, nil
 }
+
+func convertNetworkConfig(network manifest.NetworkConfig) *template.NetworkOpts {
+	opts := &template.NetworkOpts{
+		AssignPublicIP: template.EnablePublicIP,
+		SubnetsType:    template.PublicSubnetsPlacement,
+		SecurityGroups: network.VPC.SecurityGroups,
+	}
+	if aws.StringValue(network.VPC.Placement) != manifest.PublicSubnetPlacement {
+		opts.AssignPublicIP = template.DisablePublicIP
+		opts.SubnetsType = template.PrivateSubnetsPlacement
+	}
+	return opts
+}

--- a/internal/pkg/deploy/cloudformation/stack/transformers_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/transformers_test.go
@@ -512,7 +512,7 @@ func Test_convertSidecarMountPoints(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			got, err := renderSidecarMountPoints(tc.inMountPoints)
+			got, err := convertSidecarMountPoints(tc.inMountPoints)
 			if tc.wantErr != "" {
 				require.EqualError(t, err, tc.wantErr)
 			} else {

--- a/internal/pkg/manifest/backend_svc.go
+++ b/internal/pkg/manifest/backend_svc.go
@@ -39,7 +39,7 @@ type BackendServiceConfig struct {
 	TaskConfig  `yaml:",inline"`
 	*Logging    `yaml:"logging,flow"`
 	Sidecars    map[string]*SidecarConfig `yaml:"sidecars"`
-	Network     networkConfig             `yaml:"network"`
+	Network     NetworkConfig             `yaml:"network"`
 }
 
 type imageWithPortAndHealthcheck struct {
@@ -134,9 +134,9 @@ func newDefaultBackendService() *BackendService {
 					Value: aws.Int(1),
 				},
 			},
-			Network: networkConfig{
+			Network: NetworkConfig{
 				VPC: vpcConfig{
-					Placement: stringP(publicPlacement),
+					Placement: stringP(PublicSubnetPlacement),
 				},
 			},
 		},

--- a/internal/pkg/manifest/backend_svc.go
+++ b/internal/pkg/manifest/backend_svc.go
@@ -39,6 +39,7 @@ type BackendServiceConfig struct {
 	TaskConfig  `yaml:",inline"`
 	*Logging    `yaml:"logging,flow"`
 	Sidecars    map[string]*SidecarConfig `yaml:"sidecars"`
+	Network     networkConfig             `yaml:"network"`
 }
 
 type imageWithPortAndHealthcheck struct {
@@ -131,6 +132,11 @@ func newDefaultBackendService() *BackendService {
 				Memory: aws.Int(512),
 				Count: Count{
 					Value: aws.Int(1),
+				},
+			},
+			Network: networkConfig{
+				VPC: vpcConfig{
+					Placement: stringP(publicPlacement),
 				},
 			},
 		},

--- a/internal/pkg/manifest/backend_svc_test.go
+++ b/internal/pkg/manifest/backend_svc_test.go
@@ -51,7 +51,7 @@ func TestNewBackendSvc(t *testing.T) {
 							Value: aws.Int(1),
 						},
 					},
-					Network: networkConfig{
+					Network: NetworkConfig{
 						VPC: vpcConfig{
 							Placement: stringP("public"),
 						},
@@ -98,7 +98,7 @@ func TestNewBackendSvc(t *testing.T) {
 							Value: aws.Int(1),
 						},
 					},
-					Network: networkConfig{
+					Network: NetworkConfig{
 						VPC: vpcConfig{
 							Placement: stringP("public"),
 						},

--- a/internal/pkg/manifest/backend_svc_test.go
+++ b/internal/pkg/manifest/backend_svc_test.go
@@ -51,6 +51,11 @@ func TestNewBackendSvc(t *testing.T) {
 							Value: aws.Int(1),
 						},
 					},
+					Network: networkConfig{
+						VPC: vpcConfig{
+							Placement: stringP("public"),
+						},
+					},
 				},
 			},
 		},
@@ -91,6 +96,11 @@ func TestNewBackendSvc(t *testing.T) {
 						Memory: aws.Int(512),
 						Count: Count{
 							Value: aws.Int(1),
+						},
+					},
+					Network: networkConfig{
+						VPC: vpcConfig{
+							Placement: stringP("public"),
 						},
 					},
 				},

--- a/internal/pkg/manifest/job.go
+++ b/internal/pkg/manifest/job.go
@@ -42,6 +42,7 @@ type ScheduledJobConfig struct {
 	Sidecars                map[string]*SidecarConfig `yaml:"sidecars"`
 	On                      JobTriggerConfig          `yaml:"on,flow"`
 	JobFailureHandlerConfig `yaml:",inline"`
+	Network                 networkConfig `yaml:"network"`
 }
 
 // JobTriggerConfig represents the configuration for the event that triggers the job.
@@ -76,6 +77,11 @@ func newDefaultScheduledJob() *ScheduledJob {
 				Memory: aws.Int(512),
 				Count: Count{
 					Value: aws.Int(1),
+				},
+			},
+			Network: networkConfig{
+				VPC: vpcConfig{
+					Placement: stringP(publicPlacement),
 				},
 			},
 		},

--- a/internal/pkg/manifest/job.go
+++ b/internal/pkg/manifest/job.go
@@ -42,7 +42,7 @@ type ScheduledJobConfig struct {
 	Sidecars                map[string]*SidecarConfig `yaml:"sidecars"`
 	On                      JobTriggerConfig          `yaml:"on,flow"`
 	JobFailureHandlerConfig `yaml:",inline"`
-	Network                 networkConfig `yaml:"network"`
+	Network                 NetworkConfig `yaml:"network"`
 }
 
 // JobTriggerConfig represents the configuration for the event that triggers the job.
@@ -79,9 +79,9 @@ func newDefaultScheduledJob() *ScheduledJob {
 					Value: aws.Int(1),
 				},
 			},
-			Network: networkConfig{
+			Network: NetworkConfig{
 				VPC: vpcConfig{
-					Placement: stringP(publicPlacement),
+					Placement: stringP(PublicSubnetPlacement),
 				},
 			},
 		},

--- a/internal/pkg/manifest/lb_web_svc.go
+++ b/internal/pkg/manifest/lb_web_svc.go
@@ -51,7 +51,7 @@ type LoadBalancedWebServiceConfig struct {
 	TaskConfig  `yaml:",inline"`
 	*Logging    `yaml:"logging,flow"`
 	Sidecars    map[string]*SidecarConfig `yaml:"sidecars"`
-	Network     networkConfig             `yaml:"network"`
+	Network     NetworkConfig             `yaml:"network"`
 }
 
 // HTTPHealthCheckArgs holds the configuration to determine if the load balanced web service is healthy.
@@ -149,9 +149,9 @@ func newDefaultLoadBalancedWebService() *LoadBalancedWebService {
 					Value: aws.Int(1),
 				},
 			},
-			Network: networkConfig{
+			Network: NetworkConfig{
 				VPC: vpcConfig{
-					Placement: stringP(publicPlacement),
+					Placement: stringP(PublicSubnetPlacement),
 				},
 			},
 		},

--- a/internal/pkg/manifest/lb_web_svc.go
+++ b/internal/pkg/manifest/lb_web_svc.go
@@ -20,8 +20,6 @@ const (
 
 // Default values for HTTPHealthCheck for a load balanced web service.
 const (
-	// LogRetentionInDays is the default log retention time in days.
-	LogRetentionInDays     = 30
 	DefaultHealthCheckPath = "/"
 )
 
@@ -53,6 +51,7 @@ type LoadBalancedWebServiceConfig struct {
 	TaskConfig  `yaml:",inline"`
 	*Logging    `yaml:"logging,flow"`
 	Sidecars    map[string]*SidecarConfig `yaml:"sidecars"`
+	Network     networkConfig             `yaml:"network"`
 }
 
 // HTTPHealthCheckArgs holds the configuration to determine if the load balanced web service is healthy.
@@ -148,6 +147,11 @@ func newDefaultLoadBalancedWebService() *LoadBalancedWebService {
 				Memory: aws.Int(512),
 				Count: Count{
 					Value: aws.Int(1),
+				},
+			},
+			Network: networkConfig{
+				VPC: vpcConfig{
+					Placement: stringP(publicPlacement),
 				},
 			},
 		},

--- a/internal/pkg/manifest/lb_web_svc_test.go
+++ b/internal/pkg/manifest/lb_web_svc_test.go
@@ -63,7 +63,7 @@ func TestNewLoadBalancedWebService(t *testing.T) {
 							Value: aws.Int(1),
 						},
 					},
-					Network: networkConfig{
+					Network: NetworkConfig{
 						VPC: vpcConfig{
 							Placement: stringP("public"),
 						},
@@ -355,7 +355,7 @@ func TestLoadBalancedWebService_ApplyEnv(t *testing.T) {
 					Logging: &Logging{
 						ConfigFile: aws.String("mockConfigFile"),
 					},
-					Network: networkConfig{
+					Network: NetworkConfig{
 						VPC: vpcConfig{
 							Placement:      stringP("public"),
 							SecurityGroups: []string{"sg-123"},
@@ -417,7 +417,7 @@ func TestLoadBalancedWebService_ApplyEnv(t *testing.T) {
 								"FOO": "BAR",
 							},
 						},
-						Network: networkConfig{
+						Network: NetworkConfig{
 							VPC: vpcConfig{
 								SecurityGroups: []string{"sg-456", "sg-789"},
 							},
@@ -504,7 +504,7 @@ func TestLoadBalancedWebService_ApplyEnv(t *testing.T) {
 							"FOO": "BAR",
 						},
 					},
-					Network: networkConfig{
+					Network: NetworkConfig{
 						VPC: vpcConfig{
 							Placement:      stringP("public"),
 							SecurityGroups: []string{"sg-456", "sg-789"},

--- a/internal/pkg/manifest/lb_web_svc_test.go
+++ b/internal/pkg/manifest/lb_web_svc_test.go
@@ -18,6 +18,74 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+func TestNewLoadBalancedWebService(t *testing.T) {
+	testCases := map[string]struct {
+		props LoadBalancedWebServiceProps
+
+		wanted *LoadBalancedWebService
+	}{
+		"translates to default load balanced web service": {
+			props: LoadBalancedWebServiceProps{
+				WorkloadProps: &WorkloadProps{
+					Name:       "frontend",
+					Dockerfile: "./Dockerfile",
+				},
+				Path: "/",
+				Port: 80,
+			},
+
+			wanted: &LoadBalancedWebService{
+				Workload: Workload{
+					Name: stringP("frontend"),
+					Type: stringP("Load Balanced Web Service"),
+				},
+				LoadBalancedWebServiceConfig: LoadBalancedWebServiceConfig{
+					ImageConfig: ServiceImageWithPort{
+						Image: Image{
+							Build: BuildArgsOrString{
+								BuildArgs: DockerBuildArgs{
+									Dockerfile: stringP("./Dockerfile"),
+								},
+							},
+						},
+						Port: aws.Uint16(80),
+					},
+					RoutingRule: RoutingRule{
+						Path: stringP("/"),
+						HealthCheck: HealthCheckArgsOrString{
+							HealthCheckPath: stringP("/"),
+						},
+					},
+					TaskConfig: TaskConfig{
+						CPU:    aws.Int(256),
+						Memory: aws.Int(512),
+						Count: Count{
+							Value: aws.Int(1),
+						},
+					},
+					Network: networkConfig{
+						VPC: vpcConfig{
+							Placement: stringP("public"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// WHEN
+			manifest := NewLoadBalancedWebService(&tc.props)
+
+			// THEN
+			require.Equal(t, tc.wanted.Workload, manifest.Workload)
+			require.Equal(t, tc.wanted.LoadBalancedWebServiceConfig, manifest.LoadBalancedWebServiceConfig)
+			require.Equal(t, tc.wanted.Environments, manifest.Environments)
+		})
+	}
+}
+
 func TestNewLoadBalancedWebService_UnmarshalYaml(t *testing.T) {
 	testCases := map[string]struct {
 		inContent []byte
@@ -287,6 +355,12 @@ func TestLoadBalancedWebService_ApplyEnv(t *testing.T) {
 					Logging: &Logging{
 						ConfigFile: aws.String("mockConfigFile"),
 					},
+					Network: networkConfig{
+						VPC: vpcConfig{
+							Placement:      stringP("public"),
+							SecurityGroups: []string{"sg-123"},
+						},
+					},
 				},
 				Environments: map[string]*LoadBalancedWebServiceConfig{
 					"prod-iad": {
@@ -341,6 +415,11 @@ func TestLoadBalancedWebService_ApplyEnv(t *testing.T) {
 						Logging: &Logging{
 							SecretOptions: map[string]string{
 								"FOO": "BAR",
+							},
+						},
+						Network: networkConfig{
+							VPC: vpcConfig{
+								SecurityGroups: []string{"sg-456", "sg-789"},
 							},
 						},
 					},
@@ -423,6 +502,12 @@ func TestLoadBalancedWebService_ApplyEnv(t *testing.T) {
 						ConfigFile: aws.String("mockConfigFile"),
 						SecretOptions: map[string]string{
 							"FOO": "BAR",
+						},
+					},
+					Network: networkConfig{
+						VPC: vpcConfig{
+							Placement:      stringP("public"),
+							SecurityGroups: []string{"sg-456", "sg-789"},
 						},
 					},
 				},

--- a/internal/pkg/manifest/svc_test.go
+++ b/internal/pkg/manifest/svc_test.go
@@ -109,7 +109,7 @@ environments:
 								"LOG_TOKEN": "LOG_TOKEN",
 							},
 						},
-						Network: networkConfig{
+						Network: NetworkConfig{
 							VPC: vpcConfig{
 								Placement: stringP("public"),
 							},
@@ -187,7 +187,7 @@ secrets:
 								"API_TOKEN": "SUBS_API_TOKEN",
 							},
 						},
-						Network: networkConfig{
+						Network: NetworkConfig{
 							VPC: vpcConfig{
 								Placement: stringP("public"),
 							},

--- a/internal/pkg/manifest/svc_test.go
+++ b/internal/pkg/manifest/svc_test.go
@@ -109,6 +109,11 @@ environments:
 								"LOG_TOKEN": "LOG_TOKEN",
 							},
 						},
+						Network: networkConfig{
+							VPC: vpcConfig{
+								Placement: stringP("public"),
+							},
+						},
 					},
 					Environments: map[string]*LoadBalancedWebServiceConfig{
 						"test": {
@@ -180,6 +185,11 @@ secrets:
 							},
 							Secrets: map[string]string{
 								"API_TOKEN": "SUBS_API_TOKEN",
+							},
+						},
+						Network: networkConfig{
+							VPC: vpcConfig{
+								Placement: stringP("public"),
 							},
 						},
 					},

--- a/internal/pkg/manifest/workload_test.go
+++ b/internal/pkg/manifest/workload_test.go
@@ -4,6 +4,7 @@
 package manifest
 
 import (
+	"errors"
 	"path/filepath"
 	"testing"
 
@@ -262,6 +263,72 @@ func TestLogging_GetEnableMetadata(t *testing.T) {
 			got := l.GetEnableMetadata()
 
 			require.Equal(t, tc.wanted, got)
+		})
+	}
+}
+
+func TestNetworkConfig_UnmarshalYAML(t *testing.T) {
+	testCases := map[string]struct {
+		data string
+
+		wantedConfig networkConfig
+		wantedErr    error
+	}{
+		"defaults to public placement if vpc is empty": {
+			data: `
+network:
+  vpc:
+`,
+			wantedConfig: networkConfig{
+				VPC: vpcConfig{
+					Placement: stringP(publicPlacement),
+				},
+			},
+		},
+		"returns error if placement option is invalid": {
+			data: `
+network:
+  vpc:
+    placement: 'tartarus'
+`,
+			wantedErr: errors.New(`field 'network.vpc.placement' is 'tartarus' must be one of []string{"public", "private"}`),
+		},
+		"unmarshals successfully for public placement with security groups": {
+			data: `
+network:
+  vpc:
+    placement: 'public'
+    security_groups:
+    - 'sg-1234'
+    - 'sg-4567'
+`,
+			wantedConfig: networkConfig{
+				VPC: vpcConfig{
+					Placement:      stringP(publicPlacement),
+					SecurityGroups: []string{"sg-1234", "sg-4567"},
+				},
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// GIVEN
+			type manifest struct {
+				Network networkConfig `yaml:"network"`
+			}
+			var m manifest
+
+			// WHEN
+			err := yaml.Unmarshal([]byte(tc.data), &m)
+
+			// THEN
+			if tc.wantedErr != nil {
+				require.EqualError(t, err, tc.wantedErr.Error())
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.wantedConfig, m.Network)
+			}
 		})
 	}
 }

--- a/internal/pkg/manifest/workload_test.go
+++ b/internal/pkg/manifest/workload_test.go
@@ -271,7 +271,7 @@ func TestNetworkConfig_UnmarshalYAML(t *testing.T) {
 	testCases := map[string]struct {
 		data string
 
-		wantedConfig networkConfig
+		wantedConfig NetworkConfig
 		wantedErr    error
 	}{
 		"defaults to public placement if vpc is empty": {
@@ -279,9 +279,9 @@ func TestNetworkConfig_UnmarshalYAML(t *testing.T) {
 network:
   vpc:
 `,
-			wantedConfig: networkConfig{
+			wantedConfig: NetworkConfig{
 				VPC: vpcConfig{
-					Placement: stringP(publicPlacement),
+					Placement: stringP(PublicSubnetPlacement),
 				},
 			},
 		},
@@ -302,9 +302,9 @@ network:
     - 'sg-1234'
     - 'sg-4567'
 `,
-			wantedConfig: networkConfig{
+			wantedConfig: NetworkConfig{
 				VPC: vpcConfig{
-					Placement:      stringP(publicPlacement),
+					Placement:      stringP(PublicSubnetPlacement),
 					SecurityGroups: []string{"sg-1234", "sg-4567"},
 				},
 			},
@@ -315,7 +315,7 @@ network:
 		t.Run(name, func(t *testing.T) {
 			// GIVEN
 			type manifest struct {
-				Network networkConfig `yaml:"network"`
+				Network NetworkConfig `yaml:"network"`
 			}
 			var m manifest
 

--- a/internal/pkg/template/workload.go
+++ b/internal/pkg/template/workload.go
@@ -28,6 +28,15 @@ const (
 	scheduledJobTplName = "scheduled-job"
 )
 
+// Constants for workload options.
+const (
+	// AWS VPC networking configuration.
+	EnablePublicIP          = "ENABLED"
+	DisablePublicIP         = "DISABLED"
+	PublicSubnetsPlacement  = "PublicSubnets"
+	PrivateSubnetsPlacement = "PrivateSubnets"
+)
+
 var (
 	// Template names under "workloads/partials/cf/".
 	partialsWorkloadCFTemplateNames = []string{
@@ -151,8 +160,8 @@ type NetworkOpts struct {
 
 func defaultNetworkOpts() *NetworkOpts {
 	return &NetworkOpts{
-		AssignPublicIP: "ENABLED",
-		SubnetsType:    "PublicSubnets",
+		AssignPublicIP: EnablePublicIP,
+		SubnetsType:    PublicSubnetsPlacement,
 	}
 }
 


### PR DESCRIPTION
The manifests now support the following new fields:
```yaml
network:
   vpc:
      placement: 'public|private'  # which subnets to place the tasks.
      security_groups: [string]    # list of additional security groups.
```

The `network.vpc.placement` field won't be really useful atm for customers that use Copilot generated VPCs since we don't create NAT gateways. However, it will be supported in the future. This is milestone 1. of #1959.  
On the other hand, customers that imported their VPC while creating an environment will now be able to place their tasks in private subnets.

The security groups feature is available for everyone to attach additional security groups to their tasks.

Related #1959
Closes #1453

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
