### PR TITLE
chore: fix missing mkdocs requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 # Dependencies to render the Copilot website needed by mkdocs.
 mkdocs-macros-plugin==0.5.5
 mkdocs-static-i18n==0.12
+mkdocs-redirects==1.0.3


### PR DESCRIPTION
`mkdocs.yml` defines that it uses the `redirects` plugin but is missing from `requirements.txt`, resulting the following error in `mkdocs serve` command:

```
$ mkdocs serve
INFO    -  Building documentation...
ERROR   -  Config value: 'plugins'. Error: The "redirects" plugin is not installed

Aborted with 1 Configuration Errors!
```

This PR adds `mkdocs-redirects` to `requirements.txt` explicitly to run `mkdocs serve` command successfully.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
