### PR TITLE
chore(network): add vpc-endpoint CloudFormation partial and adapt other templates to accommodate `isolated` network placement option

### DIFF
--- a/templates/environment/partials/nat-gateways.yml
+++ b/templates/environment/partials/nat-gateways.yml
@@ -16,11 +16,6 @@ NatGateway{{inc $ind}}:
     Tags:
       - Key: Name
         Value: !Sub 'copilot-${AppName}-${EnvironmentName}-{{$ind}}'
-PrivateRouteTable{{inc $ind}}:
-  Type: AWS::EC2::RouteTable
-  Condition: CreateNATGateways
-  Properties:
-    VpcId: !Ref 'VPC'
 PrivateRoute{{inc $ind}}:
   Type: AWS::EC2::Route
   Condition: CreateNATGateways
@@ -28,10 +23,4 @@ PrivateRoute{{inc $ind}}:
     RouteTableId: !Ref PrivateRouteTable{{inc $ind}}
     DestinationCidrBlock: 0.0.0.0/0
     NatGatewayId: !Ref NatGateway{{inc $ind}}
-PrivateRouteTable{{inc $ind}}Association:
-  Type: AWS::EC2::SubnetRouteTableAssociation
-  Condition: CreateNATGateways
-  Properties:
-    RouteTableId: !Ref PrivateRouteTable{{inc $ind}}
-    SubnetId: !Ref PrivateSubnet{{inc $ind}}
-  {{- end}}
+{{- end}}

--- a/templates/environment/partials/vpc-endpoints.yml
+++ b/templates/environment/partials/vpc-endpoints.yml
@@ -1,6 +1,7 @@
-# Security group to allow receiving HTTPS traffic.
 VPCEndpointSecurityGroup:
   Condition: CreateVPCEndpoints
+  Metadata:
+    'aws:copilot:description': 'A security group to associate with your VPC endpoints'
   Type: AWS::EC2::SecurityGroup
   Properties:
     GroupDescription: Security Group to allow use of VPC Endpoints.
@@ -22,16 +23,6 @@ IngressFromVPCEndpoints:
     IpProtocol: -1
     SourceSecurityGroupId: !Ref 'VPCEndpointSecurityGroup'
 
-# Allow traffic from VPC endpoints.
-IngressFromItself:
-  Condition: CreateVPCEndpoints
-  Type: AWS::EC2::SecurityGroupIngress
-  Properties:
-    Description: Ingress from VPC endpoints.
-    GroupId: !Ref 'EnvironmentSecurityGroup'
-    IpProtocol: -1
-    SourceSecurityGroupId: !Ref 'EnvironmentSecurityGroup'
-
 {{- range $ind, $cidr := .PrivateSubnetCIDRs}}
 S3PrivateRouteTable{{inc $ind}}:
   Type: AWS::EC2::RouteTable
@@ -46,39 +37,6 @@ S3PrivateRouteTable{{inc $ind}}Association:
     RouteTableId: !Ref S3PrivateRouteTable{{inc $ind}}
     SubnetId: !Ref PrivateSubnet{{inc $ind}}
 {{- end}}
-
-# ECS Resources
-ECSCluster:
-  Condition: CreateVPCEndpoints
-  Type: AWS::ECS::Cluster
-
-ECSTaskExecutionRole:
-  Condition: CreateVPCEndpoints
-  Type: AWS::IAM::Role
-  Properties:
-    AssumeRolePolicyDocument:
-      Statement:
-        - Effect: Allow
-          Principal:
-            Service: [ecs-tasks.amazonaws.com]
-          Action: ['sts:AssumeRole']
-    Path: /
-    Policies:
-      - PolicyName: AmazonECSTaskExecutionRolePolicy
-        PolicyDocument:
-          Statement:
-            - Effect: Allow
-              Action:
-                # Allow the ECS Tasks to download images from ECR
-                - 'ecr:GetAuthorizationToken'
-                - 'ecr:BatchCheckLayerAvailability'
-                - 'ecr:GetDownloadUrlForLayer'
-                - 'ecr:BatchGetImage'
-
-                # Allow the ECS tasks to upload logs to CloudWatch
-                - 'logs:CreateLogStream'
-                - 'logs:PutLogEvents'
-              Resource: '*'
 
 # Gateway endpoint for S3.
 S3GatewayVPCEndpoint:

