### PR TITLE
fix(manifest): add more validation on manifest.AdvancedCount

### DIFF
--- a/internal/pkg/manifest/svc.go
+++ b/internal/pkg/manifest/svc.go
@@ -134,8 +134,7 @@ func (c *Count) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 	}
 
-	err := c.AdvancedCount.IsValid()
-	if err != nil {
+	if err := c.AdvancedCount.IsValid(); err != nil {
 		return err
 	}
 

--- a/internal/pkg/manifest/svc.go
+++ b/internal/pkg/manifest/svc.go
@@ -134,8 +134,9 @@ func (c *Count) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 	}
 
-	if !c.AdvancedCount.IsValid() {
-		return errUnmarshalSpot
+	err := c.AdvancedCount.IsValid()
+	if err != nil {
+		return err
 	}
 
 	if !c.AdvancedCount.IsEmpty() {
@@ -173,7 +174,7 @@ func (c *Count) Desired() (*int, error) {
 // AdvancedCount represents the configurable options for Auto Scaling as well as
 // Capacity configuration (spot).
 type AdvancedCount struct {
-	Spot         *int           `yaml:"spot"` // mutually exclusive with Range
+	Spot         *int           `yaml:"spot"` // mutually exclusive with other fields
 	Range        *Range         `yaml:"range"`
 	CPU          *int           `yaml:"cpu_percentage"`
 	Memory       *int           `yaml:"memory_percentage"`
@@ -192,12 +193,24 @@ func (a *AdvancedCount) IgnoreRange() bool {
 	return a.Spot != nil
 }
 
+func (a *AdvancedCount) hasAutoscaling() bool {
+	return a.Range != nil || a.CPU != nil || a.Memory != nil ||
+		a.Requests != nil || a.ResponseTime != nil
+}
+
 // IsValid checks to make sure Spot fields are compatible with other values in AdvancedCount
-func (a *AdvancedCount) IsValid() bool {
-	if a.Spot != nil && a.Range != nil {
-		return false
+func (a *AdvancedCount) IsValid() error {
+	// Spot translates to desiredCount; cannot specify with autoscaling
+	if a.Spot != nil && a.hasAutoscaling() {
+		return errInvalidAdvancedCount
 	}
-	return true
+
+	// Range must be specified if using autoscaling
+	if a.Range == nil && (a.CPU != nil || a.Memory != nil || a.Requests != nil || a.ResponseTime != nil) {
+		return errInvalidAutoscaling
+	}
+
+	return nil
 }
 
 // ServiceDockerfileBuildRequired returns if the service container image should be built from local Dockerfile.

--- a/internal/pkg/manifest/svc_test.go
+++ b/internal/pkg/manifest/svc_test.go
@@ -342,6 +342,27 @@ func TestCount_UnmarshalYAML(t *testing.T) {
 				},
 			},
 		},
+		"With all RangeConfig fields specified and autoscaling field": {
+			inContent: []byte(`count:
+  range:
+    min: 2
+    max: 8
+    spot_from: 3
+  cpu_percentage: 50
+`),
+			wantedStruct: Count{
+				AdvancedCount: AdvancedCount{
+					Range: &Range{
+						RangeConfig: RangeConfig{
+							Min:      aws.Int(2),
+							Max:      aws.Int(8),
+							SpotFrom: aws.Int(3),
+						},
+					},
+					CPU: aws.Int(50),
+				},
+			},
+		},
 		"Error if spot specified as int with range": {
 			inContent: []byte(`count:
   range: 1-10
@@ -623,8 +644,9 @@ func TestAdvancedCount_IsValid(t *testing.T) {
 			input: &AdvancedCount{
 				Range: &Range{
 					RangeConfig: RangeConfig{
-						Min: aws.Int(1),
-						Max: aws.Int(10),
+						Min:      aws.Int(1),
+						Max:      aws.Int(10),
+						SpotFrom: aws.Int(2),
 					},
 				},
 			},

--- a/internal/pkg/manifest/svc_test.go
+++ b/internal/pkg/manifest/svc_test.go
@@ -347,7 +347,13 @@ func TestCount_UnmarshalYAML(t *testing.T) {
   range: 1-10
   spot: 3
 `),
-			wantedError: errUnmarshalSpot,
+			wantedError: errInvalidAdvancedCount,
+		},
+		"Error if autoscaling specified without range": {
+			inContent: []byte(`count:
+  cpu_percentage: 30
+`),
+			wantedError: errInvalidAutoscaling,
 		},
 		"Error if unmarshalable": {
 			inContent: []byte(`count: badNumber
@@ -585,6 +591,143 @@ func TestCount_Desired(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tc.expected, actual)
+			}
+		})
+	}
+}
+
+func TestAdvancedCount_IsValid(t *testing.T) {
+	mockRange := IntRangeBand("1-10")
+	testCases := map[string]struct {
+		input *AdvancedCount
+
+		expectedErr error
+	}{
+		"with spot count": {
+			input: &AdvancedCount{
+				Spot: aws.Int(42),
+			},
+
+			expectedErr: nil,
+		},
+		"with range value": {
+			input: &AdvancedCount{
+				Range: &Range{
+					Value: &mockRange,
+				},
+			},
+
+			expectedErr: nil,
+		},
+		"with range config": {
+			input: &AdvancedCount{
+				Range: &Range{
+					RangeConfig: RangeConfig{
+						Min: aws.Int(1),
+						Max: aws.Int(10),
+					},
+				},
+			},
+
+			expectedErr: nil,
+		},
+		"with range and autoscaling config": {
+			input: &AdvancedCount{
+				Range: &Range{
+					Value: &mockRange,
+				},
+				CPU:      aws.Int(512),
+				Memory:   aws.Int(1024),
+				Requests: aws.Int(1000),
+			},
+
+			expectedErr: nil,
+		},
+		"with range config and autoscaling config": {
+			input: &AdvancedCount{
+				Range: &Range{
+					RangeConfig: RangeConfig{
+						Min: aws.Int(1),
+						Max: aws.Int(10),
+					},
+				},
+				CPU:      aws.Int(512),
+				Memory:   aws.Int(1024),
+				Requests: aws.Int(1000),
+			},
+
+			expectedErr: nil,
+		},
+		"with range config with spot and autoscaling config": {
+			input: &AdvancedCount{
+				Range: &Range{
+					RangeConfig: RangeConfig{
+						Min:      aws.Int(1),
+						Max:      aws.Int(10),
+						SpotFrom: aws.Int(3),
+					},
+				},
+				CPU:      aws.Int(512),
+				Memory:   aws.Int(1024),
+				Requests: aws.Int(1000),
+			},
+
+			expectedErr: nil,
+		},
+		"invalid with spot count and autoscaling config": {
+			input: &AdvancedCount{
+				Spot:     aws.Int(42),
+				CPU:      aws.Int(512),
+				Memory:   aws.Int(1024),
+				Requests: aws.Int(1000),
+			},
+
+			expectedErr: errInvalidAdvancedCount,
+		},
+		"invalid with spot count and range": {
+			input: &AdvancedCount{
+				Spot: aws.Int(42),
+				Range: &Range{
+					Value: &mockRange,
+				},
+			},
+
+			expectedErr: errInvalidAdvancedCount,
+		},
+		"invalid with spot count and range config": {
+			input: &AdvancedCount{
+				Spot: aws.Int(42),
+				Range: &Range{
+					RangeConfig: RangeConfig{
+						Min:      aws.Int(1),
+						Max:      aws.Int(10),
+						SpotFrom: aws.Int(3),
+					},
+				},
+			},
+
+			expectedErr: errInvalidAdvancedCount,
+		},
+		"invalid with autoscaling fields and no range": {
+			input: &AdvancedCount{
+				CPU:      aws.Int(512),
+				Memory:   aws.Int(1024),
+				Requests: aws.Int(1000),
+			},
+
+			expectedErr: errInvalidAutoscaling,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// WHEN
+			err := tc.input.IsValid()
+
+			// THEN
+			if tc.expectedErr != nil {
+				require.EqualError(t, err, tc.expectedErr.Error())
+			} else {
+				require.NoError(t, err)
 			}
 		})
 	}

--- a/internal/pkg/manifest/workload.go
+++ b/internal/pkg/manifest/workload.go
@@ -35,13 +35,14 @@ var (
 	// Error definitions.
 	errUnmarshalBuildOpts  = errors.New("cannot unmarshal build field into string or compose-style map")
 	errUnmarshalCountOpts  = errors.New(`cannot unmarshal "count" field to an integer or autoscaling configuration`)
-	errUnmarshalSpot       = errors.New(`cannot unmarshal "spot" field to an integer if range is specified`)
 	errUnmarshalRangeOpts  = errors.New(`cannot unmarshal "range" field`)
 	errUnmarshalExec       = errors.New("cannot unmarshal exec field into boolean or exec configuration")
 	errUnmarshalEntryPoint = errors.New("cannot unmarshal entrypoint into string or slice of strings")
 	errUnmarshalCommand    = errors.New("cannot unmarshal command into string or slice of strings")
 
-	errInvalidRangeOpts = errors.New(`cannot specify both "range" and "min"/"max"`)
+	errInvalidRangeOpts     = errors.New(`cannot specify both "range" and "min"/"max"`)
+	errInvalidAdvancedCount = errors.New(`cannot specify both "spot" and autoscaling fields`)
+	errInvalidAutoscaling   = errors.New(`must specify "range" if using autoscaling`)
 )
 
 // WorkloadProps contains properties for creating a new workload manifest.


### PR DESCRIPTION
Previously, invalid count specifications in the service manifest would
result in a segfault. This catches those errors during unmarshalling.

Fixes: #2229

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
