### PR TITLE
feat(deploy): deploy workloads with entrypoint and command overrides

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/backend_svc.go
+++ b/internal/pkg/deploy/cloudformation/stack/backend_svc.go
@@ -67,37 +67,39 @@ func NewBackendService(mft *manifest.BackendService, env, app string, rc Runtime
 
 // Template returns the CloudFormation template for the backend service.
 func (s *BackendService) Template() (string, error) {
-	desiredCountLambda, err := s.parser.Read(desiredCountGeneratorPath)
-	if err != nil {
-		return "", fmt.Errorf("read desired count lambda: %w", err)
-	}
-	outputs, err := s.addonsOutputs()
-	if err != nil {
-		return "", err
-	}
-	sidecars, err := convertSidecar(s.manifest.Sidecars)
-	if err != nil {
-		return "", fmt.Errorf("convert the sidecar configuration for service %s: %w", s.name, err)
-	}
-	autoscaling, err := convertAutoscaling(&s.manifest.Count.Autoscaling)
-	if err != nil {
-		return "", fmt.Errorf("convert the Auto Scaling configuration for service %s: %w", s.name, err)
-	}
-	storage, err := convertStorageOpts(s.manifest.Storage)
-	if err != nil {
-		return "", fmt.Errorf("convert storage options for service %s: %w", s.name, err)
-	}
+	//desiredCountLambda, err := s.parser.Read(desiredCountGeneratorPath)
+	//if err != nil {
+	//	return "", fmt.Errorf("read desired count lambda: %w", err)
+	//}
+	//outputs, err := s.addonsOutputs()
+	//if err != nil {
+	//	return "", err
+	//}
+	//sidecars, err := convertSidecar(s.manifest.Sidecars)
+	//if err != nil {
+	//	return "", fmt.Errorf("convert the sidecar configuration for service %s: %w", s.name, err)
+	//}
+	//autoscaling, err := convertAutoscaling(&s.manifest.Count.Autoscaling)
+	//if err != nil {
+	//	return "", fmt.Errorf("convert the Auto Scaling configuration for service %s: %w", s.name, err)
+	//}
+	//storage, err := convertStorageOpts(s.manifest.Storage)
+	//if err != nil {
+	//	return "", fmt.Errorf("convert storage options for service %s: %w", s.name, err)
+	//}
 	content, err := s.parser.ParseBackendService(template.WorkloadOpts{
 		Variables:          s.manifest.BackendServiceConfig.Variables,
 		Secrets:            s.manifest.BackendServiceConfig.Secrets,
-		NestedStack:        outputs,
-		Sidecars:           sidecars,
-		Autoscaling:        autoscaling,
+		//NestedStack:        outputs,
+		//Sidecars:           sidecars,
+		//Autoscaling:        autoscaling,
 		HealthCheck:        s.manifest.BackendServiceConfig.ImageConfig.HealthCheckOpts(),
 		LogConfig:          convertLogging(s.manifest.Logging),
-		DesiredCountLambda: desiredCountLambda.String(),
-		Storage:            storage,
+		//DesiredCountLambda: desiredCountLambda.String(),
+		//Storage:            storage,
 		Network:            convertNetworkConfig(s.manifest.Network),
+		EntryPoint:         s.manifest.EntryPoint.ToStringSlice(),
+		Command:            s.manifest.Command.ToStringSlice(),
 	})
 	if err != nil {
 		return "", fmt.Errorf("parse backend service template: %w", err)

--- a/internal/pkg/deploy/cloudformation/stack/backend_svc.go
+++ b/internal/pkg/deploy/cloudformation/stack/backend_svc.go
@@ -67,36 +67,36 @@ func NewBackendService(mft *manifest.BackendService, env, app string, rc Runtime
 
 // Template returns the CloudFormation template for the backend service.
 func (s *BackendService) Template() (string, error) {
-	//desiredCountLambda, err := s.parser.Read(desiredCountGeneratorPath)
-	//if err != nil {
-	//	return "", fmt.Errorf("read desired count lambda: %w", err)
-	//}
-	//outputs, err := s.addonsOutputs()
-	//if err != nil {
-	//	return "", err
-	//}
-	//sidecars, err := convertSidecar(s.manifest.Sidecars)
-	//if err != nil {
-	//	return "", fmt.Errorf("convert the sidecar configuration for service %s: %w", s.name, err)
-	//}
-	//autoscaling, err := convertAutoscaling(&s.manifest.Count.Autoscaling)
-	//if err != nil {
-	//	return "", fmt.Errorf("convert the Auto Scaling configuration for service %s: %w", s.name, err)
-	//}
-	//storage, err := convertStorageOpts(s.manifest.Storage)
-	//if err != nil {
-	//	return "", fmt.Errorf("convert storage options for service %s: %w", s.name, err)
-	//}
+	desiredCountLambda, err := s.parser.Read(desiredCountGeneratorPath)
+	if err != nil {
+		return "", fmt.Errorf("read desired count lambda: %w", err)
+	}
+	outputs, err := s.addonsOutputs()
+	if err != nil {
+		return "", err
+	}
+	sidecars, err := convertSidecar(s.manifest.Sidecars)
+	if err != nil {
+		return "", fmt.Errorf("convert the sidecar configuration for service %s: %w", s.name, err)
+	}
+	autoscaling, err := convertAutoscaling(&s.manifest.Count.Autoscaling)
+	if err != nil {
+		return "", fmt.Errorf("convert the Auto Scaling configuration for service %s: %w", s.name, err)
+	}
+	storage, err := convertStorageOpts(s.manifest.Storage)
+	if err != nil {
+		return "", fmt.Errorf("convert storage options for service %s: %w", s.name, err)
+	}
 	content, err := s.parser.ParseBackendService(template.WorkloadOpts{
 		Variables:          s.manifest.BackendServiceConfig.Variables,
 		Secrets:            s.manifest.BackendServiceConfig.Secrets,
-		//NestedStack:        outputs,
-		//Sidecars:           sidecars,
-		//Autoscaling:        autoscaling,
+		NestedStack:        outputs,
+		Sidecars:           sidecars,
+		Autoscaling:        autoscaling,
 		HealthCheck:        s.manifest.BackendServiceConfig.ImageConfig.HealthCheckOpts(),
 		LogConfig:          convertLogging(s.manifest.Logging),
-		//DesiredCountLambda: desiredCountLambda.String(),
-		//Storage:            storage,
+		DesiredCountLambda: desiredCountLambda.String(),
+		Storage:            storage,
 		Network:            convertNetworkConfig(s.manifest.Network),
 		EntryPoint:         s.manifest.EntryPoint.ToStringSlice(),
 		Command:            s.manifest.Command.ToStringSlice(),

--- a/internal/pkg/deploy/cloudformation/stack/lb_web_svc.go
+++ b/internal/pkg/deploy/cloudformation/stack/lb_web_svc.go
@@ -132,6 +132,8 @@ func (s *LoadBalancedWebService) Template() (string, error) {
 		EnvControllerLambda: envControllerLambda.String(),
 		Storage:             storage,
 		Network:             convertNetworkConfig(s.manifest.Network),
+		EntryPoint:          s.manifest.EntryPoint.ToStringSlice(),
+		Command:             s.manifest.Command.ToStringSlice(),
 	})
 	if err != nil {
 		return "", err

--- a/internal/pkg/deploy/cloudformation/stack/lb_web_svc_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/lb_web_svc_test.go
@@ -92,6 +92,15 @@ func TestLoadBalancedWebService_Template(t *testing.T) {
 		Path: "frontend",
 		Port: 80,
 	})
+	testLBWebServiceManifest.EntryPoint = manifest.EntryPointOverride{
+		String: nil,
+		StringSlice: []string{"/bin/echo", "hello"},
+	}
+	testLBWebServiceManifest.Command = manifest.CommandOverride{
+		String: nil,
+		StringSlice: []string{"world"},
+	}
+
 	testCases := map[string]struct {
 		mockDependencies func(t *testing.T, ctrl *gomock.Controller, c *LoadBalancedWebService)
 		wantedTemplate   string
@@ -180,6 +189,8 @@ Outputs:
 						AssignPublicIP: template.EnablePublicIP,
 						SubnetsType:    template.PublicSubnetsPlacement,
 					},
+					EntryPoint: []string{"/bin/echo", "hello"},
+					Command: []string{"world"},
 				}).Return(&template.Content{Buffer: bytes.NewBufferString("template")}, nil)
 
 				addons := mockTemplater{err: &addon.ErrAddonsDirNotExist{}}
@@ -212,6 +223,8 @@ Outputs:
 						AssignPublicIP: template.EnablePublicIP,
 						SubnetsType:    template.PublicSubnetsPlacement,
 					},
+					EntryPoint: []string{"/bin/echo", "hello"},
+					Command: []string{"world"},
 				}).Return(&template.Content{Buffer: bytes.NewBufferString("template")}, nil)
 				addons := mockTemplater{
 					tpl: `Resources:

--- a/internal/pkg/deploy/cloudformation/stack/scheduled_job.go
+++ b/internal/pkg/deploy/cloudformation/stack/scheduled_job.go
@@ -152,6 +152,8 @@ func (j *ScheduledJob) Template() (string, error) {
 		LogConfig:          convertLogging(j.manifest.Logging),
 		Storage:            storage,
 		Network:            convertNetworkConfig(j.manifest.Network),
+		EntryPoint:         j.manifest.EntryPoint.ToStringSlice(),
+		Command:            j.manifest.Command.ToStringSlice(),
 	})
 	if err != nil {
 		return "", fmt.Errorf("parse scheduled job template: %w", err)

--- a/internal/pkg/manifest/backend_svc.go
+++ b/internal/pkg/manifest/backend_svc.go
@@ -36,8 +36,9 @@ type BackendService struct {
 // BackendServiceConfig holds the configuration that can be overriden per environments.
 type BackendServiceConfig struct {
 	ImageConfig imageWithPortAndHealthcheck `yaml:"image,flow"`
-	TaskConfig  `yaml:",inline"`
-	*Logging    `yaml:"logging,flow"`
+	ImageOverride `yaml:",inline"`
+	TaskConfig    `yaml:",inline"`
+	*Logging      `yaml:"logging,flow"`
 	Sidecars    map[string]*SidecarConfig `yaml:"sidecars"`
 	Network     NetworkConfig             `yaml:"network"`
 }

--- a/internal/pkg/manifest/job.go
+++ b/internal/pkg/manifest/job.go
@@ -37,6 +37,7 @@ type ScheduledJob struct {
 // ScheduledJobConfig holds the configuration for a scheduled job
 type ScheduledJobConfig struct {
 	ImageConfig             Image `yaml:"image,flow"`
+	ImageOverride           `yaml:",inline"`
 	TaskConfig              `yaml:",inline"`
 	*Logging                `yaml:"logging,flow"`
 	Sidecars                map[string]*SidecarConfig `yaml:"sidecars"`

--- a/internal/pkg/manifest/lb_web_svc.go
+++ b/internal/pkg/manifest/lb_web_svc.go
@@ -47,9 +47,10 @@ type LoadBalancedWebService struct {
 // LoadBalancedWebServiceConfig holds the configuration for a load balanced web service.
 type LoadBalancedWebServiceConfig struct {
 	ImageConfig ServiceImageWithPort `yaml:"image,flow"`
-	RoutingRule `yaml:"http,flow"`
-	TaskConfig  `yaml:",inline"`
-	*Logging    `yaml:"logging,flow"`
+	ImageOverride `yaml:",inline"`
+	RoutingRule   `yaml:"http,flow"`
+	TaskConfig    `yaml:",inline"`
+	*Logging      `yaml:"logging,flow"`
 	Sidecars    map[string]*SidecarConfig `yaml:"sidecars"`
 	Network     NetworkConfig             `yaml:"network"`
 }

--- a/internal/pkg/template/template_integration_test.go
+++ b/internal/pkg/template/template_integration_test.go
@@ -160,6 +160,13 @@ func TestTemplate_ParseLoadBalancedWebService(t *testing.T) {
 				},
 			},
 		},
+		"renders a valid template with entrypoint and command overrides": {
+			opts: template.WorkloadOpts{
+				HTTPHealthCheck: defaultHttpHealthCheck,
+				EntryPoint: []string{"/bin/echo", "hello"},
+				Command: []string{"world"},
+			},
+		},
 	}
 
 	for name, tc := range testCases {

--- a/internal/pkg/template/workload.go
+++ b/internal/pkg/template/workload.go
@@ -58,6 +58,7 @@ var (
 		"env-controller",
 		"mount-points",
 		"volumes",
+		"image-overrides",
 	}
 )
 

--- a/internal/pkg/template/workload.go
+++ b/internal/pkg/template/workload.go
@@ -176,6 +176,8 @@ type WorkloadOpts struct {
 	Autoscaling *AutoscalingOpts
 	Storage     *StorageOpts
 	Network     *NetworkOpts
+	EntryPoint  []string
+	Command     []string
 
 	// Additional options for service templates.
 	HealthCheck         *ecs.HealthCheck

--- a/internal/pkg/template/workload_test.go
+++ b/internal/pkg/template/workload_test.go
@@ -46,6 +46,7 @@ func TestTemplate_ParseSvc(t *testing.T) {
 				mockBox.AddString("workloads/partials/cf/env-controller.yml", "env-controller")
 				mockBox.AddString("workloads/partials/cf/mount-points.yml", "mount-points")
 				mockBox.AddString("workloads/partials/cf/volumes.yml", "volumes")
+				mockBox.AddString("workloads/partials/cf/image-overrides.yml", "image-overrides")
 
 				t.box = mockBox
 			},
@@ -67,6 +68,7 @@ func TestTemplate_ParseSvc(t *testing.T) {
   env-controller
   mount-points
   volumes
+  image-overrides
 `,
 		},
 	}