--- a/templates/environment/partials/vpc-endpoints.yml
+++ b/templates/environment/partials/vpc-endpoints.yml
@@ -135,6 +135,21 @@ EC2VPCEndpoint:
     SecurityGroupIds:
       - !Ref VPCEndpointSecurityGroup
 
+SSMMessagesVPCEndpoint:
+  Condition: CreateVPCEndpoints
+  Type: AWS::EC2::VPCEndpoint
+  Properties:
+    VpcEndpointType: Interface
+    PrivateDnsEnabled: true
+    SubnetIds:
+      {{- range $ind, $cidr := .PrivateSubnetCIDRs}}
+      - !Ref PrivateSubnet{{inc $ind}}
+      {{- end}}
+    ServiceName: !Sub com.amazonaws.${AWS::Region}.ssmmessages
+    VpcId: !Ref VPC
+    SecurityGroupIds:
+      - !Ref VPCEndpointSecurityGroup
+
 SecretsManagerVPCEndpoint:
   Condition: CreateVPCEndpoints
   Metadata:

--- a/templates/environment/partials/vpc-endpoints.yml
+++ b/templates/environment/partials/vpc-endpoints.yml
@@ -27,7 +27,7 @@ IngressFromVPCEndpoints:
 S3GatewayVPCEndpoint:
   Condition: CreateVPCEndpoints
   Metadata:
-    'aws:copilot:description': 'An S3 gateway endpoint.'
+    'aws:copilot:description': 'An S3 gateway endpoint'
   Type: AWS::EC2::VPCEndpoint
   Properties:
     VpcEndpointType: Gateway
@@ -42,7 +42,7 @@ S3GatewayVPCEndpoint:
 EcrApiVPCEndpoint:
   Condition: CreateVPCEndpoints
   Metadata:
-    'aws:copilot:description': 'ECR interface endpoints.'
+    'aws:copilot:description': 'ECR interface endpoints'
   Type: AWS::EC2::VPCEndpoint
   Properties:
     VpcEndpointType: Interface
@@ -74,7 +74,7 @@ EcrDkrVPCEndpoint:
 LogsVPCEndpoint:
   Condition: CreateVPCEndpoints
   Metadata:
-    'aws:copilot:description': 'A CloudWatch Logs interface endpoint.'
+    'aws:copilot:description': 'A CloudWatch Logs interface endpoint'
   Type: AWS::EC2::VPCEndpoint
   Properties:
     VpcEndpointType: Interface
@@ -91,7 +91,7 @@ LogsVPCEndpoint:
 SSMVPCEndpoint:
   Condition: CreateVPCEndpoints
   Metadata:
-    'aws:copilot:description': 'Systems Manager interface endpoints.'
+    'aws:copilot:description': 'Systems Manager interface endpoints'
   Type: AWS::EC2::VPCEndpoint
   Properties:
     VpcEndpointType: Interface
@@ -138,15 +138,15 @@ EC2VPCEndpoint:
 SecretsManagerVPCEndpoint:
   Condition: CreateVPCEndpoints
   Metadata:
-    'aws:copilot:description': 'A Secrets Manager interface endpoint.'
+    'aws:copilot:description': 'A Secrets Manager interface endpoint'
   Type: AWS::EC2::VPCEndpoint
   Properties:
     VpcEndpointType: Interface
     PrivateDnsEnabled: true
     SubnetIds:
-      { { - range $ind, $cidr := .PrivateSubnetCIDRs } }
+      {{- range $ind, $cidr := .PrivateSubnetCIDRs}}
       - !Ref PrivateSubnet{{inc $ind}}
-      { { - end } }
+      {{- end } }
     ServiceName: !Sub com.amazonaws.${AWS::Region}.secretsmanager
     VpcId: !Ref VPC
     SecurityGroupIds:

--- a/templates/environment/partials/vpc-endpoints.yml
+++ b/templates/environment/partials/vpc-endpoints.yml
@@ -1,0 +1,140 @@
+# Security group to allow receiving HTTPS traffic.
+VPCEndpointSecurityGroup:
+  Condition: CreateVPCEndpoints
+  Type: AWS::EC2::SecurityGroup
+  Properties:
+    GroupDescription: Security Group to allow use of VPC Endpoints.
+    VpcId: !Ref VPC
+    SecurityGroupIngress:
+      - IpProtocol: tcp
+        Description: HTTPS
+        FromPort: 443
+        ToPort: 443
+        CidrIp: 10.0.0.0/0
+
+# Allow ingress traffic from VPC endpoints to our containers.
+IngressFromVPCEndpoints:
+  Condition: CreateVPCEndpoints
+  Type: AWS::EC2::SecurityGroupIngress
+  Properties:
+    Description: Ingress from VPC endpoints.
+    GroupId: !Ref 'EnvironmentSecurityGroup'
+    IpProtocol: -1
+    SourceSecurityGroupId: !Ref 'VPCEndpointSecurityGroup'
+
+# Allow traffic from VPC endpoints.
+IngressFromItself:
+  Condition: CreateVPCEndpoints
+  Type: AWS::EC2::SecurityGroupIngress
+  Properties:
+    Description: Ingress from VPC endpoints.
+    GroupId: !Ref 'EnvironmentSecurityGroup'
+    IpProtocol: -1
+    SourceSecurityGroupId: !Ref 'EnvironmentSecurityGroup'
+
+{{- range $ind, $cidr := .PrivateSubnetCIDRs}}
+S3PrivateRouteTable{{inc $ind}}:
+  Type: AWS::EC2::RouteTable
+  Condition: CreateVPCEndpoints
+  Properties:
+    VpcId: !Ref 'VPC'
+
+S3PrivateRouteTable{{inc $ind}}Association:
+  Type: AWS::EC2::SubnetRouteTableAssociation
+  Condition: CreateVPCEndpoints
+  Properties:
+    RouteTableId: !Ref S3PrivateRouteTable{{inc $ind}}
+    SubnetId: !Ref PrivateSubnet{{inc $ind}}
+{{- end}}
+
+# ECS Resources
+ECSCluster:
+  Condition: CreateVPCEndpoints
+  Type: AWS::ECS::Cluster
+
+ECSTaskExecutionRole:
+  Condition: CreateVPCEndpoints
+  Type: AWS::IAM::Role
+  Properties:
+    AssumeRolePolicyDocument:
+      Statement:
+        - Effect: Allow
+          Principal:
+            Service: [ecs-tasks.amazonaws.com]
+          Action: ['sts:AssumeRole']
+    Path: /
+    Policies:
+      - PolicyName: AmazonECSTaskExecutionRolePolicy
+        PolicyDocument:
+          Statement:
+            - Effect: Allow
+              Action:
+                # Allow the ECS Tasks to download images from ECR
+                - 'ecr:GetAuthorizationToken'
+                - 'ecr:BatchCheckLayerAvailability'
+                - 'ecr:GetDownloadUrlForLayer'
+                - 'ecr:BatchGetImage'
+
+                # Allow the ECS tasks to upload logs to CloudWatch
+                - 'logs:CreateLogStream'
+                - 'logs:PutLogEvents'
+              Resource: '*'
+
+# Gateway endpoint for S3.
+S3GatewayVPCEndpoint:
+  Condition: CreateVPCEndpoints
+  Type: AWS::EC2::VPCEndpoint
+  Properties:
+    VpcEndpointType: Gateway
+    RouteTableIds:
+      {{- range $ind, $cidr := .PrivateSubnetCIDRs}}
+      - !Ref S3PrivateRouteTable{{inc $ind}}
+      {{- end}}
+    ServiceName: !Sub com.amazonaws.${AWS::Region}.s3
+    VpcId: !Ref VPC
+
+# Interface endpoints.
+EcrApiVPCEndpoint:
+  Condition: CreateVPCEndpoints
+  Type: AWS::EC2::VPCEndpoint
+  Properties:
+    VpcEndpointType: Interface
+    PrivateDnsEnabled: true
+    SubnetIds:
+      {{- range $ind, $cidr := .PrivateSubnetCIDRs}}
+      - !Ref PrivateSubnet{{inc $ind}}
+      {{- end}}
+    ServiceName: !Sub com.amazonaws.${AWS::Region}.ecr.api
+    VpcId: !Ref VPC
+    SecurityGroupIds:
+      - !Ref VPCEndpointSecurityGroup
+
+EcrDkrVPCEndpoint:
+  Condition: CreateVPCEndpoints
+  Type: AWS::EC2::VPCEndpoint
+  Properties:
+    VpcEndpointType: Interface
+    PrivateDnsEnabled: true
+    SubnetIds:
+      {{- range $ind, $cidr := .PrivateSubnetCIDRs}}
+      - !Ref PrivateSubnet{{inc $ind}}
+      {{- end}}
+    ServiceName: !Sub com.amazonaws.${AWS::Region}.ecr.dkr
+    VpcId: !Ref VPC
+    SecurityGroupIds:
+      - !Ref VPCEndpointSecurityGroup
+
+LogVPCEndpoint:
+  Condition: CreateVPCEndpoints
+  Type: AWS::EC2::VPCEndpoint
+  Properties:
+    VpcEndpointType: Interface
+    PrivateDnsEnabled: true
+    SubnetIds:
+      {{- range $ind, $cidr := .PrivateSubnetCIDRs}}
+      - !Ref PrivateSubnet{{inc $ind}}
+      {{- end}}
+    ServiceName: !Sub com.amazonaws.${AWS::Region}.logs
+    VpcId: !Ref VPC
+    SecurityGroupIds:
+      - !Ref VPCEndpointSecurityGroup

