### PR TITLE
chore(manifest): convert StringSliceOrString into StringSlice

### DIFF
--- a/internal/pkg/manifest/workload.go
+++ b/internal/pkg/manifest/workload.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"gopkg.in/yaml.v3"
@@ -157,6 +158,11 @@ func (e *EntryPointOverride) UnmarshalYAML(unmarshal func(interface{}) error) er
 	return nil
 }
 
+// ToStringSlice converts an EntryPointOverride to a slice of string.
+func (e *EntryPointOverride) ToStringSlice() []string {
+	return  toStringSlice((*stringSliceOrString)(e))
+}
+
 // UnmarshalYAML overrides the default YAML unmarshaling logic for the CommandOverride
 // struct, allowing it to perform more complex unmarshaling behavior.
 // This method implements the yaml.Unmarshaler (v2) interface.
@@ -165,6 +171,11 @@ func (c *CommandOverride) UnmarshalYAML(unmarshal func(interface{}) error) error
 		return errUnmarshalCommand
 	}
 	return nil
+}
+
+// ToStringSlice converts an CommandOverride to a slice of string.
+func (c *CommandOverride) ToStringSlice() []string {
+	return  toStringSlice((*stringSliceOrString)(c))
 }
 
 type stringSliceOrString struct {
@@ -189,6 +200,13 @@ func unmarshalYAMLToStringSliceOrString(s *stringSliceOrString, unmarshal func(i
 	}
 
 	return unmarshal(&s.String)
+}
+
+func toStringSlice(s *stringSliceOrString) []string {
+	if s.String != nil {
+		return strings.Split(*s.String, " ")
+	}
+	return s.StringSlice
 }
 
 // BuildArgsOrString is a custom type which supports unmarshaling yaml which

--- a/internal/pkg/manifest/workload_test.go
+++ b/internal/pkg/manifest/workload_test.go
@@ -65,6 +65,44 @@ func TestEntryPointOverrides_UnmarshalYAML(t *testing.T) {
 	}
 }
 
+func TestEntryPointOverrides_ToStringSlice(t *testing.T) {
+	testCases := map[string]struct {
+		inEntryPointOverride EntryPointOverride
+
+		wantedSlice []string
+		wantedError  error
+	}{
+		"Both fields are empty": {
+			inEntryPointOverride: EntryPointOverride{
+				String: nil,
+				StringSlice: nil,
+			},
+			wantedSlice: nil,
+		},
+		"Given a string": {
+			inEntryPointOverride: EntryPointOverride{
+				String: aws.String("/bin/sh -c"),
+				StringSlice: nil,
+			},
+			wantedSlice: []string{"/bin/sh", "-c"},
+		},
+		"Given a string slice": {
+			inEntryPointOverride: EntryPointOverride{
+				String: nil,
+				StringSlice: []string{"/bin/sh", "-c"},
+			},
+			wantedSlice: []string{"/bin/sh", "-c"},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			out := tc.inEntryPointOverride.ToStringSlice()
+			require.Equal(t, tc.wantedSlice, out)
+		})
+	}
+}
+
 func TestCommandOverrides_UnmarshalYAML(t *testing.T) {
 	testCases := map[string]struct {
 		inContent []byte
@@ -113,6 +151,43 @@ func TestCommandOverrides_UnmarshalYAML(t *testing.T) {
 				require.Equal(t, tc.wantedStruct.StringSlice, e.Command.StringSlice)
 				require.Equal(t, tc.wantedStruct.String, e.Command.String)
 			}
+		})
+	}
+}
+
+func TestCommandOverrides_ToStringSlice(t *testing.T) {
+	testCases := map[string]struct {
+		inCommandOverrides CommandOverride
+
+		wantedSlice []string
+	}{
+		"Both fields are empty": {
+			inCommandOverrides: CommandOverride{
+				String: nil,
+				StringSlice: nil,
+			},
+			wantedSlice: nil,
+		},
+		"Given a string": {
+			inCommandOverrides: CommandOverride{
+				String: aws.String(`-c read some command`),
+				StringSlice: nil,
+			},
+			wantedSlice: []string{"-c", "read", "some", "command"},
+		},
+		"Given a string slice": {
+			inCommandOverrides: CommandOverride{
+				String: nil,
+				StringSlice: []string{"-c", "read", "some", "command"},
+			},
+			wantedSlice: []string{"-c", "read", "some", "command"},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			out := tc.inCommandOverrides.ToStringSlice()
+			require.Equal(t, tc.wantedSlice, out)
 		})
 	}
 }

--- a/internal/pkg/manifest/workload_test.go
+++ b/internal/pkg/manifest/workload_test.go
@@ -13,7 +13,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func TestEntryPointOverrides_UnmarshalYAML(t *testing.T) {
+func TestEntryPointOverride_UnmarshalYAML(t *testing.T) {
 	testCases := map[string]struct {
 		inContent []byte
 
@@ -65,7 +65,7 @@ func TestEntryPointOverrides_UnmarshalYAML(t *testing.T) {
 	}
 }
 
-func TestEntryPointOverrides_ToStringSlice(t *testing.T) {
+func TestEntryPointOverride_ToStringSlice(t *testing.T) {
 	testCases := map[string]struct {
 		inEntryPointOverride EntryPointOverride
 
@@ -103,7 +103,7 @@ func TestEntryPointOverrides_ToStringSlice(t *testing.T) {
 	}
 }
 
-func TestCommandOverrides_UnmarshalYAML(t *testing.T) {
+func TestCommandOverride_UnmarshalYAML(t *testing.T) {
 	testCases := map[string]struct {
 		inContent []byte
 
@@ -155,7 +155,7 @@ func TestCommandOverrides_UnmarshalYAML(t *testing.T) {
 	}
 }
 
-func TestCommandOverrides_ToStringSlice(t *testing.T) {
+func TestCommandOverride_ToStringSlice(t *testing.T) {
 	testCases := map[string]struct {
 		inCommandOverrides CommandOverride
 


### PR DESCRIPTION
This PR implements the functionality to unify entrypoint and command, which can be either type string or type slice of strings, to type slice of strings. 

In CloudFormation template the fields "EntryPoint" and "Command" need to be of type list of strings ([see here](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions.html#cfn-ecs-taskdefinition-containerdefinition-entrypoint)). Given inputs of `entrypoint` and `command` from `manifest.yml`, which can be type string or type slice of strings, unifying their data types to slice of strings makes it easier to execute the data into CloudFormation templates.

Usage of the function can be found [here in #1999](https://github.com/aws/copilot-cli/pull/1999/files#diff-ef96052956ce8fb054feb98cffccafb463a32941e692eb3164b89330fd9d9ab8).

Preceding PR: #1976 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
