### PR TITLE
chore: fix npm dependency vulnerabilities

### DIFF
--- a/cf-custom-resources/package-lock.json
+++ b/cf-custom-resources/package-lock.json
@@ -51,7 +51,7 @@
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "json5": "^2.1.0",
-        "lodash": "^4.17.13",
+        "lodash": "^4.17.21",
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
@@ -92,7 +92,7 @@
       "dependencies": {
         "@babel/types": "^7.7.2",
         "jsesc": "^2.5.1",
-        "lodash": "^4.17.13",
+        "lodash": "^4.17.21",
         "source-map": "^0.5.0"
       }
     },
@@ -141,7 +141,7 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.12.11",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.21",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -161,7 +161,7 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.12.11",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.21",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -179,7 +179,7 @@
         "@babel/template": "^7.10.4",
         "@babel/traverse": "^7.12.1",
         "@babel/types": "^7.12.1",
-        "lodash": "^4.17.19"
+        "lodash": "^4.17.21"
       }
     },
     "node_modules/@babel/helper-module-transforms/node_modules/@babel/code-frame": {
@@ -279,7 +279,7 @@
         "@babel/types": "^7.12.12",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
-        "lodash": "^4.17.19"
+        "lodash": "^4.17.21"
       }
     },
     "node_modules/@babel/helper-module-transforms/node_modules/@babel/types": {
@@ -289,7 +289,7 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.12.11",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.21",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -318,7 +318,7 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.12.11",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.21",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -437,7 +437,7 @@
         "@babel/types": "^7.12.12",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
-        "lodash": "^4.17.19"
+        "lodash": "^4.17.21"
       }
     },
     "node_modules/@babel/helper-replace-supers/node_modules/@babel/types": {
@@ -447,7 +447,7 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.12.11",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.21",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -476,7 +476,7 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.12.11",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.21",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -662,7 +662,7 @@
         "@babel/types": "^7.7.2",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
-        "lodash": "^4.17.13"
+        "lodash": "^4.17.21"
       }
     },
     "node_modules/@babel/traverse/node_modules/debug": {
@@ -687,7 +687,7 @@
       "dev": true,
       "dependencies": {
         "esutils": "^2.0.2",
-        "lodash": "^4.17.13",
+        "lodash": "^4.17.21",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -726,7 +726,7 @@
         "ignore": "^4.0.6",
         "import-fresh": "^3.2.1",
         "js-yaml": "^3.13.1",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.21",
         "minimatch": "^3.0.4",
         "strip-json-comments": "^3.1.1"
       },
@@ -2129,7 +2129,7 @@
         "@babel/core": "^7.1.0",
         "babel-preset-minify": "^0.5.1",
         "fs-readdir-recursive": "^1.1.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.21",
         "mkdirp": "^0.5.1",
         "util.promisify": "^1.0.0",
         "yargs-parser": "^10.0.0"
@@ -2212,7 +2212,7 @@
         "babel-helper-evaluate-path": "^0.5.0",
         "babel-helper-mark-eval-scopes": "^0.4.3",
         "babel-helper-remove-or-void": "^0.4.3",
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.21"
       }
     },
     "node_modules/babel-plugin-minify-flip-comparisons": {
@@ -2415,7 +2415,7 @@
         "babel-plugin-transform-remove-undefined": "^0.5.0",
         "babel-plugin-transform-simplify-comparison-operators": "^6.9.4",
         "babel-plugin-transform-undefined-to-void": "^6.9.4",
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.21"
       }
     },
     "node_modules/balanced-match": {
@@ -3290,7 +3290,7 @@
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.21",
         "minimatch": "^3.0.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
@@ -4466,9 +4466,9 @@
       }
     },
     "node_modules/hosted-git-info": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
     "node_modules/html-encoding-sniffer": {
@@ -5049,7 +5049,7 @@
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.1",
         "json5": "^2.1.2",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.21",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
       },
@@ -5165,7 +5165,7 @@
         "@babel/types": "^7.12.12",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