--- a/templates/environment/partials/vpc-endpoints.yml
+++ b/templates/environment/partials/vpc-endpoints.yml
@@ -146,7 +146,7 @@ SecretsManagerVPCEndpoint:
     SubnetIds:
       {{- range $ind, $cidr := .PrivateSubnetCIDRs}}
       - !Ref PrivateSubnet{{inc $ind}}
-      {{- end } }
+      {{- end}}
     ServiceName: !Sub com.amazonaws.${AWS::Region}.secretsmanager
     VpcId: !Ref VPC
     SecurityGroupIds:

--- a/templates/environment/partials/vpc-endpoints.yml
+++ b/templates/environment/partials/vpc-endpoints.yml
@@ -23,21 +23,6 @@ IngressFromVPCEndpoints:
     IpProtocol: -1
     SourceSecurityGroupId: !Ref 'VPCEndpointSecurityGroup'
 
-{{- range $ind, $cidr := .PrivateSubnetCIDRs}}
-S3PrivateRouteTable{{inc $ind}}:
-  Type: AWS::EC2::RouteTable
-  Condition: CreateVPCEndpoints
-  Properties:
-    VpcId: !Ref 'VPC'
-
-S3PrivateRouteTable{{inc $ind}}Association:
-  Type: AWS::EC2::SubnetRouteTableAssociation
-  Condition: CreateVPCEndpoints
-  Properties:
-    RouteTableId: !Ref S3PrivateRouteTable{{inc $ind}}
-    SubnetId: !Ref PrivateSubnet{{inc $ind}}
-{{- end}}
-
 # Gateway endpoint for S3.
 S3GatewayVPCEndpoint:
   Condition: CreateVPCEndpoints
@@ -46,7 +31,7 @@ S3GatewayVPCEndpoint:
     VpcEndpointType: Gateway
     RouteTableIds:
       {{- range $ind, $cidr := .PrivateSubnetCIDRs}}
-      - !Ref S3PrivateRouteTable{{inc $ind}}
+      - !Ref PrivateSubnet{{inc $ind}}RouteTable
       {{- end}}
     ServiceName: !Sub com.amazonaws.${AWS::Region}.s3
     VpcId: !Ref VPC

