### PR TITLE
feat(cli): include capacity provider in svc status

### DIFF
--- a/internal/pkg/aws/ecs/task.go
+++ b/internal/pkg/aws/ecs/task.go
@@ -78,13 +78,14 @@ func (t *Task) TaskStatus() (*TaskStatus, error) {
 		})
 	}
 	return &TaskStatus{
-		Health:        aws.StringValue(t.HealthStatus),
-		ID:            taskID,
-		Images:        images,
-		LastStatus:    aws.StringValue(t.LastStatus),
-		StartedAt:     startedAt,
-		StoppedAt:     stoppedAt,
-		StoppedReason: stoppedReason,
+		Health:           aws.StringValue(t.HealthStatus),
+		ID:               taskID,
+		Images:           images,
+		LastStatus:       aws.StringValue(t.LastStatus),
+		StartedAt:        startedAt,
+		StoppedAt:        stoppedAt,
+		StoppedReason:    stoppedReason,
+		CapacityProvider: aws.StringValue(t.CapacityProviderName),
 	}, nil
 }
 
@@ -118,13 +119,14 @@ func (t *Task) ENI() (string, error) {
 
 // TaskStatus contains the status info of a task.
 type TaskStatus struct {
-	Health        string    `json:"health"`
-	ID            string    `json:"id"`
-	Images        []Image   `json:"images"`
-	LastStatus    string    `json:"lastStatus"`
-	StartedAt     time.Time `json:"startedAt"`
-	StoppedAt     time.Time `json:"stoppedAt"`
-	StoppedReason string    `json:"stoppedReason"`
+	Health           string    `json:"health"`
+	ID               string    `json:"id"`
+	Images           []Image   `json:"images"`
+	LastStatus       string    `json:"lastStatus"`
+	StartedAt        time.Time `json:"startedAt"`
+	StoppedAt        time.Time `json:"stoppedAt"`
+	StoppedReason    string    `json:"stoppedReason"`
+	CapacityProvider string    `json:"capacityProvider"`
 }
 
 // HumanString returns the stringified TaskStatus struct with human readable format.
@@ -154,7 +156,12 @@ func (t TaskStatus) HumanString() string {
 	if len(t.ID) >= shortTaskIDLength {
 		shortTaskID = t.ID[:shortTaskIDLength]
 	}
-	return fmt.Sprintf("  %s\t%s\t%s\t%s\t%s\t%s\n", shortTaskID, imageDigest, t.LastStatus, startedSince, stoppedSince, taskHealthColor(t.Health))
+	cp := "-"
+	if t.CapacityProvider != "" {
+		cp = t.CapacityProvider
+	}
+
+	return fmt.Sprintf("  %s\t%s\t%s\t%s\t%s\t%s\t%s\n", shortTaskID, imageDigest, t.LastStatus, startedSince, stoppedSince, cp, taskHealthColor(t.Health))
 }
 
 // TaskDefinition wraps up ECS TaskDefinition struct.

--- a/internal/pkg/aws/ecs/task_test.go
+++ b/internal/pkg/aws/ecs/task_test.go
@@ -239,30 +239,32 @@ func TestTaskStatus_HumanString(t *testing.T) {
 	stopTime, _ := time.Parse(time.RFC3339, "2006-01-02T16:04:05+00:00")
 	mockImageDigest := "18f7eb6cff6e63e5f5273fb53f672975fe6044580f66c354f55d2de8dd28aec7"
 	testCases := map[string]struct {
-		id          string
-		health      string
-		lastStatus  string
-		imageDigest string
-		startedAt   time.Time
-		stoppedAt   time.Time
+		id               string
+		health           string
+		lastStatus       string
+		imageDigest      string
+		startedAt        time.Time
+		stoppedAt        time.Time
+		capacityProvider string
 
 		wantTaskStatus string
 	}{
 		"all params": {
-			health:      "HEALTHY",
-			id:          "aslhfnqo39j8qomimvoiqm89349",
-			lastStatus:  "RUNNING",
-			startedAt:   startTime,
-			stoppedAt:   stopTime,
-			imageDigest: mockImageDigest,
+			health:           "HEALTHY",
+			id:               "aslhfnqo39j8qomimvoiqm89349",
+			lastStatus:       "RUNNING",
+			startedAt:        startTime,
+			stoppedAt:        stopTime,
+			imageDigest:      mockImageDigest,
+			capacityProvider: "FARGATE",
 
-			wantTaskStatus: "  aslhfnqo\t18f7eb6c\tRUNNING\t14 years ago\t14 years ago\tHEALTHY\n",
+			wantTaskStatus: "  aslhfnqo\t18f7eb6c\tRUNNING\t14 years ago\t14 years ago\tFARGATE\tHEALTHY\n",
 		},
 		"missing params": {
 			health:     "HEALTHY",
 			lastStatus: "RUNNING",
 
-			wantTaskStatus: "  -\t-\tRUNNING\t-\t-\tHEALTHY\n",
+			wantTaskStatus: "  -\t-\tRUNNING\t-\t-\t-\tHEALTHY\n",
 		},
 	}
 
@@ -280,9 +282,10 @@ func TestTaskStatus_HumanString(t *testing.T) {
 						Digest: tc.imageDigest,
 					},
 				},
-				LastStatus: tc.lastStatus,
-				StartedAt:  tc.startedAt,
-				StoppedAt:  tc.stoppedAt,
+				LastStatus:       tc.lastStatus,
+				StartedAt:        tc.startedAt,
+				StoppedAt:        tc.stoppedAt,
+				CapacityProvider: tc.capacityProvider,
 			}
 
 			gotTaskStatus := task.HumanString()

