### PR TITLE
docs: update docs to use material-mkdocs v7 from v6

### DIFF
--- a/.github/workflows/doc_builder.yml
+++ b/.github/workflows/doc_builder.yml
@@ -15,6 +15,6 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Deploy docs
-        uses: mhausenblas/mkdocs-deploy-gh-pages@1.16
+        uses: mhausenblas/mkdocs-deploy-gh-pages@1.19
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -131,6 +131,7 @@ theme:
   icon:
     logo: octicons/terminal-16
   favicon: assets/images/cli.png
+  language: en
   features:
     - tabs
     - instant

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# Dependencies to render the Copilot website needed by mkdocs.
+mkdocs-macros-plugin==0.5.5

--- a/site/content/docs/developing/storage.md
+++ b/site/content/docs/developing/storage.md
@@ -80,7 +80,7 @@ storage:
         auth:
           iam: <boolean>             # Optional. Whether to use IAM authorization when
                                          # mounting this filesystem.
-          access_point_id: <access point ID}} # Optional. The ID of the EFS Access Point
+          access_point_id: <access point ID> # Optional. The ID of the EFS Access Point
                                                 # to use when mounting this filesystem.
 ```
 

--- a/site/content/docs/include/common-svc-fields.md
+++ b/site/content/docs/include/common-svc-fields.md
@@ -1,7 +1,7 @@
 <div class="separator"></div>
 
-<a id="entrypoint" href="#entrypoint" class="field">`entrypoint`</a> <span class="type">String or Array of Strings</span>
-Override the default entrypoint in the image.
+<a id="entrypoint" href="#entrypoint" class="field">`entrypoint`</a> <span class="type">String or Array of Strings</span>  
+Override the default entrypoint in the image.  
 ```yaml
 # String version.
 entrypoint: "/bin/entrypoint --p1 --p2"
@@ -11,8 +11,8 @@ entrypoint: ["/bin/entrypoint", "--p1", "--p2"]
 
 <div class="separator"></div>
 
-<a id="command" href="#command" class="field">`command`</a> <span class="type">String or Array of Strings</span>
-Override the default command in the image.
+<a id="command" href="#command" class="field">`command`</a> <span class="type">String or Array of Strings</span>  
+Override the default command in the image.  
 
 ```yaml
 # String version.
@@ -21,24 +21,26 @@ command: ps au
 command: ["ps", "au"]
 ```
 
-<div class="separator"></div>
+<div class="separator"></div>  
 
-<a id="cpu" href="#cpu" class="field">`cpu`</a> <span class="type">Integer</span>
+<a id="cpu" href="#cpu" class="field">`cpu`</a> <span class="type">Integer</span>  
 Number of CPU units for the task. See the [Amazon ECS docs](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html) for valid CPU values.
 
 <div class="separator"></div>
 
-<a id="memory" href="#memory" class="field">`memory`</a> <span class="type">Integer</span>
+<a id="memory" href="#memory" class="field">`memory`</a> <span class="type">Integer</span>  
 Amount of memory in MiB used by the task. See the [Amazon ECS docs](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html) for valid memory values.
 
 <div class="separator"></div>
 
-<a id="count" href="#count" class="field">`count`</a> <span class="type">Integer or Map</span>
+<a id="count" href="#count" class="field">`count`</a> <span class="type">Integer or Map</span>  
 If you specify a number:
 ```yaml
 count: 5
 ```
 The service will set the desired count to 5 and maintain 5 tasks in your service.
+
+<span class="parent-field">count.</span><a id="count-spot" href="#count-spot" class="field">`spot`</a> <span class="type">Integer</span>   
 
 If you want to use Fargate Spot capacity to run your services, you can specify a number under the `spot` subfield:
 ```yaml
@@ -46,7 +48,7 @@ count:
   spot: 5
 ```
 
-<span class="parent-field">count.</span><a id="count-spot" href="#count-spot" class="field">`spot`</a> <span class="type">Integer</span>
+<div class="separator"></div>
 
 Alternatively, you can specify a map for setting up autoscaling:
 ```yaml
@@ -58,7 +60,7 @@ count:
   response_time: 2s
 ```
 
