### PR TITLE
docs: update outdated task run example

### DIFF
--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -673,8 +673,8 @@ func BuildTaskRunCmd() *cobra.Command {
 		Use:   "run",
 		Short: "Run a one-off task on Amazon ECS.",
 		Example: `
-Run a task using your local Dockerfile. 
-You will be prompted to specify a task group name and an environment for the tasks to run in.
+Run a task using your local Dockerfile and display log streams after the task is running. 
+You will be prompted to specify an environment for the tasks to run in.
 /code $ copilot task run
 Run a task named "db-migrate" in the "test" environment under the current workspace.
 /code $ copilot task run -n db-migrate --env test

--- a/site/content/docs/commands/task-run.md
+++ b/site/content/docs/commands/task-run.md
@@ -50,8 +50,8 @@ Generally, the steps involved in task run are:
   --task-role string               Optional. The role for the task to use.
 ```
 ## Example
-Run a task using your local Dockerfile. 
-You will be prompted to specify a task group name and an environment for the tasks to run in.
+Run a task using your local Dockerfile and display log streams after the task is running. 
+You will be prompted to specify an environment for the tasks to run in.
 ```
 $ copilot task run --follow
 ```


### PR DESCRIPTION
This PR fixes the discrepancy between the doc and the actual behavior described in #2210. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