--- a/templates/environment/partials/vpc-endpoints.yml
+++ b/templates/environment/partials/vpc-endpoints.yml
@@ -26,6 +26,8 @@ IngressFromVPCEndpoints:
 # Gateway endpoint for S3.
 S3GatewayVPCEndpoint:
   Condition: CreateVPCEndpoints
+  Metadata:
+    'aws:copilot:description': 'An S3 gateway endpoint.'
   Type: AWS::EC2::VPCEndpoint
   Properties:
     VpcEndpointType: Gateway
@@ -39,6 +41,8 @@ S3GatewayVPCEndpoint:
 # Interface endpoints.
 EcrApiVPCEndpoint:
   Condition: CreateVPCEndpoints
+  Metadata:
+    'aws:copilot:description': 'ECR interface endpoints.'
   Type: AWS::EC2::VPCEndpoint
   Properties:
     VpcEndpointType: Interface
@@ -67,8 +71,10 @@ EcrDkrVPCEndpoint:
     SecurityGroupIds:
       - !Ref VPCEndpointSecurityGroup
 
-LogVPCEndpoint:
+LogsVPCEndpoint:
   Condition: CreateVPCEndpoints
+  Metadata:
+    'aws:copilot:description': 'A CloudWatch Logs interface endpoint.'
   Type: AWS::EC2::VPCEndpoint
   Properties:
     VpcEndpointType: Interface

--- a/templates/environment/partials/vpc-endpoints.yml
+++ b/templates/environment/partials/vpc-endpoints.yml
@@ -33,7 +33,7 @@ S3GatewayVPCEndpoint:
     VpcEndpointType: Gateway
     RouteTableIds:
       {{- range $ind, $cidr := .PrivateSubnetCIDRs}}
-      - !Ref PrivateSubnet{{inc $ind}}RouteTable
+      - !Ref PrivateRouteTable{{inc $ind}}
       {{- end}}
     ServiceName: !Sub com.amazonaws.${AWS::Region}.s3
     VpcId: !Ref VPC

--- a/templates/environment/partials/vpc-endpoints.yml
+++ b/templates/environment/partials/vpc-endpoints.yml
@@ -91,7 +91,7 @@ LogsVPCEndpoint:
 SSMVPCEndpoint:
   Condition: CreateVPCEndpoints
   Metadata:
-    'aws:copilot:description': 'A Systems Manager interface endpoint.'
+    'aws:copilot:description': 'Systems Manager interface endpoints.'
   Type: AWS::EC2::VPCEndpoint
   Properties:
     VpcEndpointType: Interface
@@ -101,6 +101,36 @@ SSMVPCEndpoint:
       - !Ref PrivateSubnet{{inc $ind}}
       {{- end}}
     ServiceName: !Sub com.amazonaws.${AWS::Region}.ssm
+    VpcId: !Ref VPC
+    SecurityGroupIds:
+      - !Ref VPCEndpointSecurityGroup
+
+EC2MessagesVPCEndpoint:
+  Condition: CreateVPCEndpoints
+  Type: AWS::EC2::VPCEndpoint
+  Properties:
+    VpcEndpointType: Interface
+    PrivateDnsEnabled: true
+    SubnetIds:
+      {{- range $ind, $cidr := .PrivateSubnetCIDRs}}
+      - !Ref PrivateSubnet{{inc $ind}}
+      {{- end}}
+    ServiceName: !Sub com.amazonaws.${AWS::Region}.ec2messages
+    VpcId: !Ref VPC
+    SecurityGroupIds:
+      - !Ref VPCEndpointSecurityGroup
+
+EC2VPCEndpoint:
+  Condition: CreateVPCEndpoints
+  Type: AWS::EC2::VPCEndpoint
+  Properties:
+    VpcEndpointType: Interface
+    PrivateDnsEnabled: true
+    SubnetIds:
+      {{- range $ind, $cidr := .PrivateSubnetCIDRs}}
+      - !Ref PrivateSubnet{{inc $ind}}
+      {{- end}}
+    ServiceName: !Sub com.amazonaws.${AWS::Region}.ec2
     VpcId: !Ref VPC
     SecurityGroupIds:
       - !Ref VPCEndpointSecurityGroup