-<span class="parent-field">count.</span><a id="count-range" href="#count-range" class="field">`range`</a> <span class="type">String or Map</span>
+<span class="parent-field">count.</span><a id="count-range" href="#count-range" class="field">`range`</a> <span class="type">String or Map</span>  
 You can specify a minimum and maximum bound for the number of tasks your service should maintain.
 ```yaml
 count:
@@ -78,64 +80,66 @@ count:
 
 This will set your range as 1-10 as above, but will place the first two copies of your service on dedicated Fargate capacity. If your service scales to 3 or higher, the third and any additional copies will be placed on Spot until the maximum is reached.
 
-<span class="parent-field">range.</span><a id="count-range-min" href="#count-range-min" class="field">`min`</a> <span class="type">Integer</span>
+<span class="parent-field">range.</span><a id="count-range-min" href="#count-range-min" class="field">`min`</a> <span class="type">Integer</span>  
 The minimum desired count for your service using autoscaling.
 
-<span class="parent-field">range.</span><a id="count-range-max" href="#count-range-max" class="field">`max`</a> <span class="type">Integer</span>
+<span class="parent-field">range.</span><a id="count-range-max" href="#count-range-max" class="field">`max`</a> <span class="type">Integer</span>  
 The maximum desired count for your service using autoscaling.
 
-<span class="parent-field">range.</span><a id="count-range-spot-from" href="#count-range-spot-from" class="field">`spot_from`</a> <span class="type">Integer</span>
+<span class="parent-field">range.</span><a id="count-range-spot-from" href="#count-range-spot-from" class="field">`spot_from`</a> <span class="type">Integer</span>  
 The desired count at which you wish to start placing your service using Fargate Spot capacity providers.
 
-<span class="parent-field">count.</span><a id="count-cpu-percentage" href="#count-cpu-percentage" class="field">`cpu_percentage`</a> <span class="type">Integer</span>
+<span class="parent-field">count.</span><a id="count-cpu-percentage" href="#count-cpu-percentage" class="field">`cpu_percentage`</a> <span class="type">Integer</span>  
 Scale up or down based on the average CPU your service should maintain.
 
-<span class="parent-field">count.</span><a id="count-memory-percentage" href="#count-memory-percentage" class="field">`memory_percentage`</a> <span class="type">Integer</span>
+<span class="parent-field">count.</span><a id="count-memory-percentage" href="#count-memory-percentage" class="field">`memory_percentage`</a> <span class="type">Integer</span>  
 Scale up or down based on the average memory your service should maintain.
 
-<span class="parent-field">count.</span><a id="requests" href="#count-requests" class="field">`requests`</a> <span class="type">Integer</span>
+<span class="parent-field">count.</span><a id="requests" href="#count-requests" class="field">`requests`</a> <span class="type">Integer</span>  
 Scale up or down based on the request count handled per tasks.
 
-<span class="parent-field">count.</span><a id="response-time" href="#count-response-time" class="field">`response_time`</a> <span class="type">Duration</span>
+<span class="parent-field">count.</span><a id="response-time" href="#count-response-time" class="field">`response_time`</a> <span class="type">Duration</span>  
 Scale up or down based on the service average response time.
 
 <div class="separator"></div>
 
-<a id="exec" href="#exec" class="field">`exec`</a> <span class="type">Boolean</span>
-Enable running commands in your container. The default is `false`. Required for `$ copilot svc exec`. Please note that this will update the service's Fargate Platform Version to 1.4.0.
+<a id="exec" href="#exec" class="field">`exec`</a> <span class="type">Boolean</span>  
+Enable running commands in your container. The default is `false`. Required for `$ copilot svc exec`.
 
-<a id="network" href="#network" class="field">`network`</a> <span class="type">Map</span>
+<div class="separator"></div>
+
+<a id="network" href="#network" class="field">`network`</a> <span class="type">Map</span>      
 The `network` section contains parameters for connecting to AWS resources in a VPC.
 
-<span class="parent-field">network.</span><a id="network-vpc" href="#network-vpc" class="field">`vpc`</a> <span class="type">Map</span>
+<span class="parent-field">network.</span><a id="network-vpc" href="#network-vpc" class="field">`vpc`</a> <span class="type">Map</span>    
 Subnets and security groups attached to your tasks.
 
-<span class="parent-field">network.vpc.</span><a id="network-vpc-placement" href="#network-vpc-placement" class="field">`placement`</a> <span class="type">String</span>
+<span class="parent-field">network.vpc.</span><a id="network-vpc-placement" href="#network-vpc-placement" class="field">`placement`</a> <span class="type">String</span>  
 Must be one of `'public'` or `'private'`. Defaults to launching your tasks in public subnets.
 
-!!! info inline end
+!!! info
     If you launch tasks in `'private'` subnets and use a Copilot-generated VPC, Copilot will add NAT Gateways to your environment. Alternatively, you can import a VPC with NAT Gateways when running `copilot env init` for internet connectivity.
 
-<span class="parent-field">network.vpc.</span><a id="network-vpc-security-groups" href="#network-vpc-security-groups" class="field">`security_groups`</a> <span class="type">Array of Strings</span>
+<span class="parent-field">network.vpc.</span><a id="network-vpc-security-groups" href="#network-vpc-security-groups" class="field">`security_groups`</a> <span class="type">Array of Strings</span>  
 Additional security group IDs associated with your tasks. Copilot always includes a security group so containers within your environment
 can communicate with each other.
 
 <div class="separator"></div>
 
-<a id="variables" href="#variables" class="field">`variables`</a> <span class="type">Map</span>
+<a id="variables" href="#variables" class="field">`variables`</a> <span class="type">Map</span>  
 Key-value pairs that represent environment variables that will be passed to your service. Copilot will include a number of environment variables by default for you.
 
 <div class="separator"></div>
 
-<a id="secrets" href="#secrets" class="field">`secrets`</a> <span class="type">Map</span>
+<a id="secrets" href="#secrets" class="field">`secrets`</a> <span class="type">Map</span>  
 Key-value pairs that represent secret values from [AWS Systems Manager Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html) that will be securely passed to your service as environment variables.
 
-<div class="separator"></div>
+<div class="separator"></div>  
 
-<a id="storage" href="#storage" class="field">`storage`</a> <span class="type">Map</span>
+<a id="storage" href="#storage" class="field">`storage`</a> <span class="type">Map</span>  
 The Storage section lets you specify external EFS volumes for your containers and sidecars to mount. This allows you to access persistent storage across regions for data processing or CMS workloads. For more detail, see the [storage](../developing/storage.md) page.
 
-<span class="parent-field">storage.</span><a id="volumes" href="#volumes" class="field">`volumes`</a> <span class="type">Map</span>
+<span class="parent-field">storage.</span><a id="volumes" href="#volumes" class="field">`volumes`</a> <span class="type">Map</span>  
 Specify the name and configuration of any EFS volumes you would like to attach. The `volumes` field is specified as a map of the form:
 ```yaml
 volumes:
