### PR TITLE
chore: ignore INACTIVE cluster in DefaultCluster

### DIFF
--- a/internal/pkg/aws/ecs/ecs.go
+++ b/internal/pkg/aws/ecs/ecs.go
@@ -189,13 +189,15 @@ func (e *ECS) DefaultCluster() (string, error) {
 		return "", fmt.Errorf("get default cluster: %w", err)
 	}
 
-	if len(resp.Clusters) == 0 {
-		return "", ErrNoDefaultCluster
+	for _, cluster := range resp.Clusters {
+		// NOTE: right now at most 1 default cluster is possible, so first cluster must be the default cluster
+
+		if aws.StringValue(cluster.Status) != "INACTIVE" {
+			return aws.StringValue(cluster.ClusterArn), nil
+		}
 	}
 
-	// NOTE: right now at most 1 default cluster is possible, so cluster[0] must be the default cluster
-	cluster := resp.Clusters[0]
-	return aws.StringValue(cluster.ClusterArn), nil
+	return "", ErrNoDefaultCluster
 }
 
 // HasDefaultCluster tries to find the default cluster and returns true if there is one.

--- a/internal/pkg/aws/ecs/ecs_test.go
+++ b/internal/pkg/aws/ecs/ecs_test.go
@@ -433,6 +433,27 @@ func TestECS_DefaultCluster(t *testing.T) {
 
 			wantedClusters: "arn:aws:ecs:us-east-1:0123456:cluster/cluster1",
 		},
+		"ignore inactive cluster": {
+			mockECSClient: func(m *mocks.Mockapi) {
+				m.EXPECT().
+					DescribeClusters(&ecs.DescribeClustersInput{}).
+					Return(&ecs.DescribeClustersOutput{
+						Clusters: []*ecs.Cluster{
+							{
+								ClusterArn:  aws.String("arn:aws:ecs:us-east-1:0123456:cluster/cluster1"),
+								ClusterName: aws.String("cluster1"),
+								Status:      aws.String("INACTIVE"),
+							},
+							{
+								ClusterArn:  aws.String("arn:aws:ecs:us-east-1:0123456:cluster/cluster2"),
+								ClusterName: aws.String("cluster2"),
+							},
+						},
+					}, nil)
+			},
+
+			wantedClusters: "arn:aws:ecs:us-east-1:0123456:cluster/cluster2",
+		},
 		"failed to get default clusters": {
 			mockECSClient: func(m *mocks.Mockapi) {
 				m.EXPECT().

--- a/internal/pkg/aws/ecs/ecs_test.go
+++ b/internal/pkg/aws/ecs/ecs_test.go
@@ -422,12 +422,12 @@ func TestECS_DefaultCluster(t *testing.T) {
 							{
 								ClusterArn:  aws.String("arn:aws:ecs:us-east-1:0123456:cluster/cluster1"),
 								ClusterName: aws.String("cluster1"),
-								Status:      aws.String("ACTIVE"),
+								Status:      aws.String(clusterStatusActive),
 							},
 							{
 								ClusterArn:  aws.String("arn:aws:ecs:us-east-1:0123456:cluster/cluster2"),
 								ClusterName: aws.String("cluster2"),
-								Status:      aws.String("ACTIVE"),
+								Status:      aws.String(clusterStatusActive),
 							},
 						},
 					}, nil)
@@ -510,7 +510,10 @@ func TestECS_HasDefaultCluster(t *testing.T) {
 				m.EXPECT().DescribeClusters(&ecs.DescribeClustersInput{}).
 					Return(&ecs.DescribeClustersOutput{
 						Clusters: []*ecs.Cluster{
-							{ClusterArn: aws.String("cluster"), Status: aws.String("ACTIVE")},
+							{
+								ClusterArn: aws.String("cluster"),
+								Status:     aws.String(clusterStatusActive),
+							},
 						},
 					}, nil)
 			},

--- a/internal/pkg/aws/ecs/ecs_test.go
+++ b/internal/pkg/aws/ecs/ecs_test.go
@@ -422,10 +422,12 @@ func TestECS_DefaultCluster(t *testing.T) {
 							{
 								ClusterArn:  aws.String("arn:aws:ecs:us-east-1:0123456:cluster/cluster1"),
 								ClusterName: aws.String("cluster1"),
+								Status:      aws.String("ACTIVE"),
 							},
 							{
 								ClusterArn:  aws.String("arn:aws:ecs:us-east-1:0123456:cluster/cluster2"),
 								ClusterName: aws.String("cluster2"),
+								Status:      aws.String("ACTIVE"),
 							},
 						},
 					}, nil)
@@ -444,15 +446,10 @@ func TestECS_DefaultCluster(t *testing.T) {
 								ClusterName: aws.String("cluster1"),
 								Status:      aws.String("INACTIVE"),
 							},
-							{
-								ClusterArn:  aws.String("arn:aws:ecs:us-east-1:0123456:cluster/cluster2"),
-								ClusterName: aws.String("cluster2"),
-							},
 						},
 					}, nil)
 			},
-
-			wantedClusters: "arn:aws:ecs:us-east-1:0123456:cluster/cluster2",
+			wantedError: fmt.Errorf("default cluster does not exist"),
 		},
 		"failed to get default clusters": {
 			mockECSClient: func(m *mocks.Mockapi) {
@@ -513,7 +510,7 @@ func TestECS_HasDefaultCluster(t *testing.T) {
 				m.EXPECT().DescribeClusters(&ecs.DescribeClustersInput{}).
 					Return(&ecs.DescribeClustersOutput{
 						Clusters: []*ecs.Cluster{
-							{ClusterArn: aws.String("cluster")},
+							{ClusterArn: aws.String("cluster"), Status: aws.String("ACTIVE")},
 						},
 					}, nil)
 			},


### PR DESCRIPTION
When we delete ECS cluster, AWS return it as INACTIVE cluster.

```
INACTIVE
The cluster has been deleted. Clusters with an INACTIVE status may remain discoverable in your account for a period of time. However, this behavior is subject to change in the future, so you should not rely on INACTIVE clusters persisting.
```
https://docs.aws.amazon.com/AmazonECS/latest/developerguide/clusters.html

We can't run task on INACTIVE cluster so we should ignore it.
