### PR TITLE
chore(aws): update aws ecs package to support `--generate-cmd`

### DIFF
--- a/internal/pkg/aws/ecs/service.go
+++ b/internal/pkg/aws/ecs/service.go
@@ -71,3 +71,10 @@ func (s *ServiceArn) ServiceName() (string, error) {
 	}
 	return resources[2], nil
 }
+
+// NetworkConfiguration holds service's NetworkConfiguration.
+type NetworkConfiguration struct {
+	AssignPublicIp string
+	SecurityGroups []string
+	Subnets        []string
+}

--- a/internal/pkg/aws/ecs/task.go
+++ b/internal/pkg/aws/ecs/task.go
@@ -204,6 +204,60 @@ func (t *TaskDefinition) Secrets() []*ContainerSecret {
 	return secrets
 }
 
+// ContainerImage holds basic info of an image.
+type ContainerImage struct {
+	Container string
+	Image     string
+}
+
+// Images returns the container images of the task definition.
+func (t *TaskDefinition) Images() []*ContainerImage {
+	var images []*ContainerImage
+	for _, container := range t.ContainerDefinitions {
+		images = append(images, &ContainerImage{
+			Container: aws.StringValue(container.Name),
+			Image:     aws.StringValue(container.Image),
+		})
+	}
+	return images
+}
+
+// ContainerCommand holds basic info of a command override.
+type ContainerCommand struct {
+	Container string
+	Command   []string
+}
+
+// Commands returns the containers' command overrides of the task definition.
+func (t *TaskDefinition) Commands() []*ContainerCommand {
+	var commands []*ContainerCommand
+	for _, container := range t.ContainerDefinitions {
+		commands = append(commands, &ContainerCommand{
+			Container: aws.StringValue(container.Name),
+			Command:   aws.StringValueSlice(container.Command),
+		})
+	}
+	return commands
+}
+
+// ContainerEntrypoint holds basic info of a entrypoint override.
+type ContainerEntrypoint struct {
+	Container  string
+	EntryPoint []string
+}
+
+// EntryPoints returns the containers' entrypoint overrides of the task definition.
+func (t *TaskDefinition) EntryPoints() []*ContainerEntrypoint {
+	var entryPoints []*ContainerEntrypoint
+	for _, container := range t.ContainerDefinitions {
+		entryPoints = append(entryPoints, &ContainerEntrypoint{
+			Container:  aws.StringValue(container.Name),
+			EntryPoint: aws.StringValueSlice(container.EntryPoint),
+		})
+	}
+	return entryPoints
+}
+
 // TaskID parses the task ARN and returns the task ID.
 // For example: arn:aws:ecs:us-west-2:123456789:task/my-project-test-Cluster-9F7Y0RLP60R7/4082490ee6c245e09d2145010aa1ba8d,
 // arn:aws:ecs:us-west-2:123456789:task/4082490ee6c245e09d2145010aa1ba8d

--- a/internal/pkg/aws/ecs/task_test.go
+++ b/internal/pkg/aws/ecs/task_test.go
@@ -434,6 +434,156 @@ func TestTaskDefinition_Secrets(t *testing.T) {
 	}
 }
 
+func TestTaskDefinition_Images(t *testing.T) {
+	testCases := map[string]struct {
+		inContainers []*ecs.ContainerDefinition
+		wantedImages []*ContainerImage
+	}{
+		"should return images of the task definition as a list of ContainerImage": {
+			inContainers: []*ecs.ContainerDefinition{
+				{
+					Name:  aws.String("container-1"),
+					Image: aws.String("image-1"),
+				},
+				{
+					Name:  aws.String("container-2"),
+					Image: aws.String("image-2"),
+				},
+			},
+
+			wantedImages: []*ContainerImage{
+				{
+					Container: "container-1",
+					Image:     "image-1",
+				},
+				{
+					Container: "container-2",
+					Image:     "image-2",
+				},
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// GIVEN
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			taskDefinition := TaskDefinition{
+				ContainerDefinitions: tc.inContainers,
+			}
+
+			gotImages := taskDefinition.Images()
+
+			require.Equal(t, tc.wantedImages, gotImages)
+		})
+
+	}
+}
+
+func TestTaskDefinition_Commands(t *testing.T) {
+	testCases := map[string]struct {
+		inContainers   []*ecs.ContainerDefinition
+		wantedCommands []*ContainerCommand
+	}{
+		"should return command overrides of the task definition as a list of ContainerCommand": {
+			inContainers: []*ecs.ContainerDefinition{
+				{
+					Name:    aws.String("container-1"),
+					Command: aws.StringSlice([]string{"echo", "strikes", "three"}),
+				},
+				{
+					Name:    aws.String("container-2"),
+					Command: aws.StringSlice([]string{"echo", "ball", "four"}),
+				},
+				{
+					Name: aws.String("container-3"),
+				},
+			},
+
+			wantedCommands: []*ContainerCommand{
+				{
+					Container: "container-1",
+					Command:   []string{"echo", "strikes", "three"},
+				},
+				{
+					Container: "container-2",
+					Command:   []string{"echo", "ball", "four"},
+				},
+				{
+					Container: "container-3",
+					Command:   []string{},
+				},
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// GIVEN
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			taskDefinition := TaskDefinition{
+				ContainerDefinitions: tc.inContainers,
+			}
+
+			gotCommands := taskDefinition.Commands()
+
+			require.Equal(t, tc.wantedCommands, gotCommands)
+		})
+
+	}
+}
+
+func TestTaskDefinition_EntryPoints(t *testing.T) {
+	testCases := map[string]struct {
+		inContainers      []*ecs.ContainerDefinition
+		wantedEntryPoints []*ContainerEntrypoint
+	}{
+		"should return command overrides of the task definition as a list of ContainerCommand": {
+			inContainers: []*ecs.ContainerDefinition{
+				{
+					Name:       aws.String("container-1"),
+					EntryPoint: aws.StringSlice([]string{"echo", "strikes", "three"}),
+				},
+				{
+					Name: aws.String("container-2"),
+				},
+			},
+
+			wantedEntryPoints: []*ContainerEntrypoint{
+				{
+					Container:  "container-1",
+					EntryPoint: []string{"echo", "strikes", "three"},
+				},
+				{
+					Container:  "container-2",
+					EntryPoint: []string{},
+				},
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// GIVEN
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			taskDefinition := TaskDefinition{
+				ContainerDefinitions: tc.inContainers,
+			}
+
+			gotEntryPoints := taskDefinition.EntryPoints()
+
+			require.Equal(t, tc.wantedEntryPoints, gotEntryPoints)
+		})
+
+	}
+}
+
 func TestFilterRunningTasks(t *testing.T) {
 	testCases := map[string]struct {
 		inTasks     []*Task


### PR DESCRIPTION
To support `--generate-cmd` for `task run`, we need to be able to:
1. Retrieve network configuration for service;
2. Extract some container-level information (i.e. image, entrypoint, command, environment variables, secrets) from task definition. We have already implemented functions to extract environment variables and secrets. This PR adds functions to extract the rest of the information needed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