@@ -145,36 +149,35 @@ volumes:
       ...
 ```
 
-<span class="parent-field">storage.volumes.</span><a id="volume" href="#volume" class="field">`volume`</a> <span class="type">Map</span>
+<span class="parent-field">storage.volumes.</span><a id="volume" href="#volume" class="field">`volume`</a> <span class="type">Map</span>  
 Specify the configuration of a volume.
 
-<span class="parent-field">volume.</span><a id="path" href="#path" class="field">`path`</a> <span class="type">String</span>
+<span class="parent-field">volume.</span><a id="path" href="#path" class="field">`path`</a> <span class="type">String</span>  
 Required. Specify the location in the container where you would like your volume to be mounted. Must be fewer than 242 characters and must consist only of the characters `a-zA-Z0-9.-_/`.
 
-<span class="parent-field">volume.</span><a id="read_only" href="#read-only" class="field">`read_only`</a> <span class="type">Bool</span>
+<span class="parent-field">volume.</span><a id="read_only" href="#read-only" class="field">`read_only`</a> <span class="type">Bool</span>  
 Optional. Defaults to `true`. Defines whether the volume is read-only or not. If false, the container is granted `elasticfilesystem:ClientWrite` permissions to the filesystem and the volume is writable.
 
-<span class="parent-field">volume.</span><a id="efs" href="#efs" class="field">`efs`</a> <span class="type">Map</span>
+<span class="parent-field">volume.</span><a id="efs" href="#efs" class="field">`efs`</a> <span class="type">Map</span>  
 Specify more detailed EFS configuration.
 
-<span class="parent-field">volume.efs.</span><a id="id" href="#id" class="field">`id`</a> <span class="type">String</span>
+<span class="parent-field">volume.efs.</span><a id="id" href="#id" class="field">`id`</a> <span class="type">String</span>  
 Required. The ID of the filesystem you would like to mount.
 
-<span class="parent-field">volume.efs.</span><a id="root_dir" href="#root-dir" class="field">`root_dir`</a> <span class="type">String</span>
+<span class="parent-field">volume.efs.</span><a id="root_dir" href="#root-dir" class="field">`root_dir`</a> <span class="type">String</span>  
 Optional. Defaults to `/`. Specify the location in the EFS filesystem you would like to use as the root of your volume. Must be fewer than 255 characters and must consist only of the characters `a-zA-Z0-9.-_/`. If using an access point, `root_dir` must be either empty or `/` and `auth.iam` must be `true`.
 
-<span class="parent-field">volume.efs.</span><a id="auth" href="#auth" class="field">`auth`</a> <span class="type">Map</span>
+<span class="parent-field">volume.efs.</span><a id="auth" href="#auth" class="field">`auth`</a> <span class="type">Map</span>  
 Specify advanced authorization configuration for EFS.
 
-<span class="parent-field">volume.efs.auth.</span><a id="iam" href="#iam" class="field">`iam`</a> <span class="type">Bool</span>
+<span class="parent-field">volume.efs.auth.</span><a id="iam" href="#iam" class="field">`iam`</a> <span class="type">Bool</span>  
 Optional. Defaults to `true`. Whether or not to use IAM authorization to determine whether the volume is allowed to connect to EFS.
 
-<span class="parent-field">volume.efs.auth.</span><a id="access_point_id" href="#access-point-id" class="field">`access_point_id`</a> <span class="type">String</span>
+<span class="parent-field">volume.efs.auth.</span><a id="access_point_id" href="#access-point-id" class="field">`access_point_id`</a> <span class="type">String</span>  
 Optional. Defaults to `""`. The ID of the EFS access point to connect to. If using an access point, `root_dir` must be either empty or `/` and `auth.iam` must be `true`.
 
 <div class="separator"></div>
 
-<a id="environments" href="#environments" class="field">`environments`</a> <span class="type">Map</span>
+<a id="environments" href="#environments" class="field">`environments`</a> <span class="type">Map</span>  
 The environment section lets you override any value in your manifest based on the environment you're in. In the example manifest above, we're overriding the count parameter so that we can run 2 copies of our service in our prod environment.
 
-<!-- TODO logging? -->

--- a/site/content/docs/include/http-config.md
+++ b/site/content/docs/include/http-config.md
@@ -1,12 +1,12 @@
 <div class="separator"></div>
 
-<a id="http" href="#http" class="field">`http`</a> <span class="type">Map</span>
+<a id="http" href="#http" class="field">`http`</a> <span class="type">Map</span>  
 The http section contains parameters related to integrating your service with an Application Load Balancer.
 
-<span class="parent-field">http.</span><a id="http-path" href="#http-path" class="field">`path`</a> <span class="type">String</span>
+<span class="parent-field">http.</span><a id="http-path" href="#http-path" class="field">`path`</a> <span class="type">String</span>  
 Requests to this path will be forwarded to your service. Each Load Balanced Web Service should listen on a unique path.
 
-<span class="parent-field">http.</span><a id="http-healthcheck" href="#http-healthcheck" class="field">`healthcheck`</a> <span class="type">String or Map</span>
+<span class="parent-field">http.</span><a id="http-healthcheck" href="#http-healthcheck" class="field">`healthcheck`</a> <span class="type">String or Map</span>  
 If you specify a string, Copilot interprets it as the path exposed in your container to handle target group health check requests. The default is "/".
 ```yaml
 http:
@@ -24,28 +24,28 @@ http:
     timeout: 10s
 ```
 
-<span class="parent-field">http.healthcheck.</span><a id="http-healthcheck-success-codes" href="#http-healthcheck-success-codes" class="field">`success_codes`</a> <span class="type">String</span>
+<span class="parent-field">http.healthcheck.</span><a id="http-healthcheck-success-codes" href="#http-healthcheck-success-codes" class="field">`success_codes`</a> <span class="type">String</span>  
 The HTTP status codes that healthy targets must use when responding to an HTTP health check. You can specify values between 200 and 499. You can specify multiple values (for example, "200,202") or a range of values (for example, "200-299"). The default is 200.
 
-<span class="parent-field">http.healthcheck.</span><a id="http-healthcheck-healthy-threshold" href="#http-healthcheck-healthy-threshold" class="field">`healthy_threshold`</a> <span class="type">Integer</span>
+<span class="parent-field">http.healthcheck.</span><a id="http-healthcheck-healthy-threshold" href="#http-healthcheck-healthy-threshold" class="field">`healthy_threshold`</a> <span class="type">Integer</span>  
 The number of consecutive health check successes required before considering an unhealthy target healthy. The default is 5. Range: 2-10.
 
-<span class="parent-field">http.healthcheck.</span><a id="http-healthcheck-unhealthy-threshold" href="#http-healthcheck-unhealthy-threshold" class="field">`unhealthy_threshold`</a> <span class="type">Integer</span>
+<span class="parent-field">http.healthcheck.</span><a id="http-healthcheck-unhealthy-threshold" href="#http-healthcheck-unhealthy-threshold" class="field">`unhealthy_threshold`</a> <span class="type">Integer</span>  
 The number of consecutive health check failures required before considering a target unhealthy. The default is 2. Range: 2-10.
 
-<span class="parent-field">http.healthcheck.</span><a id="http-healthcheck-interval" href="#http-healthcheck-interval" class="field">`interval`</a> <span class="type">Duration</span>
+<span class="parent-field">http.healthcheck.</span><a id="http-healthcheck-interval" href="#http-healthcheck-interval" class="field">`interval`</a> <span class="type">Duration</span>  
 The approximate amount of time, in seconds, between health checks of an individual target. The default is 30s. Range: 5s–300s.
 
-<span class="parent-field">http.healthcheck.</span><a id="http-healthcheck-timeout" href="#http-healthcheck-timeout" class="field">`timeout`</a> <span class="type">Duration</span>
+<span class="parent-field">http.healthcheck.</span><a id="http-healthcheck-timeout" href="#http-healthcheck-timeout" class="field">`timeout`</a> <span class="type">Duration</span>  
 The amount of time, in seconds, during which no response from a target means a failed health check. The default is 5s. Range 5s-300s.
 
-<span class="parent-field">http.</span><a id="http-target-container" href="#http-target-container" class="field">`target_container`</a> <span class="type">String</span>
+<span class="parent-field">http.</span><a id="http-target-container" href="#http-target-container" class="field">`target_container`</a> <span class="type">String</span>  
 A sidecar container that takes the place of a service container.
 
-<span class="parent-field">http.</span><a id="http-stickiness" href="#http-stickiness" class="field">`stickiness`</a> <span class="type">Boolean</span>
+<span class="parent-field">http.</span><a id="http-stickiness" href="#http-stickiness" class="field">`stickiness`</a> <span class="type">Boolean</span>  
 Indicates whether sticky sessions are enabled.
 
-<span class="parent-field">http.</span><a id="http-allowed-source-ips" href="#http-allowed-source-ips" class="field">`allowed_source_ips`</a> <span class="type">Array of Strings</span>
+<span class="parent-field">http.</span><a id="http-allowed-source-ips" href="#http-allowed-source-ips" class="field">`allowed_source_ips`</a> <span class="type">Array of Strings</span>  
 CIDR IP addresses permitted to access your service.
 ```yaml
 http:

