### PR TITLE
chore(cli): enable app upgrade in other commands

### DIFF
--- a/internal/pkg/cli/app_upgrade.go
+++ b/internal/pkg/cli/app_upgrade.go
@@ -65,6 +65,16 @@ func newAppUpgradeOpts(vars appUpgradeVars) (*appUpgradeOpts, error) {
 	}, nil
 }
 
+// Validate is a no-op for this command.
+func (o *appUpgradeOpts) Validate() error {
+	return nil
+}
+
+// Ask prompts is a no-op for this command.
+func (o *appUpgradeOpts) Ask() error {
+	return nil
+}
+
 // Execute updates the cloudformation stack as well as the stackset of an application to the latest version.
 // If any stack is busy updating, it spins and waits until the stack can be updated.
 func (o *appUpgradeOpts) Execute() error {
@@ -91,6 +101,11 @@ func (o *appUpgradeOpts) Execute() error {
 	if err != nil {
 		return err
 	}
+	return nil
+}
+
+// RecommendedActions is a no-op for this command.
+func (o *appUpgradeOpts) RecommendedActions() []string {
 	return nil
 }
 
@@ -130,11 +145,6 @@ func (o *appUpgradeOpts) upgradeApplication(app *config.Application, fromVersion
 	return nil
 }
 
-// RecommendedActions is a no-op for this command.
-func (o *appUpgradeOpts) RecommendedActions() []string {
-	return nil
-}
-
 // buildAppUpgradeCmd builds the command to update an application to the latest version.
 func buildAppUpgradeCmd() *cobra.Command {
 	vars := appUpgradeVars{}
@@ -150,6 +160,6 @@ func buildAppUpgradeCmd() *cobra.Command {
 			return opts.Execute()
 		}),
 	}
-	cmd.Flags().StringVarP(&vars.name, nameFlag, nameFlagShort, "", appFlagDescription)
+	cmd.Flags().StringVarP(&vars.name, nameFlag, nameFlagShort, tryReadingAppName(), appFlagDescription)
 	return cmd
 }

--- a/internal/pkg/deploy/cloudformation/app.go
+++ b/internal/pkg/deploy/cloudformation/app.go
@@ -477,6 +477,7 @@ func (cf CloudFormation) getLastDeployedAppConfig(appConfig *stack.AppStackConfi
 	if err != nil {
 		return nil, fmt.Errorf("parse previous deployed stackset %w", err)
 	}
+	previouslyDeployedConfig.App = appConfig.Name
 	return previouslyDeployedConfig, nil
 }
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
Part of #1188. Use `app upgrade` in other commands that require application update. Tested the following scenarios:

- [x] create an env should upgrade the legacy app
- [x] create an workload should upgrade the legacy app
- [x] should work with app with domain
- [x] App delete should work for legacy app

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
