### PR TITLE
chore: add missing struct so tests don't break

### DIFF
--- a/internal/pkg/template/workload.go
+++ b/internal/pkg/template/workload.go
@@ -88,6 +88,7 @@ type StorageOpts struct {
 	Volumes     []*Volume
 	MountPoints []*MountPoint
 	EFSPerms    []*EFSPermission
+	AccessPoint *AccessPointInfo // Used for delegating CreationInfo for Copilot-managed EFS.
 }
 
 // EFSPermission holds information needed to render an IAM policy statement.
@@ -115,6 +116,12 @@ type Volume struct {
 	// Authorization Config
 	AccessPointID *string
 	IAM           *string // ENABLED or DISABLED
+}
+
+// AccessPointInfo holds information about how to create Copilot-managed access points
+type AccessPointInfo struct {
+	Uid *string
+	Gid *string
 }
 
 // LogConfigOpts holds configuration that's needed if the service is configured with Firelens to route

--- a/internal/pkg/template/workload.go
+++ b/internal/pkg/template/workload.go
@@ -88,7 +88,7 @@ type StorageOpts struct {
 	Volumes           []*Volume
 	MountPoints       []*MountPoint
 	EFSPerms          []*EFSPermission
-	CopilotVolumeInfo *CopilotVolumeCreationInfo // Used for delegating CreationInfo for Copilot-managed EFS.
+	ManagedVolumeInfo *ManagedVolumeCreationInfo // Used for delegating CreationInfo for Copilot-managed EFS.
 }
 
 // EFSPermission holds information needed to render an IAM policy statement.
@@ -118,8 +118,8 @@ type Volume struct {
 	IAM           *string // ENABLED or DISABLED
 }
 