--- a/site/content/docs/include/image-config.md
+++ b/site/content/docs/include/image-config.md
@@ -1,9 +1,9 @@
 <div class="separator"></div>
 
-<a id="image" href="#image" class="field">`image`</a> <span class="type">Map</span>
+<a id="image" href="#image" class="field">`image`</a> <span class="type">Map</span>  
 The image section contains parameters relating to the Docker build configuration and exposed port.
 
-<span class="parent-field">image.</span><a id="image-build" href="#image-build" class="field">`build`</a> <span class="type">String or Map</span>
+<span class="parent-field">image.</span><a id="image-build" href="#image-build" class="field">`build`</a> <span class="type">String or Map</span>  
 If you specify a string, Copilot interprets it as the path to your Dockerfile. It will assume that the dirname of the string you specify should be the build context. The manifest:
 ```yaml
 image:
@@ -30,12 +30,12 @@ You can omit fields and Copilot will do its best to understand what you mean. Fo
 
 All paths are relative to your workspace root.
 
-<span class="parent-field">image.</span><a id="image-location" href="#image-location" class="field">`location`</a> <span class="type">String</span>
+<span class="parent-field">image.</span><a id="image-location" href="#image-location" class="field">`location`</a> <span class="type">String</span>  
 Instead of building a container from a Dockerfile, you can specify an existing image name. Mutually exclusive with [`image.build`](#image-build).
 The `location` field follows the same definition as the [`image` parameter](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#container_definition_image) in the Amazon ECS task definition.
 
-<span class="parent-field">image.</span><a id="image-port" href="#image-port" class="field">`port`</a> <span class="type">Integer</span>
+<span class="parent-field">image.</span><a id="image-port" href="#image-port" class="field">`port`</a> <span class="type">Integer</span>  
 The port exposed in your Dockerfile. Copilot should parse this value for you from your `EXPOSE` instruction.
 
-<span class="parent-field">image.</span><a id="image-labels" href="#image-labels" class="field">`labels`</a><span class="type">Map</span>
+<span class="parent-field">image.</span><a id="image-labels" href="#image-labels" class="field">`labels`</a><span class="type">Map</span>  
 An optional key/value map of [Docker labels](https://docs.docker.com/config/labels-custom-metadata/) to add to the container.

--- a/site/content/docs/include/image-healthcheck.md
+++ b/site/content/docs/include/image-healthcheck.md
@@ -1,19 +1,19 @@
-<span class="parent-field">image.</span><a id="image-healthcheck" href="#image-healthcheck" class="field">`healthcheck`</a> <span class="type">Map</span>
+<span class="parent-field">image.</span><a id="image-healthcheck" href="#image-healthcheck" class="field">`healthcheck`</a> <span class="type">Map</span>  
 Optional configuration for container health checks.
 
-<span class="parent-field">image.healthcheck.</span><a id="image-healthcheck-cmd" href="#image-healthcheck-cmd" class="field">`command`</a> <span class="type">Array of Strings</span>
+<span class="parent-field">image.healthcheck.</span><a id="image-healthcheck-cmd" href="#image-healthcheck-cmd" class="field">`command`</a> <span class="type">Array of Strings</span>  
 The command to run to determine if the container is healthy.
 The string array can start with `CMD` to execute the command arguments directly, or `CMD-SHELL` to run the command with the container's default shell.
 
-<span class="parent-field">image.healthcheck.</span><a id="image-healthcheck-interval" href="#image-healthcheck-interval" class="field">`interval`</a> <span class="type">Duration</span>
+<span class="parent-field">image.healthcheck.</span><a id="image-healthcheck-interval" href="#image-healthcheck-interval" class="field">`interval`</a> <span class="type">Duration</span>  
 Time period between health checks, in seconds. Default is 10s.
 
-<span class="parent-field">image.healthcheck.</span><a id="image-healthcheck-retries" href="#image-healthcheck-retries" class="field">`retries`</a> <span class="type">Integer</span>
+<span class="parent-field">image.healthcheck.</span><a id="image-healthcheck-retries" href="#image-healthcheck-retries" class="field">`retries`</a> <span class="type">Integer</span>  
 Number of times to retry before container is deemed unhealthy. Default is 2.
 
-<span class="parent-field">image.healthcheck.</span><a id="image-healthcheck-timeout" href="#image-healthcheck-timeout" class="field">`timeout`</a> <span class="type">Duration</span>
+<span class="parent-field">image.healthcheck.</span><a id="image-healthcheck-timeout" href="#image-healthcheck-timeout" class="field">`timeout`</a> <span class="type">Duration</span>  
 How long to wait before considering the health check failed, in seconds. Default is 5s.
 
-<span class="parent-field">image.healthcheck.</span><a id="image-healthcheck-start-period" href="#image-healthcheck-start-period" class="field">`start_period`</a> <span class="type">Duration</span>
+<span class="parent-field">image.healthcheck.</span><a id="image-healthcheck-start-period" href="#image-healthcheck-start-period" class="field">`start_period`</a> <span class="type">Duration</span>  
 Grace period within which to provide containers time to bootstrap before failed health checks count towards the maximum number of retries. Default is 0s.
 

--- a/site/content/docs/manifest/backend-service.md
+++ b/site/content/docs/manifest/backend-service.md
@@ -61,7 +61,7 @@ The name of your service.
 
 <div class="separator"></div>
 
-<a id="type" href="#type" class="field">`type`</a> <span class="type">String</span>
+<a id="type" href="#type" class="field">`type`</a> <span class="type">String</span>  
 The architecture type for your service. [Backend Services](../concepts/services.md#backend-service) are not reachable from the internet, but can be reached with [service discovery](../developing/service-discovery.md) from your other services.
 
 {% include 'image-config.md' %}

--- a/site/content/docs/manifest/lb-web-service.md
+++ b/site/content/docs/manifest/lb-web-service.md
@@ -57,12 +57,12 @@ List of all available properties for a `'Load Balanced Web Service'` manifest.
         count: 2
     ```
 
