### PR TITLE
test(e2e): include more possible exec log stream name

### DIFF
--- a/e2e/exec/exec_test.go
+++ b/e2e/exec/exec_test.go
@@ -232,7 +232,7 @@ var _ = Describe("exec flow", func() {
 					Expect(logLine.LogStreamName).NotTo(Equal(""))
 					Expect(logLine.Timestamp).NotTo(Equal(0))
 					Expect(logLine.IngestionTime).NotTo(Equal(0))
-					if strings.Contains(logLine.LogStreamName, "ecs-execute-command") &&
+					if (strings.Contains(logLine.LogStreamName, "ecs-execute-command") || strings.Contains(logLine.LogStreamName, "ecs-eni-provisioning")) &&
 						logLine.LogStreamName != prevExecLogStreamName {
 						validTaskExecLogsCount++
 						prevExecLogStreamName = logLine.LogStreamName


### PR DESCRIPTION
<!-- Provide summary of changes -->
A known ECS CP bug that the log stream created by each exec session could start with `ecs-eni-provisioning` instead of `ecs-execute-command`. This could make our exec suite fail occasionally.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
