### PR TITLE
chore(cli): create RDS addon from storage init

### DIFF
--- a/internal/pkg/cli/storage_init.go
+++ b/internal/pkg/cli/storage_init.go
@@ -30,7 +30,6 @@ const (
 var storageTypes = []string{
 	dynamoDBStorageType,
 	s3StorageType,
-	rdsStorageType,
 }
 
 var storageTypeHints = map[string]string {

--- a/internal/pkg/cli/storage_init.go
+++ b/internal/pkg/cli/storage_init.go
@@ -551,10 +551,6 @@ func (o *initStorageOpts) validateWorkloadName() error {
 }
 
 func (o *initStorageOpts) Execute() error {
-	return o.createAddon()
-}
-
-func (o *initStorageOpts) createAddon() error {
 	addonCf, err := o.newAddon()
 	if err != nil {
 		return err

--- a/internal/pkg/cli/storage_init.go
+++ b/internal/pkg/cli/storage_init.go
@@ -24,18 +24,41 @@ import (
 const (
 	dynamoDBStorageType = "DynamoDB"
 	s3StorageType       = "S3"
-	rdsStorageType      = "Aurora Serverless"
+	rdsStorageType      = "Aurora"
 )
 
 var storageTypes = []string{
 	dynamoDBStorageType,
 	s3StorageType,
+	//rdsStorageType,
 }
 
-var storageTypeHints = map[string]string {
-	dynamoDBStorageType: "NoSQL",
-	s3StorageType:       "Objects",
-	rdsStorageType:      "SQL",
+// Displayed options for storage types
+const (
+	dynamoDBStorageTypeOption = "DynamoDB"
+	s3StorageTypeOption       = "S3"
+	rdsStorageTypeOption      = "Aurora Serverless"
+)
+
+var optionToStorageType = map[string]string {
+	dynamoDBStorageTypeOption: dynamoDBStorageType,
+	s3StorageTypeOption:       s3StorageType,
+	rdsStorageTypeOption:      rdsStorageType,
+}
+
+var storageTypeOptions = map[string]prompt.Option {
+	dynamoDBStorageType: {
+		Value: dynamoDBStorageTypeOption,
+		Hint:  "NoSQL",
+	},
+	s3StorageType: {
+		Value: s3StorageTypeOption,
+		Hint:  "Objects",
+	},
+	rdsStorageType: {
+		Value: rdsStorageTypeOption,
+		Hint:  "SQL",
+	},
 }
 
 const (
@@ -282,12 +305,9 @@ func (o *initStorageOpts) askStorageType() error {
 
 	var options []prompt.Option
 	for _, st := range storageTypes {
-		options = append(options, prompt.Option{
-			Value: st,
-			Hint:  storageTypeHints[st],
-		})
+		options = append(options, storageTypeOptions[st])
 	}
-	storageType, err := o.prompt.SelectOption(fmt.Sprintf(
+	storageTypeOption, err := o.prompt.SelectOption(fmt.Sprintf(
 		fmtStorageInitTypePrompt, color.HighlightUserInput(o.workloadName)),
 		storageInitTypeHelp,
 		options,
@@ -295,7 +315,7 @@ func (o *initStorageOpts) askStorageType() error {
 	if err != nil {
 		return fmt.Errorf("select storage type: %w", err)
 	}
-	o.storageType = storageType
+	o.storageType = optionToStorageType[storageTypeOption]
 	return nil
 }
 

--- a/internal/pkg/cli/storage_init.go
+++ b/internal/pkg/cli/storage_init.go
@@ -30,7 +30,6 @@ const (
 var storageTypes = []string{
 	dynamoDBStorageType,
 	s3StorageType,
-	//rdsStorageType,
 }
 
 // Displayed options for storage types
@@ -64,7 +63,7 @@ var storageTypeOptions = map[string]prompt.Option {
 const (
 	s3BucketFriendlyText      = "S3 Bucket"
 	dynamoDBTableFriendlyText = "DynamoDB Table"
-	rdsFriendlyText           = "RDS Aurora Serverless Cluster"
+	rdsFriendlyText           = "Database Cluster"
 )
 
 // General-purpose prompts, collected for all storage resources.
@@ -73,7 +72,7 @@ var (
 	storageInitTypeHelp      = `The type of storage you'd like to add to your workload. 
 DynamoDB is a key-value and document database that delivers single-digit millisecond performance at any scale.
 S3 is a web object store built to store and retrieve any amount of data from anywhere on the Internet.
-RDS Aurora Serverless is an on-demand autoscaling configuration for Amazon Aurora, a MySQL and PostgreSQL-compatible relational database.
+Aurora Serverless is an on-demand autoscaling configuration for Amazon Aurora, a MySQL and PostgreSQL-compatible relational database.
 `
 
 	fmtStorageInitNamePrompt = "What would you like to " + color.Emphasize("name") + " this %s?"

--- a/internal/pkg/cli/storage_init.go
+++ b/internal/pkg/cli/storage_init.go
@@ -22,21 +22,21 @@ import (
 )
 
 const (
-	dynamoDBStorageType     = "DynamoDB"
-	s3StorageType           = "S3"
-	rdsStorageType          = "RDS"
+	dynamoDBStorageType = "DynamoDB"
+	s3StorageType       = "S3"
+	rdsStorageType      = "Aurora Serverless"
 )
 
 var storageTypes = []string{
 	dynamoDBStorageType,
 	s3StorageType,
-	//rdsStorageType, // Hide RDS option for now.
+	rdsStorageType,
 }
 
 var storageTypeHints = map[string]string {
-	dynamoDBStorageType: "",
-	s3StorageType: 		 "",
-	rdsStorageType: 	 "Aurora Serverless",
+	dynamoDBStorageType: "NoSQL",
+	s3StorageType:       "Objects",
+	rdsStorageType:      "SQL",
 }
 
 const (
@@ -51,7 +51,7 @@ var (
 	storageInitTypeHelp      = `The type of storage you'd like to add to your workload. 
 DynamoDB is a key-value and document database that delivers single-digit millisecond performance at any scale.
 S3 is a web object store built to store and retrieve any amount of data from anywhere on the Internet.
-RDS Aurora Serverless is a fully-managed auto-scaling service for relational databases.
+RDS Aurora Serverless is an on-demand autoscaling configuration for Amazon Aurora, a MySQL and PostgreSQL-compatible relational database.
 `
 
 	fmtStorageInitNamePrompt = "What would you like to " + color.Emphasize("name") + " this %s?"
@@ -102,10 +102,7 @@ var attributeTypes = []string{
 // RDS Aurora Serverless specific questions and help prompts.
 var (
 	storageInitRDSInitialDBNamePrompt = "What would you like to name the initial database in your cluster?"
-	storageInitRDSInitialDBNameHelp   = "The name of the initial database in the cluster."
-
 	storageInitRDSDBEnginePrompt = "Which database engine would you like to use?"
-	storageInitRDSDBEngineHelp   = "The database engine used in the cluster."
 )
 
 // RDS Aurora Serverless specific constants and variables.
@@ -504,7 +501,7 @@ func (o *initStorageOpts) askAuroraEngineType() error {
 		return nil
 	}
 	engine, err := o.prompt.SelectOne(storageInitRDSDBEnginePrompt,
-		storageInitRDSDBEngineHelp,
+		"",
 		engineTypes,
 		prompt.WithFinalMessage("Database engine:"))
 	if err != nil {
@@ -531,7 +528,7 @@ func (o *initStorageOpts) askAuroraInitialDBName() error {
 	}
 
 	dbName, err := o.prompt.Get(storageInitRDSInitialDBNamePrompt,
-		storageInitRDSInitialDBNameHelp,
+		"",
 		validator,
 		prompt.WithFinalMessage("Initial database name:"))
 	if err != nil {

--- a/internal/pkg/cli/storage_init.go
+++ b/internal/pkg/cli/storage_init.go
@@ -5,6 +5,7 @@ package cli
 
 import (
 	"encoding"
+	"errors"
 	"fmt"
 
 	"github.com/aws/copilot-cli/internal/pkg/addon"
@@ -21,30 +22,37 @@ import (
 )
 
 const (
-	dynamoDBStorageType = "DynamoDB"
-	s3StorageType       = "S3"
-)
-
-const (
-	s3BucketFriendlyText      = "S3 Bucket"
-	dynamoDBTableFriendlyText = "DynamoDB Table"
-)
-
-const (
-	ddbKeyString = "key"
+	dynamoDBStorageType     = "DynamoDB"
+	s3StorageType           = "S3"
+	rdsStorageType          = "RDS"
 )
 
 var storageTypes = []string{
 	dynamoDBStorageType,
 	s3StorageType,
+	//rdsStorageType, // Hide RDS option for now.
 }
+
+var storageTypeHints = map[string]string {
+	dynamoDBStorageType: "",
+	s3StorageType: 		 "",
+	rdsStorageType: 	 "Aurora Serverless",
+}
+
+const (
+	s3BucketFriendlyText      = "S3 Bucket"
+	dynamoDBTableFriendlyText = "DynamoDB Table"
+	rdsFriendlyText           = "RDS Aurora Serverless Cluster"
+)
 
 // General-purpose prompts, collected for all storage resources.
 var (
 	fmtStorageInitTypePrompt = "What " + color.Emphasize("type") + " of storage would you like to associate with %s?"
 	storageInitTypeHelp      = `The type of storage you'd like to add to your workload. 
 DynamoDB is a key-value and document database that delivers single-digit millisecond performance at any scale.
-S3 is a web object store built to store and retrieve any amount of data from anywhere on the Internet.`
+S3 is a web object store built to store and retrieve any amount of data from anywhere on the Internet.
+RDS Aurora Serverless is a fully-managed auto-scaling service for relational databases.
+`
 
 	fmtStorageInitNamePrompt = "What would you like to " + color.Emphasize("name") + " this %s?"
 	storageInitNameHelp      = "The name of this storage resource. You can use the following characters: a-zA-Z0-9-_"
@@ -74,6 +82,11 @@ partition key but a different sort key. You may specify up to 5 alternate sort k
 	storageInitDDBLSINameHelp   = "You can use the characters [a-zA-Z0-9.-_]"
 )
 
+// DynamoDB specific constants and variables.
+const (
+	ddbKeyString = "key"
+)
+
 const (
 	ddbStringType = "String"
 	ddbIntType    = "Number"
@@ -86,8 +99,19 @@ var attributeTypes = []string{
 	ddbBinaryType,
 }
 
+// RDS Aurora Serverless specific questions and help prompts.
+var (
+	storageInitRDSInitialDBNamePrompt = "What would you like to name the initial database in your cluster?"
+	storageInitRDSInitialDBNameHelp   = "The name of the initial database in the cluster."
+
+	storageInitRDSDBEnginePrompt = "Which database engine would you like to use?"
+	storageInitRDSDBEngineHelp   = "The database engine used in the cluster."
+)
+
 // RDS Aurora Serverless specific constants and variables.
 const (
+	rdsStorageNameDefault = "aurora-cluster"
+
 	engineTypeMySQL      = "MySQL"
 	engineTypePostgreSQL = "PostgreSQL"
 )
@@ -108,6 +132,11 @@ type initStorageVars struct {
 	lsiSorts     []string // lsi sort keys collected as "name:T" where T is one of [SNB]
 	noLSI        bool
 	noSort       bool
+
+	// RDS Aurora Serverless specific values collected via flags or prompts
+	rdsEngine         string
+	rdsParameterGroup string
+	rdsInitialDBName  string
 }
 
 type initStorageOpts struct {
@@ -167,6 +196,8 @@ func (o *initStorageOpts) Validate() error {
 			err = dynamoTableNameValidation(o.storageName)
 		case s3StorageType:
 			err = s3BucketNameValidation(o.storageName)
+		case rdsStorageType:
+			err = rdsNameValidation(o.storageName)
 		default:
 			// use dynamo since it's a superset of s3
 			err = dynamoTableNameValidation(o.storageName)
@@ -179,8 +210,14 @@ func (o *initStorageOpts) Validate() error {
 		return err
 	}
 
+	if o.rdsEngine != "" {
+		if err := validateEngine(o.rdsEngine); err != nil {
+			return err
+		}
+	}
 	return nil
 }
+
 func (o *initStorageOpts) validateDDB() error {
 	if o.partitionKey != "" {
 		if err := validateKey(o.partitionKey); err != nil {
@@ -230,6 +267,14 @@ func (o *initStorageOpts) Ask() error {
 		if err := o.askDynamoLSIConfig(); err != nil {
 			return err
 		}
+	case rdsStorageType:
+		if err := o.askAuroraEngineType(); err != nil {
+			return err
+		}
+		// Ask for initial db name after engine type since the name needs to be validated accordingly.
+		if err := o.askAuroraInitialDBName(); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -239,16 +284,37 @@ func (o *initStorageOpts) askStorageType() error {
 		return nil
 	}
 
-	storageType, err := o.prompt.SelectOne(fmt.Sprintf(
+	var options []prompt.Option
+	for _, st := range storageTypes {
+		options = append(options, prompt.Option{
+			Value: st,
+			Hint:  storageTypeHints[st],
+		})
+	}
+	storageType, err := o.prompt.SelectOption(fmt.Sprintf(
 		fmtStorageInitTypePrompt, color.HighlightUserInput(o.workloadName)),
 		storageInitTypeHelp,
-		storageTypes,
+		options,
 		prompt.WithFinalMessage("Storage type:"))
 	if err != nil {
 		return fmt.Errorf("select storage type: %w", err)
 	}
-
 	o.storageType = storageType
+	return nil
+}
+
+func (o *initStorageOpts) askStorageNameWithDefault(friendlyText, defaultName string, validator func(interface{}) error) error {
+	name, err := o.prompt.Get(fmt.Sprintf(fmtStorageInitNamePrompt,
+		color.HighlightUserInput(friendlyText)),
+		storageInitNameHelp,
+		validator,
+		prompt.WithFinalMessage("Storage resource name:"),
+		prompt.WithDefaultInput(defaultName))
+
+	if err != nil {
+		return fmt.Errorf("input storage name: %w", err)
+	}
+	o.storageName = name
 	return nil
 }
 
@@ -265,6 +331,8 @@ func (o *initStorageOpts) askStorageName() error {
 	case dynamoDBStorageType:
 		validator = dynamoTableNameValidation
 		friendlyText = dynamoDBTableFriendlyText
+	case rdsStorageType:
+		return o.askStorageNameWithDefault(rdsFriendlyText, rdsStorageNameDefault, rdsNameValidation)
 	}
 
 	name, err := o.prompt.Get(fmt.Sprintf(fmtStorageInitNamePrompt,
@@ -272,7 +340,6 @@ func (o *initStorageOpts) askStorageName() error {
 		storageInitNameHelp,
 		validator,
 		prompt.WithFinalMessage("Storage resource name:"))
-
 	if err != nil {
 		return fmt.Errorf("input storage name: %w", err)
 	}
@@ -369,6 +436,7 @@ func (o *initStorageOpts) askDynamoSortKey() error {
 	o.sortKey = key + ":" + keyType
 	return nil
 }
+
 func (o *initStorageOpts) askDynamoLSIConfig() error {
 	// LSI has already been specified by flags.
 	if len(o.lsiSorts) > 0 {
@@ -431,6 +499,48 @@ func (o *initStorageOpts) askDynamoLSIConfig() error {
 	}
 }
 
+func (o *initStorageOpts) askAuroraEngineType() error {
+	if o.rdsEngine != "" {
+		return nil
+	}
+	engine, err := o.prompt.SelectOne(storageInitRDSDBEnginePrompt,
+		storageInitRDSDBEngineHelp,
+		engineTypes,
+		prompt.WithFinalMessage("Database engine:"))
+	if err != nil {
+		return fmt.Errorf("select database engine: %w", err)
+	}
+	o.rdsEngine = engine
+	return nil
+}
+
+func (o *initStorageOpts) askAuroraInitialDBName() error {
+	var validator func(interface{}) error
+	switch o.rdsEngine {
+	case engineTypeMySQL:
+		validator = validateMySQLDBName
+	case engineTypePostgreSQL:
+		validator = validatePostgreSQLDBName
+	default:
+		return errors.New("unknown engine type")
+	}
+
+	if o.rdsInitialDBName != "" {
+		// The flag input is validated here because it needs engine type to determine which validator to use.
+		return validator(o.rdsInitialDBName)
+	}
+
+	dbName, err := o.prompt.Get(storageInitRDSInitialDBNamePrompt,
+		storageInitRDSInitialDBNameHelp,
+		validator,
+		prompt.WithFinalMessage("Initial database name:"))
+	if err != nil {
+		return fmt.Errorf("input initial database name: %w", err)
+	}
+	o.rdsInitialDBName = dbName
+	return nil
+}
+
 func (o *initStorageOpts) validateWorkloadName() error {
 	names, err := o.ws.WorkloadNames()
 	if err != nil {
@@ -445,7 +555,6 @@ func (o *initStorageOpts) validateWorkloadName() error {
 }
 
 func (o *initStorageOpts) Execute() error {
-
 	return o.createAddon()
 }
 
@@ -475,6 +584,8 @@ func (o *initStorageOpts) createAddon() error {
 		addonFriendlyText = dynamoDBTableFriendlyText
 	case s3StorageType:
 		addonFriendlyText = s3BucketFriendlyText
+	case rdsStorageType:
+		addonFriendlyText = rdsFriendlyText
 	default:
 		return fmt.Errorf(fmtErrInvalidStorageType, o.storageType, prettify(storageTypes))
 	}
@@ -487,12 +598,15 @@ func (o *initStorageOpts) createAddon() error {
 
 	return nil
 }
+
 func (o *initStorageOpts) newAddon() (encoding.BinaryMarshaler, error) {
 	switch o.storageType {
 	case dynamoDBStorageType:
 		return o.newDynamoDBAddon()
 	case s3StorageType:
 		return o.newS3Addon()
+	case rdsStorageType:
+		return o.newRDSAddon()
 	default:
 		return nil, fmt.Errorf("storage type %s doesn't have a CF template", o.storageType)
 	}
@@ -531,6 +645,43 @@ func (o *initStorageOpts) newS3Addon() (*addon.S3, error) {
 		},
 	}
 	return addon.NewS3(props), nil
+}
+
+func (o *initStorageOpts) newRDSAddon() (*addon.RDS, error) {
+	var engine string
+	switch o.rdsEngine {
+	case engineTypeMySQL:
+		engine = addon.RDSEngineTypeMySQL
+	case engineTypePostgreSQL:
+		engine = addon.RDSEngineTypePostgreSQL
+	default:
+		return nil, errors.New("unknown engine type")
+	}
+
+	envs, err := o.environmentNames()
+	if err != nil {
+		return nil, err
+	}
+
+	return addon.NewRDS(addon.RDSProps{
+		ClusterName:    o.storageName,
+		Engine:         engine,
+		InitialDBName:  o.rdsInitialDBName,
+		ParameterGroup: o.rdsParameterGroup,
+		Envs:           envs,
+	}), nil
+}
+
+func (o *initStorageOpts) environmentNames() ([]string, error) {
+	var envNames []string
+	envs, err := o.store.ListEnvironments(o.appName)
+	if err != nil {
+		return nil, fmt.Errorf("list environments: %w", err)
+	}
+	for _, env := range envs {
+		envNames = append(envNames, env.Name)
+	}
+	return envNames, nil
 }
 
 func (o *initStorageOpts) RecommendedActions() []string {

--- a/internal/pkg/cli/storage_init_test.go
+++ b/internal/pkg/cli/storage_init_test.go
@@ -254,16 +254,12 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 				options := []prompt.Option {
 					{
 						Value: dynamoDBStorageType,
-						Hint: "",
+						Hint: "NoSQL",
 					},
 					{
 						Value: s3StorageType,
-						Hint: "",
+						Hint: "Objects",
 					},
-					//{
-					//	Value: rdsStorageType,
-					//	Hint: "Aurora Serverless",
-					//}, // RDS is hidden for now
 				}
 				m.EXPECT().SelectOption(gomock.Any(), gomock.Any(), gomock.Eq(options), gomock.Any()).Return(s3StorageType, nil)
 			},

--- a/internal/pkg/cli/storage_init_test.go
+++ b/internal/pkg/cli/storage_init_test.go
@@ -332,7 +332,7 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 
 			mockPrompt: func(m *mocks.Mockprompter) {
 				m.EXPECT().Get(
-					gomock.Eq("What would you like to name this RDS Aurora Serverless Cluster?"),
+					gomock.Eq("What would you like to name this Database Cluster?"),
 					gomock.Any(),
 					gomock.Any(),
 					gomock.Any(),

--- a/internal/pkg/cli/storage_init_test.go
+++ b/internal/pkg/cli/storage_init_test.go
@@ -253,11 +253,11 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 			mockPrompt: func(m *mocks.Mockprompter) {
 				options := []prompt.Option {
 					{
-						Value: dynamoDBStorageType,
+						Value: dynamoDBStorageTypeOption,
 						Hint: "NoSQL",
 					},
 					{
-						Value: s3StorageType,
+						Value: s3StorageTypeOption,
 						Hint: "Objects",
 					},
 				}

--- a/internal/pkg/cli/storage_init_test.go
+++ b/internal/pkg/cli/storage_init_test.go
@@ -6,6 +6,7 @@ package cli
 import (
 	"errors"
 	"fmt"
+	"github.com/aws/copilot-cli/internal/pkg/term/prompt"
 	"testing"
 
 	"github.com/aws/copilot-cli/internal/pkg/cli/mocks"
@@ -27,6 +28,7 @@ func TestStorageInitOpts_Validate(t *testing.T) {
 		inLSISorts    []string
 		inNoSort      bool
 		inNoLSI       bool
+		inEngine      string
 
 		mockWs    func(m *mocks.MockwsAddonManager)
 		mockStore func(m *mocks.Mockstore)
@@ -161,6 +163,15 @@ func TestStorageInitOpts_Validate(t *testing.T) {
 			inNoSort:      true,
 			wantedErr:     fmt.Errorf("validate LSI configuration: cannot specify --no-sort and --lsi options at once"),
 		},
+		"invalid database engine type": {
+			inAppName: "meow",
+			inEngine:  "mysql",
+
+			mockWs:        func(m *mocks.MockwsAddonManager) {},
+			mockStore:     func(m *mocks.Mockstore) {},
+
+			wantedErr: errors.New("invalid engine type mysql: must be one of \"MySQL\", \"PostgreSQL\""),
+		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
@@ -181,6 +192,7 @@ func TestStorageInitOpts_Validate(t *testing.T) {
 					lsiSorts:     tc.inLSISorts,
 					noLSI:        tc.inNoLSI,
 					noSort:       tc.inNoSort,
+					rdsEngine:    tc.inEngine,
 				},
 				appName: tc.inAppName,
 				ws:      mockWs,
@@ -208,6 +220,9 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 		wantedTableName    = "coolTable"
 		wantedPartitionKey = "DogName:String"
 		wantedSortKey      = "PhotoId:Number"
+
+		wantedInitialDBName = "mydb"
+		wantedDBEngine      = engineTypePostgreSQL
 	)
 	testCases := map[string]struct {
 		inAppName     string
@@ -219,6 +234,9 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 		inLSISorts    []string
 		inNoLSI       bool
 		inNoSort      bool
+
+		inDBEngine      string
+		inInitialDBName string
 
 		mockPrompt func(m *mocks.Mockprompter)
 		mockCfg    func(m *mocks.MockwsSelector)
@@ -233,7 +251,21 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 			inStorageName: wantedBucketName,
 
 			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().SelectOne(gomock.Any(), gomock.Any(), gomock.Eq(storageTypes), gomock.Any()).Return(s3StorageType, nil)
+				options := []prompt.Option {
+					{
+						Value: dynamoDBStorageType,
+						Hint: "",
+					},
+					{
+						Value: s3StorageType,
+						Hint: "",
+					},
+					//{
+					//	Value: rdsStorageType,
+					//	Hint: "Aurora Serverless",
+					//}, // RDS is hidden for now
+				}
+				m.EXPECT().SelectOption(gomock.Any(), gomock.Any(), gomock.Eq(options), gomock.Any()).Return(s3StorageType, nil)
 			},
 			mockCfg: func(m *mocks.MockwsSelector) {},
 
@@ -245,7 +277,7 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 			inStorageName: wantedBucketName,
 
 			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().SelectOne(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", errors.New("some error"))
+				m.EXPECT().SelectOption(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", errors.New("some error"))
 			},
 			mockCfg: func(m *mocks.MockwsSelector) {},
 
@@ -294,6 +326,32 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 			mockCfg: func(m *mocks.MockwsSelector) {},
 
 			wantedErr: nil,
+		},
+		"Asks for cluster name for RDS storage": {
+			inAppName:       wantedAppName,
+			inSvcName:       wantedSvcName,
+			inStorageType:   rdsStorageType,
+			inDBEngine:      wantedDBEngine,
+			inInitialDBName: wantedInitialDBName,
+
+			mockPrompt: func(m *mocks.Mockprompter) {
+				m.EXPECT().Get(
+					gomock.Eq("What would you like to name this RDS Aurora Serverless Cluster?"),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+				).Return(wantedBucketName, nil)
+			},
+			mockCfg: func(m *mocks.MockwsSelector) {},
+
+			wantedErr: nil,
+			wantedVars: &initStorageVars{
+				storageType:      rdsStorageType,
+				storageName:      wantedBucketName,
+				workloadName:     wantedSvcName,
+				rdsEngine:        wantedDBEngine,
+				rdsInitialDBName: wantedInitialDBName,
+			},
 		},
 		"error if storage name not returned": {
 			inAppName:     wantedAppName,
@@ -707,6 +765,83 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 
 			wantedErr: nil,
 		},
+		"asks for engine if not specified": {
+			inAppName:       wantedAppName,
+			inSvcName:       wantedSvcName,
+			inStorageName:   wantedBucketName,
+
+			inStorageType:   rdsStorageType,
+			inInitialDBName: wantedInitialDBName,
+
+			mockPrompt: func(m *mocks.Mockprompter) {
+				m.EXPECT().SelectOne(gomock.Eq(storageInitRDSDBEnginePrompt), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(wantedDBEngine, nil)
+			},
+			mockCfg: func(m *mocks.MockwsSelector) {},
+
+			wantedVars: &initStorageVars{
+				storageType:      rdsStorageType,
+				storageName:      wantedBucketName,
+				workloadName:     wantedSvcName,
+				rdsInitialDBName: wantedInitialDBName,
+				rdsEngine:        wantedDBEngine,
+			},
+		},
+		"error if engine not gotten": {
+			inAppName:       wantedAppName,
+			inSvcName:       wantedSvcName,
+			inStorageName:   wantedBucketName,
+
+			inStorageType:   rdsStorageType,
+			inInitialDBName: wantedInitialDBName,
+
+			mockPrompt: func(m *mocks.Mockprompter) {
+				m.EXPECT().SelectOne(storageInitRDSDBEnginePrompt, gomock.Any(), gomock.Any(), gomock.Any()).
+					Return("", errors.New("some error"))
+			},
+			mockCfg: func(m *mocks.MockwsSelector) {},
+
+			wantedErr: errors.New("select database engine: some error"),
+		},
+		"asks for initial database name": {
+			inAppName:     wantedAppName,
+			inSvcName:     wantedSvcName,
+			inStorageName: wantedBucketName,
+
+			inStorageType: rdsStorageType,
+			inDBEngine:    wantedDBEngine,
+
+			mockPrompt: func(m *mocks.Mockprompter) {
+				m.EXPECT().Get(gomock.Eq(storageInitRDSInitialDBNamePrompt), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(wantedInitialDBName, nil)
+			},
+			mockCfg: func(m *mocks.MockwsSelector) {},
+
+			wantedVars: &initStorageVars{
+				storageType:      rdsStorageType,
+				storageName:      wantedBucketName,
+				workloadName:     wantedSvcName,
+				rdsEngine:        wantedDBEngine,
+				rdsInitialDBName: wantedInitialDBName,
+			},
+		},
+		"error if initial database name not gotten": {
+			inAppName:     wantedAppName,
+			inSvcName:     wantedSvcName,
+			inStorageName: wantedBucketName,
+
+			inStorageType: rdsStorageType,
+			inDBEngine:    wantedDBEngine,
+
+			mockPrompt: func(m *mocks.Mockprompter) {
+				m.EXPECT().Get(storageInitRDSInitialDBNamePrompt, gomock.Any(), gomock.Any(), gomock.Any()).
+					Return("", errors.New("some error"))
+			},
+			mockCfg: func(m *mocks.MockwsSelector) {},
+
+			wantedErr: fmt.Errorf("input initial database name: some error"),
+		},
+
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
@@ -726,6 +861,9 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 					lsiSorts:     tc.inLSISorts,
 					noLSI:        tc.inNoLSI,
 					noSort:       tc.inNoSort,
+
+					rdsEngine:        tc.inDBEngine,
+					rdsInitialDBName: tc.inInitialDBName,
 				},
 				appName: tc.inAppName,
 				sel:     mockConfig,
@@ -753,8 +891,6 @@ func TestStorageInitOpts_Execute(t *testing.T) {
 	const (
 		wantedAppName      = "ddos"
 		wantedSvcName      = "frontend"
-		wantedBucketName   = "coolBucket"
-		wantedTableName    = "coolTable"
 		wantedPartitionKey = "DogName:String"
 		wantedSortKey      = "PhotoId:Number"
 	)
@@ -764,13 +900,19 @@ func TestStorageInitOpts_Execute(t *testing.T) {
 		inStorageType string
 		inSvcName     string
 		inStorageName string
+
 		inPartition   string
 		inSort        string
 		inLSISorts    []string
 		inNoLSI       bool
 		inNoSort      bool
 
-		mockWs func(m *mocks.MockwsAddonManager)
+		inEngine            string
+		inInitialDBName     string
+		inParameterGroup    string
+
+		mockWs    func(m *mocks.MockwsAddonManager)
+		mockStore func(m *mocks.Mockstore)
 
 		wantedErr error
 	}{
@@ -816,6 +958,22 @@ func TestStorageInitOpts_Execute(t *testing.T) {
 
 			wantedErr: nil,
 		},
+		"happy calls for RDS": {
+			inSvcName: wantedSvcName,
+
+			inStorageType:      rdsStorageType,
+			inStorageName:      "mycluster",
+			inEngine:           engineTypeMySQL,
+			inParameterGroup:    "mygroup",
+
+			mockWs: func(m *mocks.MockwsAddonManager) {
+				m.EXPECT().WriteAddon(gomock.Any(), wantedSvcName, "mycluster").Return("/frontend/addons/mycluster.yml", nil)
+			},
+			mockStore: func(m *mocks.Mockstore) {
+				m.EXPECT().ListEnvironments(gomock.Any()).AnyTimes()
+			},
+			wantedErr: nil,
+		},
 		"error addon exists": {
 			inAppName:     wantedAppName,
 			inStorageType: s3StorageType,
@@ -824,6 +982,9 @@ func TestStorageInitOpts_Execute(t *testing.T) {
 
 			mockWs: func(m *mocks.MockwsAddonManager) {
 				m.EXPECT().WriteAddon(gomock.Any(), wantedSvcName, "my-bucket").Return("", fileExistsError)
+			},
+			mockStore: func(m *mocks.Mockstore) {
+				m.EXPECT().ListEnvironments(gomock.Any()).AnyTimes()
 			},
 
 			wantedErr: fmt.Errorf("addon already exists: %w", fileExistsError),
@@ -848,6 +1009,7 @@ func TestStorageInitOpts_Execute(t *testing.T) {
 			defer ctrl.Finish()
 
 			mockAddon := mocks.NewMockwsAddonManager(ctrl)
+			mockStore := mocks.NewMockstore(ctrl)
 			opts := initStorageOpts{
 				initStorageVars: initStorageVars{
 					storageType:  tc.inStorageType,
@@ -858,11 +1020,19 @@ func TestStorageInitOpts_Execute(t *testing.T) {
 					lsiSorts:     tc.inLSISorts,
 					noLSI:        tc.inNoLSI,
 					noSort:       tc.inNoSort,
+
+					rdsEngine:         tc.inEngine,
+					rdsParameterGroup: tc.inParameterGroup,
 				},
 				appName: tc.inAppName,
 				ws:      mockAddon,
+				store:   mockStore,
 			}
 			tc.mockWs(mockAddon)
+			if tc.mockStore != nil {
+				tc.mockStore(mockStore)
+			}
+
 			// WHEN
 			err := opts.Execute()
 


### PR DESCRIPTION
This PR adds RDS option to `storage init`. 

The guided experience is as follow:
```bash
$ copilot storage init

Which workload would you like to associate with this storage resource?  [Use arrows to move, type to filter]
  > my-svc
    their-svc

  The type of storage you'd like to add to your workload.
  DynamoDB is a key-value and document database that delivers single-digit millisecond performance at any scale.
  S3 is a web object store built to store and retrieve any amount of data from anywhere on the Internet.
  RDS Aurora Serverless is a fully-managed auto-scaling service for relational databases.
Which type of storge would you like to add?  [Use arrows to move, type to filter]
    DynamoDB     
    S3
  > RDS                        (Aurora Serverless) 

  The name of this storage resource. You can use the following characters: a-zA-Z0-9-_
What would you like to name this RDS Aurora Serverless Cluster? (aurora-cluster)

  The database engine used in the cluster.
What database engine would you like to use?  [Use arrows to move, type to filter]
    MySQL
  > PostgreSQL

The name of the initial database in the cluster.
  What would you like to name the initial database in your cluster? [? for help] initDB

✔ Wrote CloudFormation template for RDS Aurora Serverless Cluster aurora-cluster at copilot/my-svc/addons/aurora-cluste.yml

Recommended follow-up actions:
- Update my-svc's code to leverage the injected environment variables `AURORACLUSTER_SECRET`.
- Run `copilot deploy --name my-svc` to deploy your storage resources.

```

Preceding PR: #2123 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
