### PR TITLE
chore(cli): generate task run command from a Copilot job

### DIFF
--- a/internal/pkg/cli/flag.go
+++ b/internal/pkg/cli/flag.go
@@ -240,6 +240,7 @@ Tasks with the same group name share the same set of resources.
 	generateCommandFlagDescription = `Optional. Generate a command with a pre-filled value for each flag.
 To use it for an ECS service, specify --generate-cmd <cluster name>/<service name>.
 Alternatively, if the service is created with Copilot, specify --generate-cmd <application>/<environment>/<service>.
+Similarly, to use it for a job created with Copilot, specify --generate-cmd <application>/<environment>/<job>.
 Cannot be specified with any other flags.`
 
 	vpcIDFlagDescription          = "Optional. Use an existing VPC ID."

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -552,7 +552,7 @@ func (o *runTaskOpts) runTaskCommand() (cliStringer, error) {
 			return nil, err
 		}
 	default:
-		return nil, errors.New("invalid input to --generate-cmd: must be of one the form <cluster>/<service> or <app>/<env>/<workload>")
+		return nil, errors.New("invalid input to --generate-cmd: must be of format <cluster>/<service> or <app>/<env>/<workload>")
 	}
 
 	return cmd, nil
@@ -601,8 +601,6 @@ func (o *runTaskOpts) runTaskCommandFromWorkload(sess *session.Session, appName,
 		if err != nil {
 			return nil, fmt.Errorf("generate task run command from service %s of application %s deployed in environment %s: %w", workloadName, appName, envName, err)
 		}
-	default:
-		return nil, fmt.Errorf("workload %s is neither a service nor a job", workloadName)
 	}
 	return cmd, nil
 }
@@ -628,7 +626,7 @@ func (o *runTaskOpts) workloadType(appName, workloadName string) (string, error)
 		return "", fmt.Errorf("determine whether workload %s is a service: %w", workloadName, err)
 	}
 
-	return workloadTypeInvalid, nil
+	return workloadTypeInvalid, fmt.Errorf("workload %s is neither a service nor a job", workloadName)
 }
 
 func (o *runTaskOpts) displayLogStream() error {

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -889,6 +889,6 @@ Run a task with a command.
 	cmd.Flags().BoolVar(&vars.follow, followFlag, false, followFlagDescription)
 	cmd.Flags().StringVar(&vars.generateCommandTarget, generateCommandFlag, "", generateCommandFlagDescription)
 
-	cmd.Flags().MarkHidden(generateCommandFlag)
+	_ = cmd.Flags().MarkHidden(generateCommandFlag)
 	return cmd
 }

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -888,6 +888,8 @@ Run a task with a command.
 	cmd.Flags().StringToStringVar(&vars.resourceTags, resourceTagsFlag, nil, resourceTagsFlagDescription)
 
 	cmd.Flags().BoolVar(&vars.follow, followFlag, false, followFlagDescription)
+	cmd.Flags().StringVar(&vars.generateCommandTarget, generateCommandFlag, "", generateCommandFlagDescription)
 
+	cmd.Flags().MarkHidden(generateCommandFlag)
 	return cmd
 }

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -837,11 +837,10 @@ Run a task with a command.
 /code $ copilot task run --command "python migrate-script.py"`,
 		RunE: runCmdE(func(cmd *cobra.Command, args []string) error {
 			opts, err := newTaskRunOpts(vars)
-			opts.nFlag = cmd.Flags().NFlag()
 			if err != nil {
 				return err
 			}
-
+			opts.nFlag = cmd.Flags().NFlag()
 			if cmd.Flags().Changed(dockerFileFlag) {
 				opts.isDockerfileSet = true
 			}

--- a/internal/pkg/cli/task_run_test.go
+++ b/internal/pkg/cli/task_run_test.go
@@ -1034,7 +1034,7 @@ func TestTaskRunOpts_runTaskCommand(t *testing.T) {
 		},
 		"invalid input": {
 			inGenerateCommandTarget: "invalid/illegal/not-good/input/is/bad",
-			wantedError:             errors.New("invalid input to --generate-cmd: must be of one the form <cluster>/<service> or <app>/<env>/<workload>"),
+			wantedError:             errors.New("invalid input to --generate-cmd: must be of format <cluster>/<service> or <app>/<env>/<workload>"),
 		},
 	}
 	for name, tc := range testCases {

--- a/internal/pkg/ecs/run_task_request.go
+++ b/internal/pkg/ecs/run_task_request.go
@@ -31,7 +31,8 @@ type ServiceDescriber interface {
 	ClusterARN(app, env string) (string, error)
 }
 
-type jobDescriber interface {
+// JobDescriber provides information on a Copilot job.
+type JobDescriber interface {
 	TaskDefinition(app, env, job string) (*awsecs.TaskDefinition, error)
 	NetworkConfigurationForJob(app, env, job string) (*awsecs.NetworkConfiguration, error)
 	ClusterARN(app, env string) (string, error)
@@ -128,7 +129,7 @@ func RunTaskRequestFromService(client ServiceDescriber, app, env, svc string) (*
 }
 
 // RunTaskRequestFromJob populates a RunTaskRequest with information from a Copilot job.
-func RunTaskRequestFromJob(client jobDescriber, app, env, job string) (*RunTaskRequest, error) {
+func RunTaskRequestFromJob(client JobDescriber, app, env, job string) (*RunTaskRequest, error) {
 	config, err := client.NetworkConfigurationForJob(app, env, job)
 	if err != nil {
 		return nil, fmt.Errorf("retrieve network configuration for job %s: %w", job, err)


### PR DESCRIPTION
This PR enables generating a task run command from a Copilot job. Manually tested.

Preceding PR: #2246 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
