### PR TITLE
chore: remove unused make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,22 +130,6 @@ tools:
 	@echo "Installing custom resource dependencies" &&\
 	cd ${SOURCE_CUSTOM_RESOURCES} && npm install
 
-# Run the docs locally.
-.PHONY: start-docs
-start-docs:
-	cd ${SOURDE_DOCS} &&\
-	git submodule update --init --recursive &&\
-	hugo server -D
-
-# Build and minify the documentation to the docs/ directory.
-.PHONY: build-docs
-build-docs:
-	cd ${SOURDE_DOCS} &&\
-	git submodule update --init --recursive &&\
-	npm install &&\
-	hugo &&\
-	cd ..
-
 .PHONY: gen-mocks
 gen-mocks: tools
 	# TODO: make this more extensible?


### PR DESCRIPTION
Docs are now generated using GitHub actions, so these targets are no
longer necessary.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
