### PR TITLE
docs: fix run command option from `--num` to `--count`

### DIFF
--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -678,7 +678,7 @@ You will be prompted to specify an environment for the tasks to run in.
 Run a task named "db-migrate" in the "test" environment under the current workspace.
 /code $ copilot task run -n db-migrate --env test
 Run 4 tasks with 2GB memory, an existing image, and a custom task role.
-/code $ copilot task run --num 4 --memory 2048 --image=rds-migrate --task-role migrate-role
+/code $ copilot task run --count 4 --memory 2048 --image=rds-migrate --task-role migrate-role
 Run a task with environment variables.
 /code $ copilot task run --env-vars name=myName,user=myUser
 Run a task using the current workspace with specific subnets and security groups.

--- a/site/content/docs/commands/task-run.en.md
+++ b/site/content/docs/commands/task-run.en.md
@@ -63,7 +63,7 @@ $ copilot task run -n db-migrate --env test --follow
 
 Run 4 tasks with 2GB memory, an existing image, and a custom task role.
 ```
-$ copilot task run --num 4 --memory 2048 --image=rds-migrate --task-role migrate-role --follow
+$ copilot task run --count 4 --memory 2048 --image=rds-migrate --task-role migrate-role --follow
 ```
 
 Run a task with environment variables.


### PR DESCRIPTION
<!-- Provide summary of changes -->

I run [documented command](https://aws.github.io/copilot-cli/docs/commands/task-run/) of `task run`, output error message bellow.

```sh
$ copilot task run --num 4 --memory 2048 --image=rds-migrate --task-role migrate-role
✘ unknown flag: --num
```

I think `--num` option is correctly `--count` to specify the number of tasks to set up.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
