### PR TITLE
feat(stack): Allow sidecars to be marked as non-essential

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/transformers.go
+++ b/internal/pkg/deploy/cloudformation/stack/transformers.go
@@ -60,6 +60,7 @@ func convertSidecar(s map[string]*manifest.SidecarConfig) ([]*template.SidecarOp
 		sidecars = append(sidecars, &template.SidecarOpts{
 			Name:        aws.String(name),
 			Image:       config.Image,
+			Essential:   config.Essential,
 			Port:        port,
 			Protocol:    protocol,
 			CredsParam:  config.CredsParam,

--- a/internal/pkg/deploy/cloudformation/stack/transformers_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/transformers_test.go
@@ -18,6 +18,7 @@ func Test_convertSidecar(t *testing.T) {
 	mockImage := aws.String("mockImage")
 	mockMap := map[string]string{"foo": "bar"}
 	mockCredsParam := aws.String("mockCredsParam")
+	mockEssential := aws.Bool(false)
 	testCases := map[string]struct {
 		inPort string
 
@@ -39,6 +40,7 @@ func Test_convertSidecar(t *testing.T) {
 				Image:      mockImage,
 				Secrets:    mockMap,
 				Variables:  mockMap,
+				Essential:  mockEssential,
 			},
 		},
 		"good port with protocol": {
@@ -52,6 +54,7 @@ func Test_convertSidecar(t *testing.T) {
 				Image:      mockImage,
 				Secrets:    mockMap,
 				Variables:  mockMap,
+				Essential:  mockEssential,
 			},
 		},
 	}
@@ -63,6 +66,7 @@ func Test_convertSidecar(t *testing.T) {
 					Image:      mockImage,
 					Secrets:    mockMap,
 					Variables:  mockMap,
+					Essential:  mockEssential,
 					Port:       aws.String(tc.inPort),
 				},
 			}

--- a/internal/pkg/deploy/cloudformation/stack/transformers_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/transformers_test.go
@@ -18,9 +18,9 @@ func Test_convertSidecar(t *testing.T) {
 	mockImage := aws.String("mockImage")
 	mockMap := map[string]string{"foo": "bar"}
 	mockCredsParam := aws.String("mockCredsParam")
-	mockEssential := aws.Bool(false)
 	testCases := map[string]struct {
-		inPort string
+		inPort      string
+		inEssential bool
 
 		wanted    *template.SidecarOpts
 		wantedErr error
@@ -31,7 +31,8 @@ func Test_convertSidecar(t *testing.T) {
 			wantedErr: fmt.Errorf("cannot parse port mapping from b/a/d/P/o/r/t"),
 		},
 		"good port without protocol": {
-			inPort: "2000",
+			inPort:      "2000",
+			inEssential: true,
 
 			wanted: &template.SidecarOpts{
 				Name:       aws.String("foo"),
@@ -40,11 +41,12 @@ func Test_convertSidecar(t *testing.T) {
 				Image:      mockImage,
 				Secrets:    mockMap,
 				Variables:  mockMap,
-				Essential:  mockEssential,
+				Essential:  aws.Bool(true),
 			},
 		},
 		"good port with protocol": {
-			inPort: "2000/udp",
+			inPort:      "2000/udp",
+			inEssential: true,
 
 			wanted: &template.SidecarOpts{
 				Name:       aws.String("foo"),
@@ -54,7 +56,21 @@ func Test_convertSidecar(t *testing.T) {
 				Image:      mockImage,
 				Secrets:    mockMap,
 				Variables:  mockMap,
-				Essential:  mockEssential,
+				Essential:  aws.Bool(true),
+			},
+		},
+		"specify essential as false": {
+			inPort:     "2000",
+			inEssential: false,
+
+			wanted: &template.SidecarOpts{
+				Name:       aws.String("foo"),
+				Port:       aws.String("2000"),
+				CredsParam: mockCredsParam,
+				Image:      mockImage,
+				Secrets:    mockMap,
+				Variables:  mockMap,
+				Essential:  aws.Bool(false),
 			},
 		},
 	}
@@ -66,7 +82,7 @@ func Test_convertSidecar(t *testing.T) {
 					Image:      mockImage,
 					Secrets:    mockMap,
 					Variables:  mockMap,
-					Essential:  mockEssential,
+					Essential:  aws.Bool(tc.inEssential),
 					Port:       aws.String(tc.inPort),
 				},
 			}

--- a/internal/pkg/manifest/workload.go
+++ b/internal/pkg/manifest/workload.go
@@ -357,6 +357,7 @@ func (lc *Logging) GetEnableMetadata() *string {
 type SidecarConfig struct {
 	Port        *string             `yaml:"port"`
 	Image       *string             `yaml:"image"`
+	Essential   *bool               `yaml:"essential"`
 	CredsParam  *string             `yaml:"credentialsParameter"`
 	Variables   map[string]string   `yaml:"variables"`
 	Secrets     map[string]string   `yaml:"secrets"`

--- a/internal/pkg/template/workload.go
+++ b/internal/pkg/template/workload.go
@@ -75,6 +75,7 @@ type WorkloadNestedStackOpts struct {
 type SidecarOpts struct {
 	Name        *string
 	Image       *string
+	Essential   *bool
 	Port        *string
 	Protocol    *string
 	CredsParam  *string

--- a/templates/workloads/partials/cf/sidecars.yml
+++ b/templates/workloads/partials/cf/sidecars.yml
@@ -16,7 +16,8 @@
 {{- end}}
 {{- range $sidecar := .Sidecars}}
 - Name: {{$sidecar.Name}}
-  Image: {{$sidecar.Image}}{{if $sidecar.Port}}
+  Image: {{$sidecar.Image}}{{if $sidecar.Essential}}
+  Essential: {{$sidecar.Essential}}{{end}}{{if $sidecar.Port}}
   PortMappings:
     - ContainerPort: {{$sidecar.Port}}{{if $sidecar.Protocol}}
       Protocol: {{$sidecar.Protocol}}{{end}}{{end}}


### PR DESCRIPTION
Now we can specify essential parameter for sidecars in service manifest.

Addresses #2066

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
