### PR TITLE
feat(cli): add entrypoint flag to `task run`

### DIFF
--- a/internal/pkg/cli/flag.go
+++ b/internal/pkg/cli/flag.go
@@ -200,7 +200,7 @@ Must be of the format '<keyName>:<dataType>'.`
 	executionRoleFlagDescription = "Optional. The ARN of the role that grants the container agent permission to make AWS API calls."
 	envVarsFlagDescription       = "Optional. Environment variables specified by key=value separated with commas."
 	commandFlagDescription       = `Optional. The command that is passed to "docker run" to override the default command.`
-	entrypointFlagDescription    = `Optional. A description for entrypoint.` //TODO
+	entrypointFlagDescription    = `Optional. The entrypoint that is passed to "docker run" to override the default entrypoint.`
 	taskGroupFlagDescription     = `Optional. The group name of the task. 
 Tasks with the same group name share the same set of resources. 
 (default directory name)`

--- a/internal/pkg/cli/flag.go
+++ b/internal/pkg/cli/flag.go
@@ -68,6 +68,7 @@ const (
 	securityGroupsFlag = "security-groups"
 	envVarsFlag        = "env-vars"
 	commandFlag        = "command"
+	entrypointFlag     = "entrypoint"
 	taskDefaultFlag    = "default"
 
 	vpcIDFlag          = "import-vpc-id"
@@ -199,6 +200,7 @@ Must be of the format '<keyName>:<dataType>'.`
 	executionRoleFlagDescription = "Optional. The ARN of the role that grants the container agent permission to make AWS API calls."
 	envVarsFlagDescription       = "Optional. Environment variables specified by key=value separated with commas."
 	commandFlagDescription       = `Optional. The command that is passed to "docker run" to override the default command.`
+	entrypointFlagDescription    = `Optional. A description for entrypoint.` //TODO
 	taskGroupFlagDescription     = `Optional. The group name of the task. 
 Tasks with the same group name share the same set of resources. 
 (default directory name)`

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/logging"
 	"github.com/aws/copilot-cli/internal/pkg/term/prompt"
 
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/copilot-cli/internal/pkg/aws/ec2"
 	"github.com/aws/copilot-cli/internal/pkg/aws/ecr"
 	awsecs "github.com/aws/copilot-cli/internal/pkg/aws/ecs"
@@ -29,11 +30,9 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/term/log"
 	termprogress "github.com/aws/copilot-cli/internal/pkg/term/progress"
 	"github.com/aws/copilot-cli/internal/pkg/term/selector"
-	"github.com/google/shlex"
-
-	"github.com/aws/aws-sdk-go/aws/session"
 
 	"github.com/dustin/go-humanize/english"
