### PR TITLE
style(cli): display AWS resources as hints next to patterns

### DIFF
--- a/internal/pkg/cli/init.go
+++ b/internal/pkg/cli/init.go
@@ -348,9 +348,9 @@ func (o *initOpts) askWorkload() (string, error) {
 
 ` + fmt.Sprintf(fmtJobInitTypeHelp, manifest.ScheduledJobType)
 
-	t, err := o.prompt.SelectOne(wkldInitTypePrompt, wkldHelp, manifest.WorkloadTypes, prompt.WithFinalMessage("Workload type:"))
+	t, err := o.prompt.SelectOption(wkldInitTypePrompt, wkldHelp, append(svcTypePromptOpts(), jobTypePromptOpts()...), prompt.WithFinalMessage("Workload type:"))
 	if err != nil {
-		return "", fmt.Errorf("select service type: %w", err)
+		return "", fmt.Errorf("select workload type: %w", err)
 	}
 	o.wkldType = t
 	return t, nil

--- a/internal/pkg/cli/init_test.go
+++ b/internal/pkg/cli/init_test.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/aws/copilot-cli/internal/pkg/term/prompt"
+
 	climocks "github.com/aws/copilot-cli/internal/pkg/cli/mocks"
 	"github.com/aws/copilot-cli/internal/pkg/manifest"
 	"github.com/golang/mock/gomock"
@@ -63,7 +65,7 @@ func TestInitOpts_Run(t *testing.T) {
 		},
 		"returns execute error for application": {
 			expect: func(opts *initOpts) {
-				opts.prompt.(*climocks.Mockprompter).EXPECT().SelectOne(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+				opts.prompt.(*climocks.Mockprompter).EXPECT().SelectOption(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 				opts.initAppCmd.(*climocks.MockactionCommand).EXPECT().Ask().Return(nil)
 				opts.initAppCmd.(*climocks.MockactionCommand).EXPECT().Validate().Return(nil)
 				opts.initWlCmd.(*climocks.MockactionCommand).EXPECT().Ask().Return(nil)
@@ -88,7 +90,7 @@ func TestInitOpts_Run(t *testing.T) {
 		"deploys environment": {
 			inPromptForShouldDeploy: true,
 			expect: func(opts *initOpts) {
-				opts.prompt.(*climocks.Mockprompter).EXPECT().SelectOne(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(manifest.LoadBalancedWebServiceType, nil)
+				opts.prompt.(*climocks.Mockprompter).EXPECT().SelectOption(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(manifest.LoadBalancedWebServiceType, nil)
 				opts.initAppCmd.(*climocks.MockactionCommand).EXPECT().Ask().Return(nil)
 				opts.initAppCmd.(*climocks.MockactionCommand).EXPECT().Validate().Return(nil)
 				opts.initWlCmd.(*climocks.MockactionCommand).EXPECT().Ask().Return(nil)
@@ -103,11 +105,24 @@ func TestInitOpts_Run(t *testing.T) {
 				opts.deploySvcCmd.(*climocks.MockactionCommand).EXPECT().Execute().Return(nil)
 			},
 		},
-		"svc deploy happy path": {
+		"deploy workload happy path": {
 			inPromptForShouldDeploy: true,
 			inShouldDeploy:          true,
 			expect: func(opts *initOpts) {
-				opts.prompt.(*climocks.Mockprompter).EXPECT().SelectOne(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+				opts.prompt.(*climocks.Mockprompter).EXPECT().SelectOption(gomock.Any(), gomock.Any(), []prompt.Option{
+					{
+						Value: manifest.LoadBalancedWebServiceType,
+						Hint:  "Internet to ECS on Fargate",
+					},
+					{
+						Value: manifest.BackendServiceType,
+						Hint:  "ECS on Fargate",
+					},
+					{
+						Value: manifest.ScheduledJobType,
+						Hint:  "Scheduled event to State Machine to Fargate",
+					},
+				}, gomock.Any())
 				opts.initAppCmd.(*climocks.MockactionCommand).EXPECT().Ask().Return(nil)
 				opts.initAppCmd.(*climocks.MockactionCommand).EXPECT().Validate().Return(nil)
 				opts.initWlCmd.(*climocks.MockactionCommand).EXPECT().Ask().Return(nil)
@@ -126,7 +141,7 @@ func TestInitOpts_Run(t *testing.T) {
 			inPromptForShouldDeploy: true,
 			inShouldDeploy:          false,
 			expect: func(opts *initOpts) {
-				opts.prompt.(*climocks.Mockprompter).EXPECT().SelectOne(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(manifest.LoadBalancedWebServiceType, nil)
+				opts.prompt.(*climocks.Mockprompter).EXPECT().SelectOption(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(manifest.LoadBalancedWebServiceType, nil)
 				opts.initAppCmd.(*climocks.MockactionCommand).EXPECT().Ask().Return(nil)
 				opts.initAppCmd.(*climocks.MockactionCommand).EXPECT().Validate().Return(nil)
 				opts.initWlCmd.(*climocks.MockactionCommand).EXPECT().Ask().Return(nil)

--- a/internal/pkg/cli/svc_init_test.go
+++ b/internal/pkg/cli/svc_init_test.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/aws/copilot-cli/internal/pkg/term/prompt"
+
 	"github.com/aws/copilot-cli/internal/pkg/cli/mocks"
 	"github.com/aws/copilot-cli/internal/pkg/exec"
 	"github.com/aws/copilot-cli/internal/pkg/initialize"
@@ -129,7 +131,16 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 			inDockerfilePath: wantedDockerfilePath,
 
 			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().SelectOne(gomock.Eq(fmt.Sprintf(fmtSvcInitSvcTypePrompt, "service type")), gomock.Any(), gomock.Eq(manifest.ServiceTypes), gomock.Any()).
+				m.EXPECT().SelectOption(gomock.Eq(fmt.Sprintf(fmtSvcInitSvcTypePrompt, "service type")), gomock.Any(), gomock.Eq([]prompt.Option{
+					{
+						Value: manifest.LoadBalancedWebServiceType,
+						Hint:  "Internet to ECS on Fargate",
+					},
+					{
+						Value: manifest.BackendServiceType,
+						Hint:  "ECS on Fargate",
+					},
+				}), gomock.Any()).
 					Return(wantedSvcType, nil)
 			},
 			mockDockerfile: func(m *mocks.MockdockerfileParser) {},
@@ -144,7 +155,7 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 			inDockerfilePath: wantedDockerfilePath,
 
 			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().SelectOne(gomock.Any(), gomock.Any(), gomock.Eq(manifest.ServiceTypes), gomock.Any()).
+				m.EXPECT().SelectOption(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return("", errors.New("some error"))
 			},
 			mockDockerfile: func(m *mocks.MockdockerfileParser) {},

--- a/internal/pkg/term/prompt/prompt.go
+++ b/internal/pkg/term/prompt/prompt.go
@@ -40,7 +40,7 @@ func init() {
 {{ end }}{{- end }}{{color "reset"}}{{end}}
 {{- color .Config.Icons.Question.Format }}{{if not .ShowAnswer}}  {{ .Config.Icons.Question.Text }}{{else}}{{ .Config.Icons.Question.Text }}{{end}}{{color "reset"}}
 {{- color "default"}}{{ .Message }}{{ .FilterMessage }}{{color "reset"}}
-{{- if .ShowAnswer}}{{color "default"}} {{.Answer}}{{color "reset"}}{{"\n"}}
+{{- if .ShowAnswer}}{{color "default"}} {{parseAnswer .Answer}}{{color "reset"}}{{"\n"}}
 {{- else}}
   {{- "  "}}{{- color "white"}}[Use arrows to move, type to filter{{- if and .Help (not .ShowHelp)}}, {{ .Config.HelpInput }} for more help{{end}}]{{color "reset"}}
   {{- "\n"}}
@@ -100,7 +100,9 @@ func init() {
 		return strings.Split(s, sep)
 	}
 	core.TemplateFuncsWithColor["split"] = split
+	core.TemplateFuncsWithColor["parseAnswer"] = parseValueFromOptionFmt
 	core.TemplateFuncsNoColor["split"] = split
+	core.TemplateFuncsNoColor["parseAnswer"] = parseValueFromOptionFmt
 }
 
 // ErrEmptyOptions indicates the input options list was empty.
@@ -135,7 +137,6 @@ func (p *prompt) Cleanup(config *survey.PromptConfig, val interface{}) error {
 	if p.FinalMessage == "" {
 		return p.prompter.Cleanup(config, val) // Delegate to the parent Cleanup.
 	}
-
 	// Update the message of the underlying struct.
 	switch typedPrompt := p.prompter.(type) {
 	case *survey.Select:


### PR DESCRIPTION
We now display hints on which underlying AWS container service and trigger we will use while initializing a workload:

https://user-images.githubusercontent.com/879348/114942272-23532080-9df9-11eb-9729-cc42e7932bfd.mov

This change also makes sure that the hint is removed once the user selects an option.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
