### PR TITLE
docs: update network sections with `isolated` option for backend svcs and jobs

### DIFF
--- a/site/content/docs/include/common-svc-fields.md
+++ b/site/content/docs/include/common-svc-fields.md
@@ -108,24 +108,6 @@ Enable running commands in your container. The default is `false`. Required for 
 
 <div class="separator"></div>
 
-<a id="network" href="#network" class="field">`network`</a> <span class="type">Map</span>      
-The `network` section contains parameters for connecting to AWS resources in a VPC.
-
-<span class="parent-field">network.</span><a id="network-vpc" href="#network-vpc" class="field">`vpc`</a> <span class="type">Map</span>    
-Subnets and security groups attached to your tasks.
-
-<span class="parent-field">network.vpc.</span><a id="network-vpc-placement" href="#network-vpc-placement" class="field">`placement`</a> <span class="type">String</span>  
-Must be one of `'public'` or `'private'`. Defaults to launching your tasks in public subnets.
-
-!!! info
-    If you launch tasks in `'private'` subnets and use a Copilot-generated VPC, Copilot will add NAT Gateways to your environment. Alternatively, you can import a VPC with NAT Gateways when running `copilot env init` for internet connectivity.
-
-<span class="parent-field">network.vpc.</span><a id="network-vpc-security-groups" href="#network-vpc-security-groups" class="field">`security_groups`</a> <span class="type">Array of Strings</span>  
-Additional security group IDs associated with your tasks. Copilot always includes a security group so containers within your environment
-can communicate with each other.
-
-<div class="separator"></div>
-
 <a id="variables" href="#variables" class="field">`variables`</a> <span class="type">Map</span>  
 Key-value pairs that represent environment variables that will be passed to your service. Copilot will include a number of environment variables by default for you.
 
@@ -213,7 +195,3 @@ Optional. Defaults to `true`. Whether or not to use IAM authorization to determi
 <span class="parent-field">volume.efs.auth.</span><a id="access_point_id" href="#access-point-id" class="field">`access_point_id`</a> <span class="type">String</span>  
 Optional. Defaults to `""`. The ID of the EFS access point to connect to. If using an access point, `root_dir` must be either empty or `/` and `auth.iam` must be `true`.
 
-<div class="separator"></div>
-
-<a id="environments" href="#environments" class="field">`environments`</a> <span class="type">Map</span>  
-The environment section lets you override any value in your manifest based on the environment you're in. In the example manifest above, we're overriding the count parameter so that we can run 2 copies of our service in our prod environment.

