### PR TITLE
chore(cli): put secrets from input file

### DIFF
--- a/internal/pkg/cli/secret_init.go
+++ b/internal/pkg/cli/secret_init.go
@@ -215,7 +215,7 @@ func (o *secretInitOpts) putSecret(secretName string, values map[string]string) 
 		}
 	}
 
-	for envName, _ := range errorsForEnvironments {
+	for envName := range errorsForEnvironments {
 		log.Errorf("Failed to put secret %s in environment %s. See error message below.\n", color.HighlightUserInput(secretName), color.HighlightUserInput(envName))
 	}
 	log.Infoln("")

--- a/internal/pkg/cli/secret_init.go
+++ b/internal/pkg/cli/secret_init.go
@@ -98,7 +98,7 @@ func newSecretInitOpts(vars secretInitVars) (*secretInitOpts, error) {
 		if err != nil {
 			return nil, fmt.Errorf("open input file %s: %w", opts.inputFilePath, err)
 		}
-
+		defer file.Close()
 		f, err := afero.ReadFile(opts.fs, file.Name())
 		if err != nil {
 			return nil, fmt.Errorf("read input file %s: %w", opts.inputFilePath, err)

--- a/internal/pkg/cli/secret_init.go
+++ b/internal/pkg/cli/secret_init.go
@@ -154,7 +154,7 @@ func (o *secretInitOpts) Validate() error {
 // Ask prompts the user for any required or important fields that are not provided.
 func (o *secretInitOpts) Ask() error {
 	if o.overwrite {
-		log.Warningf("You have specified %s flag. Please note that overwriting an existing secret may break your deployed service.\n", color.HighlightCode("--overwrite"))
+		log.Warningf("You have specified %s flag. Please note that overwriting an existing secret may break your deployed service.\n", color.HighlightCode(fmt.Sprintf("--%s", overwriteFlag)))
 	}
 
 	if o.inputFilePath != "" {
@@ -413,7 +413,7 @@ func BuildSecretInitCmd() *cobra.Command {
 
 			err = opts.Execute()
 			if opts.shouldShowOverwriteHint {
-				log.Warningf("If you want to overwrite an existing secret, use the %s flag.\n", color.HighlightCode("--overwrite"))
+				log.Warningf("If you want to overwrite an existing secret, use the %s flag.\n", color.HighlightCode(fmt.Sprintf("--%s", overwriteFlag)))
 			}
 			if err != nil {
 				return err

--- a/internal/pkg/cli/secret_init.go
+++ b/internal/pkg/cli/secret_init.go
@@ -7,8 +7,6 @@ import (
 	"errors"
 	"fmt"
 
-	termprogress "github.com/aws/copilot-cli/internal/pkg/term/progress"
-
 	"gopkg.in/yaml.v3"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -188,9 +186,6 @@ func (o *secretInitOpts) Execute() error {
 }
 
 func (o *secretInitOpts) putSecret(secretName string, values map[string]string) {
-	spinner := termprogress.NewSpinner(log.DiagnosticWriter)
-
-	spinner.Start("start creating secret")
 	errLogs := make([]string, 0)
 	for envName, value := range values {
 		err := o.putSecretInEnv(secretName, envName, value)
@@ -203,7 +198,6 @@ func (o *secretInitOpts) putSecret(secretName string, values map[string]string) 
 	for _, errLog := range errLogs {
 		log.Errorln(errLog)
 	}
-	spinner.Stop("finish creating secret")
 	log.Infoln("")
 }
 

--- a/internal/pkg/cli/secret_init.go
+++ b/internal/pkg/cli/secret_init.go
@@ -352,9 +352,6 @@ func (o *secretInitOpts) askForSecretValues() error {
 
 // RecommendedActions shows recommended actions to do after running `secret init`.
 func (o *secretInitOpts) RecommendedActions() {
-	if o.shouldShowOverwriteHint {
-		log.Warningf("If you want to overwrite an existing secret, use the %s flag.\n", color.HighlightCode("--overwrite"))
-	}
 }
 
 type errSecretFailedInSomeEnvironments struct {

--- a/internal/pkg/cli/secret_init_test.go
+++ b/internal/pkg/cli/secret_init_test.go
@@ -500,3 +500,39 @@ func TestSecretInitOpts_Execute(t *testing.T) {
 		})
 	}
 }
+
+func Test_SecretInitParseSecretsInputFile(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		opts := secretInitOpts{
+			readFile: func() ([]byte, error) {
+				raw := `db-password:
+    test: test-password
+    prod: prod-password
+db-host:
+    test: test-host
+    prod: prod-host
+test-only-secret:
+    test: test-only`
+				return []byte(raw), nil
+			},
+		}
+
+		expected := map[string]map[string]string{
+			"db-password": {
+				"test": "test-password",
+				"prod": "prod-password",
+			},
+			"db-host": {
+				"test": "test-host",
+				"prod": "prod-host",
+			},
+			"test-only-secret": {
+				"test": "test-only",
+			},
+		}
+
+		secrets, err := opts.parseSecretsInputFile()
+		require.NoError(t, err)
+		require.Equal(t, expected, secrets)
+	})
+}

--- a/internal/pkg/cli/secret_init_test.go
+++ b/internal/pkg/cli/secret_init_test.go
@@ -434,36 +434,6 @@ func TestSecretInitOpts_Execute(t *testing.T) {
 				}, nil)
 			},
 		},
-		"error out if received other errors": {
-			inAppName: testApp,
-			inName:    testName,
-			inValues:  testValues,
-
-			setupMocks: func(m secretInitExecuteMocks) {
-				m.mockSecretPutter.EXPECT().PutSecret(ssm.PutSecretInput{
-					Name:      "/copilot/test-app/test/secrets/db-password",
-					Value:     "test-password",
-					Overwrite: false,
-					Tags: map[string]string{
-						deploy.AppTagKey: "test-app",
-						deploy.EnvTagKey: "test",
-					},
-				}).Return(nil, errors.New("some error"))
-				m.mockSecretPutter.EXPECT().PutSecret(ssm.PutSecretInput{
-					Name:      "/copilot/test-app/prod/secrets/db-password",
-					Value:     "prod-password",
-					Overwrite: false,
-					Tags: map[string]string{
-						deploy.AppTagKey: "test-app",
-						deploy.EnvTagKey: "prod",
-					},
-				}).Return(&ssm.PutSecretOutput{
-					Version: aws.Int64(1),
-				}, nil).MinTimes(0).MaxTimes(1)
-			},
-
-			wantedError: errors.New("put secret db-password in environment test: some error"),
-		},
 	}
 
 	for name, tc := range testCases {

--- a/internal/pkg/cli/secret_init_test.go
+++ b/internal/pkg/cli/secret_init_test.go
@@ -408,6 +408,37 @@ func TestSecretInitOpts_Execute(t *testing.T) {
 				}, nil)
 			},
 		},
+		"should make calls to overwrite if overwrite is specified": {
+			inAppName:   testApp,
+			inName:      testName,
+			inValues:    testValues,
+			inOverwrite: true,
+
+			setupMocks: func(m secretInitExecuteMocks) {
+				m.mockSecretPutter.EXPECT().PutSecret(ssm.PutSecretInput{
+					Name:      "/copilot/test-app/test/secrets/db-password",
+					Value:     "test-password",
+					Overwrite: true,
+					Tags: map[string]string{
+						deploy.AppTagKey: "test-app",
+						deploy.EnvTagKey: "test",
+					},
+				}).Return(&ssm.PutSecretOutput{
+					Version: aws.Int64(1),
+				}, nil)
+				m.mockSecretPutter.EXPECT().PutSecret(ssm.PutSecretInput{
+					Name:      "/copilot/test-app/prod/secrets/db-password",
+					Value:     "prod-password",
+					Overwrite: true,
+					Tags: map[string]string{
+						deploy.AppTagKey: "test-app",
+						deploy.EnvTagKey: "prod",
+					},
+				}).Return(&ssm.PutSecretOutput{
+					Version: aws.Int64(1),
+				}, nil)
+			},
+		},
 		"do not throw error if parameter already exists": {
 			inAppName: testApp,
 			inName:    testName,

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -538,16 +538,20 @@ func (o *runTaskOpts) runTaskCommand() (cliStringer, error) {
 			return nil, err
 		}
 	case 3:
-		appName, envName, serviceName := parts[0], parts[1], parts[2]
-		cmd, err = o.runTaskRequestFromService(ecs.New(sess), appName, envName, serviceName)
+		appName, envName, workloadName := parts[0], parts[1], parts[2]
+		cmd, err = o.runTaskRequestFromService(ecs.New(sess), appName, envName, workloadName)
 		if err != nil {
-			return nil, fmt.Errorf("generate task run command from service %s of application %s deployed in environment %s: %w", serviceName, appName, envName, err)
+			return nil, fmt.Errorf("generate task run command from service %s of application %s deployed in environment %s: %w", workloadName, appName, envName, err)
 		}
 	default:
 		return nil, errors.New("invalid input to --generate-cmd: must be of one the form <cluster>/<service> or <app>/<env>/<workload>")
 	}
 
 	return cmd, nil
+}
+
+func (o *runTaskOpts) typeOfWorkload() (string, error) {
+	return "", nil
 }
 
 func (o *runTaskOpts) parseARN() (string, string, error) {

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -538,20 +538,16 @@ func (o *runTaskOpts) runTaskCommand() (cliStringer, error) {
 			return nil, err
 		}
 	case 3:
-		appName, envName, workloadName := parts[0], parts[1], parts[2]
-		cmd, err = o.runTaskRequestFromService(ecs.New(sess), appName, envName, workloadName)
+		appName, envName, serviceName := parts[0], parts[1], parts[2]
+		cmd, err = o.runTaskRequestFromService(ecs.New(sess), appName, envName, serviceName)
 		if err != nil {
-			return nil, fmt.Errorf("generate task run command from service %s of application %s deployed in environment %s: %w", workloadName, appName, envName, err)
+			return nil, fmt.Errorf("generate task run command from service %s of application %s deployed in environment %s: %w", serviceName, appName, envName, err)
 		}
 	default:
 		return nil, errors.New("invalid input to --generate-cmd: must be of one the form <cluster>/<service> or <app>/<env>/<workload>")
 	}
 
 	return cmd, nil
-}
-
-func (o *runTaskOpts) typeOfWorkload() (string, error) {
-	return "", nil
 }
 
 func (o *runTaskOpts) parseARN() (string, string, error) {


### PR DESCRIPTION
This PR reads secret names and values in each environment, and create or update each of the secrets.
This completes `secret init`'s `Execute` function.

Preceding PR: #2284 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
