### PR TITLE
test(e2e): fix flaky task exec

### DIFF
--- a/e2e/exec/exec_test.go
+++ b/e2e/exec/exec_test.go
@@ -276,7 +276,7 @@ var _ = Describe("exec flow", func() {
 					EnvName: envName,
 				})
 				return resp, err
-			}, "60s", "10s").ShouldNot(BeEmpty())
+			}, "120s", "20s").ShouldNot(BeEmpty())
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp).To(ContainSubstring("hello"))


### PR DESCRIPTION
<!-- Provide summary of changes -->
Fix flaky task exec by increasing the interval because it could take more than 10s (though very rare) to respond for each request.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
