### PR TITLE
feat(manifest): add Range subfields

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/backend_svc_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/backend_svc_test.go
@@ -108,7 +108,9 @@ Outputs:
 				testBackendSvcManifestWithBadAutoScaling := manifest.NewBackendService(baseProps)
 				badRange := manifest.Range("badRange")
 				testBackendSvcManifestWithBadAutoScaling.Count.Autoscaling = manifest.Autoscaling{
-					Range: &badRange,
+					Range: &manifest.RangeOpts{
+						Range: &badRange,
+					},
 				}
 				svc.manifest = testBackendSvcManifestWithBadAutoScaling
 			},

--- a/internal/pkg/deploy/cloudformation/stack/lb_web_svc_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/lb_web_svc_test.go
@@ -311,14 +311,18 @@ func TestLoadBalancedWebService_Parameters(t *testing.T) {
 	testLBWebServiceManifest.Count = manifest.Count{
 		Value: aws.Int(1),
 		Autoscaling: manifest.Autoscaling{
-			Range: &testLBWebServiceManifestRange,
+			Range: &manifest.RangeOpts{
+				Range: &testLBWebServiceManifestRange,
+			},
 		},
 	}
 	testLBWebServiceManifestWithBadCount := manifest.NewLoadBalancedWebService(baseProps)
 	testLBWebServiceManifestWithBadCountRange := manifest.Range("badCount")
 	testLBWebServiceManifestWithBadCount.Count = manifest.Count{
 		Autoscaling: manifest.Autoscaling{
-			Range: &testLBWebServiceManifestWithBadCountRange,
+			Range: &manifest.RangeOpts{
+				Range: &testLBWebServiceManifestWithBadCountRange,
+			},
 		},
 	}
 	testLBWebServiceManifestWithSidecar := manifest.NewLoadBalancedWebService(baseProps)

--- a/internal/pkg/deploy/cloudformation/stack/transformers_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/transformers_test.go
@@ -119,8 +119,10 @@ func Test_convertCapacityProviders(t *testing.T) {
 		},
 		"errors if spot specified with range": {
 			input: &manifest.Autoscaling{
-				Range: &mockRange,
-				Spot:  aws.Int(3),
+				Range: &manifest.RangeOpts{
+					Range: &mockRange,
+				},
+				Spot: aws.Int(3),
 			},
 			wantedErr: errInvalidSpotConfig,
 		},
@@ -153,14 +155,18 @@ func Test_convertAutoscaling(t *testing.T) {
 	}{
 		"invalid range": {
 			input: &manifest.Autoscaling{
-				Range: &badRange,
+				Range: &manifest.RangeOpts{
+					Range: &badRange,
+				},
 			},
 
 			wantedErr: fmt.Errorf("invalid range value badRange. Should be in format of ${min}-${max}"),
 		},
 		"success": {
 			input: &manifest.Autoscaling{
-				Range:        &mockRange,
+				Range: &manifest.RangeOpts{
+					Range: &mockRange,
+				},
 				CPU:          aws.Int(70),
 				Memory:       aws.Int(80),
 				Requests:     aws.Int(mockRequests),

--- a/internal/pkg/deploy/cloudformation/stack/workload.go
+++ b/internal/pkg/deploy/cloudformation/stack/workload.go
@@ -102,9 +102,9 @@ func (w *wkld) Parameters() ([]*cloudformation.Parameter, error) {
 		if w.tc.Count.Autoscaling.IgnoreRange() {
 			desiredCount = w.tc.Count.Autoscaling.Spot
 		} else {
-			min, _, err := w.tc.Count.Autoscaling.Range.Parse()
+			min, _, err := w.tc.Count.Autoscaling.Range.Parse() // TODO fix
 			if err != nil {
-				return nil, fmt.Errorf("parse task count value %s: %w", aws.StringValue((*string)(w.tc.Count.Autoscaling.Range)), err)
+				return nil, fmt.Errorf("parse task count value %s: %w", aws.StringValue((*string)(w.tc.Count.Autoscaling.Range.Range)), err)
 			}
 			desiredCount = aws.Int(min)
 		}

--- a/internal/pkg/manifest/lb_web_svc_test.go
+++ b/internal/pkg/manifest/lb_web_svc_test.go
@@ -520,7 +520,7 @@ func TestLoadBalancedWebService_ApplyEnv(t *testing.T) {
 					TaskConfig: TaskConfig{
 						Count: Count{
 							Autoscaling: Autoscaling{
-								Range: &mockRange,
+								Range: &RangeOpts{Range: &mockRange},
 								CPU:   aws.Int(80),
 							},
 						},
@@ -538,7 +538,7 @@ func TestLoadBalancedWebService_ApplyEnv(t *testing.T) {
 						Count: Count{
 							Value: nil,
 							Autoscaling: Autoscaling{
-								Range: &mockRange,
+								Range: &RangeOpts{Range: &mockRange},
 								CPU:   aws.Int(80),
 							},
 						},

--- a/internal/pkg/manifest/svc.go
+++ b/internal/pkg/manifest/svc.go
@@ -26,6 +26,50 @@ var ServiceTypes = []string{
 	BackendServiceType,
 }
 
+// RangeOpts contains either a Range or a range configuration for Autoscaling ranges
+type RangeOpts struct {
+	Range       *Range // Mutually exclusive with RangeConfig
+	RangeConfig RangeConfig
+}
+
+// Parse extracts the min and max from RangeOpts
+func (r RangeOpts) Parse() (min int, max int, err error) {
+	if r.Range != nil && !r.RangeConfig.IsEmpty() {
+		return 0, 0, errInvalidRangeOpts
+	}
+
+	if r.Range != nil {
+		return r.Range.Parse()
+	}
+
+	return *r.RangeConfig.Min, *r.RangeConfig.Max, nil
+}
+
+// UnmarshalYAML overrides the default YAML unmarshaling logic for the RangeOpts
+// struct, allowing it to perform more complex unmarshaling behavior.
+// This method implements the yaml.Unmarshaler (v2) interface.
+func (r *RangeOpts) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	if err := unmarshal(&r.RangeConfig); err != nil {
+		switch err.(type) {
+		case *yaml.TypeError:
+			break
+		default:
+			return err
+		}
+	}
+
+	if !r.RangeConfig.IsEmpty() {
+		// Unmarshaled successfully to r.RangeConfig, unset r.Range, and return.
+		r.Range = nil
+		return nil
+	}
+
+	if err := unmarshal(&r.Range); err != nil {
+		return errUnmarshalRangeOpts
+	}
+	return nil
+}
+
 // Range is a number range with maximum and minimum values.
 type Range string
 
@@ -45,6 +89,22 @@ func (r Range) Parse() (min int, max int, err error) {
 		return 0, 0, fmt.Errorf("cannot convert maximum value %s to integer", minMax[1])
 	}
 	return min, max, nil
+}
+
+// RangeConfig containers a Min/Max and an optional SpotFrom field which
+// specifies the number of services you want to start placing on spot. For
+// example, if your range is 1-10 and `spot_from` is 5, up to 4 services will
+// be placed on dedicated Fargate capacity, and then after that, any scaling
+// event will place additioanl services on spot capacity.
+type RangeConfig struct {
+	Min      *int `yaml:"min"`
+	Max      *int `yaml:"max"`
+	SpotFrom *int `yaml:"spot_from"`
+}
+
+// IsEmpty returns whether RangeConfig is empty.
+func (r *RangeConfig) IsEmpty() bool {
+	return r.Min == nil && r.Max == nil && r.SpotFrom == nil
 }
 
 // ServiceImageWithPort represents a container image with an exposed port.
@@ -92,7 +152,7 @@ func (c *Count) UnmarshalYAML(unmarshal func(interface{}) error) error {
 // Capacity configuration (spot).
 type Autoscaling struct {
 	Spot         *int           `yaml:"spot"` // mutually exclusive with Range
-	Range        *Range         `yaml:"range"`
+	Range        *RangeOpts     `yaml:"range"`
 	CPU          *int           `yaml:"cpu_percentage"`
 	Memory       *int           `yaml:"memory_percentage"`
 	Requests     *int           `yaml:"requests"`

--- a/internal/pkg/manifest/workload.go
+++ b/internal/pkg/manifest/workload.go
@@ -36,9 +36,12 @@ var (
 	errUnmarshalBuildOpts  = errors.New("cannot unmarshal build field into string or compose-style map")
 	errUnmarshalCountOpts  = errors.New(`cannot unmarshal "count" field to an integer or autoscaling configuration`)
 	errUnmarshalSpot       = errors.New(`cannot unmarshal "spot" field to an integer if range is specified`)
+	errUnmarshalRangeOpts  = errors.New(`cannot unmarshal "range" field`)
 	errUnmarshalExec       = errors.New("cannot unmarshal exec field into boolean or exec configuration")
 	errUnmarshalEntryPoint = errors.New("cannot unmarshal entrypoint into string or slice of strings")
 	errUnmarshalCommand    = errors.New("cannot unmarshal command into string or slice of strings")
+
+	errInvalidRangeOpts = errors.New(`cannot specify both "range" and "min"/"max"`)
 )
 
 // WorkloadProps contains properties for creating a new workload manifest.


### PR DESCRIPTION
Range can now either be a range string or a map containing the subfields
"min", "max" and "spot_from". This allows customers to use Application
Autoscaling with spot capacity.


Part of #2162

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
