### PR TITLE
feat(vpc): enable `isolated` network placement

### DIFF
--- a/internal/pkg/aws/ssm/errors.go
+++ b/internal/pkg/aws/ssm/errors.go
@@ -1,0 +1,12 @@
+package ssm
+
+import "fmt"
+
+// ErrParameterAlreadyExists occurs when the parameter with name already existed.
+type ErrParameterAlreadyExists struct {
+	name string
+}
+
+func (e *ErrParameterAlreadyExists) Error() string {
+	return fmt.Sprintf("parameter %s already exists", e.name)
+}

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -7,6 +7,8 @@ import (
 	"encoding"
 	"io"
 
+	"github.com/aws/copilot-cli/internal/pkg/aws/ssm"
+
 	"github.com/aws/aws-sdk-go/aws/session"
 	awscloudformation "github.com/aws/copilot-cli/internal/pkg/aws/cloudformation"
 	"github.com/aws/copilot-cli/internal/pkg/aws/codepipeline"
@@ -572,4 +574,8 @@ type publicIPGetter interface {
 
 type cliStringer interface {
 	CLIString() string
+}
+
+type secretPutter interface {
+	PutSecret(in ssm.PutSecretInput) (*ssm.PutSecretOutput, error)
 }

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -14,6 +14,7 @@ import (
 	codepipeline "github.com/aws/copilot-cli/internal/pkg/aws/codepipeline"
 	ecs "github.com/aws/copilot-cli/internal/pkg/aws/ecs"
 	s3 "github.com/aws/copilot-cli/internal/pkg/aws/s3"
+	ssm "github.com/aws/copilot-cli/internal/pkg/aws/ssm"
 	config "github.com/aws/copilot-cli/internal/pkg/config"
 	deploy "github.com/aws/copilot-cli/internal/pkg/deploy"
 	cloudformation0 "github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation"
@@ -6038,4 +6039,79 @@ func (m *MockpublicIPGetter) PublicIP(ENI string) (string, error) {
 func (mr *MockpublicIPGetterMockRecorder) PublicIP(ENI interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublicIP", reflect.TypeOf((*MockpublicIPGetter)(nil).PublicIP), ENI)
+}
+
+// MockcliStringer is a mock of cliStringer interface.
+type MockcliStringer struct {
+	ctrl     *gomock.Controller
+	recorder *MockcliStringerMockRecorder
+}
+
+// MockcliStringerMockRecorder is the mock recorder for MockcliStringer.
+type MockcliStringerMockRecorder struct {
+	mock *MockcliStringer
+}
+
+// NewMockcliStringer creates a new mock instance.
+func NewMockcliStringer(ctrl *gomock.Controller) *MockcliStringer {
+	mock := &MockcliStringer{ctrl: ctrl}
+	mock.recorder = &MockcliStringerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockcliStringer) EXPECT() *MockcliStringerMockRecorder {
+	return m.recorder
+}
+
+// CLIString mocks base method.
+func (m *MockcliStringer) CLIString() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CLIString")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// CLIString indicates an expected call of CLIString.
+func (mr *MockcliStringerMockRecorder) CLIString() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CLIString", reflect.TypeOf((*MockcliStringer)(nil).CLIString))
+}
+
+// MocksecretPutter is a mock of secretPutter interface.
+type MocksecretPutter struct {
+	ctrl     *gomock.Controller
+	recorder *MocksecretPutterMockRecorder
+}
+
+// MocksecretPutterMockRecorder is the mock recorder for MocksecretPutter.
+type MocksecretPutterMockRecorder struct {
+	mock *MocksecretPutter
+}
+
+// NewMocksecretPutter creates a new mock instance.
+func NewMocksecretPutter(ctrl *gomock.Controller) *MocksecretPutter {
+	mock := &MocksecretPutter{ctrl: ctrl}
+	mock.recorder = &MocksecretPutterMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MocksecretPutter) EXPECT() *MocksecretPutterMockRecorder {
+	return m.recorder
+}
+
+// PutSecret mocks base method.
+func (m *MocksecretPutter) PutSecret(in ssm.PutSecretInput) (*ssm.PutSecretOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PutSecret", in)
+	ret0, _ := ret[0].(*ssm.PutSecretOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PutSecret indicates an expected call of PutSecret.
+func (mr *MocksecretPutterMockRecorder) PutSecret(in interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutSecret", reflect.TypeOf((*MocksecretPutter)(nil).PutSecret), in)
 }

--- a/internal/pkg/cli/secret_init.go
+++ b/internal/pkg/cli/secret_init.go
@@ -4,17 +4,26 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 
-	"github.com/aws/copilot-cli/internal/pkg/term/color"
+	"github.com/aws/aws-sdk-go/aws"
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 
+	"github.com/aws/copilot-cli/internal/pkg/aws/sessions"
+	"github.com/aws/copilot-cli/internal/pkg/aws/ssm"
 	"github.com/aws/copilot-cli/internal/pkg/config"
+	"github.com/aws/copilot-cli/internal/pkg/deploy"
+	"github.com/aws/copilot-cli/internal/pkg/term/color"
 	"github.com/aws/copilot-cli/internal/pkg/term/log"
 	"github.com/aws/copilot-cli/internal/pkg/term/prompt"
 	"github.com/aws/copilot-cli/internal/pkg/term/selector"
+)
+
+const (
+	fmtSecretParameterName = "/copilot/%s/%s/secrets/%s"
 )
 
 const (
@@ -47,6 +56,8 @@ type secretInitOpts struct {
 
 	prompter prompter
 	selector appSelector
+
+	configureSecretPutter func(envName string) (secretPutter, error)
 }
 
 func newSecretInitOpts(vars secretInitVars) (*secretInitOpts, error) {
@@ -64,11 +75,31 @@ func newSecretInitOpts(vars secretInitVars) (*secretInitOpts, error) {
 		prompter: prompter,
 		selector: selector.NewSelect(prompter, store),
 	}
+
+	opts.configureSecretPutter = func(envName string) (secretPutter, error) {
+		env, err := opts.targetEnv(envName)
+		if err != nil {
+			return nil, err
+		}
+		sess, err := sessions.NewProvider().FromRole(env.ManagerRoleARN, env.Region)
+		if err != nil {
+			return nil, fmt.Errorf("create session from environment manager role %s in region %s: %w", env.ManagerRoleARN, env.Region, err)
+		}
+		return ssm.New(sess), nil
+	}
 	return &opts, nil
 }
 
 // Validate returns an error if the flag values passed by the user are invalid.
 func (o *secretInitOpts) Validate() error {
+	if o.inputFilePath != "" && o.name != "" {
+		return errors.New("cannot specify `--cli-input-yaml` with `--name`")
+	}
+
+	if o.inputFilePath != "" && o.values != nil {
+		return errors.New("cannot specify `--cli-input-yaml` with `--values`")
+	}
+
 	if o.appName != "" {
 		_, err := o.store.GetApplication(o.appName)
 		if err != nil {
@@ -84,8 +115,8 @@ func (o *secretInitOpts) Validate() error {
 
 	if o.values != nil {
 		for env := range o.values {
-			if _, err := o.store.GetEnvironment(o.appName, env); err != nil {
-				return fmt.Errorf("get environment %s in application %s: %w", env, o.appName, err)
+			if _, err := o.targetEnv(env); err != nil {
+				return err
 			}
 		}
 	}
@@ -117,7 +148,73 @@ func (o *secretInitOpts) Ask() error {
 
 // Execute creates the secrets.
 func (o *secretInitOpts) Execute() error {
+	secretName := o.name
+	secretValues := o.values
+
+	if o.inputFilePath != "" {
+		var err error
+		secretName, secretValues, err = o.parseFile()
+		if err != nil {
+			return err
+		}
+	}
+
+	return o.putSecrets(secretName, secretValues)
+}
+
+func (o *secretInitOpts) putSecrets(secretName string, values map[string]string) error {
+	for envName, value := range values {
+		err := o.putSecret(secretName, envName, value)
+		if err != nil {
+			return err
+		}
+	}
 	return nil
+}
+
+func (o *secretInitOpts) putSecret(secretName, envName, value string) error {
+	client, err := o.configureSecretPutter(envName)
+	if err != nil {
+		return err
+	}
+
+	tags := make(map[string]string)
+	for k, v := range o.resourceTags {
+		tags[k] = v
+	}
+	tags[deploy.AppTagKey] = o.appName
+	tags[deploy.EnvTagKey] = envName
+
+	name := fmt.Sprintf(fmtSecretParameterName, o.appName, envName, secretName)
+	in := ssm.PutSecretInput{
+		Name:      name,
+		Value:     value,
+		Overwrite: o.overwrite,
+		Tags:      tags,
+	}
+
+	out, err := client.PutSecret(in)
+	if err != nil {
+		var targetErr *ssm.ErrParameterAlreadyExists
+		if errors.As(err, &targetErr) {
+			log.Infoln(fmt.Sprintf("Secret %s already exists. If you want to overwrite an existing secret, use the %s flag.\n", name, color.HighlightCode("--overwrite")))
+			return nil
+		}
+		return fmt.Errorf("put secret %s in environment %s: %w", secretName, envName, err)
+	}
+
+	version := aws.Int64Value(out.Version)
+	if version != 1 {
+		log.Infoln(fmt.Sprintf("Secret %s already exists in environment %s. Overwritten.", name, envName))
+		return nil
+	}
+
+	log.Infoln(fmt.Sprintf("Successfully created %s", name))
+	return nil
+}
+
+func (o *secretInitOpts) parseFile() (string, map[string]string, error) {
+	return "", nil, nil
 }
 
 func (o *secretInitOpts) askForAppName() error {
@@ -182,11 +279,19 @@ func (o *secretInitOpts) askForSecretValues() error {
 	return nil
 }
 
+func (o *secretInitOpts) targetEnv(envName string) (*config.Environment, error) {
+	env, err := o.store.GetEnvironment(o.appName, envName)
+	if err != nil {
+		return nil, fmt.Errorf("get environment %s in application %s: %w", envName, o.appName, err)
+	}
+	return env, nil
+}
+
 // BuildSecretInitCmd build the command for creating a new secret or updating an existing one.
 func BuildSecretInitCmd() *cobra.Command {
 	vars := secretInitVars{}
 	cmd := &cobra.Command{
-		Use:     "init",
+		Use:     "secret init",
 		Short:   "Create or update an SSM SecureString parameter.",
 		Example: ``, // TODO
 		RunE: runCmdE(func(cmd *cobra.Command, args []string) error {

--- a/internal/pkg/deploy/cloudformation/stack/transformers.go
+++ b/internal/pkg/deploy/cloudformation/stack/transformers.go
@@ -496,7 +496,12 @@ func convertNetworkConfig(network manifest.NetworkConfig) *template.NetworkOpts 
 	}
 	if aws.StringValue(network.VPC.Placement) != manifest.PublicSubnetPlacement {
 		opts.AssignPublicIP = template.DisablePublicIP
-		opts.SubnetsType = template.PrivateSubnetsPlacement
+		switch aws.StringValue(network.VPC.Placement) {
+		case manifest.PrivateSubnetPlacement:
+			opts.SubnetsType = template.PrivateSubnetsPlacement
+		case manifest.IsolatedSubnetPlacement:
+			opts.SubnetsType = template.IsolatedSubnetsPlacement
+		}
 	}
 	return opts
 }

--- a/internal/pkg/manifest/backend_svc.go
+++ b/internal/pkg/manifest/backend_svc.go
@@ -150,7 +150,8 @@ func newDefaultBackendService() *BackendService {
 			},
 			Network: NetworkConfig{
 				VPC: vpcConfig{
-					Placement: stringP(PublicSubnetPlacement),
+					Placement:         stringP(PublicSubnetPlacement),
+					AllowedPlacements: []string{PublicSubnetPlacement, PrivateSubnetPlacement, IsolatedSubnetPlacement},
 				},
 			},
 		},

--- a/internal/pkg/manifest/backend_svc_test.go
+++ b/internal/pkg/manifest/backend_svc_test.go
@@ -56,7 +56,8 @@ func TestNewBackendSvc(t *testing.T) {
 					},
 					Network: NetworkConfig{
 						VPC: vpcConfig{
-							Placement: stringP("public"),
+							Placement:         stringP("public"),
+							AllowedPlacements: []string{PublicSubnetPlacement, PrivateSubnetPlacement, IsolatedSubnetPlacement},
 						},
 					},
 				},
@@ -106,7 +107,8 @@ func TestNewBackendSvc(t *testing.T) {
 					},
 					Network: NetworkConfig{
 						VPC: vpcConfig{
-							Placement: stringP("public"),
+							Placement:         stringP("public"),
+							AllowedPlacements: []string{PublicSubnetPlacement, PrivateSubnetPlacement, IsolatedSubnetPlacement},
 						},
 					},
 				},

--- a/internal/pkg/manifest/job.go
+++ b/internal/pkg/manifest/job.go
@@ -82,7 +82,8 @@ func newDefaultScheduledJob() *ScheduledJob {
 			},
 			Network: NetworkConfig{
 				VPC: vpcConfig{
-					Placement: stringP(PublicSubnetPlacement),
+					Placement:         stringP(PublicSubnetPlacement),
+					AllowedPlacements: []string{PublicSubnetPlacement, PrivateSubnetPlacement, IsolatedSubnetPlacement},
 				},
 			},
 		},

--- a/internal/pkg/manifest/lb_web_svc.go
+++ b/internal/pkg/manifest/lb_web_svc.go
@@ -162,7 +162,8 @@ func newDefaultLoadBalancedWebService() *LoadBalancedWebService {
 			},
 			Network: NetworkConfig{
 				VPC: vpcConfig{
-					Placement: stringP(PublicSubnetPlacement),
+					Placement:         stringP(PublicSubnetPlacement),
+					AllowedPlacements: []string{PublicSubnetPlacement, PrivateSubnetPlacement},
 				},
 			},
 		},

--- a/internal/pkg/manifest/lb_web_svc_test.go
+++ b/internal/pkg/manifest/lb_web_svc_test.go
@@ -67,7 +67,8 @@ func TestNewLoadBalancedWebService(t *testing.T) {
 					},
 					Network: NetworkConfig{
 						VPC: vpcConfig{
-							Placement: stringP("public"),
+							Placement:         stringP("public"),
+							AllowedPlacements: []string{PublicSubnetPlacement, PrivateSubnetPlacement},
 						},
 					},
 				},
@@ -354,8 +355,9 @@ func TestLoadBalancedWebService_ApplyEnv(t *testing.T) {
 					},
 					Network: NetworkConfig{
 						VPC: vpcConfig{
-							Placement:      stringP("public"),
-							SecurityGroups: []string{"sg-123"},
+							Placement:         stringP("public"),
+							AllowedPlacements: []string{PublicSubnetPlacement, PrivateSubnetPlacement},
+							SecurityGroups:    []string{"sg-123"},
 						},
 					},
 				},

--- a/internal/pkg/manifest/svc_test.go
+++ b/internal/pkg/manifest/svc_test.go
@@ -124,7 +124,8 @@ environments:
 						},
 						Network: NetworkConfig{
 							VPC: vpcConfig{
-								Placement: stringP("public"),
+								Placement:         stringP("public"),
+								AllowedPlacements: []string{PublicSubnetPlacement, PrivateSubnetPlacement},
 							},
 						},
 					},
@@ -231,7 +232,8 @@ secrets:
 						},
 						Network: NetworkConfig{
 							VPC: vpcConfig{
-								Placement: stringP("public"),
+								Placement:         stringP("public"),
+								AllowedPlacements: []string{PublicSubnetPlacement, PrivateSubnetPlacement, IsolatedSubnetPlacement},
 							},
 						},
 					},

--- a/internal/pkg/manifest/workload_test.go
+++ b/internal/pkg/manifest/workload_test.go
@@ -528,7 +528,8 @@ network:
 `,
 			wantedConfig: NetworkConfig{
 				VPC: vpcConfig{
-					Placement: stringP(PublicSubnetPlacement),
+					Placement:         stringP(PublicSubnetPlacement),
+					AllowedPlacements: []string{PublicSubnetPlacement, PrivateSubnetPlacement},
 				},
 			},
 		},
@@ -538,7 +539,7 @@ network:
   vpc:
     placement: 'tartarus'
 `,
-			wantedErr: errors.New(`field 'network.vpc.placement' is 'tartarus' must be one of []string{"public", "private"}`),
+			wantedErr: errors.New(`field 'network.vpc.placement' is 'tartarus'; must be one of []string{"public", "private"}`),
 		},
 		"unmarshals successfully for public placement with security groups": {
 			data: `
@@ -551,8 +552,9 @@ network:
 `,
 			wantedConfig: NetworkConfig{
 				VPC: vpcConfig{
-					Placement:      stringP(PublicSubnetPlacement),
-					SecurityGroups: []string{"sg-1234", "sg-4567"},
+					Placement:         stringP(PublicSubnetPlacement),
+					AllowedPlacements: []string{PublicSubnetPlacement, PrivateSubnetPlacement},
+					SecurityGroups:    []string{"sg-1234", "sg-4567"},
 				},
 			},
 		},
@@ -565,6 +567,7 @@ network:
 				Network NetworkConfig `yaml:"network"`
 			}
 			var m manifest
+			m.Network.VPC.AllowedPlacements = []string{PublicSubnetPlacement, PrivateSubnetPlacement}
 
 			// WHEN
 			err := yaml.Unmarshal([]byte(tc.data), &m)

--- a/internal/pkg/template/env.go
+++ b/internal/pkg/template/env.go
@@ -25,6 +25,7 @@ var (
 		"lambdas",
 		"vpc-resources",
 		"nat-gateways",
+		"vpc-endpoints",
 	}
 )
 