--- a/internal/pkg/describe/status.go
+++ b/internal/pkg/describe/status.go
@@ -165,7 +165,7 @@ func (s *ServiceStatusDesc) HumanString() string {
 	fmt.Fprintf(writer, "  %s\t%s\n", "Task Definition", s.Service.TaskDefinition)
 	fmt.Fprint(writer, color.Bold.Sprint("\nTask Status\n\n"))
 	writer.Flush()
-	headers := []string{"ID", "Image Digest", "Last Status", "Started At", "Stopped At", "Health Status"}
+	headers := []string{"ID", "Image Digest", "Last Status", "Started At", "Stopped At", "Capacity Provider", "Health Status"}
 	fmt.Fprintf(writer, "  %s\n", strings.Join(headers, "\t"))
 	fmt.Fprintf(writer, "  %s\n", strings.Join(underline(headers), "\t"))
 	for _, task := range s.Tasks {

--- a/internal/pkg/describe/status_test.go
+++ b/internal/pkg/describe/status_test.go
@@ -349,9 +349,9 @@ Last Deployment
 
 Task Status
 
-  ID                Image Digest        Last Status         Started At          Stopped At          Health Status
-  --                ------------        -----------         ----------          ----------          -------------
-  12345678          -                   PROVISIONING        -                   -                   HEALTHY
+  ID                Image Digest        Last Status         Started At          Stopped At          Capacity Provider    Health Status
+  --                ------------        -----------         ----------          ----------          -----------------    -------------
+  12345678          -                   PROVISIONING        -                   -                   -                    HEALTHY
 
 Alarms
 
@@ -364,7 +364,7 @@ Alarms
   rm                                atapoints within 3 minutes                             
                                                                                            
 `,
-			json: "{\"Service\":{\"desiredCount\":1,\"runningCount\":0,\"status\":\"ACTIVE\",\"lastDeploymentAt\":\"2006-01-02T15:04:05Z\",\"taskDefinition\":\"mockTaskDefinition\"},\"tasks\":[{\"health\":\"HEALTHY\",\"id\":\"1234567890123456789\",\"images\":null,\"lastStatus\":\"PROVISIONING\",\"startedAt\":\"0001-01-01T00:00:00Z\",\"stoppedAt\":\"0001-01-01T00:00:00Z\",\"stoppedReason\":\"\"}],\"alarms\":[{\"arn\":\"mockAlarmArn1\",\"name\":\"mySupercalifragilisticexpialidociousAlarm\",\"condition\":\"RequestCount \\u003e 100.00 for 3 datapoints within 25 minutes\",\"status\":\"OK\",\"type\":\"Metric\",\"updatedTimes\":\"2020-03-13T19:50:30Z\"},{\"arn\":\"mockAlarmArn2\",\"name\":\"Um-dittle-ittl-um-dittle-I-Alarm\",\"condition\":\"CPUUtilization \\u003e 70.00 for 3 datapoints within 3 minutes\",\"status\":\"OK\",\"type\":\"Metric\",\"updatedTimes\":\"2020-03-13T19:50:30Z\"}]}\n",
+			json: "{\"Service\":{\"desiredCount\":1,\"runningCount\":0,\"status\":\"ACTIVE\",\"lastDeploymentAt\":\"2006-01-02T15:04:05Z\",\"taskDefinition\":\"mockTaskDefinition\"},\"tasks\":[{\"health\":\"HEALTHY\",\"id\":\"1234567890123456789\",\"images\":null,\"lastStatus\":\"PROVISIONING\",\"startedAt\":\"0001-01-01T00:00:00Z\",\"stoppedAt\":\"0001-01-01T00:00:00Z\",\"stoppedReason\":\"\",\"capacityProvider\":\"\"}],\"alarms\":[{\"arn\":\"mockAlarmArn1\",\"name\":\"mySupercalifragilisticexpialidociousAlarm\",\"condition\":\"RequestCount \\u003e 100.00 for 3 datapoints within 25 minutes\",\"status\":\"OK\",\"type\":\"Metric\",\"updatedTimes\":\"2020-03-13T19:50:30Z\"},{\"arn\":\"mockAlarmArn2\",\"name\":\"Um-dittle-ittl-um-dittle-I-Alarm\",\"condition\":\"CPUUtilization \\u003e 70.00 for 3 datapoints within 3 minutes\",\"status\":\"OK\",\"type\":\"Metric\",\"updatedTimes\":\"2020-03-13T19:50:30Z\"}]}\n",
 		},
 		"running": {
 			desc: &ServiceStatusDesc{
@@ -415,9 +415,9 @@ Last Deployment
 
 Task Status
 
-  ID                Image Digest         Last Status         Started At          Stopped At          Health Status
-  --                ------------         -----------         ----------          ----------          -------------
-  12345678          69671a96,ca27a44e    RUNNING             -                   -                   HEALTHY
+  ID                Image Digest         Last Status         Started At          Stopped At          Capacity Provider    Health Status
+  --                ------------         -----------         ----------          ----------          -----------------    -------------
+  12345678          69671a96,ca27a44e    RUNNING             -                   -                   -                    HEALTHY
 
 Alarms
 
@@ -426,7 +426,7 @@ Alarms
   mockAlarm         mockCondition       2 months from now    OK
                                                              
 `,
-			json: "{\"Service\":{\"desiredCount\":1,\"runningCount\":1,\"status\":\"ACTIVE\",\"lastDeploymentAt\":\"2006-01-02T15:04:05Z\",\"taskDefinition\":\"mockTaskDefinition\"},\"tasks\":[{\"health\":\"HEALTHY\",\"id\":\"1234567890123456789\",\"images\":[{\"ID\":\"mockImageID1\",\"Digest\":\"69671a968e8ec3648e2697417750e\"},{\"ID\":\"mockImageID2\",\"Digest\":\"ca27a44e25ce17fea7b07940ad793\"}],\"lastStatus\":\"RUNNING\",\"startedAt\":\"0001-01-01T00:00:00Z\",\"stoppedAt\":\"0001-01-01T00:00:00Z\",\"stoppedReason\":\"some reason\"}],\"alarms\":[{\"arn\":\"mockAlarmArn\",\"name\":\"mockAlarm\",\"condition\":\"mockCondition\",\"status\":\"OK\",\"type\":\"Metric\",\"updatedTimes\":\"2020-03-13T19:50:30Z\"}]}\n",
+			json: "{\"Service\":{\"desiredCount\":1,\"runningCount\":1,\"status\":\"ACTIVE\",\"lastDeploymentAt\":\"2006-01-02T15:04:05Z\",\"taskDefinition\":\"mockTaskDefinition\"},\"tasks\":[{\"health\":\"HEALTHY\",\"id\":\"1234567890123456789\",\"images\":[{\"ID\":\"mockImageID1\",\"Digest\":\"69671a968e8ec3648e2697417750e\"},{\"ID\":\"mockImageID2\",\"Digest\":\"ca27a44e25ce17fea7b07940ad793\"}],\"lastStatus\":\"RUNNING\",\"startedAt\":\"0001-01-01T00:00:00Z\",\"stoppedAt\":\"0001-01-01T00:00:00Z\",\"stoppedReason\":\"some reason\",\"capacityProvider\":\"\"}],\"alarms\":[{\"arn\":\"mockAlarmArn\",\"name\":\"mockAlarm\",\"condition\":\"mockCondition\",\"status\":\"OK\",\"type\":\"Metric\",\"updatedTimes\":\"2020-03-13T19:50:30Z\"}]}\n",
 		},
 	}
 


### PR DESCRIPTION
Final part of https://github.com/aws/copilot-cli/issues/2162

NOTE: the new `Capacity Provider` column is placed before the `Health Status` column due to weird spacing issues caused by colorizing the status field.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
