### PR TITLE
chore(term): update select package to escape sgr sequence before trimming whitespace

### DIFF
--- a/internal/pkg/cli/mocks/mock_prompter.go
+++ b/internal/pkg/cli/mocks/mock_prompter.go
@@ -133,3 +133,23 @@ func (mr *MockprompterMockRecorder) SelectOne(message, help, options interface{}
 	varargs := append([]interface{}{message, help, options}, promptOpts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelectOne", reflect.TypeOf((*Mockprompter)(nil).SelectOne), varargs...)
 }
+
+// SelectOption mocks base method.
+func (m *Mockprompter) SelectOption(message, help string, opts []prompt.Option, promptCfgs ...prompt.PromptConfig) (string, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{message, help, opts}
+	for _, a := range promptCfgs {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "SelectOption", varargs...)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SelectOption indicates an expected call of SelectOption.
+func (mr *MockprompterMockRecorder) SelectOption(message, help, opts interface{}, promptCfgs ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{message, help, opts}, promptCfgs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelectOption", reflect.TypeOf((*Mockprompter)(nil).SelectOption), varargs...)
+}

--- a/internal/pkg/cli/prompter.go
+++ b/internal/pkg/cli/prompter.go
@@ -11,4 +11,5 @@ type prompter interface {
 	SelectOne(message, help string, options []string, promptOpts ...prompt.PromptConfig) (string, error)
 	MultiSelect(message, help string, options []string, promptOpts ...prompt.PromptConfig) ([]string, error)
 	Confirm(message, help string, promptOpts ...prompt.PromptConfig) (bool, error)
+	SelectOption(message, help string, opts []prompt.Option, promptCfgs ...prompt.PromptConfig) (value string, err error)
 }

--- a/internal/pkg/term/prompt/select.go
+++ b/internal/pkg/term/prompt/select.go
@@ -38,7 +38,7 @@ func (o Option) String() string {
 }
 
 // SelectOption prompts the user to select one option from options and returns the Value of the option.
-func (p Prompt) SelectOption(message string, opts []Option, promptCfgs ...PromptConfig) (value string, err error) {
+func (p Prompt) SelectOption(message, help string, opts []Option, promptCfgs ...PromptConfig) (value string, err error) {
 	if len(opts) <= 0 {
 		return "", ErrEmptyOptions
 	}
@@ -47,7 +47,7 @@ func (p Prompt) SelectOption(message string, opts []Option, promptCfgs ...Prompt
 	if err != nil {
 		return "", err
 	}
-	result, err := p.SelectOne(message, "", choices, promptCfgs...)
+	result, err := p.SelectOne(message, help, choices, promptCfgs...)
 	if err != nil {
 		return "", err
 	}

--- a/internal/pkg/term/prompt/select.go
+++ b/internal/pkg/term/prompt/select.go
@@ -21,7 +21,21 @@ const (
 	noAdditionalFormatting = 0
 )
 
-var regexpSGR = regexp.MustCompile("\x1b\\[([0-9]{1,2}(;[0-9]{1,2})?)?m")
+// SGR(Select Graphic Rendition) is used to colorize outputs in terminals.
+// Example matches:
+// '\x1b[2m'        (for Faint output)
+// '\x1b[1;31m'     (for bold, red output)
+const (
+	sgrStart = "\x1b\\["            // SGR sequences start with "\[".
+	sgrEnd = "m"                    // SGR sequences end with "m".
+	sgrParameter = "[0-9]{1,2,3}"   // SGR parameter values range from 0 to 107.
+)
+
+var (
+	sgrParameterGroups = fmt.Sprintf("%s(;%s)*", sgrParameter, sgrParameter)            // One or more SGR parameters separated by ";"
+	sgr                = fmt.Sprintf("%s(%s)?%s", sgrStart, sgrParameterGroups, sgrEnd) // A complete SGR sequence: \x1b\\[([0-9]{1,2,3}(;[0-9]{1,2,3})*)?m
+)
+var regexpSGR = regexp.MustCompile(sgr)
 
 // Option represents a choice with a hint for clarification.
 type Option struct {

--- a/internal/pkg/term/prompt/select.go
+++ b/internal/pkg/term/prompt/select.go
@@ -26,7 +26,7 @@ const (
 // '\x1b[2m'        (for Faint output)
 // '\x1b[1;31m'     (for bold, red output)
 const (
-	sgrStart = "\x1b\\["            // SGR sequences start with "\[".
+	sgrStart = "\x1b\\["            // SGR sequences start with "ESC[".
 	sgrEnd = "m"                    // SGR sequences end with "m".
 	sgrParameter = "[0-9]{1,2,3}"   // SGR parameter values range from 0 to 107.
 )

--- a/internal/pkg/term/prompt/select.go
+++ b/internal/pkg/term/prompt/select.go
@@ -5,11 +5,11 @@ package prompt
 
 import (
 	"fmt"
-	"strings"
-	"text/tabwriter"
-
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/aws/copilot-cli/internal/pkg/term/color"
+	"regexp"
+	"strings"
+	"text/tabwriter"
 )
 
 // Configuration while spacing text with a tabwriter.
@@ -20,6 +20,8 @@ const (
 	paddingChar            = ' ' // character in between columns.
 	noAdditionalFormatting = 0
 )
+
+var regexpSGR = regexp.MustCompile("\x1b\\[([0-9]{1,2}(;[0-9]{1,2})?)?m")
 
 // Option represents a choice with a hint for clarification.
 type Option struct {
@@ -97,7 +99,8 @@ func stringifyOptions(opts []Option) ([]string, error) {
 
 func parseValueFromOptionFmt(formatted string) string {
 	if idx := strings.Index(formatted, "("); idx != -1 {
-		return strings.TrimSpace(formatted[:idx])
+		s := regexpSGR.ReplaceAllString(formatted[:idx], "")
+		return strings.TrimSpace(s)
 	}
 	return strings.TrimSpace(formatted)
 }

--- a/internal/pkg/term/prompt/select_test.go
+++ b/internal/pkg/term/prompt/select_test.go
@@ -40,7 +40,7 @@ func TestOption_String(t *testing.T) {
 
 func TestPrompt_SelectOption(t *testing.T) {
 	t.Run("should return ErrEmptyOptions if there are no options", func(t *testing.T) {
-		_, err := New().SelectOption("to be or not to be?", nil)
+		_, err := New().SelectOption("to be or not to be?", "this is the question", nil)
 		require.EqualError(t, err, ErrEmptyOptions.Error())
 	})
 	t.Run("should return value without hint", func(t *testing.T) {
@@ -72,7 +72,7 @@ func TestPrompt_SelectOption(t *testing.T) {
 		}
 
 		// WHEN
-		actual, err := p.SelectOption("Which workload type?", opts)
+		actual, err := p.SelectOption("Which workload type?", "choose!", opts)
 
 		// THEN
 		require.NoError(t, err)
@@ -106,7 +106,7 @@ func TestPrompt_SelectOption(t *testing.T) {
 		}
 
 		// WHEN
-		actual, err := p.SelectOption("Which workload type?", opts)
+		actual, err := p.SelectOption("Which workload type?", "choose!", opts)
 
 		// THEN
 		require.NoError(t, err)


### PR DESCRIPTION
The SGR escape sequence resulted from colored input prevents `strings.TrimSpace` to function properly. This PR removes SGR sequences before trimming whitespaces.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
