### PR TITLE
fix(cli): svc/job delete should select from SSM

### DIFF
--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -455,6 +455,7 @@ type appEnvSelector interface {
 type configSelector interface {
 	appEnvSelector
 	Service(prompt, help, app string) (string, error)
+	Job(prompt, help, app string) (string, error)
 }
 
 type deploySelector interface {

--- a/internal/pkg/cli/job_delete_test.go
+++ b/internal/pkg/cli/job_delete_test.go
@@ -126,7 +126,7 @@ func TestDeleteJobOpts_Ask(t *testing.T) {
 		appName          string
 
 		mockPrompt func(m *mocks.Mockprompter)
-		mockSel    func(m *mocks.MockwsSelector)
+		mockSel    func(m *mocks.MockconfigSelector)
 
 		wantedName  string
 		wantedError error
@@ -135,7 +135,7 @@ func TestDeleteJobOpts_Ask(t *testing.T) {
 			appName:          "",
 			inName:           testJobName,
 			skipConfirmation: true,
-			mockSel: func(m *mocks.MockwsSelector) {
+			mockSel: func(m *mocks.MockconfigSelector) {
 				m.EXPECT().Application("Which application's job would you like to delete?", "").Return(testAppName, nil)
 			},
 			mockPrompt: func(m *mocks.Mockprompter) {},
@@ -146,8 +146,8 @@ func TestDeleteJobOpts_Ask(t *testing.T) {
 			appName:          testAppName,
 			inName:           "",
 			skipConfirmation: true,
-			mockSel: func(m *mocks.MockwsSelector) {
-				m.EXPECT().Job("Which job would you like to delete?", "").Return(testJobName, nil)
+			mockSel: func(m *mocks.MockconfigSelector) {
+				m.EXPECT().Job("Which job would you like to delete?", "", testAppName).Return(testJobName, nil)
 			},
 			mockPrompt: func(m *mocks.Mockprompter) {},
 
@@ -157,8 +157,8 @@ func TestDeleteJobOpts_Ask(t *testing.T) {
 			appName:          testAppName,
 			inName:           "",
 			skipConfirmation: true,
-			mockSel: func(m *mocks.MockwsSelector) {
-				m.EXPECT().Job("Which job would you like to delete?", "").Return("", mockError)
+			mockSel: func(m *mocks.MockconfigSelector) {
+				m.EXPECT().Job("Which job would you like to delete?", "", testAppName).Return("", mockError)
 			},
 			mockPrompt: func(m *mocks.Mockprompter) {},
 
@@ -168,9 +168,8 @@ func TestDeleteJobOpts_Ask(t *testing.T) {
 			appName:          testAppName,
 			inName:           "",
 			skipConfirmation: true,
-			mockSel: func(m *mocks.MockwsSelector) {
-				m.EXPECT().Job(gomock.Any(), gomock.Any()).Times(0)
-				m.EXPECT().Job("Which job would you like to delete?", "").Return("", mockError)
+			mockSel: func(m *mocks.MockconfigSelector) {
+				m.EXPECT().Job("Which job would you like to delete?", "", testAppName).Return("", mockError)
 			},
 			mockPrompt: func(m *mocks.Mockprompter) {},
 
@@ -180,8 +179,8 @@ func TestDeleteJobOpts_Ask(t *testing.T) {
 			appName:          testAppName,
 			inName:           testJobName,
 			skipConfirmation: true,
-			mockSel: func(m *mocks.MockwsSelector) {
-				m.EXPECT().Job(gomock.Any(), gomock.Any()).Times(0)
+			mockSel: func(m *mocks.MockconfigSelector) {
+				m.EXPECT().Job(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 			},
 			mockPrompt: func(m *mocks.Mockprompter) {},
 
@@ -191,8 +190,8 @@ func TestDeleteJobOpts_Ask(t *testing.T) {
 			appName:          testAppName,
 			inName:           testJobName,
 			skipConfirmation: false,
-			mockSel: func(m *mocks.MockwsSelector) {
-				m.EXPECT().Job(gomock.Any(), gomock.Any()).Times(0)
+			mockSel: func(m *mocks.MockconfigSelector) {
+				m.EXPECT().Job(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 			},
 			mockPrompt: func(m *mocks.Mockprompter) {
 				m.EXPECT().Confirm(
@@ -207,8 +206,8 @@ func TestDeleteJobOpts_Ask(t *testing.T) {
 			appName:          testAppName,
 			inName:           testJobName,
 			skipConfirmation: false,
-			mockSel: func(m *mocks.MockwsSelector) {
-				m.EXPECT().Job(gomock.Any(), gomock.Any()).Times(0)
+			mockSel: func(m *mocks.MockconfigSelector) {
+				m.EXPECT().Job(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 			},
 			mockPrompt: func(m *mocks.Mockprompter) {
 				m.EXPECT().Confirm(
@@ -223,8 +222,8 @@ func TestDeleteJobOpts_Ask(t *testing.T) {
 			appName:          testAppName,
 			inName:           testJobName,
 			skipConfirmation: false,
-			mockSel: func(m *mocks.MockwsSelector) {
-				m.EXPECT().Job(gomock.Any(), gomock.Any()).Times(0)
+			mockSel: func(m *mocks.MockconfigSelector) {
+				m.EXPECT().Job(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 			},
 			mockPrompt: func(m *mocks.Mockprompter) {
 				m.EXPECT().Confirm(
@@ -240,8 +239,8 @@ func TestDeleteJobOpts_Ask(t *testing.T) {
 			inName:           testJobName,
 			envName:          "test",
 			skipConfirmation: false,
-			mockSel: func(m *mocks.MockwsSelector) {
-				m.EXPECT().Job(gomock.Any(), gomock.Any()).Times(0)
+			mockSel: func(m *mocks.MockconfigSelector) {
+				m.EXPECT().Job(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 			},
 			mockPrompt: func(m *mocks.Mockprompter) {
 				m.EXPECT().Confirm(
@@ -260,7 +259,7 @@ func TestDeleteJobOpts_Ask(t *testing.T) {
 			defer ctrl.Finish()
 
 			mockPrompter := mocks.NewMockprompter(ctrl)
-			mockSel := mocks.NewMockwsSelector(ctrl)
+			mockSel := mocks.NewMockconfigSelector(ctrl)
 			test.mockPrompt(mockPrompter)
 			test.mockSel(mockSel)
 

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -4818,6 +4818,21 @@ func (mr *MockconfigSelectorMockRecorder) Environment(prompt, help, app interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Environment", reflect.TypeOf((*MockconfigSelector)(nil).Environment), varargs...)
 }
 
+// Job mocks base method.
+func (m *MockconfigSelector) Job(prompt, help, app string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Job", prompt, help, app)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Job indicates an expected call of Job.
+func (mr *MockconfigSelectorMockRecorder) Job(prompt, help, app interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Job", reflect.TypeOf((*MockconfigSelector)(nil).Job), prompt, help, app)
+}
+
 // Service mocks base method.
 func (m *MockconfigSelector) Service(prompt, help, app string) (string, error) {
 	m.ctrl.T.Helper()

--- a/internal/pkg/cli/svc_delete_test.go
+++ b/internal/pkg/cli/svc_delete_test.go
@@ -124,7 +124,7 @@ func TestDeleteSvcOpts_Ask(t *testing.T) {
 		envName          string
 		appName          string
 
-		mockSel    func(m *mocks.MockwsSelector)
+		mockSel    func(m *mocks.MockconfigSelector)
 		mockPrompt func(m *mocks.Mockprompter)
 
 		wantedName  string
@@ -134,7 +134,7 @@ func TestDeleteSvcOpts_Ask(t *testing.T) {
 			appName:          "",
 			inName:           testSvcName,
 			skipConfirmation: true,
-			mockSel: func(m *mocks.MockwsSelector) {
+			mockSel: func(m *mocks.MockconfigSelector) {
 				m.EXPECT().Application(svcAppNamePrompt, svcAppNameHelpPrompt).Return(testAppName, nil)
 			},
 			mockPrompt: func(m *mocks.Mockprompter) {},
@@ -145,8 +145,8 @@ func TestDeleteSvcOpts_Ask(t *testing.T) {
 			appName:          testAppName,
 			inName:           "",
 			skipConfirmation: true,
-			mockSel: func(m *mocks.MockwsSelector) {
-				m.EXPECT().Service("Which service would you like to delete?", "").Return(testSvcName, nil)
+			mockSel: func(m *mocks.MockconfigSelector) {
+				m.EXPECT().Service("Which service would you like to delete?", "", testAppName).Return(testSvcName, nil)
 			},
 			mockPrompt: func(m *mocks.Mockprompter) {},
 
@@ -156,8 +156,8 @@ func TestDeleteSvcOpts_Ask(t *testing.T) {
 			appName:          testAppName,
 			inName:           "",
 			skipConfirmation: true,
-			mockSel: func(m *mocks.MockwsSelector) {
-				m.EXPECT().Service("Which service would you like to delete?", "").Return("", mockError)
+			mockSel: func(m *mocks.MockconfigSelector) {
+				m.EXPECT().Service("Which service would you like to delete?", "", testAppName).Return("", mockError)
 			},
 			mockPrompt: func(m *mocks.Mockprompter) {},
 
@@ -167,8 +167,8 @@ func TestDeleteSvcOpts_Ask(t *testing.T) {
 			appName:          testAppName,
 			inName:           "",
 			skipConfirmation: true,
-			mockSel: func(m *mocks.MockwsSelector) {
-				m.EXPECT().Service("Which service would you like to delete?", "").Return("", mockError)
+			mockSel: func(m *mocks.MockconfigSelector) {
+				m.EXPECT().Service("Which service would you like to delete?", "", testAppName).Return("", mockError)
 			},
 			mockPrompt: func(m *mocks.Mockprompter) {
 			},
@@ -179,8 +179,8 @@ func TestDeleteSvcOpts_Ask(t *testing.T) {
 			appName:          testAppName,
 			inName:           testSvcName,
 			skipConfirmation: true,
-			mockSel: func(m *mocks.MockwsSelector) {
-				m.EXPECT().Service(gomock.Any(), gomock.Any()).Times(0)
+			mockSel: func(m *mocks.MockconfigSelector) {
+				m.EXPECT().Service(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 			},
 			mockPrompt: func(m *mocks.Mockprompter) {},
 
@@ -190,8 +190,8 @@ func TestDeleteSvcOpts_Ask(t *testing.T) {
 			appName:          testAppName,
 			inName:           testSvcName,
 			skipConfirmation: false,
-			mockSel: func(m *mocks.MockwsSelector) {
-				m.EXPECT().Service(gomock.Any(), gomock.Any()).Times(0)
+			mockSel: func(m *mocks.MockconfigSelector) {
+				m.EXPECT().Service(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 			},
 			mockPrompt: func(m *mocks.Mockprompter) {
 				m.EXPECT().Confirm(
@@ -206,8 +206,8 @@ func TestDeleteSvcOpts_Ask(t *testing.T) {
 			appName:          testAppName,
 			inName:           testSvcName,
 			skipConfirmation: false,
-			mockSel: func(m *mocks.MockwsSelector) {
-				m.EXPECT().Service(gomock.Any(), gomock.Any()).Times(0)
+			mockSel: func(m *mocks.MockconfigSelector) {
+				m.EXPECT().Service(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 			},
 			mockPrompt: func(m *mocks.Mockprompter) {
 				m.EXPECT().Confirm(
@@ -222,8 +222,8 @@ func TestDeleteSvcOpts_Ask(t *testing.T) {
 			appName:          testAppName,
 			inName:           testSvcName,
 			skipConfirmation: false,
-			mockSel: func(m *mocks.MockwsSelector) {
-				m.EXPECT().Service(gomock.Any(), gomock.Any()).Times(0)
+			mockSel: func(m *mocks.MockconfigSelector) {
+				m.EXPECT().Service(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 			},
 			mockPrompt: func(m *mocks.Mockprompter) {
 				m.EXPECT().Confirm(
@@ -239,8 +239,8 @@ func TestDeleteSvcOpts_Ask(t *testing.T) {
 			inName:           testSvcName,
 			envName:          "test",
 			skipConfirmation: false,
-			mockSel: func(m *mocks.MockwsSelector) {
-				m.EXPECT().Service(gomock.Any(), gomock.Any()).Times(0)
+			mockSel: func(m *mocks.MockconfigSelector) {
+				m.EXPECT().Service(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 			},
 			mockPrompt: func(m *mocks.Mockprompter) {
 				m.EXPECT().Confirm(
@@ -259,7 +259,7 @@ func TestDeleteSvcOpts_Ask(t *testing.T) {
 			defer ctrl.Finish()
 
 			mockPrompter := mocks.NewMockprompter(ctrl)
-			mockSel := mocks.NewMockwsSelector(ctrl)
+			mockSel := mocks.NewMockconfigSelector(ctrl)
 			test.mockPrompt(mockPrompter)
 			test.mockSel(mockSel)
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
Currently our `svc/job delete` select candidates with local workspace files. However, this is not ideal since delete doesn't require to be in the workspace since we won't delete the local files. Also, this could hurt the idempotency since if the local files are removed, users cannot use `svc/job delete` to delete their workloads anymore.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