--- a/templates/environment/partials/vpc-endpoints.yml
+++ b/templates/environment/partials/vpc-endpoints.yml
@@ -11,7 +11,7 @@ VPCEndpointSecurityGroup:
         Description: HTTPS
         FromPort: 443
         ToPort: 443
-        CidrIp: 10.0.0.0/0
+        CidrIp: {{.CIDR}}
 
 # Allow ingress traffic from VPC endpoints to our containers.
 IngressFromVPCEndpoints:

--- a/templates/environment/partials/vpc-endpoints.yml
+++ b/templates/environment/partials/vpc-endpoints.yml
@@ -87,3 +87,37 @@ LogsVPCEndpoint:
     VpcId: !Ref VPC
     SecurityGroupIds:
       - !Ref VPCEndpointSecurityGroup
+
+SSMVPCEndpoint:
+  Condition: CreateVPCEndpoints
+  Metadata:
+    'aws:copilot:description': 'A Systems Manager interface endpoint.'
+  Type: AWS::EC2::VPCEndpoint
+  Properties:
+    VpcEndpointType: Interface
+    PrivateDnsEnabled: true
+    SubnetIds:
+      {{- range $ind, $cidr := .PrivateSubnetCIDRs}}
+      - !Ref PrivateSubnet{{inc $ind}}
+      {{- end}}
+    ServiceName: !Sub com.amazonaws.${AWS::Region}.ssm
+    VpcId: !Ref VPC
+    SecurityGroupIds:
+      - !Ref VPCEndpointSecurityGroup
+
+SecretsManagerVPCEndpoint:
+  Condition: CreateVPCEndpoints
+  Metadata:
+    'aws:copilot:description': 'A Secrets Manager interface endpoint.'
+  Type: AWS::EC2::VPCEndpoint
+  Properties:
+    VpcEndpointType: Interface
+    PrivateDnsEnabled: true
+    SubnetIds:
+      { { - range $ind, $cidr := .PrivateSubnetCIDRs } }
+      - !Ref PrivateSubnet{{inc $ind}}
+      { { - end } }
+    ServiceName: !Sub com.amazonaws.${AWS::Region}.secretsmanager
+    VpcId: !Ref VPC
+    SecurityGroupIds:
+      - !Ref VPCEndpointSecurityGroup

--- a/templates/environment/partials/vpc-resources.yml
+++ b/templates/environment/partials/vpc-resources.yml
@@ -41,6 +41,7 @@ InternetGatewayAttachment:
   Properties:
     InternetGatewayId: !Ref InternetGateway
     VpcId: !Ref VPC
+
 {{range $ind, $cidr := .PublicSubnetCIDRs}}
 PublicSubnet{{inc $ind}}:
   Metadata:
@@ -67,10 +68,12 @@ PrivateSubnet{{inc $ind}}:
     Tags:
       - Key: Name
         Value: !Sub 'copilot-${AppName}-${EnvironmentName}-priv{{$ind}}'
-PrivateSubnet{{inc $ind}}RouteTable:
+
+PrivateRouteTable{{inc $ind}}:
   Type: AWS::EC2::RouteTable
   Properties:
     VpcId: !Ref 'VPC'
+
 PrivateSubnet{{inc $ind}}RouteTableAssociation:
   Type: AWS::EC2::SubnetRouteTableAssociation
   Properties:

--- a/templates/environment/partials/vpc-resources.yml
+++ b/templates/environment/partials/vpc-resources.yml
@@ -67,6 +67,15 @@ PrivateSubnet{{inc $ind}}:
     Tags:
       - Key: Name
         Value: !Sub 'copilot-${AppName}-${EnvironmentName}-priv{{$ind}}'
+PrivateSubnet{{inc $ind}}RouteTable:
+  Type: AWS::EC2::RouteTable
+  Properties:
+    VpcId: !Ref 'VPC'
+PrivateSubnet{{inc $ind}}RouteTableAssociation:
+  Type: AWS::EC2::SubnetRouteTableAssociation
+  Properties:
+    RouteTableId: !Ref PrivateRouteTable{{inc $ind}}
+    SubnetId: !Ref PrivateSubnet{{inc $ind}}
 {{end}}{{range $ind, $cidr := .PublicSubnetCIDRs}}
 PublicSubnet{{inc $ind}}RouteTableAssociation:
   Type: AWS::EC2::SubnetRouteTableAssociation

