### PR TITLE
test(exec): make fake http GET calls instead of downloading plugin

### DIFF
--- a/internal/pkg/exec/exec.go
+++ b/internal/pkg/exec/exec.go
@@ -5,8 +5,14 @@
 package exec
 
 import (
+	"net/http"
+
 	"github.com/aws/copilot-cli/internal/pkg/term/command"
 )
+
+type httpClient interface {
+	Get(url string) (resp *http.Response, err error)
+}
 
 type runner interface {
 	Run(name string, args []string, options ...command.Option) error

--- a/internal/pkg/exec/ssm_plugin.go
+++ b/internal/pkg/exec/ssm_plugin.go
@@ -29,6 +29,7 @@ const (
 type SSMPluginCommand struct {
 	sess *session.Session
 	runner
+	http httpClient
 
 	// facilitate unit test.
 	latestVersionBuffer    bytes.Buffer
@@ -42,6 +43,7 @@ func NewSSMPluginCommand(s *session.Session) SSMPluginCommand {
 	return SSMPluginCommand{
 		runner: command.New(),
 		sess:   s,
+		http:   http.DefaultClient,
 	}
 }
 
@@ -58,8 +60,8 @@ func (s SSMPluginCommand) StartSession(ssmSess *ecs.Session) error {
 	return nil
 }
 
-func download(filepath string, url string) error {
-	resp, err := http.Get(url)
+func download(client httpClient, filepath string, url string) error {
+	resp, err := client.Get(url)
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/exec/ssm_plugin_install_latest_binary_darwin.go
+++ b/internal/pkg/exec/ssm_plugin_install_latest_binary_darwin.go
@@ -25,7 +25,7 @@ func (s SSMPluginCommand) InstallLatestBinary() error {
 		defer os.RemoveAll(dir)
 		s.tempDir = dir
 	}
-	if err := download(filepath.Join(s.tempDir, "sessionmanager-bundle.zip"), ssmPluginBinaryURL); err != nil {
+	if err := download(s.http, filepath.Join(s.tempDir, "sessionmanager-bundle.zip"), ssmPluginBinaryURL); err != nil {
 		return fmt.Errorf("download ssm plugin: %w", err)
 	}
 	if err := s.runner.Run("unzip", []string{"-o", filepath.Join(s.tempDir, "sessionmanager-bundle.zip"),

--- a/internal/pkg/exec/ssm_plugin_install_latest_binary_darwin_test.go
+++ b/internal/pkg/exec/ssm_plugin_install_latest_binary_darwin_test.go
@@ -67,6 +67,9 @@ func TestSSMPluginCommand_InstallLatestBinary_darwin(t *testing.T) {
 			s := SSMPluginCommand{
 				runner:  mockRunner,
 				tempDir: mockDir,
+				http: &fakeHTTPClient{
+					content: []byte("hello"),
+				},
 			}
 			err := s.InstallLatestBinary()
 			if tc.wantedError != nil {

--- a/internal/pkg/exec/ssm_plugin_install_latest_binary_linux.go
+++ b/internal/pkg/exec/ssm_plugin_install_latest_binary_linux.go
@@ -42,7 +42,7 @@ func (s SSMPluginCommand) isUbuntu() (bool, error) {
 }
 
 func (s SSMPluginCommand) installLinuxBinary() error {
-	if err := download(filepath.Join(s.tempDir, "session-manager-plugin.rpm"), linuxSSMPluginBinaryURL); err != nil {
+	if err := download(s.http, filepath.Join(s.tempDir, "session-manager-plugin.rpm"), linuxSSMPluginBinaryURL); err != nil {
 		return fmt.Errorf("download ssm plugin: %w", err)
 	}
 	if err := s.runner.Run("sudo", []string{"yum", "install", "-y",
@@ -53,7 +53,7 @@ func (s SSMPluginCommand) installLinuxBinary() error {
 }
 
 func (s SSMPluginCommand) installUbuntuBinary() error {
-	if err := download(filepath.Join(s.tempDir, "session-manager-plugin.deb"), ubuntuSSMPluginBinaryURL); err != nil {
+	if err := download(s.http, filepath.Join(s.tempDir, "session-manager-plugin.deb"), ubuntuSSMPluginBinaryURL); err != nil {
 		return fmt.Errorf("download ssm plugin: %w", err)
 	}
 	if err := s.runner.Run("sudo", []string{"dpkg", "-i",

--- a/internal/pkg/exec/ssm_plugin_install_latest_binary_linux_test.go
+++ b/internal/pkg/exec/ssm_plugin_install_latest_binary_linux_test.go
@@ -86,6 +86,9 @@ func TestSSMPluginCommand_InstallLatestBinary_linux(t *testing.T) {
 				runner:                 mockRunner,
 				tempDir:                mockDir,
 				linuxDistVersionBuffer: *bytes.NewBufferString(tc.linuxVersion),
+				http: &fakeHTTPClient{
+					content: []byte("hello"),
+				},
 			}
 			err := s.InstallLatestBinary()
 			if tc.wantedError != nil {

--- a/internal/pkg/exec/ssm_plugin_test.go
+++ b/internal/pkg/exec/ssm_plugin_test.go
@@ -6,6 +6,8 @@ package exec
 import (
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -15,6 +17,20 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 )
+
+type fakeHTTPClient struct {
+	content []byte
+	err     error
+}
+
+func (c *fakeHTTPClient) Get(url string) (resp *http.Response, err error) {
+	if c.err != nil {
+		return nil, c.err
+	}
+	r := httptest.NewRecorder()
+	_, _ = r.Write(c.content)
+	return r.Result(), nil
+}
 
 func TestSSMPluginCommand_StartSession(t *testing.T) {
 	mockSession := &ecs.Session{


### PR DESCRIPTION
Currently, the unit tests make calls over the internet to download
the ssm plugin. This change replaces it with a fake response and speeds
up our unit tests from 11s to 458ms on my terrible home wifi.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