--- a/internal/pkg/template/env_test.go
+++ b/internal/pkg/template/env_test.go
@@ -35,6 +35,7 @@ func TestTemplate_ParseEnv(t *testing.T) {
   lambdas
   vpc-resources
   nat-gateways
+  vpc-endpoints
 `,
 		},
 		"renders v1.0.0 template": {
@@ -60,6 +61,7 @@ func TestTemplate_ParseEnv(t *testing.T) {
 			tpl.box.AddString("environment/partials/lambdas.yml", "lambdas")
 			tpl.box.AddString("environment/partials/vpc-resources.yml", "vpc-resources")
 			tpl.box.AddString("environment/partials/nat-gateways.yml", "nat-gateways")
+			tpl.box.AddString("environment/partials/vpc-endpoints.yml", "vpc-endpoints")
 
 			// WHEN
 			c, err := tpl.ParseEnv(&EnvOpts{

--- a/internal/pkg/template/workload.go
+++ b/internal/pkg/template/workload.go
@@ -32,10 +32,11 @@ const (
 // Constants for workload options.
 const (
 	// AWS VPC networking configuration.
-	EnablePublicIP          = "ENABLED"
-	DisablePublicIP         = "DISABLED"
-	PublicSubnetsPlacement  = "PublicSubnets"
-	PrivateSubnetsPlacement = "PrivateSubnets"
+	EnablePublicIP           = "ENABLED"
+	DisablePublicIP          = "DISABLED"
+	PublicSubnetsPlacement   = "PublicSubnets"
+	PrivateSubnetsPlacement  = "PrivateSubnets"
+	IsolatedSubnetsPlacement = "IsolatedSubnets"
 )
 
 var (
@@ -342,6 +343,9 @@ func envControllerParameters(o WorkloadOpts) []string {
 	}
 	if o.Network.SubnetsType == PrivateSubnetsPlacement {
 		parameters = append(parameters, "NATWorkloads,") // YAML needs the comma separator; resolved in EnvContr.
+	}
+	if o.Network.SubnetsType == IsolatedSubnetsPlacement {
+		parameters = append(parameters, "VPCEndpointWorkloads,")
 	}
 	if o.Storage != nil && o.Storage.requiresEFSCreation() {
 		parameters = append(parameters, "EFSWorkloads,")

--- a/templates/environment/partials/nat-gateways.yml
+++ b/templates/environment/partials/nat-gateways.yml
@@ -16,11 +16,6 @@ NatGateway{{inc $ind}}:
     Tags:
       - Key: Name
         Value: !Sub 'copilot-${AppName}-${EnvironmentName}-{{$ind}}'
-PrivateRouteTable{{inc $ind}}:
-  Type: AWS::EC2::RouteTable
-  Condition: CreateNATGateways
-  Properties:
-    VpcId: !Ref 'VPC'
 PrivateRoute{{inc $ind}}:
   Type: AWS::EC2::Route
   Condition: CreateNATGateways
@@ -28,10 +23,4 @@ PrivateRoute{{inc $ind}}:
     RouteTableId: !Ref PrivateRouteTable{{inc $ind}}
     DestinationCidrBlock: 0.0.0.0/0
     NatGatewayId: !Ref NatGateway{{inc $ind}}
-PrivateRouteTable{{inc $ind}}Association:
-  Type: AWS::EC2::SubnetRouteTableAssociation
-  Condition: CreateNATGateways
-  Properties:
-    RouteTableId: !Ref PrivateRouteTable{{inc $ind}}
-    SubnetId: !Ref PrivateSubnet{{inc $ind}}
   {{- end}}

--- a/templates/environment/partials/vpc-endpoints.yml
+++ b/templates/environment/partials/vpc-endpoints.yml
@@ -1,0 +1,168 @@
+VPCEndpointSecurityGroup:
+  Condition: CreateVPCEndpoints
+  Metadata:
+    'aws:copilot:description': 'A security group to associate with your VPC endpoints'
+  Type: AWS::EC2::SecurityGroup
+  Properties:
+    GroupDescription: Security Group to allow use of VPC Endpoints.
+    VpcId: !Ref VPC
+    SecurityGroupIngress:
+      - IpProtocol: tcp
+        Description: HTTPS
+        FromPort: 443
+        ToPort: 443
+        CidrIp: {{.CIDR}}
+
+# Allow ingress traffic from VPC endpoints to our containers.
+IngressFromVPCEndpoints:
+  Condition: CreateVPCEndpoints
+  Type: AWS::EC2::SecurityGroupIngress
+  Properties:
+    Description: Ingress from VPC endpoints.
+    GroupId: !Ref 'EnvironmentSecurityGroup'
+    IpProtocol: -1
+    SourceSecurityGroupId: !Ref 'VPCEndpointSecurityGroup'
+
+# Gateway endpoint for S3.
+S3GatewayVPCEndpoint:
+  Condition: CreateVPCEndpoints
+  Metadata:
+    'aws:copilot:description': 'An S3 gateway endpoint'
+  Type: AWS::EC2::VPCEndpoint
+  Properties:
+    VpcEndpointType: Gateway
+    RouteTableIds:
+      {{- range $ind, $cidr := .PrivateSubnetCIDRs}}
+      - !Ref PrivateRouteTable{{inc $ind}}
+      {{- end}}
+    ServiceName: !Sub com.amazonaws.${AWS::Region}.s3
+    VpcId: !Ref VPC
+
+# Interface endpoints.
+EcrApiVPCEndpoint:
+  Condition: CreateVPCEndpoints
+  Metadata:
+    'aws:copilot:description': 'ECR interface endpoints'
+  Type: AWS::EC2::VPCEndpoint
+  Properties:
+    VpcEndpointType: Interface
+    PrivateDnsEnabled: true
+    SubnetIds:
+      {{- range $ind, $cidr := .PrivateSubnetCIDRs}}
+      - !Ref PrivateSubnet{{inc $ind}}
+      {{- end}}
+    ServiceName: !Sub com.amazonaws.${AWS::Region}.ecr.api
+    VpcId: !Ref VPC
+    SecurityGroupIds:
+      - !Ref VPCEndpointSecurityGroup
+
+EcrDkrVPCEndpoint:
+  Condition: CreateVPCEndpoints
+  Type: AWS::EC2::VPCEndpoint
+  Properties:
+    VpcEndpointType: Interface
+    PrivateDnsEnabled: true
+    SubnetIds:
+      {{- range $ind, $cidr := .PrivateSubnetCIDRs}}
+      - !Ref PrivateSubnet{{inc $ind}}
+      {{- end}}
+    ServiceName: !Sub com.amazonaws.${AWS::Region}.ecr.dkr
+    VpcId: !Ref VPC
+    SecurityGroupIds:
+      - !Ref VPCEndpointSecurityGroup
+
+LogsVPCEndpoint:
+  Condition: CreateVPCEndpoints
+  Metadata:
+    'aws:copilot:description': 'A CloudWatch Logs interface endpoint'
+  Type: AWS::EC2::VPCEndpoint
+  Properties:
+    VpcEndpointType: Interface
+    PrivateDnsEnabled: true
+    SubnetIds:
+      {{- range $ind, $cidr := .PrivateSubnetCIDRs}}
+      - !Ref PrivateSubnet{{inc $ind}}
+      {{- end}}
+    ServiceName: !Sub com.amazonaws.${AWS::Region}.logs
+    VpcId: !Ref VPC
+    SecurityGroupIds:
+      - !Ref VPCEndpointSecurityGroup
+
+SSMVPCEndpoint:
+  Condition: CreateVPCEndpoints
+  Metadata:
+    'aws:copilot:description': 'Systems Manager interface endpoints'
+  Type: AWS::EC2::VPCEndpoint
+  Properties:
+    VpcEndpointType: Interface
+    PrivateDnsEnabled: true
+    SubnetIds:
+      {{- range $ind, $cidr := .PrivateSubnetCIDRs}}
+      - !Ref PrivateSubnet{{inc $ind}}
+      {{- end}}
+    ServiceName: !Sub com.amazonaws.${AWS::Region}.ssm
+    VpcId: !Ref VPC
+    SecurityGroupIds:
+      - !Ref VPCEndpointSecurityGroup
+
+EC2MessagesVPCEndpoint:
+  Condition: CreateVPCEndpoints
+  Type: AWS::EC2::VPCEndpoint
+  Properties:
+    VpcEndpointType: Interface
+    PrivateDnsEnabled: true
+    SubnetIds:
+      {{- range $ind, $cidr := .PrivateSubnetCIDRs}}
+      - !Ref PrivateSubnet{{inc $ind}}
+      {{- end}}
+    ServiceName: !Sub com.amazonaws.${AWS::Region}.ec2messages
+    VpcId: !Ref VPC
+    SecurityGroupIds:
+      - !Ref VPCEndpointSecurityGroup
+
+EC2VPCEndpoint:
+  Condition: CreateVPCEndpoints
+  Type: AWS::EC2::VPCEndpoint
+  Properties:
+    VpcEndpointType: Interface
+    PrivateDnsEnabled: true
+    SubnetIds:
+      {{- range $ind, $cidr := .PrivateSubnetCIDRs}}
+      - !Ref PrivateSubnet{{inc $ind}}
+      {{- end}}
+    ServiceName: !Sub com.amazonaws.${AWS::Region}.ec2
+    VpcId: !Ref VPC
+    SecurityGroupIds:
+      - !Ref VPCEndpointSecurityGroup
+
+SSMMessagesVPCEndpoint:
+  Condition: CreateVPCEndpoints
+  Type: AWS::EC2::VPCEndpoint
+  Properties:
+    VpcEndpointType: Interface
+    PrivateDnsEnabled: true
+    SubnetIds:
+      {{- range $ind, $cidr := .PrivateSubnetCIDRs}}
+      - !Ref PrivateSubnet{{inc $ind}}
+      {{- end}}
+    ServiceName: !Sub com.amazonaws.${AWS::Region}.ssmmessages
+    VpcId: !Ref VPC
+    SecurityGroupIds:
+      - !Ref VPCEndpointSecurityGroup
+
+SecretsManagerVPCEndpoint:
+  Condition: CreateVPCEndpoints
+  Metadata:
+    'aws:copilot:description': 'A Secrets Manager interface endpoint'
+  Type: AWS::EC2::VPCEndpoint
+  Properties:
+    VpcEndpointType: Interface
+    PrivateDnsEnabled: true
+    SubnetIds:
+      {{- range $ind, $cidr := .PrivateSubnetCIDRs}}
+      - !Ref PrivateSubnet{{inc $ind}}
+      {{- end}}
+    ServiceName: !Sub com.amazonaws.${AWS::Region}.secretsmanager
+    VpcId: !Ref VPC
+    SecurityGroupIds:
+      - !Ref VPCEndpointSecurityGroup

--- a/templates/environment/partials/vpc-resources.yml
+++ b/templates/environment/partials/vpc-resources.yml
@@ -41,6 +41,7 @@ InternetGatewayAttachment:
   Properties:
     InternetGatewayId: !Ref InternetGateway
     VpcId: !Ref VPC
+
 {{range $ind, $cidr := .PublicSubnetCIDRs}}
 PublicSubnet{{inc $ind}}:
   Metadata:
@@ -54,7 +55,21 @@ PublicSubnet{{inc $ind}}:
     Tags:
       - Key: Name
         Value: !Sub 'copilot-${AppName}-${EnvironmentName}-pub{{$ind}}'
-{{end}}{{range $ind, $cidr := .PrivateSubnetCIDRs}}
+
+PublicSubnet{{inc $ind}}RouteTableAssociation:
+  Type: AWS::EC2::SubnetRouteTableAssociation
+  Properties:
+    RouteTableId: !Ref PublicRouteTable
+    SubnetId: !Ref PublicSubnet{{inc $ind}}{{end}}
+
+{{range $ind, $cidr := .PrivateSubnetCIDRs}}
+PrivateRouteTable{{inc $ind}}:
+  Metadata:
+    'aws:copilot:description': 'Private route table {{inc $ind}}'
+  Type: AWS::EC2::RouteTable
+  Properties:
+    VpcId: !Ref 'VPC'
+
 PrivateSubnet{{inc $ind}}:
   Metadata:
     'aws:copilot:description': 'Private subnet {{inc $ind}} for resources with no internet access'
@@ -67,9 +82,10 @@ PrivateSubnet{{inc $ind}}:
     Tags:
       - Key: Name
         Value: !Sub 'copilot-${AppName}-${EnvironmentName}-priv{{$ind}}'
-{{end}}{{range $ind, $cidr := .PublicSubnetCIDRs}}
-PublicSubnet{{inc $ind}}RouteTableAssociation:
+
+PrivateSubnet{{inc $ind}}RouteTableAssociation:
   Type: AWS::EC2::SubnetRouteTableAssociation
   Properties:
-    RouteTableId: !Ref PublicRouteTable
-    SubnetId: !Ref PublicSubnet{{inc $ind}}{{end}}
+    RouteTableId: !Ref PrivateRouteTable{{inc $ind}}
+    SubnetId: !Ref PrivateSubnet{{inc $ind}}
+{{end}}

--- a/templates/environment/versions/cf-v1.3.0.yml
+++ b/templates/environment/versions/cf-v1.3.0.yml
@@ -41,6 +41,7 @@ Resources:
 {{- if not .ImportVPC}}
 {{include "vpc-resources" .VPCConfig | indent 2}}
 {{include "nat-gateways" .VPCConfig | indent 2}}
+{{include "vpc-endpoints" .VPCConfig | indent 2}}
 {{- end}}
   # Creates a service discovery namespace with the form:
   # {svc}.{appname}.local

--- a/templates/environment/versions/cf-v1.4.0.yml
+++ b/templates/environment/versions/cf-v1.4.0.yml
@@ -17,6 +17,9 @@ Parameters:
   NATWorkloads:
     Type: String
     Default: ""
+  VPCEndpointWorkloads:
+    Type: String
+    Default: ""
   ToolsAccountPrincipalARN:
     Type: String
   AppDNSName:
@@ -40,12 +43,15 @@ Conditions:
     !Not [!Equals [ !Ref EFSWorkloads, ""]]
   CreateNATGateways:
     !Not [!Equals [ !Ref NATWorkloads, ""]]
+  CreateVPCEndpoints:
+    !Not [ !Equals [ !Ref VPCEndpointWorkloads, "" ] ]
   HasAliases:
     !Not [!Equals [ !Ref Aliases, "" ]]
 Resources:
 {{- if not .ImportVPC}}
 {{include "vpc-resources" .VPCConfig | indent 2}}
 {{include "nat-gateways" .VPCConfig | indent 2}}
+{{include "vpc-endpoints" .VPCConfig | indent 2}}
 {{- end}}
   # Creates a service discovery namespace with the form:
   # {svc}.{appname}.local
@@ -366,7 +372,7 @@ Outputs:
     Export:
       Name: !Sub ${AWS::StackName}-SubDomain
   EnabledFeatures:
-    Value: !Sub '${ALBWorkloads},${EFSWorkloads},${NATWorkloads}'
+    Value: !Sub '${ALBWorkloads},${EFSWorkloads},${NATWorkloads},${VPCEndpointWorkloads}'
     Description: Required output to force the stack to update if mutating feature params, like ALBWorkloads, does not change the template.
   ManagedFileSystemID:
     Condition: CreateEFS

--- a/templates/workloads/partials/cf/service-base-properties.yml
+++ b/templates/workloads/partials/cf/service-base-properties.yml
@@ -40,12 +40,20 @@ NetworkConfiguration:
         - 0
         - Fn::Split:
           - ','
+          {{- if eq .Network.SubnetsType "IsolatedSubnets"}}
+          - Fn::ImportValue: !Sub '${AppName}-${EnvName}-PrivateSubnets'
+          {{- else}}
           - Fn::ImportValue: !Sub '${AppName}-${EnvName}-{{.Network.SubnetsType}}'
+          {{- end}}
       - Fn::Select:
         - 1
         - Fn::Split:
           - ','
+          {{- if eq .Network.SubnetsType "IsolatedSubnets"}}
+          - Fn::ImportValue: !Sub '${AppName}-${EnvName}-PrivateSubnets'
+          {{- else}}
           - Fn::ImportValue: !Sub '${AppName}-${EnvName}-{{.Network.SubnetsType}}'
+          {{- end}}
     SecurityGroups:
       - Fn::ImportValue: !Sub '${AppName}-${EnvName}-EnvironmentSecurityGroup'
       {{- range $sg := .Network.SecurityGroups}}

--- a/templates/workloads/partials/cf/state-machine.yml
+++ b/templates/workloads/partials/cf/state-machine.yml
@@ -24,12 +24,20 @@ StateMachine:
               - 0
               - Fn::Split:
                 - ','
+                {{- if eq .Network.SubnetsType "IsolatedSubnets"}}
+                - Fn::ImportValue: !Sub '${AppName}-${EnvName}-PrivateSubnets'
+                {{- else}}
                 - Fn::ImportValue: !Sub '${AppName}-${EnvName}-{{.Network.SubnetsType}}'
+                {{- end}}
             - Fn::Select:
               - 1
               - Fn::Split:
                 - ','
+                {{- if eq .Network.SubnetsType "IsolatedSubnets"}}
+                - Fn::ImportValue: !Sub '${AppName}-${EnvName}-PrivateSubnets'
+                {{- else}}
                 - Fn::ImportValue: !Sub '${AppName}-${EnvName}-{{.Network.SubnetsType}}'
+                {{- end}}
       AssignPublicIp: {{.Network.AssignPublicIP}}
       SecurityGroups:
         Fn::Join:


### PR DESCRIPTION
These changes support `isolated` network placement-- services in private subnets without access to the internet (no NAT gateways like `private` placement). Instead, VPC endpoints are added to enable the service to communicate with Amazon services. This PR adds the basic VPC endpoints required; more endpoints that support Auto Scaling, EFS, and add-ons will be added later.

Manual testing to check that there is no internet connectivity:

```
% copilot svc exec
Found only one deployed service backend in environment test
Execute `/bin/sh` in container backend in task 9206cbee2af04ab9b31c50e581b86d6e.

Starting session with SessionId: ecs-execute-command-0b119b24ab4ae0e06
# curl -I https://www.google.com
curl: (7) Failed to connect to www.google.com port 443: Connection timed out
# exit
```

Related: #1959.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