--- a/templates/environment/versions/cf-v1.3.0.yml
+++ b/templates/environment/versions/cf-v1.3.0.yml
@@ -17,6 +17,9 @@ Parameters:
   NATWorkloads:
     Type: String
     Default: ""
+  VPCEndpointWorkloads:
+    Type: String
+    Default: ""
   ToolsAccountPrincipalARN:
     Type: String
   AppDNSName:
@@ -43,6 +46,7 @@ Resources:
 {{- if not .ImportVPC}}
 {{include "vpc-resources" .VPCConfig | indent 2}}
 {{include "nat-gateways" .VPCConfig | indent 2}}
+{{include "vpc-endpoints" .VPCConfig | indent 2}}
 {{- end}}
   # Creates a service discovery namespace with the form:
   # {svc}.{appname}.local

--- a/templates/environment/versions/cf-v1.3.0.yml
+++ b/templates/environment/versions/cf-v1.3.0.yml
@@ -17,9 +17,6 @@ Parameters:
   NATWorkloads:
     Type: String
     Default: ""
-  VPCEndpointWorkloads:
-    Type: String
-    Default: ""
   ToolsAccountPrincipalARN:
     Type: String
   AppDNSName:
@@ -40,13 +37,10 @@ Conditions:
     !Not [!Equals [ !Ref EFSWorkloads, ""]]
   CreateNATGateways:
     !Not [!Equals [ !Ref NATWorkloads, ""]]
-  CreateVPCEndpoints:
-    !Not [!Equals [ !Ref VPCEndpointWorkloads, ""]]
 Resources:
 {{- if not .ImportVPC}}
 {{include "vpc-resources" .VPCConfig | indent 2}}
 {{include "nat-gateways" .VPCConfig | indent 2}}
-{{include "vpc-endpoints" .VPCConfig | indent 2}}
 {{- end}}
   # Creates a service discovery namespace with the form:
   # {svc}.{appname}.local
@@ -367,7 +361,7 @@ Outputs:
     Export:
       Name: !Sub ${AWS::StackName}-SubDomain
   EnabledFeatures:
-    Value: !Sub '${ALBWorkloads},${EFSWorkloads},${NATWorkloads},${VPCEndpointWorkloads}'
+    Value: !Sub '${ALBWorkloads},${EFSWorkloads},${NATWorkloads}'
     Description: Required output to force the stack to update if mutating feature params, like ALBWorkloads, does not change the template.
   ManagedFileSystemID:
     Condition: CreateEFS

--- a/templates/environment/versions/cf-v1.3.0.yml
+++ b/templates/environment/versions/cf-v1.3.0.yml
@@ -37,6 +37,8 @@ Conditions:
     !Not [!Equals [ !Ref EFSWorkloads, ""]]
   CreateNATGateways:
     !Not [!Equals [ !Ref NATWorkloads, ""]]
+  CreateVPCEndpoints:
+    !Not [!Equals [ !Ref VPCEndpointWorkloads, ""]]
 Resources:
 {{- if not .ImportVPC}}
 {{include "vpc-resources" .VPCConfig | indent 2}}
@@ -361,7 +363,7 @@ Outputs:
     Export:
       Name: !Sub ${AWS::StackName}-SubDomain
   EnabledFeatures:
-    Value: !Sub '${ALBWorkloads},${EFSWorkloads},${NATWorkloads}'
+    Value: !Sub '${ALBWorkloads},${EFSWorkloads},${NATWorkloads},${VPCEndpointWorkloads}'
     Description: Required output to force the stack to update if mutating feature params, like ALBWorkloads, does not change the template.
   ManagedFileSystemID:
     Condition: CreateEFS

--- a/templates/environment/versions/cf-v1.4.0.yml
+++ b/templates/environment/versions/cf-v1.4.0.yml
@@ -17,6 +17,9 @@ Parameters:
   NATWorkloads:
     Type: String
     Default: ""
