### PR TITLE
chore(manifest): add spot subfield

### DIFF
--- a/internal/pkg/manifest/svc.go
+++ b/internal/pkg/manifest/svc.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"gopkg.in/yaml.v3"
 )
 
@@ -110,18 +111,13 @@ func (s *Spot) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 	}
 
-	if *s.Base != 0 {
+	if aws.IntValue(s.Base) != 0 {
 		s.Enabled = nil
 		return nil
 	}
 
 	if err := unmarshal(&s.Enabled); err != nil {
-		switch err.(type) {
-		case *yaml.TypeError:
-			break
-		default:
-			return err
-		}
+		return err
 	}
 
 	if s.Enabled != nil {

--- a/internal/pkg/manifest/svc_test.go
+++ b/internal/pkg/manifest/svc_test.go
@@ -58,13 +58,7 @@ environments:
     count: 3
   staging1:
     count:
-      spot: true
-      range: 1-10
-      cpu_percentage: 70
-  staging2:
-    count:
       spot: 5
-      cpu_percentage: 70
   prod:
     count:
       range: 1-10
@@ -140,23 +134,7 @@ environments:
 							TaskConfig: TaskConfig{
 								Count: Count{
 									Autoscaling: Autoscaling{
-										Range: &mockRange,
-										Spot: &Spot{
-											Enabled: aws.Bool(true),
-										},
-										CPU: aws.Int(70),
-									},
-								},
-							},
-						},
-						"staging2": {
-							TaskConfig: TaskConfig{
-								Count: Count{
-									Autoscaling: Autoscaling{
-										Spot: &Spot{
-											Base: aws.Int(5),
-										},
-										CPU: aws.Int(70),
+										Spot: aws.Int(5),
 									},
 								},
 							},
@@ -301,23 +279,7 @@ func TestCount_UnmarshalYAML(t *testing.T) {
 `),
 			wantedStruct: Count{
 				Autoscaling: Autoscaling{
-					Spot: &Spot{
-						Base: aws.Int(42),
-					},
-				},
-			},
-		},
-		"With spot enabled with autoscaling range": {
-			inContent: []byte(`count:
-  range: 1-10
-  spot: true
-`),
-			wantedStruct: Count{
-				Autoscaling: Autoscaling{
-					Range: &mockRange,
-					Spot: &Spot{
-						Enabled: aws.Bool(true),
-					},
+					Spot: aws.Int(42),
 				},
 			},
 		},
@@ -349,10 +311,7 @@ func TestCount_UnmarshalYAML(t *testing.T) {
 				require.Equal(t, tc.wantedStruct.Autoscaling.Memory, b.Count.Autoscaling.Memory)
 				require.Equal(t, tc.wantedStruct.Autoscaling.Requests, b.Count.Autoscaling.Requests)
 				require.Equal(t, tc.wantedStruct.Autoscaling.ResponseTime, b.Count.Autoscaling.ResponseTime)
-				if tc.wantedStruct.Autoscaling.Spot != nil {
-					require.Equal(t, tc.wantedStruct.Autoscaling.Spot.Enabled, b.Count.Autoscaling.Spot.Enabled)
-					require.Equal(t, tc.wantedStruct.Autoscaling.Spot.Base, b.Count.Autoscaling.Spot.Base)
-				}
+				require.Equal(t, tc.wantedStruct.Autoscaling.Spot, b.Count.Autoscaling.Spot)
 			}
 		})
 	}

--- a/internal/pkg/manifest/workload.go
+++ b/internal/pkg/manifest/workload.go
@@ -35,6 +35,7 @@ var (
 	// Error definitions.
 	errUnmarshalBuildOpts  = errors.New("cannot unmarshal build field into string or compose-style map")
 	errUnmarshalCountOpts  = errors.New(`cannot unmarshal "count" field to an integer or autoscaling configuration`)
+	errUnmarshalSpot       = errors.New(`cannot unmarshal "spot" field to an integer or boolean`)
 	errUnmarshalExec       = errors.New("cannot unmarshal exec field into boolean or exec configuration")
 	errUnmarshalEntryPoint = errors.New("cannot unmarshal entrypoint into string or slice of strings")
 	errUnmarshalCommand    = errors.New("cannot unmarshal command into string or slice of strings")

--- a/internal/pkg/manifest/workload.go
+++ b/internal/pkg/manifest/workload.go
@@ -35,7 +35,7 @@ var (
 	// Error definitions.
 	errUnmarshalBuildOpts  = errors.New("cannot unmarshal build field into string or compose-style map")
 	errUnmarshalCountOpts  = errors.New(`cannot unmarshal "count" field to an integer or autoscaling configuration`)
-	errUnmarshalSpot       = errors.New(`cannot unmarshal "spot" field to an integer or boolean`)
+	errUnmarshalSpot       = errors.New(`cannot unmarshal "spot" field to an integer if range is specified`)
 	errUnmarshalExec       = errors.New("cannot unmarshal exec field into boolean or exec configuration")
 	errUnmarshalEntryPoint = errors.New("cannot unmarshal entrypoint into string or slice of strings")
 	errUnmarshalCommand    = errors.New("cannot unmarshal command into string or slice of strings")


### PR DESCRIPTION
This adds a new field, `spot` to the manifest as a subfield of `count`.  

First step of https://github.com/aws/copilot-cli/issues/2162

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
