### PR TITLE
feat(cli): allow to reject any ssm plugin install/update

### DIFF
--- a/internal/pkg/cli/exec.go
+++ b/internal/pkg/cli/exec.go
@@ -15,4 +15,5 @@ type execVars struct {
 	taskID           string
 	containerName    string
 	skipConfirmation bool
+	yes              *bool
 }

--- a/internal/pkg/cli/exec.go
+++ b/internal/pkg/cli/exec.go
@@ -14,6 +14,5 @@ type execVars struct {
 	command          string
 	taskID           string
 	containerName    string
-	skipConfirmation bool
-	yes              *bool
+	skipConfirmation *bool // If nil, we will prompt to upgrade the ssm plugin.
 }

--- a/internal/pkg/cli/flag.go
+++ b/internal/pkg/cli/flag.go
@@ -155,6 +155,7 @@ const (
 	pipelineFlagDescription = "Name of the pipeline."
 	profileFlagDescription  = "Name of the profile."
 	yesFlagDescription      = "Skips confirmation prompt."
+	execYesFlagDescription  = "Optional. Whether to install/update the Session Manager Plugin."
 	jsonFlagDescription     = "Optional. Outputs in JSON format."
 
 	imageTagFlagDescription     = `Optional. The container image tag.`

--- a/internal/pkg/cli/flag.go
+++ b/internal/pkg/cli/flag.go
@@ -155,7 +155,7 @@ const (
 	pipelineFlagDescription = "Name of the pipeline."
 	profileFlagDescription  = "Name of the profile."
 	yesFlagDescription      = "Skips confirmation prompt."
-	execYesFlagDescription  = "Optional. Whether to install/update the Session Manager Plugin."
+	execYesFlagDescription  = "Optional. Whether to update the Session Manager Plugin."
 	jsonFlagDescription     = "Optional. Outputs in JSON format."
 
 	imageTagFlagDescription     = `Optional. The container image tag.`

--- a/internal/pkg/cli/svc_exec_test.go
+++ b/internal/pkg/cli/svc_exec_test.go
@@ -37,8 +37,8 @@ func TestSvcExec_Validate(t *testing.T) {
 	)
 	mockErr := errors.New("some error")
 	testCases := map[string]struct {
-		yes        *bool
-		setupMocks func(mocks execSvcMocks)
+		skipConfirmation *bool
+		setupMocks       func(mocks execSvcMocks)
 
 		wantedError error
 	}{
@@ -77,7 +77,7 @@ func TestSvcExec_Validate(t *testing.T) {
 			wantedError: fmt.Errorf("some error"),
 		},
 		"skip without installing/updating if yes flag is set to be false": {
-			yes: aws.Bool(false),
+			skipConfirmation: aws.Bool(false),
 			setupMocks: func(m execSvcMocks) {
 				gomock.InOrder(
 					m.storeSvc.EXPECT().GetApplication("my-app").Return(&config.Application{
@@ -266,7 +266,7 @@ func TestSvcExec_Validate(t *testing.T) {
 			wantedError: nil,
 		},
 		"valid case with ssm plugin updating and skip confirming to install": {
-			yes: aws.Bool(true),
+			skipConfirmation: aws.Bool(true),
 			setupMocks: func(m execSvcMocks) {
 				gomock.InOrder(
 					m.storeSvc.EXPECT().GetApplication("my-app").Return(&config.Application{
@@ -308,10 +308,10 @@ func TestSvcExec_Validate(t *testing.T) {
 
 			execSvcs := &svcExecOpts{
 				execVars: execVars{
-					name:    inputSvc,
-					appName: inputApp,
-					envName: inputEnv,
-					yes:     tc.yes,
+					name:             inputSvc,
+					appName:          inputApp,
+					envName:          inputEnv,
+					skipConfirmation: tc.skipConfirmation,
 				},
 				store:            mockStoreReader,
 				ssmPluginManager: mockSSMPluginManager,

--- a/internal/pkg/cli/task_exec.go
+++ b/internal/pkg/cli/task_exec.go
@@ -89,7 +89,7 @@ func (o *taskExecOpts) Validate() error {
 			return err
 		}
 	}
-	return validateSSMBinary(o.prompter, o.ssmPluginManager, o.yes)
+	return validateSSMBinary(o.prompter, o.ssmPluginManager, o.skipConfirmation)
 }
 
 // Ask asks for fields that are required but not passed in.
@@ -192,6 +192,7 @@ func (o *taskExecOpts) configSession() (*session.Session, error) {
 
 // buildTaskExecCmd builds the command for execute a running container in a one-off task.
 func buildTaskExecCmd() *cobra.Command {
+	var skipPrompt bool
 	vars := taskExecVars{}
 	cmd := &cobra.Command{
 		Use:   "exec",
@@ -209,9 +210,9 @@ func buildTaskExecCmd() *cobra.Command {
 				return err
 			}
 			if cmd.Flags().Changed(yesFlag) {
-				opts.yes = aws.Bool(false)
-				if opts.skipConfirmation {
-					opts.yes = aws.Bool(true)
+				opts.skipConfirmation = aws.Bool(false)
+				if skipPrompt {
+					opts.skipConfirmation = aws.Bool(true)
 				}
 			}
 			if err := opts.Validate(); err != nil {
@@ -229,7 +230,7 @@ func buildTaskExecCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&vars.command, commandFlag, commandFlagShort, defaultCommand, execCommandFlagDescription)
 	cmd.Flags().StringVar(&vars.taskID, taskIDFlag, "", taskIDFlagDescription)
 	cmd.Flags().BoolVar(&vars.useDefault, taskDefaultFlag, false, taskExecDefaultFlagDescription)
-	cmd.Flags().BoolVar(&vars.skipConfirmation, yesFlag, false, execYesFlagDescription)
+	cmd.Flags().BoolVar(&skipPrompt, yesFlag, false, execYesFlagDescription)
 
 	cmd.SetUsageTemplate(template.Usage)
 	return cmd

--- a/internal/pkg/cli/task_exec.go
+++ b/internal/pkg/cli/task_exec.go
@@ -89,7 +89,7 @@ func (o *taskExecOpts) Validate() error {
 			return err
 		}
 	}
-	return validateSSMBinary(o.prompter, o.ssmPluginManager, o.skipConfirmation)
+	return validateSSMBinary(o.prompter, o.ssmPluginManager, o.yes)
 }
 
 // Ask asks for fields that are required but not passed in.
@@ -208,6 +208,12 @@ func buildTaskExecCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if cmd.Flags().Changed(yesFlag) {
+				opts.yes = aws.Bool(false)
+				if opts.skipConfirmation {
+					opts.yes = aws.Bool(true)
+				}
+			}
 			if err := opts.Validate(); err != nil {
 				return err
 			}
@@ -223,7 +229,7 @@ func buildTaskExecCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&vars.command, commandFlag, commandFlagShort, defaultCommand, execCommandFlagDescription)
 	cmd.Flags().StringVar(&vars.taskID, taskIDFlag, "", taskIDFlagDescription)
 	cmd.Flags().BoolVar(&vars.useDefault, taskDefaultFlag, false, taskExecDefaultFlagDescription)
-	cmd.Flags().BoolVar(&vars.skipConfirmation, yesFlag, false, yesFlagDescription)
+	cmd.Flags().BoolVar(&vars.skipConfirmation, yesFlag, false, execYesFlagDescription)
 
 	cmd.SetUsageTemplate(template.Usage)
 	return cmd


### PR DESCRIPTION
<!-- Provide summary of changes -->
This PR makes it possible to reject any SSM plugin install/update with `--yes=false`. Technically not many users want to use this feature. It is mainly for the e2e tests so that we can skip without updating the SSM plugin.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