-<a id="name" href="#name" class="field">`name`</a> <span class="type">String</span>
+<a id="name" href="#name" class="field">`name`</a> <span class="type">String</span>  
 The name of your service.
 
 <div class="separator"></div>
 
-<a id="type" href="#type" class="field">`type`</a> <span class="type">String</span>
+<a id="type" href="#type" class="field">`type`</a> <span class="type">String</span>  
 The architecture type for your service. A [Load Balanced Web Service](../concepts/services.md#load-balanced-web-service) is an internet-facing service that's behind a load balancer, orchestrated by Amazon ECS on AWS Fargate.
 
 {% include 'http-config.md' %}

--- a/site/content/docs/manifest/pipeline.md
+++ b/site/content/docs/manifest/pipeline.md
@@ -28,57 +28,57 @@ List of all available properties for a Copilot pipeline manifest.
           requires_approval: true
     ```
 
-<a id="name" href="#name" class="field">`name`</a> <span class="type">String</span>
+<a id="name" href="#name" class="field">`name`</a> <span class="type">String</span>  
 The name of your pipeline.
 
 <div class="separator"></div>
 
-<a id="version" href="#version" class="field">`version`</a> <span class="type">String</span>
+<a id="version" href="#version" class="field">`version`</a> <span class="type">String</span>  
 The schema version for the template. There is only one version, `1`, supported at the moment.
 
 <div class="separator"></div>
 
-<a id="source" href="#source" class="field">`source`</a> <span class="type">Map</span>
+<a id="source" href="#source" class="field">`source`</a> <span class="type">Map</span>  
 Configuration for how your pipeline is triggered.
 
-<span class="parent-field">source.</span><a id="source-provider" href="#source-provider" class="field">`provider`</a> <span class="type">String</span>
+<span class="parent-field">source.</span><a id="source-provider" href="#source-provider" class="field">`provider`</a> <span class="type">String</span>  
 The name of your provider. Currently, `GitHub`, `Bitbucket`, and `CodeCommit` are supported.
 
-<span class="parent-field">source.</span><a id="source-properties" href="#source-properties" class="field">`properties`</a> <span class="type">Map</span>
+<span class="parent-field">source.</span><a id="source-properties" href="#source-properties" class="field">`properties`</a> <span class="type">Map</span>  
 Provider-specific configuration on how the pipeline is triggered.
 
-<span class="parent-field">source.properties.</span><a id="source-properties-ats" href="#source-properties-ats" class="field">`access_token_secret`</a> <span class="type">String</span>
+<span class="parent-field">source.properties.</span><a id="source-properties-ats" href="#source-properties-ats" class="field">`access_token_secret`</a> <span class="type">String</span>  
 The name of AWS Secrets Manager secret that holds the GitHub access token to trigger the pipeline if your provider is GitHub and you created your pipeline with a personal access token.
 !!! info
     As of AWS Copilot v1.4.0, the access token is no longer needed for GitHub repository sources. Instead, Copilot will trigger the pipeline [using AWS CodeStar connections](https://docs.aws.amazon.com/codepipeline/latest/userguide/update-github-action-connections.html).
 
-<span class="parent-field">source.properties.</span><a id="source-properties-branch" href="#source-properties-branch" class="field">`branch`</a> <span class="type">String</span>
+<span class="parent-field">source.properties.</span><a id="source-properties-branch" href="#source-properties-branch" class="field">`branch`</a> <span class="type">String</span>  
 The name of the branch in your repository that triggers the pipeline. The default for GitHub is `main`; the default for Bitbucket and CodeCommit is `master`.
 
-<span class="parent-field">source.properties.</span><a id="source-properties-repository" href="#source-properties-repository" class="field">`repository`</a> <span class="type">String</span>
+<span class="parent-field">source.properties.</span><a id="source-properties-repository" href="#source-properties-repository" class="field">`repository`</a> <span class="type">String</span>  
 The URL of your repository.
 
-<span class="parent-field">source.properties.</span><a id="source-properties-connection-name" href="#source-properties-connection-name" class="field">`connection_name`</a> <span class="type">String</span>
+<span class="parent-field">source.properties.</span><a id="source-properties-connection-name" href="#source-properties-connection-name" class="field">`connection_name`</a> <span class="type">String</span>  
 The name of an existing CodeStar Connections connection. If omitted, Copilot will generate a connection for you.
 
 <div class="separator"></div>
 
-<a id="build" href="#build" class="field">`build`</a> <span class="type">Map</span>
+<a id="build" href="#build" class="field">`build`</a> <span class="type">Map</span>  
 Configuration for CodeBuild project.
 
-<span class="parent-field">build.</span><a id="build-image" href="#build-image" class="field">`image`</a> <span class="type">String</span>
+<span class="parent-field">build.</span><a id="build-image" href="#build-image" class="field">`image`</a> <span class="type">String</span>  
 The URI that identifies the Docker image to use for this build project. As of now, `aws/codebuild/amazonlinux2-x86_64-standard:3.0` is used by default.
 
 <div class="separator"></div>
 
-<a id="stages" href="#stages" class="field">`stages`</a> <span class="type">Array of Maps</span>
+<a id="stages" href="#stages" class="field">`stages`</a> <span class="type">Array of Maps</span>  
 Ordered list of environments that your pipeline will deploy to.
 
-<span class="parent-field">stages.</span><a id="stages-name" href="#stages-name" class="field">`name`</a> <span class="type">String</span>
+<span class="parent-field">stages.</span><a id="stages-name" href="#stages-name" class="field">`name`</a> <span class="type">String</span>  
 The name of an environment to deploy your services to.
 
-<span class="parent-field">stages.</span><a id="stages-approval" href="#stages-approval" class="field">`requires_approval`</a> <span class="type">Boolean</span>
+<span class="parent-field">stages.</span><a id="stages-approval" href="#stages-approval" class="field">`requires_approval`</a> <span class="type">Boolean</span>  
 Indicates whether to add a manual approval step before the deployment.
 
-<span class="parent-field">stages.</span><a id="stages-test-cmds" href="#stages-test-cmds" class="field">`test_commands`</a> <span class="type">Array of Strings</span>
+<span class="parent-field">stages.</span><a id="stages-test-cmds" href="#stages-test-cmds" class="field">`test_commands`</a> <span class="type">Array of Strings</span>  
 Commands to run integration or end-to-end tests after deployment.

--- a/site/content/docs/manifest/scheduled-job.md
+++ b/site/content/docs/manifest/scheduled-job.md
@@ -24,21 +24,21 @@ List of all available properties for a `'Scheduled Job'` manifest.
       GITHUB_TOKEN: GITHUB_TOKEN
     ```
 
-<a id="name" href="#name" class="field">`name`</a> <span class="type">String</span>
+<a id="name" href="#name" class="field">`name`</a> <span class="type">String</span>  
 The name of your job.
 
 <div class="separator"></div>
 
-<a id="type" href="#type" class="field">`type`</a> <span class="type">String</span>
+<a id="type" href="#type" class="field">`type`</a> <span class="type">String</span>  
 The architecture type for your job.
 Currently, Copilot only supports the "Scheduled Job" type for tasks that are triggered either on a fixed schedule or periodically.
 
 <div class="separator"></div>
 
-<a id="on" href="#on" class="field">`on`</a> <span class="type">Map</span>
+<a id="on" href="#on" class="field">`on`</a> <span class="type">Map</span>  
 The configuration for the event that triggers your job.
 
-<span class="parent-field">on.</span><a id="on-schedule" href="#on-schedule" class="field">`schedule`</a> <span class="type">String</span>
+<span class="parent-field">on.</span><a id="on-schedule" href="#on-schedule" class="field">`schedule`</a> <span class="type">String</span>  
 You can specify a rate to periodically trigger your job. Supported rates:
 
 * `"@yearly"`
@@ -56,10 +56,10 @@ Alternatively, you can specify a cron schedule if you'd like to trigger the job 
 
 <div class="separator"></div>
 
-<a id="image" href="#image" class="field">`image`</a> <span class="type">Map</span>
+<a id="image" href="#image" class="field">`image`</a> <span class="type">Map</span>  
 The image section contains parameters relating to the Docker build configuration.
 
-<span class="parent-field">image.</span><a id="image-build" href="#image-build" class="field">`build`</a> <span class="type">String or Map</span>
+<span class="parent-field">image.</span><a id="image-build" href="#image-build" class="field">`build`</a> <span class="type">String or Map</span>  
 If you specify a string, Copilot interprets it as the path to your Dockerfile. It will assume that the dirname of the string you specify should be the build context. The manifest:
 ```yaml
 image:
@@ -86,16 +86,16 @@ You can omit fields and Copilot will do its best to understand what you mean. Fo
 
 All paths are relative to your workspace root.
 
-<span class="parent-field">image.</span><a id="image-location" href="#image-location" class="field">`location`</a> <span class="type">String</span>
+<span class="parent-field">image.</span><a id="image-location" href="#image-location" class="field">`location`</a> <span class="type">String</span>  
 Instead of building a container from a Dockerfile, you can specify an existing image name. Mutually exclusive with [`image.build`](#image-build).
 The `location` field follows the same definition as the [`image` parameter](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#container_definition_image) in the Amazon ECS task definition.
 
-<span class="parent-field">image.</span><a id="image-labels" href="#image-labels" class="field">`labels`</a><span class="type">Map</span>
+<span class="parent-field">image.</span><a id="image-labels" href="#image-labels" class="field">`labels`</a><span class="type">Map</span>  
 An optional key/value map of [Docker labels](https://docs.docker.com/config/labels-custom-metadata/) to add to the container.
 
-<div class="separator"></div>
+<div class="separator"></div>  
 
-<a id="entrypoint" href="#entrypoint" class="field">`entrypoint`</a> <span class="type">String or Array of Strings</span>
+<a id="entrypoint" href="#entrypoint" class="field">`entrypoint`</a> <span class="type">String or Array of Strings</span>  
 Override the default entrypoint in the image.
 ```yaml
 # String version.
@@ -106,7 +106,7 @@ entrypoint: ["/bin/entrypoint", "--p1", "--p2"]
 
 <div class="separator"></div>
 
-<a id="command" href="#command" class="field">`command`</a> <span class="type">String or Array of Strings</span>
+<a id="command" href="#command" class="field">`command`</a> <span class="type">String or Array of Strings</span>  
 Override the default command in the image.
 
 ```yaml
@@ -118,60 +118,60 @@ command: ["ps", "au"]
 
 <div class="separator"></div>
 
-<a id="cpu" href="#cpu" class="field">`cpu`</a> <span class="type">Integer</span>
+<a id="cpu" href="#cpu" class="field">`cpu`</a> <span class="type">Integer</span>  
 Number of CPU units for the task. See the [Amazon ECS docs](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html) for valid CPU values.
 
 <div class="separator"></div>
 
-<a id="memory" href="#memory" class="field">`memory`</a> <span class="type">Integer</span>
+<a id="memory" href="#memory" class="field">`memory`</a> <span class="type">Integer</span>  
 Amount of memory in MiB used by the task. See the [Amazon ECS docs](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html) for valid memory values.
 
 <div class="separator"></div>
 
-<a id="retries" href="#retries" class="field">`retries`</a> <span class="type">Integer</span>
+<a id="retries" href="#retries" class="field">`retries`</a> <span class="type">Integer</span>  
 The number of times to retry the job before failing.
 
 <div class="separator"></div>
 
-<a id="timeout" href="#timeout" class="field">`timeout`</a> <span class="type">Duration</span>
+<a id="timeout" href="#timeout" class="field">`timeout`</a> <span class="type">Duration</span>  
 How long the job should run before it aborts and fails. You can use the units: `h`, `m`, or `s`.
 
 <div class="separator"></div>
 
-<a id="network" href="#network" class="field">`network`</a> <span class="type">Map</span>
+<a id="network" href="#network" class="field">`network`</a> <span class="type">Map</span>  
 The `network` section contains parameters for connecting to AWS resources in a VPC.
 
-<span class="parent-field">network.</span><a id="network-vpc" href="#network-vpc" class="field">`vpc`</a> <span class="type">Map</span>
+<span class="parent-field">network.</span><a id="network-vpc" href="#network-vpc" class="field">`vpc`</a> <span class="type">Map</span>  
 Subnets and security groups attached to your tasks.
 
-<span class="parent-field">network.vpc.</span><a id="network-vpc-placement" href="#network-vpc-placement" class="field">`placement`</a> <span class="type">String</span>
+<span class="parent-field">network.vpc.</span><a id="network-vpc-placement" href="#network-vpc-placement" class="field">`placement`</a> <span class="type">String</span>    
 Must be one of `'public'` or `'private'`. Defaults to launching your tasks in public subnets.
 
-!!! info inline end
+!!! info
     Launching tasks in `'private'` subnets that need internet connectivity is only supported if you imported a VPC with
     NAT Gateways when running `copilot env init`. See [#1959](https://github.com/aws/copilot-cli/issues/1959) for tracking
     NAT Gateways support in Copilot-generated VPCs.
 
-<span class="parent-field">network.vpc.</span><a id="network-vpc-security-groups" href="#network-vpc-security-groups" class="field">`security_groups`</a> <span class="type">Array of Strings</span>
+<span class="parent-field">network.vpc.</span><a id="network-vpc-security-groups" href="#network-vpc-security-groups" class="field">`security_groups`</a> <span class="type">Array of Strings</span>  
 Additional security group IDs associated with your tasks. Copilot always includes a security group so containers within your environment
 can communicate with each other.
 
 <div class="separator"></div>
 
-<a id="variables" href="#variables" class="field">`variables`</a> <span class="type">Map</span>
+<a id="variables" href="#variables" class="field">`variables`</a> <span class="type">Map</span>  
 Key-value pairs that represent environment variables that will be passed to your job. Copilot will include a number of environment variables by default for you.
 
 <div class="separator"></div>
 
-<a id="secrets" href="#secrets" class="field">`secrets`</a> <span class="type">Map</span>
+<a id="secrets" href="#secrets" class="field">`secrets`</a> <span class="type">Map</span>  
 Key-value pairs that represent secret values from [AWS Systems Manager Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html) that will be securely passed to your job as environment variables.
 
 <div class="separator"></div>
 
-<a id="storage" href="#storage" class="field">`storage`</a> <span class="type">Map</span>
+<a id="storage" href="#storage" class="field">`storage`</a> <span class="type">Map</span>  
 The Storage section lets you specify external EFS volumes for your containers and sidecars to mount. This allows you to access persistent storage across regions for data processing or CMS workloads. For more detail, see the [storage](../developing/storage.md) page.
 
-<span class="parent-field">storage.</span><a id="volumes" href="#volumes" class="field">`volumes`</a> <span class="type">Map</span>
+<span class="parent-field">storage.</span><a id="volumes" href="#volumes" class="field">`volumes`</a> <span class="type">Map</span>  
 Specify the name and configuration of any EFS volumes you would like to attach. The `volumes` field is specified as a map of the form:
 ```yaml
 volumes:
@@ -181,33 +181,33 @@ volumes:
       ...
 ```
 
-<span class="parent-field">storage.volumes.</span><a id="volume" href="#volume" class="field">`volume`</a> <span class="type">Map</span>
+<span class="parent-field">storage.volumes.</span><a id="volume" href="#volume" class="field">`volume`</a> <span class="type">Map</span>  
 Specify the configuration of a volume.
 
-<span class="parent-field">volume.</span><a id="path" href="#path" class="field">`path`</a> <span class="type">String</span>
+<span class="parent-field">volume.</span><a id="path" href="#path" class="field">`path`</a> <span class="type">String</span>  
 Required. Specify the location in the container where you would like your volume to be mounted. Must be fewer than 242 characters and must consist only of the characters `a-zA-Z0-9.-_/`.
 
-<span class="parent-field">volume.</span><a id="read_only" href="#read-only" class="field">`read_only`</a> <span class="type">Bool</span>
+<span class="parent-field">volume.</span><a id="read_only" href="#read-only" class="field">`read_only`</a> <span class="type">Bool</span>  
 Optional. Defaults to `true`. Defines whether the volume is read-only or not. If false, the container is granted `elasticfilesystem:ClientWrite` permissions to the filesystem and the volume is writable.
 
-<span class="parent-field">volume.</span><a id="efs" href="#efs" class="field">`efs`</a> <span class="type">Map</span>
+<span class="parent-field">volume.</span><a id="efs" href="#efs" class="field">`efs`</a> <span class="type">Map</span>  
 Specify more detailed EFS configuration.
 
-<span class="parent-field">volume.efs.</span><a id="id" href="#id" class="field">`id`</a> <span class="type">String</span>
+<span class="parent-field">volume.efs.</span><a id="id" href="#id" class="field">`id`</a> <span class="type">String</span>  
 Required. The ID of the filesystem you would like to mount.
 
-<span class="parent-field">volume.efs.</span><a id="root_dir" href="#root-dir" class="field">`root_dir`</a> <span class="type">String</span>
+<span class="parent-field">volume.efs.</span><a id="root_dir" href="#root-dir" class="field">`root_dir`</a> <span class="type">String</span>  
 Optional. Defaults to `/`. Specify the location in the EFS filesystem you would like to use as the root of your volume. Must be fewer than 255 characters and must consist only of the characters `a-zA-Z0-9.-_/`. If using an access point, `root_dir` must be either empty or `/` and `auth.iam` must be `true`.
 
-<span class="parent-field">volume.efs.</span><a id="auth" href="#auth" class="field">`auth`</a> <span class="type">Map</span>
+<span class="parent-field">volume.efs.</span><a id="auth" href="#auth" class="field">`auth`</a> <span class="type">Map</span>  
 Specify advanced authorization configuration for EFS.
 
-<span class="parent-field">volume.efs.auth.</span><a id="iam" href="#iam" class="field">`iam`</a> <span class="type">Bool</span>
+<span class="parent-field">volume.efs.auth.</span><a id="iam" href="#iam" class="field">`iam`</a> <span class="type">Bool</span>  
 Optional. Defaults to `true`. Whether or not to use IAM authorization to determine whether the volume is allowed to connect to EFS.
 
-<span class="parent-field">volume.efs.auth.</span><a id="access_point_id" href="#access-point-id" class="field">`access_point_id`</a> <span class="type">String</span>
+<span class="parent-field">volume.efs.auth.</span><a id="access_point_id" href="#access-point-id" class="field">`access_point_id`</a> <span class="type">String</span>  
 Optional. Defaults to `""`. The ID of the EFS access point to connect to. If using an access point, `root_dir` must be either empty or `/` and `auth.iam` must be `true`.
 
-<a id="environments" href="#environments" class="field">`environments`</a> <span class="type">Map</span>
+<a id="environments" href="#environments" class="field">`environments`</a> <span class="type">Map</span>  
 The environment section lets you override any value in your manifest based on the environment you're in.
 In the example manifest above, we're overriding the CPU parameter so that our production container is more performant.

--- a/site/overrides/partials/header.html
+++ b/site/overrides/partials/header.html
@@ -2,35 +2,28 @@
 <header class="md-header" data-md-component="header">
 
   <!-- Top-level navigation -->
-  <nav class="md-header-nav md-grid" aria-label="{{ lang.t('header.title') }}">
+  <nav class="md-header__inner md-grid" aria-label="{{ lang.t('header.title') }}">
 
     <!-- Link to home -->
-    <a
-      href="{{ config.site_url | default(nav.homepage.url, true) | url }}"
-      title="{{ config.site_name }}"
-      class="md-header-nav__button md-logo"
-      aria-label="{{ config.site_name }}"
-    >
+    <a href="{{ config.site_url }}" title="{{ config.site_name | e }}" class="md-header__button md-logo" aria-label="{{ config.site_name }}">
       {% include "partials/logo.html" %}
     </a>
 
     <!-- Button to open drawer -->
-    <label class="md-header-nav__button md-icon" for="__drawer">
+    <label class="md-header__button md-icon" for="__drawer">
       {% include ".icons/material/menu" ~ ".svg" %}
     </label>
 
     <!-- Header title -->
-    <div class="md-header-nav__title" data-md-component="header-title">
-      {% if config.site_name == page.title %}
-        <div class="md-header-nav__ellipsis md-ellipsis title">
-          {{ config.site_name }}
-        </div>
-      {% else %}
-        <div class="md-header-nav__ellipsis">
-          <span class="md-header-nav__topic md-ellipsis title">
+    <div class="md-header__title" data-md-component="header-title">
+      <div class="md-header__ellipsis">
+        <div class="md-header__topic">
+          <span class="md-ellipsis">
             {{ config.site_name }}
           </span>
-          <span class="md-header-nav__topic md-ellipsis">
+        </div>
+        <div class="md-header__topic" data-md-component="header-topic">
+          <span class="md-ellipsis">
             {% if page and page.meta and page.meta.title %}
               {{ page.meta.title }}
             {% else %}
@@ -38,12 +31,39 @@
             {% endif %}
           </span>
         </div>
-      {% endif %}
+      </div>
     </div>
+
+    <!-- Site language selector -->
+    {% if config.extra.alternate %}
+    <div class="md-header__option"></form>
+      <div class="md-select">
+        {% set icon = config.theme.icon.alternate or "material/translate" %}
+        <button class="md-header__button md-icon">
+          {% include ".icons/" ~ icon ~ ".svg" %}
+        </button>
+        <div class="md-select__inner">
+          <ul class="md-select__list">
+            {% for alt in config.extra.alternate %}
+            <li class="md-select__item">
+              <a
+                      href="{{ alt.link | url }}"
+                      hreflang="{{ alt.lang }}"
+                      class="md-select__link"
+              >
+                {{ alt.name }}
+              </a>
+            </li>
+            {% endfor %}
+          </ul>
+        </div>
+      </div>
+    </div>
+    {% endif %}
 
     <!-- Button to open search dialogue -->
     {% if "search" in config["plugins"] %}
-      <label class="md-header-nav__button md-icon" for="__search">
+      <label class="md-header__button md-icon" for="__search">
         {% include ".icons/material/magnify.svg" %}
       </label>
 
@@ -53,7 +73,7 @@
 
     <!-- Repository containing source -->
     {% if config.repo_url %}
-      <div class="md-header-nav__source">
+      <div class="md-header__source">
         {% include "partials/source.html" %}
       </div>
     {% endif %}


### PR DESCRIPTION
Upgrade to v7 of material-mkdocs: https://squidfunk.github.io/mkdocs-material/upgrading/#upgrading-from-6x-to-7x so that we can use newer features such as multi-language support.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