+	"github.com/google/shlex"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
@@ -86,6 +85,7 @@ type runTaskVars struct {
 
 	envVars      map[string]string
 	command      string
+	entrypoint   string
 	resourceTags map[string]string
 
 	follow bool
@@ -481,10 +481,17 @@ func (o *runTaskOpts) deploy() error {
 	if o.env != "" {
 		deployOpts = []awscloudformation.StackOption{awscloudformation.WithRoleARN(o.targetEnvironment.ExecutionRoleARN)}
 	}
+
+	entrypoint, err := shlex.Split(o.entrypoint)
+	if err != nil {
+		return fmt.Errorf("split entrypoint %s into tokens using shell-style rules: %w", o.entrypoint, err)
+	}
+
 	command, err := shlex.Split(o.command)
 	if err != nil {
 		return fmt.Errorf("split command %s into tokens using shell-style rules: %w", o.command, err)
 	}
+
 	input := &deploy.CreateTaskResourcesInput{
 		Name:           o.groupName,
 		CPU:            o.cpu,
@@ -493,6 +500,7 @@ func (o *runTaskOpts) deploy() error {
 		TaskRole:       o.taskRole,
 		ExecutionRole:  o.executionRole,
 		Command:        command,
+		EntryPoint:     entrypoint,
 		EnvVars:        o.envVars,
 		App:            o.appName,
 		Env:            o.env,
@@ -636,6 +644,7 @@ Run a task with a command.
 
 	cmd.Flags().StringToStringVar(&vars.envVars, envVarsFlag, nil, envVarsFlagDescription)
 	cmd.Flags().StringVar(&vars.command, commandFlag, "", commandFlagDescription)
+	cmd.Flags().StringVar(&vars.entrypoint, entrypointFlag, "", entrypointFlagDescription)
 	cmd.Flags().StringToStringVar(&vars.resourceTags, resourceTagsFlag, nil, resourceTagsFlagDescription)
 
 	cmd.Flags().BoolVar(&vars.follow, followFlag, false, followFlagDescription)

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -143,11 +143,11 @@ func newTaskRunOpts(vars runTaskVars) (*runTaskOpts, error) {
 	opts.configureRepository = func() error {
 		repoName := fmt.Sprintf(deploy.FmtTaskECRRepoName, opts.groupName)
 		registry := ecr.New(opts.sess)
-		repository, err := repository.New(repoName, registry)
+		repo, err := repository.New(repoName, registry)
 		if err != nil {
 			return fmt.Errorf("initialize repository %s: %w", repoName, err)
 		}
-		opts.repository = repository
+		opts.repository = repo
 		return nil
 	}
 

--- a/internal/pkg/cli/task_run_test.go
+++ b/internal/pkg/cli/task_run_test.go
@@ -639,9 +639,9 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 				m.repository.EXPECT().BuildAndPush(gomock.Any(), gomock.Eq(&defaultBuildArguments))
 				m.repository.EXPECT().URI().Return(mockRepoURI)
 				m.deployer.EXPECT().DeployTask(gomock.Any(), &deploy.CreateTaskResourcesInput{
-					Name:    inGroupName,
-					Image:   "uri/repo:latest",
-					Command: []string{},
+					Name:       inGroupName,
+					Image:      "uri/repo:latest",
+					Command:    []string{},
 					EntryPoint: []string{},
 				}).Times(1).Return(errors.New("error updating"))
 				mockHasDefaultCluster(m)

--- a/internal/pkg/deploy/cloudformation/stack/task.go
+++ b/internal/pkg/deploy/cloudformation/stack/task.go
@@ -27,6 +27,7 @@ const (
 	taskTaskRoleParamKey       = "TaskRole"
 	taskExecutionRoleParamKey  = "ExecutionRole"
 	taskCommandParamKey        = "Command"
+	taskEntryPointParamKey     = "EntryPoint"
 
 	taskLogRetentionInDays = "1"
 )
@@ -97,6 +98,10 @@ func (t *taskStackConfig) Parameters() ([]*cloudformation.Parameter, error) {
 		{
 			ParameterKey:   aws.String(taskCommandParamKey),
 			ParameterValue: aws.String(strings.Join(t.Command, ",")),
+		},
+		{
+			ParameterKey:   aws.String(taskEntryPointParamKey),
+			ParameterValue: aws.String(strings.Join(t.EntryPoint, ",")),
 		},
 	}, nil
 }

--- a/internal/pkg/deploy/cloudformation/stack/task_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/task_test.go
@@ -107,6 +107,10 @@ func TestTaskStackConfig_Parameters(t *testing.T) {
 			ParameterKey:   aws.String(taskCommandParamKey),
 			ParameterValue: aws.String("echo hooray"),
 		},
+		{
+			ParameterKey:   aws.String(taskEntryPointParamKey),
+			ParameterValue: aws.String("exec,some command"),
+		},
 	}
 
 	taskInput := deploy.CreateTaskResourcesInput{
@@ -118,6 +122,7 @@ func TestTaskStackConfig_Parameters(t *testing.T) {
 		TaskRole:      "task-role",
 		ExecutionRole: "execution-role",
 		Command:       []string{"echo hooray"},
+		EntryPoint:    []string{"exec", "some command"},
 	}
 
 	task := &taskStackConfig{

--- a/internal/pkg/deploy/task.go
+++ b/internal/pkg/deploy/task.go
@@ -23,6 +23,7 @@ type CreateTaskResourcesInput struct {
 	TaskRole      string
 	ExecutionRole string
 	Command       []string
+	EntryPoint    []string
 	EnvVars       map[string]string
 
 	App string

--- a/templates/task/cf.yml
+++ b/templates/task/cf.yml
@@ -19,6 +19,8 @@ Parameters:
     Type: String
   Command:
     Type: CommaDelimitedList
+  EntryPoint:
+    Type: CommaDelimitedList
 Conditions:
   # NOTE: Image cannot be pushed until the ECR repo is created, at which time ContainerImage would be "".
   HasImage:
@@ -29,6 +31,8 @@ Conditions:
     !Not [!Equals [!Ref ExecutionRole, ""]]
   HasCommand:
     !Not [!Equals [ !Join ["", !Ref Command], ""]]
+  HasEntryPoint:
+    !Not [ !Equals [ !Join [ "", !Ref EntryPoint ], "" ] ]
 Resources:
   TaskDefinition:
     Metadata:
@@ -40,6 +44,7 @@ Resources:
       ContainerDefinitions:
         -
           Image: !Ref ContainerImage
+          EntryPoint: !If [HasEntryPoint, !Ref EntryPoint, !Ref "AWS::NoValue"]
           Command: !If [HasCommand, !Ref Command, !Ref "AWS::NoValue"]
           LogConfiguration:
             LogDriver: awslogs


### PR DESCRIPTION
This PR adds `--entrypoint` flag to `task run` and deploy a task with entrypoint override.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