--- a/site/content/docs/manifest/backend-service.en.md
+++ b/site/content/docs/manifest/backend-service.en.md
@@ -67,3 +67,27 @@ The architecture type for your service. [Backend Services](../concepts/services.
 {% include 'image-config.md' %}
 {% include 'image-healthcheck.md' %}
 {% include 'common-svc-fields.md' %}
+
+<div class="separator"></div>
+
+<a id="network" href="#network" class="field">`network`</a> <span class="type">Map</span>      
+The `network` section contains parameters for connecting to AWS resources in a VPC.
+
+<span class="parent-field">network.</span><a id="network-vpc" href="#network-vpc" class="field">`vpc`</a> <span class="type">Map</span>    
+Subnets and security groups attached to your tasks.
+
+<span class="parent-field">network.vpc.</span><a id="network-vpc-placement" href="#network-vpc-placement" class="field">`placement`</a> <span class="type">String</span>  
+Must be one of `'public'`, `'private'`, or `'isolated'`. Defaults to launching your tasks in public subnets.
+
+!!! info
+    If you launch tasks in `'private'` subnets and use a Copilot-generated VPC, Copilot will add NAT gateways to your environment. Alternatively, you can import a VPC with NAT gateways when running `copilot env init` for internet connectivity.
+    If you launch tasks in `'isolated'` subnets and use a Copilot-generated VPC, Copilot will add VPC endpoints to your environment. Alternatively, you can import a VPC when running `copilot env init` to customize your networking resources.
+
+<span class="parent-field">network.vpc.</span><a id="network-vpc-security-groups" href="#network-vpc-security-groups" class="field">`security_groups`</a> <span class="type">Array of Strings</span>  
+Additional security group IDs associated with your tasks. Copilot always includes a security group so containers within your environment
+can communicate with each other.
+
+<div class="separator"></div>
+
+<a id="environments" href="#environments" class="field">`environments`</a> <span class="type">Map</span>  
+The environment section lets you override any value in your manifest based on the environment you're in. In the example manifest above, we're overriding the count parameter so that we can run 2 copies of our service in our prod environment.

--- a/site/content/docs/manifest/lb-web-service.en.md
+++ b/site/content/docs/manifest/lb-web-service.en.md
@@ -68,3 +68,26 @@ The architecture type for your service. A [Load Balanced Web Service](../concept
 {% include 'http-config.md' %}
 {% include 'image-config.md' %}
 {% include 'common-svc-fields.md' %}
+
+<div class="separator"></div>
+
+<a id="network" href="#network" class="field">`network`</a> <span class="type">Map</span>      
+The `network` section contains parameters for connecting to AWS resources in a VPC.
+
+<span class="parent-field">network.</span><a id="network-vpc" href="#network-vpc" class="field">`vpc`</a> <span class="type">Map</span>    
+Subnets and security groups attached to your tasks.
+
+<span class="parent-field">network.vpc.</span><a id="network-vpc-placement" href="#network-vpc-placement" class="field">`placement`</a> <span class="type">String</span>  
+Must be one of `'public'` or `'private'`. Defaults to launching your tasks in public subnets.
+
+!!! info
+    If you launch tasks in `'private'` subnets and use a Copilot-generated VPC, Copilot will add NAT gateways to your environment. Alternatively, you can import a VPC with NAT gateways when running `copilot env init` for internet connectivity.
+
+<span class="parent-field">network.vpc.</span><a id="network-vpc-security-groups" href="#network-vpc-security-groups" class="field">`security_groups`</a> <span class="type">Array of Strings</span>  
+Additional security group IDs associated with your tasks. Copilot always includes a security group so containers within your environment
+can communicate with each other.
+
+<div class="separator"></div>
+
+<a id="environments" href="#environments" class="field">`environments`</a> <span class="type">Map</span>  
+The environment section lets you override any value in your manifest based on the environment you're in. In the example manifest above, we're overriding the count parameter so that we can run 2 copies of our service in our prod environment.

--- a/site/content/docs/manifest/scheduled-job.en.md
+++ b/site/content/docs/manifest/scheduled-job.en.md
@@ -145,12 +145,11 @@ The `network` section contains parameters for connecting to AWS resources in a V
 Subnets and security groups attached to your tasks.
 
 <span class="parent-field">network.vpc.</span><a id="network-vpc-placement" href="#network-vpc-placement" class="field">`placement`</a> <span class="type">String</span>    
-Must be one of `'public'` or `'private'`. Defaults to launching your tasks in public subnets.
+Must be one of `'public'`, `'private'`, or `'isolated'`. Defaults to launching your tasks in public subnets.
 
 !!! info
-    Launching tasks in `'private'` subnets that need internet connectivity is only supported if you imported a VPC with
-    NAT Gateways when running `copilot env init`. See [#1959](https://github.com/aws/copilot-cli/issues/1959) for tracking
-    NAT Gateways support in Copilot-generated VPCs.
+    If you launch tasks in `'private'` subnets and use a Copilot-generated VPC, Copilot will add NAT gateways to your environment. Alternatively, you can import a VPC with NAT gateways when running `copilot env init` for internet connectivity.
+    If you launch tasks in `'isolated'` subnets and use a Copilot-generated VPC, Copilot will add VPC endpoints to your environment. Alternatively, you can import a VPC when running `copilot env init` to customize your networking resources.
 
 <span class="parent-field">network.vpc.</span><a id="network-vpc-security-groups" href="#network-vpc-security-groups" class="field">`security_groups`</a> <span class="type">Array of Strings</span>  
 Additional security group IDs associated with your tasks. Copilot always includes a security group so containers within your environment


### PR DESCRIPTION
This moves the `network` fields out of the shared `common-svc-fields` partial because LBWS don't have the `isolated` option, whereas backend services and scheduled jobs do. 

I also moved the `environments` section out of the shared partial so that it can appear last on the page.

Related: #1959.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
