### PR TITLE
chore(cli): app upgrade should upgrade SSM store

### DIFF
--- a/internal/pkg/cli/app_upgrade.go
+++ b/internal/pkg/cli/app_upgrade.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/aws/copilot-cli/internal/pkg/aws/identity"
+	"github.com/aws/copilot-cli/internal/pkg/aws/route53"
 	"github.com/aws/copilot-cli/internal/pkg/aws/sessions"
 	"github.com/aws/copilot-cli/internal/pkg/config"
 	"github.com/aws/copilot-cli/internal/pkg/deploy"
@@ -43,6 +44,7 @@ type appUpgradeOpts struct {
 	store         store
 	prog          progress
 	versionGetter versionGetter
+	route53       domainHostedZoneGetter
 	sel           appSelector
 	identity      identityService
 	upgrader      appUpgrader
@@ -66,6 +68,7 @@ func newAppUpgradeOpts(vars appUpgradeVars) (*appUpgradeOpts, error) {
 		store:          store,
 		identity:       identity.New(sess),
 		prog:           termprogress.NewSpinner(log.DiagnosticWriter),
+		route53:        route53.New(sess),
 		sel:            selector.NewSelect(prompt.New(), store),
 		versionGetter:  d,
 		upgrader:       cloudformation.New(sess),
@@ -156,6 +159,11 @@ func (o *appUpgradeOpts) upgradeApplication(app *config.Application, fromVersion
 	if err != nil {
 		return fmt.Errorf("get identity: %w", err)
 	}
+	// Upgrade SSM Parameter Store record.
+	if err := o.upgradeAppSSMStore(app); err != nil {
+		return err
+	}
+	// Upgrade app CloudFormation resources.
 	if err := o.upgrader.UpgradeApplication(&deploy.CreateAppInput{
 		Name:               o.name,
 		AccountID:          caller.Account,
@@ -164,6 +172,20 @@ func (o *appUpgradeOpts) upgradeApplication(app *config.Application, fromVersion
 		Version:            toVersion,
 	}); err != nil {
 		return fmt.Errorf("upgrade application %s from version %s to version %s: %v", app.Name, fromVersion, toVersion, err)
+	}
+	return nil
+}
+
+func (o *appUpgradeOpts) upgradeAppSSMStore(app *config.Application) error {
+	if app.Domain != "" && app.DomainHostedZoneID == "" {
+		hostedZoneID, err := o.route53.DomainHostedZoneID(app.Domain)
+		if err != nil {
+			return fmt.Errorf("get hosted zone ID for domain %s: %w", app.Domain, err)
+		}
+		app.DomainHostedZoneID = hostedZoneID
+	}
+	if err := o.store.UpdateApplication(app); err != nil {
+		return fmt.Errorf("update application %s: %w", app.Name, err)
 	}
 	return nil
 }

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -71,6 +71,7 @@ type workloadListWriter interface {
 
 type applicationStore interface {
 	applicationCreator
+	applicationUpdator
 	applicationGetter
 	applicationLister
 	applicationDeleter
@@ -78,6 +79,10 @@ type applicationStore interface {
 
 type applicationCreator interface {
 	CreateApplication(app *config.Application) error
+}
+
+type applicationUpdator interface {
+	UpdateApplication(app *config.Application) error
 }
 
 type applicationGetter interface {

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -71,7 +71,7 @@ type workloadListWriter interface {
 
 type applicationStore interface {
 	applicationCreator
-	applicationUpdator
+	applicationUpdater
 	applicationGetter
 	applicationLister
 	applicationDeleter
@@ -81,7 +81,7 @@ type applicationCreator interface {
 	CreateApplication(app *config.Application) error
 }
 
-type applicationUpdator interface {
+type applicationUpdater interface {
 	UpdateApplication(app *config.Application) error
 }
 

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -495,31 +495,31 @@ func (mr *MockapplicationCreatorMockRecorder) CreateApplication(app interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateApplication", reflect.TypeOf((*MockapplicationCreator)(nil).CreateApplication), app)
 }
 
-// MockapplicationUpdator is a mock of applicationUpdator interface.
-type MockapplicationUpdator struct {
+// MockapplicationUpdater is a mock of applicationUpdater interface.
+type MockapplicationUpdater struct {
 	ctrl     *gomock.Controller
-	recorder *MockapplicationUpdatorMockRecorder
+	recorder *MockapplicationUpdaterMockRecorder
 }
 
-// MockapplicationUpdatorMockRecorder is the mock recorder for MockapplicationUpdator.
-type MockapplicationUpdatorMockRecorder struct {
-	mock *MockapplicationUpdator
+// MockapplicationUpdaterMockRecorder is the mock recorder for MockapplicationUpdater.
+type MockapplicationUpdaterMockRecorder struct {
+	mock *MockapplicationUpdater
 }
 
-// NewMockapplicationUpdator creates a new mock instance.
-func NewMockapplicationUpdator(ctrl *gomock.Controller) *MockapplicationUpdator {
-	mock := &MockapplicationUpdator{ctrl: ctrl}
-	mock.recorder = &MockapplicationUpdatorMockRecorder{mock}
+// NewMockapplicationUpdater creates a new mock instance.
+func NewMockapplicationUpdater(ctrl *gomock.Controller) *MockapplicationUpdater {
+	mock := &MockapplicationUpdater{ctrl: ctrl}
+	mock.recorder = &MockapplicationUpdaterMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockapplicationUpdator) EXPECT() *MockapplicationUpdatorMockRecorder {
+func (m *MockapplicationUpdater) EXPECT() *MockapplicationUpdaterMockRecorder {
 	return m.recorder
 }
 
 // UpdateApplication mocks base method.
-func (m *MockapplicationUpdator) UpdateApplication(app *config.Application) error {
+func (m *MockapplicationUpdater) UpdateApplication(app *config.Application) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateApplication", app)
 	ret0, _ := ret[0].(error)
@@ -527,9 +527,9 @@ func (m *MockapplicationUpdator) UpdateApplication(app *config.Application) erro
 }
 
 // UpdateApplication indicates an expected call of UpdateApplication.
-func (mr *MockapplicationUpdatorMockRecorder) UpdateApplication(app interface{}) *gomock.Call {
+func (mr *MockapplicationUpdaterMockRecorder) UpdateApplication(app interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateApplication", reflect.TypeOf((*MockapplicationUpdator)(nil).UpdateApplication), app)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateApplication", reflect.TypeOf((*MockapplicationUpdater)(nil).UpdateApplication), app)
 }
 
 // MockapplicationGetter is a mock of applicationGetter interface.

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -444,6 +444,20 @@ func (mr *MockapplicationStoreMockRecorder) ListApplications() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListApplications", reflect.TypeOf((*MockapplicationStore)(nil).ListApplications))
 }
 
+// UpdateApplication mocks base method.
+func (m *MockapplicationStore) UpdateApplication(app *config.Application) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateApplication", app)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateApplication indicates an expected call of UpdateApplication.
+func (mr *MockapplicationStoreMockRecorder) UpdateApplication(app interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateApplication", reflect.TypeOf((*MockapplicationStore)(nil).UpdateApplication), app)
+}
+
 // MockapplicationCreator is a mock of applicationCreator interface.
 type MockapplicationCreator struct {
 	ctrl     *gomock.Controller
@@ -479,6 +493,43 @@ func (m *MockapplicationCreator) CreateApplication(app *config.Application) erro
 func (mr *MockapplicationCreatorMockRecorder) CreateApplication(app interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateApplication", reflect.TypeOf((*MockapplicationCreator)(nil).CreateApplication), app)
+}
+
+// MockapplicationUpdator is a mock of applicationUpdator interface.
+type MockapplicationUpdator struct {
+	ctrl     *gomock.Controller
+	recorder *MockapplicationUpdatorMockRecorder
+}
+
+// MockapplicationUpdatorMockRecorder is the mock recorder for MockapplicationUpdator.
+type MockapplicationUpdatorMockRecorder struct {
+	mock *MockapplicationUpdator
+}
+
+// NewMockapplicationUpdator creates a new mock instance.
+func NewMockapplicationUpdator(ctrl *gomock.Controller) *MockapplicationUpdator {
+	mock := &MockapplicationUpdator{ctrl: ctrl}
+	mock.recorder = &MockapplicationUpdatorMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockapplicationUpdator) EXPECT() *MockapplicationUpdatorMockRecorder {
+	return m.recorder
+}
+
+// UpdateApplication mocks base method.
+func (m *MockapplicationUpdator) UpdateApplication(app *config.Application) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateApplication", app)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateApplication indicates an expected call of UpdateApplication.
+func (mr *MockapplicationUpdatorMockRecorder) UpdateApplication(app interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateApplication", reflect.TypeOf((*MockapplicationUpdator)(nil).UpdateApplication), app)
 }
 
 // MockapplicationGetter is a mock of applicationGetter interface.
@@ -1108,6 +1159,20 @@ func (m *Mockstore) ListWorkloads(appName string) ([]*config.Workload, error) {
 func (mr *MockstoreMockRecorder) ListWorkloads(appName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListWorkloads", reflect.TypeOf((*Mockstore)(nil).ListWorkloads), appName)
+}
+
+// UpdateApplication mocks base method.
+func (m *Mockstore) UpdateApplication(app *config.Application) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateApplication", app)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateApplication indicates an expected call of UpdateApplication.
+func (mr *MockstoreMockRecorder) UpdateApplication(app interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateApplication", reflect.TypeOf((*Mockstore)(nil).UpdateApplication), app)
 }
 
 // MockdeployedEnvironmentLister is a mock of deployedEnvironmentLister interface.

--- a/internal/pkg/config/app.go
+++ b/internal/pkg/config/app.go
@@ -56,6 +56,27 @@ func (s *Store) CreateApplication(application *Application) error {
 	return nil
 }
 
+func (s *Store) UpdateApplication(application *Application) error {
+	applicationPath := fmt.Sprintf(fmtApplicationPath, application.Name)
+	application.Version = schemaVersion
+
+	data, err := marshal(application)
+	if err != nil {
+		return fmt.Errorf("serializing application %s: %w", application.Name, err)
+	}
+
+	if _, err = s.ssmClient.PutParameter(&ssm.PutParameterInput{
+		Name:        aws.String(applicationPath),
+		Description: aws.String("Copilot Application"),
+		Type:        aws.String(ssm.ParameterTypeString),
+		Value:       aws.String(data),
+		Overwrite:   aws.Bool(true),
+	}); err != nil {
+		return fmt.Errorf("update application %s: %w", application.Name, err)
+	}
+	return nil
+}
+
 // GetApplication fetches an application by name. If it can't be found, return a ErrNoSuchApplication
 func (s *Store) GetApplication(applicationName string) (*Application, error) {
 	applicationPath := fmt.Sprintf(fmtApplicationPath, applicationName)

--- a/internal/pkg/deploy/cloudformation/app.go
+++ b/internal/pkg/deploy/cloudformation/app.go
@@ -99,11 +99,11 @@ func (cf CloudFormation) upgradeAppStack(s *cloudformation.Stack) error {
 			_ = cf.cfnClient.WaitForUpdate(context.Background(), s.Name)
 			continue
 		}
-		s.Parameters = descr.Parameters
+		// We only need the tags from the previously deployed stack.
 		s.Tags = descr.Tags
 
 		err = cf.cfnClient.UpdateAndWait(s)
-		if err == nil { // Success.
+		if err == nil {
 			return nil
 		}
 		if retryable := isRetryableUpdateError(s.Name, err); retryable {


### PR DESCRIPTION
<!-- Provide summary of changes -->
Currently `app upgrade` doesn't upgrade the SSM store. So if users created the app using the previous copilot version then it won't have fields that were newly added.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
