### PR TITLE
test(integ): fix pipeline tests by adding Build field

### DIFF
--- a/internal/pkg/deploy/cloudformation/cc_pipeline_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/cc_pipeline_integration_test.go
@@ -205,6 +205,7 @@ func TestCCPipelineCreation(t *testing.T) {
 				Branch:        "master",
 				RepositoryURL: "https://us-west-2.console.aws.amazon.com/codesuite/codecommit/repositories/repo-name/browse",
 			},
+			Build: deploy.PipelineBuildFromManifest(nil),
 			Stages: []deploy.PipelineStage{
 				{
 					AssociatedEnvironment: &deploy.AssociatedEnvironment{

--- a/internal/pkg/deploy/cloudformation/ghV1_pipeline_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/ghV1_pipeline_integration_test.go
@@ -223,6 +223,7 @@ func TestGHv1PipelineCreation(t *testing.T) {
 				RepositoryURL:               "https://github.com/chicken/wings",
 				PersonalAccessTokenSecretID: secretId,
 			},
+			Build: deploy.PipelineBuildFromManifest(nil),
 			Stages: []deploy.PipelineStage{
 				{
 					AssociatedEnvironment: &deploy.AssociatedEnvironment{


### PR DESCRIPTION
We recently introduced a "build" field to pipeline manifests, but forgot to update
the integ tests that create the pipeline 😬. This change adds the default
build config so that the pipeline is created successfully.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
