### PR TITLE
test(e2e): remove FS size check due to eventual consistency problems

### DIFF
--- a/e2e/multi-svc-app/front-end/main.go
+++ b/e2e/multi-svc-app/front-end/main.go
@@ -96,7 +96,7 @@ func PutEFSCheck(w http.ResponseWriter, req *http.Request, ps httprouter.Params)
 	}
 	fileObj.Close()
 
-	// Shred file to ensure metered size increases and it's not read as sparse.
+	// Shred file to write 10MiB of data to the filesystem.
 	shredCmd := exec.Command("shred", "-n", "1", fileName)
 	if err := shredCmd.Run(); err != nil {
 		log.Println("Shred test file in EFS volume FAILED")

--- a/e2e/multi-svc-app/multi_svc_app_test.go
+++ b/e2e/multi-svc-app/multi_svc_app_test.go
@@ -353,19 +353,6 @@ var _ = Describe("Multiple Service App", func() {
 			Expect(envShowOutput.Resources).To(ContainElement(HaveKeyWithValue("type", "AWS::EFS::FileSystem")))
 		})
 
-		It("EFS filesystem size should be greater than 1 MiB", func() {
-			Eventually(func() (bool, error) {
-				size, err := aws.GetFileSystemSize()
-				if err != nil {
-					return false, err
-				}
-				return size > 1024*1024, nil
-			}, "4m", "15s").Should(BeTrue())
-			// This is shorthand for "error is nil and comparison is true"
-			// These numbers are based on an experiment I did: it takes about 100 seconds for the new size
-			// of an EFS filesystem to show up in metering. We should allow for the possibility of it taking longer.
-		})
-
 		It("job should have run", func() {
 			// Job should have run. We check this by hitting the "job-checker" path, which tells us the value
 			// of the "TEST_JOB_CHECK_VAR" in the frontend service, which will have been updated by a GET on


### PR DESCRIPTION
<!-- Provide summary of changes -->
This PR cleans up an e2e test case which relied on EFS updating the metered size of a newly created file system. This led to timeouts and eventual consistency issues. This check was overkill, since we already verify that the EFS filesystem is created and visible in the output of Env Show.

```
2021-05-13T09:30:27.982-07:00 | EFS filesystem size should be greater than 1 MiB [It]
  | 2021-05-13T09:30:27.982-07:00 | /github.com/aws/copilot-cli/e2e/multi-svc-app/multi_svc_app_test.go:356
  | 2021-05-13T09:30:27.982-07:00 |  
  | 2021-05-13T09:30:27.982-07:00 | Timed out after 240.000s.
  | 2021-05-13T09:30:27.982-07:00 | Expected
  | 2021-05-13T09:30:27.982-07:00 | <bool>: false
  | 2021-05-13T09:30:27.982-07:00 | to be true
```

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
