### PR TITLE
chore(templates): add security groups from nested stack to job

### DIFF
--- a/templates/workloads/partials/cf/state-machine.yml
+++ b/templates/workloads/partials/cf/state-machine.yml
@@ -38,6 +38,9 @@ StateMachine:
             {{- range $sg := .Network.SecurityGroups }}
             - {{$sg}}
             {{- end }}
+            {{- if .NestedStack}}{{$stackName := .NestedStack.StackName}}{{range $sg := .NestedStack.SecurityGroupOutputs}}
+            - Fn::GetAtt: [ {{$stackName}}, Outputs.{{$sg}}]
+            {{- end}}{{end}}
     DefinitionString: |-
 {{include "state-machine-definition.json" . | indent 6}}      
       


### PR DESCRIPTION
Renders security groups created in nested stack (e.g. add-on nested stacks) into state machine for job.

This is the same as what's done [here](https://github.com/aws/copilot-cli/blob/9768ab721cdb914ac73de1ec37dcac93cb332a26/templates/workloads/partials/cf/service-base-properties.yml#L44) in #2075 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
