### PR TITLE
test(e2e): fix e2e test caused by strings with trailing whitespace passed to `Atoi`

### DIFF
--- a/e2e/internal/client/aws.go
+++ b/e2e/internal/client/aws.go
@@ -178,5 +178,5 @@ func (a *AWS) GetFileSystemSize() (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	return strconv.Atoi(b.String())
+	return strconv.Atoi(strings.TrimSpace(b.String()))
 }


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
