### PR TITLE
feat(cicd): add conditional field in pipeline manifest for connection_name

### DIFF
--- a/internal/pkg/manifest/pipeline.go
+++ b/internal/pkg/manifest/pipeline.go
@@ -230,6 +230,14 @@ func UnmarshalPipeline(in []byte) (*PipelineManifest, error) {
 	return nil, errors.New("unexpected error occurs while unmarshalling pipeline.yml")
 }
 
+// IsCodeStarConnection indicates to the manifest if this source requires a CSC connection.
+func (s Source) IsCodeStarConnection() bool {
+	if s.ProviderName == "GitHub" || s.ProviderName == "Bitbucket" {
+		return true
+	}
+	return false
+}
+
 func validateVersion(pm *PipelineManifest) (PipelineSchemaMajorVersion, error) {
 	switch pm.Version {
 	case Ver1:

--- a/internal/pkg/manifest/pipeline.go
+++ b/internal/pkg/manifest/pipeline.go
@@ -232,10 +232,14 @@ func UnmarshalPipeline(in []byte) (*PipelineManifest, error) {
 
 // IsCodeStarConnection indicates to the manifest if this source requires a CSC connection.
 func (s Source) IsCodeStarConnection() bool {
-	if s.ProviderName == "GitHub" || s.ProviderName == "Bitbucket" {
+	switch s.ProviderName {
+	case GithubProviderName:
 		return true
+	case BitbucketProviderName:
+		return true
+	default:
+		return false
 	}
-	return false
 }
 
 func validateVersion(pm *PipelineManifest) (PipelineSchemaMajorVersion, error) {

--- a/site/content/docs/concepts/pipelines.md
+++ b/site/content/docs/concepts/pipelines.md
@@ -74,6 +74,8 @@ source:
   properties:
     branch: main
     repository: https://github.com/kohidave/demo-api-frontend
+    # Optional: specify the name of an existing CodeStar Connections connection.
+    # connection_name:
 
 # The deployment section defines the order the pipeline will deploy
 # to your environments.
@@ -90,7 +92,7 @@ stages:
 
 There are 3 main parts of this file: the `name` field, which is the name of your CodePipeline, the `source` section, which details the repository and branch to track, and the `stages` section, which lists the environments you want this pipeline to deploy to. You can update this anytime, but you must run `copilot pipeline update` afterwards.
 
-Typically, you'll update this file if you add new environments you want to deploy to, or want to track a different branch. The pipeline manifest is also where you may add a manual approval step before deployment or commands to run tests (see "Adding Tests," below) after deployment.
+Typically, you'll update this file if you add new environments you want to deploy to, or want to track a different branch. If you are using CodeStar Connections to connect to your repository and would like to utilize an existing connection rather than let Copilot generate one for you, you may add the connection name here. The pipeline manifest is also where you may add a manual approval step before deployment or commands to run tests (see "Adding Tests," below) after deployment.
 
 ### Step 3: Updating the Buildspec (optional)
 

--- a/site/content/docs/concepts/pipelines.md
+++ b/site/content/docs/concepts/pipelines.md
@@ -75,7 +75,7 @@ source:
     branch: main
     repository: https://github.com/kohidave/demo-api-frontend
     # Optional: specify the name of an existing CodeStar Connections connection.
-    # connection_name:
+    # connection_name: a-connection
 
 # The deployment section defines the order the pipeline will deploy
 # to your environments.

--- a/site/content/docs/manifest/pipeline.md
+++ b/site/content/docs/manifest/pipeline.md
@@ -12,7 +12,7 @@ List of all available properties for a Copilot pipeline manifest.
         branch: main
         repository: https://github.com/<user>/sample-app-frontend
         # Optional: specify the name of an existing CodeStar Connections connection.
-        connection_name: MyPreexistingConnection
+        connection_name: a-connection
     
     stages:
         - 
@@ -56,7 +56,7 @@ The name of the branch in your repository that triggers the pipeline. The defaul
 The URL of your repository.
 
 <span class="parent-field">source.properties.</span><a id="source-properties-connection-name" href="#source-properties-connection-name" class="field">`connection_name`</a> <span class="type">String</span>  
-The name of an existing CodeStar Connections connection. By default, Copilot will generate a connection for you.
+The name of an existing CodeStar Connections connection. If omitted, Copilot will generate a connection for you.
 
 <div class="separator"></div>
 

--- a/site/content/docs/manifest/pipeline.md
+++ b/site/content/docs/manifest/pipeline.md
@@ -11,6 +11,8 @@ List of all available properties for a Copilot pipeline manifest.
       properties:
         branch: main
         repository: https://github.com/<user>/sample-app-frontend
+        # Optional: specify the name of an existing CodeStar Connections connection.
+        connection_name:
     
     stages:
         - 
@@ -52,6 +54,9 @@ The name of the branch in your repository that triggers the pipeline. The defaul
 
 <span class="parent-field">source.properties.</span><a id="source-properties-repository" href="#source-properties-repository" class="field">`repository`</a> <span class="type">String</span>  
 The URL of your repository.
+
+<span class="parent-field">source.properties.</span><a id="source-properties-connection-name" href="#source-properties-connection-name" class="field">`connection_name`</a> <span class="type">String</span>  
+The name of an existing CodeStar Connections connection. By default, Copilot will generate a connection for you.
 
 <div class="separator"></div>
 

--- a/site/content/docs/manifest/pipeline.md
+++ b/site/content/docs/manifest/pipeline.md
@@ -12,7 +12,7 @@ List of all available properties for a Copilot pipeline manifest.
         branch: main
         repository: https://github.com/<user>/sample-app-frontend
         # Optional: specify the name of an existing CodeStar Connections connection.
-        connection_name:
+        connection_name: MyPreexistingConnection
     
     stages:
         - 

--- a/templates/cicd/pipeline.yml
+++ b/templates/cicd/pipeline.yml
@@ -17,7 +17,7 @@ source:
     {{$key}}: {{$value}}{{end}}
     {{- if .Source.IsCodeStarConnection}}
     # Optional: specify the name of an existing CodeStar Connections connection.
-    # connection_name:
+    # connection_name: a-connection
     {{- end}}
 {{$length := len .Stages}}{{if gt $length 0}}
 # The deployment section defines the order the pipeline will deploy

--- a/templates/cicd/pipeline.yml
+++ b/templates/cicd/pipeline.yml
@@ -15,6 +15,10 @@ source:
   # has the following properties: repository, branch.
   properties:{{range $key, $value := .Source.Properties}}
     {{$key}}: {{$value}}{{end}}
+    {{- if .Source.IsCodeStarConnection}}
+    # Optional: specify the name of an existing CodeStar Connections connection.
+    # connection_name:
+    {{- end}}
 {{$length := len .Stages}}{{if gt $length 0}}
 # The deployment section defines the order the pipeline will deploy
 # to your environments.


### PR DESCRIPTION
These changes add a commented-out optional field in the pipeline manifest for `connection_name` when the source provider is GitHub or Bitbucket.
Manually tested with non-CSC, Bb, GH, CSC w/ existing connection, CSC w/o existing connection.

Updated docs accordingly.

Related https://github.com/aws/copilot-cli/pull/2042, Resolves #2012, Resolves #1247, Related #1339.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
