### PR TITLE
chore: log cmd to create default cluster on task run error

### DIFF
--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -404,6 +404,11 @@ func (o *runTaskOpts) Execute() error {
 			return fmt.Errorf(`find "default" cluster to deploy the task to: %v`, err)
 		}
 		if !hasDefaultCluster {
+			log.Errorf(
+				"Looks like there is no \"default\" cluster in your region!\nPlease run %s to create the cluster first, and then re-run %s.\n",
+				color.HighlightCode("aws ecs create-cluster"),
+				color.HighlightCode("copilot task run"),
+			)
 			return errors.New(`cannot find a "default" cluster to deploy the task to`)
 		}
 	}

--- a/site/content/docs/commands/task-run.md
+++ b/site/content/docs/commands/task-run.md
@@ -16,8 +16,7 @@ Generally, the steps involved in task run are:
 !!!info
     1. Tasks with the same group name share the same set of resources, including the CloudFormation stack, ECR repository, CloudWatch log group and task definition.
     2. If the tasks are deployed to a Copilot environment (i.e. by specifying `--env`), only public subnets that are created by that environment will be used. 
-    3. The `--env` flag only works with environments created with v0.3.0 of Copilot or later. Customers using environments created with v0.2.0 or earlier can update their environment manager role with [this](https://github.com/aws/copilot-cli/blob/mainline/templates/environment/cf/environment-manager-role.yml) policy. 
-    4. If you are using the `--default` flag and get an error saying there's no default cluster, run `aws ecs create-cluster` and then re-run the Copilot command. 
+    3. If you are using the `--default` flag and get an error saying there's no default cluster, run `aws ecs create-cluster` and then re-run the Copilot command. 
 
 ## What are the flags?
 ```


### PR DESCRIPTION
When we don't set `--env` flags, [Copilot run task on default cluster](https://github.com/aws/copilot-cli/blob/mainline/internal/pkg/cli/task_run.go#L197).
In the old description, it is difficult to understand what happens if we don't set `--default` flag.

Copilot allows to deploy the service to another region(environment) without changing profile's region, but task run without `--env` use default region only (perhaps) so I added description about region.
I think it is better to add `--region` option in `run task` command but there is a workaround so I can't say it should be done 🤔 
Therefore, I added only the explanation first.
