### PR TITLE
feat(manifest): add docker labels section to manifest

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/backend_svc.go
+++ b/internal/pkg/deploy/cloudformation/stack/backend_svc.go
@@ -109,6 +109,7 @@ func (s *BackendService) Template() (string, error) {
 		WorkloadType:        manifest.BackendServiceType,
 		HealthCheck:         s.manifest.BackendServiceConfig.ImageConfig.HealthCheckOpts(),
 		LogConfig:           convertLogging(s.manifest.Logging),
+		DockerLabels:        s.manifest.DockerLabels,
 		DesiredCountLambda:  desiredCountLambda.String(),
 		EnvControllerLambda: envControllerLambda.String(),
 		Storage:             storage,

--- a/internal/pkg/deploy/cloudformation/stack/lb_web_svc.go
+++ b/internal/pkg/deploy/cloudformation/stack/lb_web_svc.go
@@ -132,6 +132,7 @@ func (s *LoadBalancedWebService) Template() (string, error) {
 		NestedStack:         outputs,
 		Sidecars:            sidecars,
 		LogConfig:           convertLogging(s.manifest.Logging),
+		DockerLabels:        s.manifest.DockerLabels,
 		Autoscaling:         autoscaling,
 		ExecuteCommand:      convertExecuteCommand(&s.manifest.ExecuteCommand),
 		WorkloadType:        manifest.LoadBalancedWebServiceType,

--- a/internal/pkg/deploy/cloudformation/stack/scheduled_job.go
+++ b/internal/pkg/deploy/cloudformation/stack/scheduled_job.go
@@ -158,6 +158,7 @@ func (j *ScheduledJob) Template() (string, error) {
 		ScheduleExpression: schedule,
 		StateMachine:       stateMachine,
 		LogConfig:          convertLogging(j.manifest.Logging),
+		DockerLabels:       j.manifest.DockerLabels,
 		Storage:            storage,
 		Network:            convertNetworkConfig(j.manifest.Network),
 		EntryPoint:         entrypoint,

--- a/internal/pkg/manifest/backend_svc.go
+++ b/internal/pkg/manifest/backend_svc.go
@@ -41,6 +41,7 @@ type BackendServiceConfig struct {
 	*Logging      `yaml:"logging,flow"`
 	Sidecars      map[string]*SidecarConfig `yaml:"sidecars"`
 	Network       NetworkConfig             `yaml:"network"`
+	DockerLabels  map[string]string         `yaml:"docker_labels,flow"`
 }
 
 type imageWithPortAndHealthcheck struct {

--- a/internal/pkg/manifest/job.go
+++ b/internal/pkg/manifest/job.go
@@ -43,7 +43,8 @@ type ScheduledJobConfig struct {
 	Sidecars                map[string]*SidecarConfig `yaml:"sidecars"`
 	On                      JobTriggerConfig          `yaml:"on,flow"`
 	JobFailureHandlerConfig `yaml:",inline"`
-	Network                 NetworkConfig `yaml:"network"`
+	Network                 NetworkConfig     `yaml:"network"`
+	DockerLabels            map[string]string `yaml:"docker_labels,flow"`
 }
 
 // JobTriggerConfig represents the configuration for the event that triggers the job.

--- a/internal/pkg/manifest/lb_web_svc.go
+++ b/internal/pkg/manifest/lb_web_svc.go
@@ -46,13 +46,14 @@ type LoadBalancedWebService struct {
 
 // LoadBalancedWebServiceConfig holds the configuration for a load balanced web service.
 type LoadBalancedWebServiceConfig struct {
-	ImageConfig ServiceImageWithPort `yaml:"image,flow"`
+	ImageConfig   ServiceImageWithPort `yaml:"image,flow"`
 	ImageOverride `yaml:",inline"`
 	RoutingRule   `yaml:"http,flow"`
 	TaskConfig    `yaml:",inline"`
 	*Logging      `yaml:"logging,flow"`
-	Sidecars    map[string]*SidecarConfig `yaml:"sidecars"`
-	Network     NetworkConfig             `yaml:"network"`
+	Sidecars      map[string]*SidecarConfig `yaml:"sidecars"`
+	Network       NetworkConfig             `yaml:"network"`
+	DockerLabels  map[string]string         `yaml:"docker_labels,flow"`
 
 	// Fields that are used while marshaling the template for additional clarifications,
 	// but don't correspond to a field in the manifests.

--- a/internal/pkg/template/workload.go
+++ b/internal/pkg/template/workload.go
@@ -200,6 +200,7 @@ type WorkloadOpts struct {
 	EntryPoint     []string
 	Command        []string
 	DomainAlias    string
+	DockerLabels   map[string]string
 
 	// Additional options for service templates.
 	WorkloadType        string

--- a/site/content/docs/manifest/backend-service.md
+++ b/site/content/docs/manifest/backend-service.md
@@ -257,3 +257,6 @@ Optional. Defaults to `""`. The ID of the EFS access point to connect to. If usi
 
 <a id="environments" href="#environments" class="field">`environments`</a> <span class="type">Map</span>  
 The environment section lets you override any value in your manifest based on the environment you're in. In the example manifest above, we're overriding the count parameter so that we can run 2 copies of our service in our prod environment.
+
+<a id="docker-labels" href="#docker-labels" class="field">`docker_labels`</a> <span class="type">Map</span>  
+An optional key/value map of labels to add to the container.

--- a/site/content/docs/manifest/lb-web-service.md
+++ b/site/content/docs/manifest/lb-web-service.md
@@ -288,3 +288,6 @@ Optional. Defaults to `""`. The ID of the EFS access point to connect to. If usi
 
 <a id="environments" href="#environments" class="field">`environments`</a> <span class="type">Map</span>  
 The environment section lets you override any value in your manifest based on the environment you're in. In the example manifest above, we're overriding the count parameter so that we can run 2 copies of our service in our prod environment.
+
+<a id="docker-labels" href="#docker-labels" class="field">`docker_labels`</a> <span class="type">Map</span>  
+An optional key/value map of labels to add to the container.

--- a/templates/workloads/jobs/scheduled-job/cf.yml
+++ b/templates/workloads/jobs/scheduled-job/cf.yml
@@ -48,6 +48,10 @@ Resources:
 {{- if .Storage -}}
 {{include "mount-points" . | indent 10}}
 {{- end -}}
+{{- if .DockerLabels}}
+          DockerLabels:{{range $name, $value := .DockerLabels}}
+            {{$name | printf "%q"}}: {{$value | printf "%q"}}{{end}}
+{{- end -}}
 {{include "sidecars" . | indent 8}}
 {{- if .Storage -}}
 {{include "volumes" . | indent 6}}

--- a/templates/workloads/services/backend/cf.yml
+++ b/templates/workloads/services/backend/cf.yml
@@ -60,6 +60,10 @@ Resources:
 {{- if .Storage -}}
 {{include "mount-points" . | indent 10}}
 {{- end -}}
+{{- if .DockerLabels}}
+          DockerLabels:{{range $name, $value := .DockerLabels}}
+            {{$name | printf "%q"}}: {{$value | printf "%q"}}{{end}}
+{{- end -}}
 {{include "sidecars" . | indent 8}}
 {{- if .Storage -}}
 {{include "volumes" . | indent 6}}

--- a/templates/workloads/services/lb-web/cf.yml
+++ b/templates/workloads/services/lb-web/cf.yml
@@ -71,6 +71,10 @@ Resources:
 {{- if .Storage -}}
 {{include "mount-points" . | indent 10}}
 {{- end -}}
+{{- if .DockerLabels}}
+          DockerLabels:{{range $name, $value := .DockerLabels}}
+            {{$name | printf "%q"}}: {{$value | printf "%q"}}{{end}}
+{{- end -}}
 {{include "sidecars" . | indent 8}}
 {{if .Storage -}}
 {{include "volumes" . | indent 6}}


### PR DESCRIPTION
Allow user to specify [DockerLabels](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions.html#cfn-ecs-taskdefinition-containerdefinition-dockerlabels) from `manifest.yml`

```yaml
name: backend
type: Backend Service

docker_labels:
  com.acme.corp.service: foo-service

...

environments:
  prod:
    docker_labels:
      com.acme.corp.env: prod
```

Use case: some third-party [service/tools](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/?tab=ecs#partial-configuration) utilize DockerLabels as part of the integration process.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
