### PR TITLE
docs: replace old term

### DIFF
--- a/site/content/docs/concepts/pipelines.en.md
+++ b/site/content/docs/concepts/pipelines.en.md
@@ -110,7 +110,7 @@ Here's the fun part! Run:
 
 `copilot pipeline update`
 
-This parses your `pipeline.yml`, creates a CodePipeline in the same account and region as your project and kicks off a pipeline execution. Log into the AWS Console to watch your pipeline go, or run `copilot pipeline status` to check in on its execution.
+This parses your `pipeline.yml`, creates a CodePipeline in the same account and region as your application and kicks off a pipeline execution. Log into the AWS Console to watch your pipeline go, or run `copilot pipeline status` to check in on its execution.
 
 ![Your completed CodePipeline](https://user-images.githubusercontent.com/828419/71861318-c7083980-30aa-11ea-80bb-4bea25bf5d04.png)
 


### PR DESCRIPTION
This PR replaces the old term `project` as it's called as `application` today.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
