### PR TITLE
fix: create dedicated kms for Aurora addon

### DIFF
--- a/templates/addons/aurora/cf.yml
+++ b/templates/addons/aurora/cf.yml
@@ -33,7 +33,6 @@ Mappings:
 Resources:
   {{logicalIDSafe .ClusterName}}AuroraKMSCMK:
     Type: 'AWS::KMS::Key'
-    DeletionPolicy: Retain
     Properties:
       KeyPolicy:
         Version: '2012-10-17'

--- a/templates/addons/aurora/cf.yml
+++ b/templates/addons/aurora/cf.yml
@@ -31,6 +31,34 @@ Mappings:
       {{end -}}
     {{end}}
 Resources:
+  {{logicalIDSafe .ClusterName}}AuroraKMSCMK:
+    Type: 'AWS::KMS::Key'
+    DeletionPolicy: Retain
+    Properties:
+      KeyPolicy:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:root'
+            Action: 'kms:*'
+            Resource: '*'
+          - Effect: Allow
+            Principal:
+              AWS: '*'
+            Action:
+              - 'kms:Encrypt'
+              - 'kms:Decrypt'
+              - 'kms:ReEncrypt*'
+              - 'kms:GenerateDataKey*'
+              - 'kms:CreateGrant'
+              - 'kms:ListGrants'
+              - 'kms:DescribeKey'
+            Resource: '*'
+            Condition:
+              StringEquals:
+                'kms:CallerAccount': !Ref 'AWS::AccountId'
+                'kms:ViaService': !Sub 'rds.${AWS::Region}.amazonaws.com'
   {{logicalIDSafe .ClusterName}}DBSubnetGroup:
     Type: 'AWS::RDS::DBSubnetGroup'
     Properties:
@@ -121,9 +149,7 @@ Resources:
       {{- end}}
       EngineMode: serverless
       StorageEncrypted: true
-      KmsKeyId:
-        Fn::ImportValue:
-          !Sub '${App}-ArtifactKey'
+      KmsKeyId: !Ref {{logicalIDSafe .ClusterName}}AuroraKMSCMK
       DBClusterParameterGroupName: {{- if .ParameterGroup}} {{.ParameterGroup}} {{- else}} !Ref {{logicalIDSafe .ClusterName}}DBClusterParameterGroup {{- end}}
       DBSubnetGroupName: !Ref {{logicalIDSafe .ClusterName}}DBSubnetGroup
       VpcSecurityGroupIds:

--- a/templates/addons/aurora/cf.yml
+++ b/templates/addons/aurora/cf.yml
@@ -31,33 +31,6 @@ Mappings:
       {{end -}}
     {{end}}
 Resources:
-  {{logicalIDSafe .ClusterName}}AuroraKMSCMK:
-    Type: 'AWS::KMS::Key'
-    Properties:
-      KeyPolicy:
-        Version: '2012-10-17'
-        Statement:
-          - Effect: Allow
-            Principal:
-              AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:root'
-            Action: 'kms:*'
-            Resource: '*'
-          - Effect: Allow
-            Principal:
-              AWS: '*'
-            Action:
-              - 'kms:Encrypt'
-              - 'kms:Decrypt'
-              - 'kms:ReEncrypt*'
-              - 'kms:GenerateDataKey*'
-              - 'kms:CreateGrant'
-              - 'kms:ListGrants'
-              - 'kms:DescribeKey'
-            Resource: '*'
-            Condition:
-              StringEquals:
-                'kms:CallerAccount': !Ref 'AWS::AccountId'
-                'kms:ViaService': !Sub 'rds.${AWS::Region}.amazonaws.com'
   {{logicalIDSafe .ClusterName}}DBSubnetGroup:
     Type: 'AWS::RDS::DBSubnetGroup'
     Properties:
@@ -147,8 +120,6 @@ Resources:
       EngineVersion: '10.12'
       {{- end}}
       EngineMode: serverless
-      StorageEncrypted: true
-      KmsKeyId: !Ref {{logicalIDSafe .ClusterName}}AuroraKMSCMK
       DBClusterParameterGroupName: {{- if .ParameterGroup}} {{.ParameterGroup}} {{- else}} !Ref {{logicalIDSafe .ClusterName}}DBClusterParameterGroup {{- end}}
       DBSubnetGroupName: !Ref {{logicalIDSafe .ClusterName}}DBSubnetGroup
       VpcSecurityGroupIds:


### PR DESCRIPTION
Previously the Aurora addons use the default KMS key for app by importing the exported KMS resource. However, it's not able to`ImportValue` if the service uses a different account. This PR fixes this issue by creating a dedicated KMS resource for each Aurora addon.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