+  VPCEndpointWorkloads:
+    Type: String
+    Default: ""
   ToolsAccountPrincipalARN:
     Type: String
   AppDNSName:
@@ -40,12 +43,15 @@ Conditions:
     !Not [!Equals [ !Ref EFSWorkloads, ""]]
   CreateNATGateways:
     !Not [!Equals [ !Ref NATWorkloads, ""]]
+  CreateVPCEndpoints:
+    !Not [ !Equals [ !Ref VPCEndpointWorkloads, "" ] ]
   HasAliases:
     !Not [!Equals [ !Ref Aliases, "" ]]
 Resources:
 {{- if not .ImportVPC}}
 {{include "vpc-resources" .VPCConfig | indent 2}}
 {{include "nat-gateways" .VPCConfig | indent 2}}
+{{include "vpc-endpoints" .VPCConfig | indent 2}}
 {{- end}}
   # Creates a service discovery namespace with the form:
   # {svc}.{appname}.local
@@ -366,7 +372,7 @@ Outputs:
     Export:
       Name: !Sub ${AWS::StackName}-SubDomain
   EnabledFeatures:
-    Value: !Sub '${ALBWorkloads},${EFSWorkloads},${NATWorkloads}'
+    Value: !Sub '${ALBWorkloads},${EFSWorkloads},${NATWorkloads},${VPCEndpointWorkloads}'
     Description: Required output to force the stack to update if mutating feature params, like ALBWorkloads, does not change the template.
   ManagedFileSystemID:
     Condition: CreateEFS

--- a/templates/workloads/partials/cf/service-base-properties.yml
+++ b/templates/workloads/partials/cf/service-base-properties.yml
@@ -40,12 +40,20 @@ NetworkConfiguration:
         - 0
         - Fn::Split:
           - ','
+          {{- if eq .Network.SubnetsType "IsolatedSubnets"}}
+          - Fn::ImportValue: !Sub '${AppName}-${EnvName}-PrivateSubnets'
+          {{- else}}
           - Fn::ImportValue: !Sub '${AppName}-${EnvName}-{{.Network.SubnetsType}}'
+          {{- end}}
       - Fn::Select:
         - 1
         - Fn::Split:
           - ','
+          {{- if eq .Network.SubnetsType "IsolatedSubnets" }}
+          - Fn::ImportValue: !Sub '${AppName}-${EnvName}-PrivateSubnets'
+          {{- else }}
           - Fn::ImportValue: !Sub '${AppName}-${EnvName}-{{.Network.SubnetsType}}'
+          {{- end }}
     SecurityGroups:
       - Fn::ImportValue: !Sub '${AppName}-${EnvName}-EnvironmentSecurityGroup'
       {{- range $sg := .Network.SecurityGroups}}

--- a/templates/workloads/partials/cf/state-machine.yml
+++ b/templates/workloads/partials/cf/state-machine.yml
@@ -24,12 +24,20 @@ StateMachine:
               - 0
               - Fn::Split:
                 - ','
+                {{- if eq .Network.SubnetsType "IsolatedSubnets"}}
+                - Fn::ImportValue: !Sub '${AppName}-${EnvName}-PrivateSubnets'
+                {{- else}}
                 - Fn::ImportValue: !Sub '${AppName}-${EnvName}-{{.Network.SubnetsType}}'
+                {{- end}}
             - Fn::Select:
               - 1
               - Fn::Split:
                 - ','
+                {{- if eq .Network.SubnetsType "IsolatedSubnets" }}
+                - Fn::ImportValue: !Sub '${AppName}-${EnvName}-PrivateSubnets'
+                {{- else}}
                 - Fn::ImportValue: !Sub '${AppName}-${EnvName}-{{.Network.SubnetsType}}'
+                {{- end }}
       AssignPublicIp: {{.Network.AssignPublicIP}}
       SecurityGroups:
         Fn::Join:


### PR DESCRIPTION
These are the CloudFormation template additions/changes related to enabling the `isolated` network placement (services in private subnets that do not require access to the internet but do require access to Amazon services).

Related: #1959.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