--- a/templates/workloads/jobs/scheduled-job/cf.yml
+++ b/templates/workloads/jobs/scheduled-job/cf.yml
@@ -44,6 +44,7 @@ Resources:
 {{include "envvars" . | indent 10}}
 {{include "secrets" . | indent 10}}
 {{include "logconfig" . | indent 10}}
+{{include "image-overrides" . | indent 10}}
 {{- if .Storage -}}
 {{include "mount-points" . | indent 10}}
 {{- end -}}

--- a/templates/workloads/partials/cf/image-overrides.yml
+++ b/templates/workloads/partials/cf/image-overrides.yml
@@ -1,0 +1,12 @@
+{{- if .EntryPoint}}
+EntryPoint:
+{{- range $part := .EntryPoint}}
+- {{$part}}
+{{- end}}
+{{- end -}}
+{{- if .Command}}
+Command:
+{{- range $part := .Command}}
+- {{$part}}
+{{- end }}
+{{- end -}}

--- a/templates/workloads/partials/cf/image-overrides.yml
+++ b/templates/workloads/partials/cf/image-overrides.yml
@@ -3,10 +3,10 @@ EntryPoint:
 {{- range $part := .EntryPoint}}
 - {{$part}}
 {{- end}}
-{{- end -}}
+{{- end}}
 {{- if .Command}}
 Command:
 {{- range $part := .Command}}
 - {{$part}}
-{{- end }}
-{{- end -}}
+{{- end}}
+{{- end}}

--- a/templates/workloads/services/backend/cf.yml
+++ b/templates/workloads/services/backend/cf.yml
@@ -48,6 +48,7 @@ Resources:
 {{include "envvars" . | indent 10}}
 {{include "secrets" . | indent 10}}
 {{include "logconfig" . | indent 10}}
+{{include "image-overrides" . | indent 10}}
 {{- if .HealthCheck}}
           HealthCheck:
             Command: {{quoteSlice .HealthCheck.Command | fmtSlice}}

--- a/templates/workloads/services/lb-web/cf.yml
+++ b/templates/workloads/services/lb-web/cf.yml
@@ -65,6 +65,7 @@ Resources:
 {{include "envvars" . | indent 10}}
           - Name: COPILOT_LB_DNS
             Value: !GetAtt EnvControllerAction.PublicLoadBalancerDNSName
+{{include "image-overrides" . | indent 10}}
 {{include "secrets" . | indent 10}}
 {{include "logconfig" . | indent 10}}
 {{- if .Storage -}}


### PR DESCRIPTION
This PR deploys workloads given entrypoint and command overrides read from `manifest.yml`.

Preceding PR: #1998 
Resolves #1950 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