-// CopilotVolumeCreationInfo holds information about how to create Copilot-managed access points
-type CopilotVolumeCreationInfo struct {
+// ManagedVolumeCreationInfo holds information about how to create Copilot-managed access points.
+type ManagedVolumeCreationInfo struct {
 	Name *string
 	UID  *string
 	GID  *string

--- a/internal/pkg/template/workload.go
+++ b/internal/pkg/template/workload.go
@@ -85,10 +85,10 @@ type SidecarOpts struct {
 
 // StorageOpts holds data structures for rendering Volumes and Mount Points
 type StorageOpts struct {
-	Volumes     []*Volume
-	MountPoints []*MountPoint
-	EFSPerms    []*EFSPermission
-	AccessPoint *AccessPointInfo // Used for delegating CreationInfo for Copilot-managed EFS.
+	Volumes           []*Volume
+	MountPoints       []*MountPoint
+	EFSPerms          []*EFSPermission
+	CopilotVolumeInfo *CopilotVolumeCreationInfo // Used for delegating CreationInfo for Copilot-managed EFS.
 }
 
 // EFSPermission holds information needed to render an IAM policy statement.
@@ -118,10 +118,11 @@ type Volume struct {
 	IAM           *string // ENABLED or DISABLED
 }
 
-// AccessPointInfo holds information about how to create Copilot-managed access points
-type AccessPointInfo struct {
-	Uid *string
-	Gid *string
+// CopilotVolumeCreationInfo holds information about how to create Copilot-managed access points
+type CopilotVolumeCreationInfo struct {
+	Name *string
+	UID  *string
+	GID  *string
 }
 
 // LogConfigOpts holds configuration that's needed if the service is configured with Firelens to route

--- a/templates/workloads/partials/cf/efs-access-point.yml
+++ b/templates/workloads/partials/cf/efs-access-point.yml
@@ -1,5 +1,5 @@
 {{- if .Storage}}
-{{- if .Storage.CopilotVolumeInfo}}
+{{- if .Storage.ManagedVolumeInfo}}
 AccessPoint:
   Type: AWS::EFS::AccessPoint
   Properties:
@@ -8,13 +8,13 @@ AccessPoint:
       Fn::ImportValue:
         !Sub '${AppName}-${EnvName}-FilesystemID'
     PosixUser: 
-      Uid: {{.Storage.CopilotVolumeInfo.UID}}
-      Gid: {{.Storage.CopilotVolumeInfo.GID}}
+      Uid: {{.Storage.ManagedVolumeInfo.UID}}
+      Gid: {{.Storage.ManagedVolumeInfo.GID}}
     RootDirectory: 
       Path: !Sub '/${WorkloadName}'
       CreationInfo:
-        OwnerUid: {{.Storage.CopilotVolumeInfo.UID}}
-        OwnerGid: {{.Storage.CopilotVolumeInfo.GID}}
+        OwnerUid: {{.Storage.ManagedVolumeInfo.UID}}
+        OwnerGid: {{.Storage.ManagedVolumeInfo.GID}}
         Permissions: 0755
 {{- end}}
 {{- end}}

--- a/templates/workloads/partials/cf/efs-access-point.yml
+++ b/templates/workloads/partials/cf/efs-access-point.yml
@@ -1,5 +1,5 @@
 {{- if .Storage}}
-{{- if .Storage.AccessPoint}}
+{{- if .Storage.CopilotVolumeInfo}}
 AccessPoint:
   Type: AWS::EFS::AccessPoint
   Properties:
@@ -8,13 +8,13 @@ AccessPoint:
       Fn::ImportValue:
         !Sub '${AppName}-${EnvName}-FilesystemID'
     PosixUser: 
-      Uid: {{.Storage.AccessPoint.Uid}}
-      Gid: {{.Storage.AccessPoint.Gid}}
+      Uid: {{.Storage.CopilotVolumeInfo.UID}}
+      Gid: {{.Storage.CopilotVolumeInfo.GID}}
     RootDirectory: 
       Path: !Sub '/${WorkloadName}'
       CreationInfo:
-        OwnerUid: {{.Storage.AccessPoint.Uid}}
-        OwnerGid: {{.Storage.AccessPoint.Gid}}
+        OwnerUid: {{.Storage.CopilotVolumeInfo.UID}}
+        OwnerGid: {{.Storage.CopilotVolumeInfo.GID}}
         Permissions: 0755
 {{- end}}
 {{- end}}

--- a/templates/workloads/partials/cf/taskrole.yml
+++ b/templates/workloads/partials/cf/taskrole.yml
@@ -70,7 +70,7 @@ TaskRole:
                 - !Sub 'arn:aws:elasticfilesystem:${AWS::Region}:${AWS::AccountId}:file-system/{{$EFS.FilesystemID}}'
       {{- end}}
       {{- end -}}
-      {{- if .Storage.CopilotVolumeInfo}}
+      {{- if .Storage.ManagedVolumeInfo}}
       - PolicyName: 'GrantAccessCopilotManagedEFS'
         PolicyDocument:
           Version: '2012-10-17'

--- a/templates/workloads/partials/cf/taskrole.yml
+++ b/templates/workloads/partials/cf/taskrole.yml
@@ -70,7 +70,7 @@ TaskRole:
                 - !Sub 'arn:aws:elasticfilesystem:${AWS::Region}:${AWS::AccountId}:file-system/{{$EFS.FilesystemID}}'
       {{- end}}
       {{- end -}}
-      {{- if .Storage.AccessPoint}}
+      {{- if .Storage.CopilotVolumeInfo}}
       - PolicyName: 'GrantAccessCopilotManagedEFS'
         PolicyDocument:
           Version: '2012-10-17'

--- a/templates/workloads/partials/cf/volumes.yml
+++ b/templates/workloads/partials/cf/volumes.yml
@@ -1,5 +1,17 @@
 {{- if .Storage.Volumes}}
 Volumes:
+{{- if .Storage.CopilotVolumeInfo}}
+  - Name: {{.Storage.CopilotVolumeInfo.Name}}
+    EFSVolumeConfiguration:
+      FilesystemId:
+        Fn::ImportValue:
+          !Sub '${AppName}-${EnvName}-FilesystemID'
+      RootDirectory: "/"
+      TransitEncryption: ENABLED
+      AuthorizationConfig:
+        AccessPointId: !Ref AccessPoint
+        IAM: ENABLED
+{{- end}}
 {{- range $vol := .Storage.Volumes}}
   - Name: {{$vol.Name}}
     EFSVolumeConfiguration:

--- a/templates/workloads/partials/cf/volumes.yml
+++ b/templates/workloads/partials/cf/volumes.yml
@@ -1,7 +1,7 @@
 {{- if .Storage.Volumes}}
 Volumes:
-{{- if .Storage.CopilotVolumeInfo}}
-  - Name: {{.Storage.CopilotVolumeInfo.Name}}
+{{- if .Storage.ManagedVolumeInfo}}
+  - Name: {{.Storage.ManagedVolumeInfo.Name}}
     EFSVolumeConfiguration:
       FilesystemId:
         Fn::ImportValue:


### PR DESCRIPTION
<!-- Provide summary of changes -->
I thought I fixed things before but I missed a struct that I hadn't added in the template. 

Turns out that golang templates don't like non-existent fields. 

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