-        "lodash": "^4.17.19"
+        "lodash": "^4.17.21"
       }
     },
     "node_modules/istanbul-lib-instrument/node_modules/@babel/types": {
@@ -5175,7 +5175,7 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.12.11",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.21",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -5353,6 +5353,103 @@
       "dev": true,
       "dependencies": {
         "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-cli": {
+      "version": "26.6.3",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.6.3.tgz",
+      "integrity": "sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==",
+      "dev": true,
+      "dependencies": {
+        "@jest/core": "^26.6.3",
+        "@jest/test-result": "^26.6.2",
+        "@jest/types": "^26.6.2",
+        "chalk": "^4.0.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.4",
+        "import-local": "^3.0.2",
+        "is-ci": "^2.0.0",
+        "jest-config": "^26.6.3",
+        "jest-util": "^26.6.2",
+        "jest-validate": "^26.6.2",
+        "prompts": "^2.0.1",
+        "yargs": "^15.4.1"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": ">= 10.14.2"
+      }
+    },
+    "node_modules/jest-cli/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-cli/node_modules/chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-cli/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-cli/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/jest-cli/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-cli/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
       },
       "engines": {
         "node": ">=8"
@@ -6836,97 +6933,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/jest/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest/node_modules/chalk": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-      "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/jest/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/jest/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/jest/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest/node_modules/jest-cli": {
-      "version": "26.6.3",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.6.3.tgz",
-      "integrity": "sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==",
-      "dev": true,
-      "dependencies": {
-        "@jest/core": "^26.6.3",
-        "@jest/test-result": "^26.6.2",
-        "@jest/types": "^26.6.2",
-        "chalk": "^4.0.0",
-        "exit": "^0.1.2",
-        "graceful-fs": "^4.2.4",
-        "import-local": "^3.0.2",
-        "is-ci": "^2.0.0",
-        "jest-config": "^26.6.3",
-        "jest-util": "^26.6.2",
-        "jest-validate": "^26.6.2",
-        "prompts": "^2.0.1",
-        "yargs": "^15.4.1"
-      },
-      "bin": {
-        "jest": "bin/jest.js"
-      },
-      "engines": {
-        "node": ">= 10.14.2"
-      }
-    },
-    "node_modules/jest/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/jmespath": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
@@ -7227,9 +7233,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
     "node_modules/lodash.get": {
@@ -7418,22 +7424,16 @@
       }
     },
     "node_modules/mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "dev": true,
       "dependencies": {
-        "minimist": "0.0.8"
+        "minimist": "^1.2.5"
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
-    },
-    "node_modules/mkdirp/node_modules/minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -7565,7 +7565,7 @@
       "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
       "dev": true,
       "dependencies": {
-        "hosted-git-info": "^2.1.4",
+        "hosted-git-info": "^3.0.8",
         "resolve": "^1.10.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
@@ -8290,7 +8290,7 @@
       "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
       "dev": true,
       "dependencies": {
-        "lodash": "^4.17.19"
+        "lodash": "^4.17.21"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -9330,19 +9330,13 @@
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.21",
         "slice-ansi": "^4.0.0",
         "string-width": "^4.2.0"
       },
       "engines": {
         "node": ">=10.0.0"
       }
-    },
-    "node_modules/table/node_modules/lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-      "dev": true
     },
     "node_modules/terminal-link": {
       "version": "2.1.1",
@@ -10169,7 +10163,7 @@
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "json5": "^2.1.0",
-        "lodash": "^4.17.13",
+        "lodash": "^4.17.21",
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
@@ -10206,7 +10200,7 @@
       "requires": {
         "@babel/types": "^7.7.2",
         "jsesc": "^2.5.1",
-        "lodash": "^4.17.13",
+        "lodash": "^4.17.21",
         "source-map": "^0.5.0"
       },
       "dependencies": {
@@ -10254,7 +10248,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.12.11",
-            "lodash": "^4.17.19",
+            "lodash": "^4.17.21",
             "to-fast-properties": "^2.0.0"
           }
         }
@@ -10276,7 +10270,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.12.11",
-            "lodash": "^4.17.19",
+            "lodash": "^4.17.21",
             "to-fast-properties": "^2.0.0"
           }
         }
@@ -10296,7 +10290,7 @@
         "@babel/template": "^7.10.4",
         "@babel/traverse": "^7.12.1",
         "@babel/types": "^7.12.1",
-        "lodash": "^4.17.19"
+        "lodash": "^4.17.21"
       },
       "dependencies": {
         "@babel/code-frame": {
@@ -10390,7 +10384,7 @@
             "@babel/types": "^7.12.12",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.19"
+            "lodash": "^4.17.21"
           }
         },
         "@babel/types": {
@@ -10400,7 +10394,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.12.11",
-            "lodash": "^4.17.19",
+            "lodash": "^4.17.21",
             "to-fast-properties": "^2.0.0"
           }
         },
@@ -10428,7 +10422,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.12.11",
-            "lodash": "^4.17.19",
+            "lodash": "^4.17.21",
             "to-fast-properties": "^2.0.0"
           }
         }
@@ -10543,7 +10537,7 @@
             "@babel/types": "^7.12.12",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.19"
+            "lodash": "^4.17.21"
           }
         },
         "@babel/types": {
@@ -10553,7 +10547,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.12.11",
-            "lodash": "^4.17.19",
+            "lodash": "^4.17.21",
             "to-fast-properties": "^2.0.0"
           }
         },
@@ -10581,7 +10575,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.12.11",
-            "lodash": "^4.17.19",
+            "lodash": "^4.17.21",
             "to-fast-properties": "^2.0.0"
           }
         }
@@ -10763,7 +10757,7 @@
         "@babel/types": "^7.7.2",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
