### PR TITLE
chore(cli): Aurora minor update on default storage name and environment variable prompt

### DIFF
--- a/internal/pkg/addon/storage.go
+++ b/internal/pkg/addon/storage.go
@@ -29,6 +29,7 @@ var regexpMatchAttribute = regexp.MustCompile(`^(\S+):([sbnSBN])`)
 var storageTemplateFunctions = map[string]interface{}{
 	"logicalIDSafe": template.StripNonAlphaNumFunc,
 	"envVarName":    template.EnvVarNameFunc,
+	"envVarSecret":  template.EnvVarSecretFunc,
 	"toSnakeCase":   template.ToSnakeCaseFunc,
 }
 
@@ -92,15 +93,15 @@ type DDBLocalSecondaryIndex struct {
 // RDSProps holds RDS-specific properties for addon.NewRDS().
 type RDSProps struct {
 	// The name of the cluster.
-	ClusterName   string
+	ClusterName string
 	// The engine type of the RDS Aurora Serverless cluster.
-	Engine         string
+	Engine string
 	// The name of the initial database created inside the cluster.
-	InitialDBName  string
+	InitialDBName string
 	// The parameter group to use for the cluster.
 	ParameterGroup string
 	// The copilot environments found inside the current app.
-	Envs           []string
+	Envs []string
 }
 
 // MarshalBinary serializes the DynamoDB object into a binary YAML CF template.

--- a/internal/pkg/cli/storage_init.go
+++ b/internal/pkg/cli/storage_init.go
@@ -712,7 +712,8 @@ func (o *initStorageOpts) RecommendedActions() []string {
 	}
 
 	actionRetrieveEnvVar := fmt.Sprintf(
-		"Update %s's code to leverage the injected environment variable %s. For example, in JavaScript you can write %s.",
+		`Update %s's code to leverage the injected environment variable %s.
+For example, in JavaScript you can write %s.`,
 		o.workloadName,
 		newVar,
 		color.HighlightCode(retrieveEnvVarCode))
@@ -720,8 +721,8 @@ func (o *initStorageOpts) RecommendedActions() []string {
 	deployCmd := fmt.Sprintf("copilot deploy --name %s", o.workloadName)
 	actionDeploy := fmt.Sprintf("Run %s to deploy your storage resources.", color.HighlightCode(deployCmd))
 	return []string{
-		fmt.Sprintf("1. %s", actionRetrieveEnvVar),
-		fmt.Sprintf("2. %s", actionDeploy),
+		fmt.Sprintf("%s", actionRetrieveEnvVar),
+		fmt.Sprintf("%s", actionDeploy),
 	}
 }
 

--- a/internal/pkg/cli/storage_init.go
+++ b/internal/pkg/cli/storage_init.go
@@ -721,8 +721,8 @@ For example, in JavaScript you can write %s.`,
 	deployCmd := fmt.Sprintf("copilot deploy --name %s", o.workloadName)
 	actionDeploy := fmt.Sprintf("Run %s to deploy your storage resources.", color.HighlightCode(deployCmd))
 	return []string{
-		fmt.Sprintf("%s", actionRetrieveEnvVar),
-		fmt.Sprintf("%s", actionDeploy),
+		actionRetrieveEnvVar,
+		actionDeploy,
 	}
 }
 

--- a/internal/pkg/template/template_functions.go
+++ b/internal/pkg/template/template_functions.go
@@ -44,6 +44,12 @@ func EnvVarNameFunc(s string) string {
 	return StripNonAlphaNumFunc(s) + "Name"
 }
 
+// EnvVarSecretFunc converts an input resource name to LogicalIDSafe, then appends
+// "Secret" to the end.
+func EnvVarSecretFunc(s string) string {
+	return StripNonAlphaNumFunc(s) + "Secret"
+}
+
 // Grabs word boundaries in default CamelCase. Matches lowercase letters & numbers
 // before the next capital as capturing group 1, and the first capital in the
 // next word as capturing group 2. Will match "yC" in "MyCamel" and "y2ndC" in"My2ndCamel"

--- a/templates/addons/aurora/cf.yml
+++ b/templates/addons/aurora/cf.yml
@@ -140,7 +140,7 @@ Resources:
       TargetId: !Ref {{logicalIDSafe .ClusterName}}DBCluster
       TargetType: AWS::RDS::DBCluster
 Outputs:
-  {{logicalIDSafe .ClusterName}}Secret: # injected as {{logicalIDSafe .ClusterName | toSnakeCase}}_SECRET environment variable by Copilot.
+  {{logicalIDSafe .ClusterName}}Secret: # injected as {{envVarSecret .ClusterName | toSnakeCase}} environment variable by Copilot.
     Description: "The JSON secret that holds the database username and password. Fields are 'host', 'dbname', 'username', 'password'"
     Value: !Ref {{logicalIDSafe .ClusterName}}AuroraSecret
   {{logicalIDSafe .ClusterName}}SecurityGroup:


### PR DESCRIPTION
This PR: 
1. Updates how Aurora storage's default cluster name is constructed; 
2. Update the prompt that shows the new environment variables that will be added because of addon, so that for DDB and S3 it is `<storage>_NAME` and for RDS it is `<storage>_SECRET`

Related: #2129 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
