### PR TITLE
fix(cicd): remove Name field for test command build projects

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/bb_template.yaml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/bb_template.yaml
@@ -212,7 +212,7 @@ Resources:
   BuildTestCommandstest:
     Type: AWS::CodeBuild::Project
     Properties:
-      Name: BuildTestCommands-phonetool-test
+      Name: BuildTestCommands-phonetool-test-huanjani/sample-master
       EncryptionKey: !ImportValue phonetool-ArtifactKey
       ServiceRole: !GetAtt BuildProjectRole.Arn
       Artifacts:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/bb_template.yaml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/bb_template.yaml
@@ -209,10 +209,9 @@ Resources:
               - arn:aws:iam::1111:role/phonetool-test-EnvManagerRole
       Roles:
         - !Ref PipelineRole
-  BuildTestCommandstest:
+  BuildTestCommands-test:
     Type: AWS::CodeBuild::Project
     Properties:
-      Name: BuildTestCommands-phonetool-test-huanjani/sample-master
       EncryptionKey: !ImportValue phonetool-ArtifactKey
       ServiceRole: !GetAtt BuildProjectRole.Arn
       Artifacts:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/bb_template.yaml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/bb_template.yaml
@@ -209,7 +209,7 @@ Resources:
               - arn:aws:iam::1111:role/phonetool-test-EnvManagerRole
       Roles:
         - !Ref PipelineRole
-  BuildTestCommands-test:
+  BuildTestCommandstest:
     Type: AWS::CodeBuild::Project
     Properties:
       EncryptionKey: !ImportValue phonetool-ArtifactKey

--- a/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/cc_template.yaml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/cc_template.yaml
@@ -185,7 +185,7 @@ Resources:
   BuildTestCommandstest:
     Type: AWS::CodeBuild::Project
     Properties:
-      Name: BuildTestCommands-phonetool-test
+      Name: BuildTestCommands-phonetool-test-aws-sample-master
       EncryptionKey: !ImportValue phonetool-ArtifactKey
       ServiceRole: !GetAtt BuildProjectRole.Arn
       Artifacts:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/cc_template.yaml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/cc_template.yaml
@@ -182,10 +182,9 @@ Resources:
               - arn:aws:iam::1111:role/phonetool-test-EnvManagerRole
       Roles:
         - !Ref PipelineRole
-  BuildTestCommandstest:
+  BuildTestCommands-test:
     Type: AWS::CodeBuild::Project
     Properties:
-      Name: BuildTestCommands-phonetool-test-aws-sample-master
       EncryptionKey: !ImportValue phonetool-ArtifactKey
       ServiceRole: !GetAtt BuildProjectRole.Arn
       Artifacts:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/cc_template.yaml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/cc_template.yaml
@@ -182,7 +182,7 @@ Resources:
               - arn:aws:iam::1111:role/phonetool-test-EnvManagerRole
       Roles:
         - !Ref PipelineRole
-  BuildTestCommands-test:
+  BuildTestCommandstest:
     Type: AWS::CodeBuild::Project
     Properties:
       EncryptionKey: !ImportValue phonetool-ArtifactKey

--- a/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/gh_template.yaml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/gh_template.yaml
@@ -182,7 +182,7 @@ Resources:
               - arn:aws:iam::1111:role/phonetool-test-EnvManagerRole
       Roles:
         - !Ref PipelineRole
-  BuildTestCommands-test:
+  BuildTestCommandstest:
     Type: AWS::CodeBuild::Project
     Properties:
       EncryptionKey: !ImportValue phonetool-ArtifactKey

--- a/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/gh_template.yaml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/gh_template.yaml
@@ -182,10 +182,9 @@ Resources:
               - arn:aws:iam::1111:role/phonetool-test-EnvManagerRole
       Roles:
         - !Ref PipelineRole
-  BuildTestCommandstest:
+  BuildTestCommands-test:
     Type: AWS::CodeBuild::Project
     Properties:
-      Name: BuildTestCommands-phonetool-test-phonetool-mainline
       EncryptionKey: !ImportValue phonetool-ArtifactKey
       ServiceRole: !GetAtt BuildProjectRole.Arn
       Artifacts:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/gh_template.yaml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/gh_template.yaml
@@ -185,7 +185,7 @@ Resources:
   BuildTestCommandstest:
     Type: AWS::CodeBuild::Project
     Properties:
-      Name: BuildTestCommands-phonetool-test
+      Name: BuildTestCommands-phonetool-test-phonetool-mainline
       EncryptionKey: !ImportValue phonetool-ArtifactKey
       ServiceRole: !GetAtt BuildProjectRole.Arn
       Artifacts:

--- a/templates/cicd/pipeline_cfn.yml
+++ b/templates/cicd/pipeline_cfn.yml
@@ -222,7 +222,7 @@ Resources:
   BuildTestCommands{{$stage.Name}}:
     Type: AWS::CodeBuild::Project
     Properties:
-      Name: BuildTestCommands-{{$.AppName}}-{{$stage.Name}}
+      Name: BuildTestCommands-{{$.AppName}}-{{$stage.Name}}-{{$.Source.Repository}}-{{$.Source.Branch}}
       EncryptionKey: !ImportValue {{$.AppName}}-ArtifactKey
       ServiceRole: !GetAtt BuildProjectRole.Arn
       Artifacts:

--- a/templates/cicd/pipeline_cfn.yml
+++ b/templates/cicd/pipeline_cfn.yml
@@ -219,10 +219,9 @@ Resources:
         - !Ref PipelineRole
 {{- range $index, $stage := .Stages}}
   {{- if $stage.TestCommands}}
-  BuildTestCommands{{$stage.Name}}:
+  BuildTestCommands-{{$stage.Name}}:
     Type: AWS::CodeBuild::Project
     Properties:
-      Name: BuildTestCommands-{{$.AppName}}-{{$stage.Name}}-{{$.Source.Repository}}-{{$.Source.Branch}}
       EncryptionKey: !ImportValue {{$.AppName}}-ArtifactKey
       ServiceRole: !GetAtt BuildProjectRole.Arn
       Artifacts:

--- a/templates/cicd/pipeline_cfn.yml
+++ b/templates/cicd/pipeline_cfn.yml
@@ -219,7 +219,7 @@ Resources:
         - !Ref PipelineRole
 {{- range $index, $stage := .Stages}}
   {{- if $stage.TestCommands}}
-  BuildTestCommands-{{$stage.Name}}:
+  BuildTestCommands{{$stage.Name}}:
     Type: AWS::CodeBuild::Project
     Properties:
       EncryptionKey: !ImportValue {{$.AppName}}-ArtifactKey


### PR DESCRIPTION
This change gives Copilot pipelines more flexibility, as it enables users to build pipelines that share an app and env, but different repos/svcs or branches. We are seeing that customers want to build multiple pipelines for single apps, and this makes our pipeline functionality more extensible by avoiding overlapping CodeBuild project names. 

We have [255 characters](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codebuild-project.html#cfn-codebuild-project-name) to work with, so stringing together `BuildTestCommands-[appName]-[env/stageName]-[repoName]-[branchName]` should be okay.

UPDATE: We removed the Name field entirely.

Fixes #1986.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