-        "lodash": "^4.17.13"
+        "lodash": "^4.17.21"
       },
       "dependencies": {
         "debug": {
@@ -10790,7 +10784,7 @@
       "dev": true,
       "requires": {
         "esutils": "^2.0.2",
-        "lodash": "^4.17.13",
+        "lodash": "^4.17.21",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -10823,7 +10817,7 @@
         "ignore": "^4.0.6",
         "import-fresh": "^3.2.1",
         "js-yaml": "^3.13.1",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.21",
         "minimatch": "^3.0.4",
         "strip-json-comments": "^3.1.1"
       },
@@ -11994,7 +11988,7 @@
         "@babel/core": "^7.1.0",
         "babel-preset-minify": "^0.5.1",
         "fs-readdir-recursive": "^1.1.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.21",
         "mkdirp": "^0.5.1",
         "util.promisify": "^1.0.0",
         "yargs-parser": "^10.0.0"
@@ -12066,7 +12060,7 @@
         "babel-helper-evaluate-path": "^0.5.0",
         "babel-helper-mark-eval-scopes": "^0.4.3",
         "babel-helper-remove-or-void": "^0.4.3",
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.21"
       }
     },
     "babel-plugin-minify-flip-comparisons": {
@@ -12266,7 +12260,7 @@
         "babel-plugin-transform-remove-undefined": "^0.5.0",
         "babel-plugin-transform-simplify-comparison-operators": "^6.9.4",
         "babel-plugin-transform-undefined-to-void": "^6.9.4",
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.21"
       }
     },
     "balanced-match": {
@@ -12992,7 +12986,7 @@
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.21",
         "minimatch": "^3.0.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
@@ -13949,9 +13943,9 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
     "html-encoding-sniffer": {
@@ -14404,7 +14398,7 @@
             "debug": "^4.1.0",
             "gensync": "^1.0.0-beta.1",
             "json5": "^2.1.2",
-            "lodash": "^4.17.19",
+            "lodash": "^4.17.21",
             "semver": "^5.4.1",
             "source-map": "^0.5.0"
           },
@@ -14510,7 +14504,7 @@
             "@babel/types": "^7.12.12",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.19"
+            "lodash": "^4.17.21"
           }
         },
         "@babel/types": {
@@ -14520,7 +14514,7 @@
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.12.11",
-            "lodash": "^4.17.19",
+            "lodash": "^4.17.21",
             "to-fast-properties": "^2.0.0"
           }
         },
@@ -14605,78 +14599,6 @@
         "@jest/core": "^26.6.3",
         "import-local": "^3.0.2",
         "jest-cli": "^26.6.3"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "jest-cli": {
-          "version": "26.6.3",
-          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.6.3.tgz",
-          "integrity": "sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==",
-          "dev": true,
-          "requires": {
-            "@jest/core": "^26.6.3",
-            "@jest/test-result": "^26.6.2",
-            "@jest/types": "^26.6.2",
-            "chalk": "^4.0.0",
-            "exit": "^0.1.2",
-            "graceful-fs": "^4.2.4",
-            "import-local": "^3.0.2",
-            "is-ci": "^2.0.0",
-            "jest-config": "^26.6.3",
-            "jest-util": "^26.6.2",
-            "jest-validate": "^26.6.2",
-            "prompts": "^2.0.1",
-            "yargs": "^15.4.1"
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
       }
     },
     "jest-changed-files": {
@@ -14729,6 +14651,78 @@
           "dev": true,
           "requires": {
             "path-key": "^3.0.0"
+          }
+        }
+      }
+    },
+    "jest-cli": {
+      "version": "26.6.3",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.6.3.tgz",
+      "integrity": "sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==",
+      "dev": true,
+      "requires": {
+        "@jest/core": "^26.6.3",
+        "@jest/test-result": "^26.6.2",
+        "@jest/types": "^26.6.2",
+        "chalk": "^4.0.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.4",
+        "import-local": "^3.0.2",
+        "is-ci": "^2.0.0",
+        "jest-config": "^26.6.3",
+        "jest-util": "^26.6.2",
+        "jest-validate": "^26.6.2",
+        "prompts": "^2.0.1",
+        "yargs": "^15.4.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
           }
         }
       }
@@ -16162,9 +16156,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
     "lodash.get": {
@@ -16321,20 +16315,12 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        }
+        "minimist": "^1.2.5"
       }
     },
     "ms": {
@@ -16451,7 +16437,7 @@
       "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "^2.1.4",
+        "hosted-git-info": "^3.0.8",
         "resolve": "^1.10.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
@@ -17047,7 +17033,7 @@
       "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.19"
+        "lodash": "^4.17.21"
       }
     },
     "request-promise-native": {
@@ -17894,17 +17880,9 @@
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.21",
         "slice-ansi": "^4.0.0",
         "string-width": "^4.2.0"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.20",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-          "dev": true
-        }
       }
     },
     "terminal-link": {


### PR DESCRIPTION
<!-- Provide summary of changes -->
Addressed [GH dependency alerts](https://github.com/aws/copilot-cli/security/dependabot) and ran `npm audit` to fix vulnerabilities as well.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
