### PR TITLE
chore: remove resource tags for `secret init`

### DIFF
--- a/internal/pkg/aws/ssm/mocks/mock_ssm.go
+++ b/internal/pkg/aws/ssm/mocks/mock_ssm.go
@@ -34,6 +34,21 @@ func (m *Mockapi) EXPECT() *MockapiMockRecorder {
 	return m.recorder
 }
 
+// AddTagsToResource mocks base method.
+func (m *Mockapi) AddTagsToResource(input *ssm.AddTagsToResourceInput) (*ssm.AddTagsToResourceOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddTagsToResource", input)
+	ret0, _ := ret[0].(*ssm.AddTagsToResourceOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AddTagsToResource indicates an expected call of AddTagsToResource.
+func (mr *MockapiMockRecorder) AddTagsToResource(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddTagsToResource", reflect.TypeOf((*Mockapi)(nil).AddTagsToResource), input)
+}
+
 // PutParameter mocks base method.
 func (m *Mockapi) PutParameter(input *ssm.PutParameterInput) (*ssm.PutParameterOutput, error) {
 	m.ctrl.T.Helper()

--- a/internal/pkg/aws/ssm/ssm.go
+++ b/internal/pkg/aws/ssm/ssm.go
@@ -5,6 +5,7 @@
 package ssm
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 
@@ -17,6 +18,7 @@ import (
 
 type api interface {
 	PutParameter(input *ssm.PutParameterInput) (*ssm.PutParameterOutput, error)
+	AddTagsToResource(input *ssm.AddTagsToResourceInput) (*ssm.AddTagsToResourceOutput, error)
 }
 
 // SSM wraps an AWS SSM client.
@@ -42,31 +44,35 @@ type PutSecretInput struct {
 // PutSecretOutput wraps an ssm PutParameterOutput struct.
 type PutSecretOutput ssm.PutParameterOutput
 
-// PutSecret creates or updates a SecureString parameter.
+// PutSecret tries to create the secret, and overwrites it if the secret exists and that `Overwrite` is true.
+// ErrParameterAlreadyExists is returned if the secret exists and `Overwrite` is false.
 func (s *SSM) PutSecret(in PutSecretInput) (*PutSecretOutput, error) {
-	tags := make([]*ssm.Tag, 0, len(in.Tags))
-
-	// Sort the map so that the unit test won't be flaky.
-	keys := make([]string, 0, len(in.Tags))
-	for k := range in.Tags {
-		keys = append(keys, k)
+	// First try to create the secret with the tags.
+	out, err := s.createSecret(in)
+	if err == nil {
+		return out, nil
 	}
-	sort.Strings(keys)
 
-	for _, key := range keys {
-		tags = append(tags, &ssm.Tag{
-			Key:   aws.String(key),
-			Value: aws.String(in.Tags[key]),
-		})
+	// If the parameter already exists and we want to overwrite, we try to overwrite it.
+	var errParameterExists *ErrParameterAlreadyExists
+	if errors.As(err, &errParameterExists) && in.Overwrite {
+		return s.overwriteSecret(in)
 	}
+	return nil, err
+}
+
+func (s *SSM) createSecret(in PutSecretInput) (*PutSecretOutput, error) {
+	// Create a secret while adding the tags in a single call instead of separate calls to `PutParameter` and
+	// `AddTagsToResource` so that there won't be a case where the parameter is created while the tags are not added.
+
+	tags := convertTags(in.Tags)
 
 	input := &ssm.PutParameterInput{
-		DataType:  aws.String("text"),
-		Type:      aws.String("SecureString"),
-		Name:      aws.String(in.Name),
-		Value:     aws.String(in.Value),
-		Overwrite: aws.Bool(in.Overwrite),
-		Tags:      tags,
+		DataType: aws.String("text"),
+		Type:     aws.String("SecureString"),
+		Name:     aws.String(in.Name),
+		Value:    aws.String(in.Value),
+		Tags:     tags,
 	}
 	output, err := s.client.PutParameter(input)
 	if err == nil {
@@ -78,6 +84,51 @@ func (s *SSM) PutSecret(in PutSecretInput) (*PutSecretOutput, error) {
 			return nil, &ErrParameterAlreadyExists{in.Name}
 		}
 	}
-	return nil, fmt.Errorf("put parameter %s: %w", in.Name, err)
+	return nil, fmt.Errorf("create parameter %s: %w", in.Name, err)
+}
 
+func (s *SSM) overwriteSecret(in PutSecretInput) (*PutSecretOutput, error) {
+	// SSM API does not allow `Overwrite` to be true while `Tags` are not nil, so we have to overwrite the resource and
+	// add the tags in two separate calls.
+
+	input := &ssm.PutParameterInput{
+		DataType:  aws.String("text"),
+		Type:      aws.String("SecureString"),
+		Name:      aws.String(in.Name),
+		Value:     aws.String(in.Value),
+		Overwrite: aws.Bool(in.Overwrite),
+	}
+	output, err := s.client.PutParameter(input)
+	if err != nil {
+		return nil, fmt.Errorf("update parameter %s: %w", in.Name, err)
+	}
+
+	tags := convertTags(in.Tags)
+	_, err = s.client.AddTagsToResource(&ssm.AddTagsToResourceInput{
+		ResourceType: aws.String(ssm.ResourceTypeForTaggingParameter),
+		ResourceId:   aws.String(in.Name),
+		Tags:         tags,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("add tags to resource %s: %w", in.Name, err)
+	}
+	return (*PutSecretOutput)(output), nil
+}
+
+func convertTags(inTags map[string]string) []*ssm.Tag {
+	// Sort the map so that the unit test won't be flaky.
+	keys := make([]string, 0, len(inTags))
+	for k := range inTags {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var tags []*ssm.Tag
+	for _, key := range keys {
+		tags = append(tags, &ssm.Tag{
+			Key:   aws.String(key),
+			Value: aws.String(inTags[key]),
+		})
+	}
+	return tags
 }

--- a/internal/pkg/aws/ssm/ssm_test.go
+++ b/internal/pkg/aws/ssm/ssm_test.go
@@ -22,96 +22,342 @@ import (
 )
 
 func TestSSM_PutSecret(t *testing.T) {
-	t.Run("success", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
+	const (
+		mockApp = "myapp"
+		mockEnv = "myenv"
+	)
 
-		mockSSMClient := mocks.NewMockapi(ctrl)
-		mockApp := "myapp"
-		mockEnv := "myenv"
-		mockInput := &ssm.PutParameterInput{
-			DataType:  aws.String("text"),
-			Type:      aws.String("SecureString"),
-			Name:      aws.String(fmt.Sprintf("/copilot/%s/%s/secrets/db-password", mockApp, mockEnv)),
-			Value:     aws.String("super secure password"),
-			Overwrite: aws.Bool(false),
-			Tags: []*ssm.Tag{
-				{
-					Key:   aws.String(deploy.AppTagKey),
-					Value: aws.String(mockApp),
+	testCases := map[string]struct {
+		inPutSecretInput PutSecretInput
+
+		mockClient func(*mocks.Mockapi)
+
+		wantedOut   *PutSecretOutput
+		wantedError error
+	}{
+		"attempt to create a new secret": {
+			inPutSecretInput: PutSecretInput{
+				Name:  fmt.Sprintf("/copilot/%s/%s/secrets/db-password", mockApp, mockEnv),
+				Value: "super secure password",
+				Tags: map[string]string{
+					deploy.AppTagKey: mockApp,
+					deploy.EnvTagKey: mockEnv,
 				},
-				{
-					Key:   aws.String(deploy.EnvTagKey),
-					Value: aws.String(mockEnv),
+			},
+			mockClient: func(m *mocks.Mockapi) {
+				m.EXPECT().PutParameter(&ssm.PutParameterInput{
+					DataType: aws.String("text"),
+					Type:     aws.String("SecureString"),
+					Name:     aws.String(fmt.Sprintf("/copilot/%s/%s/secrets/db-password", mockApp, mockEnv)),
+					Value:    aws.String("super secure password"),
+					Tags: []*ssm.Tag{
+						{
+							Key:   aws.String(deploy.AppTagKey),
+							Value: aws.String(mockApp),
+						},
+						{
+							Key:   aws.String(deploy.EnvTagKey),
+							Value: aws.String(mockEnv),
+						},
+					},
+				}).Return(&ssm.PutParameterOutput{
+					Tier:    aws.String("Standard"),
+					Version: aws.Int64(1),
+				}, nil)
+			},
+			wantedOut: &PutSecretOutput{
+				Tier:    aws.String("Standard"),
+				Version: aws.Int64(1),
+			},
+		},
+		"attempt to create a new secret even if overwrite is true": {
+			inPutSecretInput: PutSecretInput{
+				Name:  fmt.Sprintf("/copilot/%s/%s/secrets/db-password", mockApp, mockEnv),
+				Value: "super secure password",
+				Tags: map[string]string{
+					deploy.AppTagKey: mockApp,
+					deploy.EnvTagKey: mockEnv,
+				},
+				Overwrite: true,
+			},
+			mockClient: func(m *mocks.Mockapi) {
+				m.EXPECT().PutParameter(&ssm.PutParameterInput{
+					DataType: aws.String("text"),
+					Type:     aws.String("SecureString"),
+					Name:     aws.String(fmt.Sprintf("/copilot/%s/%s/secrets/db-password", mockApp, mockEnv)),
+					Value:    aws.String("super secure password"),
+					Tags: []*ssm.Tag{
+						{
+							Key:   aws.String(deploy.AppTagKey),
+							Value: aws.String(mockApp),
+						},
+						{
+							Key:   aws.String(deploy.EnvTagKey),
+							Value: aws.String(mockEnv),
+						},
+					},
+				}).Return(&ssm.PutParameterOutput{
+					Tier:    aws.String("Standard"),
+					Version: aws.Int64(1),
+				}, nil)
+			},
+			wantedOut: &PutSecretOutput{
+				Tier:    aws.String("Standard"),
+				Version: aws.Int64(1),
+			},
+		},
+		"no overwrite attempt when overwrite is false and creation fails because the secret exists": {
+			inPutSecretInput: PutSecretInput{
+				Name:  fmt.Sprintf("/copilot/%s/%s/secrets/db-password", mockApp, mockEnv),
+				Value: "super secure password",
+				Tags: map[string]string{
+					deploy.AppTagKey: mockApp,
+					deploy.EnvTagKey: mockEnv,
 				},
 			},
-		}
-		wanted := &PutSecretOutput{
-			Tier:    aws.String("Standard"),
-			Version: aws.Int64(1),
-		}
-		mockSSMClient.EXPECT().PutParameter(mockInput).Return(&ssm.PutParameterOutput{
-			Tier:    aws.String("Standard"),
-			Version: aws.Int64(1),
-		}, nil)
-
-		client := SSM{
-			client: mockSSMClient,
-		}
-		got, err := client.PutSecret(PutSecretInput{
-			Name:  fmt.Sprintf("/copilot/%s/%s/secrets/db-password", mockApp, mockEnv),
-			Value: "super secure password",
-			Tags: map[string]string{
-				deploy.AppTagKey: mockApp,
-				deploy.EnvTagKey: mockEnv,
+			mockClient: func(m *mocks.Mockapi) {
+				m.EXPECT().PutParameter(&ssm.PutParameterInput{
+					DataType: aws.String("text"),
+					Type:     aws.String("SecureString"),
+					Name:     aws.String(fmt.Sprintf("/copilot/%s/%s/secrets/db-password", mockApp, mockEnv)),
+					Value:    aws.String("super secure password"),
+					Tags: []*ssm.Tag{
+						{
+							Key:   aws.String(deploy.AppTagKey),
+							Value: aws.String(mockApp),
+						},
+						{
+							Key:   aws.String(deploy.EnvTagKey),
+							Value: aws.String(mockEnv),
+						},
+					},
+				}).Return(nil, awserr.New(ssm.ErrCodeParameterAlreadyExists, "parameter already exists", fmt.Errorf("parameter already exists")))
 			},
-		})
-		require.NoError(t, err)
-		require.Equal(t, wanted, got)
-	})
-
-	t.Run("fail to put parameter because it already exists", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
-		mockSSMClient := mocks.NewMockapi(ctrl)
-		mockSSMClient.EXPECT().PutParameter(gomock.Any()).
-			Return(nil, awserr.New(ssm.ErrCodeParameterAlreadyExists, "parameter already exists", fmt.Errorf("parameter already exists")))
-
-		client := SSM{
-			client: mockSSMClient,
-		}
-		got, err := client.PutSecret(PutSecretInput{
-			Name:  "/copilot/myapp/myenv/secrets/db-password",
-			Value: "super secure password",
-			Tags: map[string]string{
-				deploy.AppTagKey: "myapp",
-				deploy.EnvTagKey: "myenv",
+			wantedError: &ErrParameterAlreadyExists{"/copilot/myapp/myenv/secrets/db-password"},
+		},
+		"no overwrite attempt when overwrite is false and creation fails because of other errors": {
+			inPutSecretInput: PutSecretInput{
+				Name:  fmt.Sprintf("/copilot/%s/%s/secrets/db-password", mockApp, mockEnv),
+				Value: "super secure password",
+				Tags: map[string]string{
+					deploy.AppTagKey: mockApp,
+					deploy.EnvTagKey: mockEnv,
+				},
 			},
-		})
-		require.EqualError(t, &ErrParameterAlreadyExists{"/copilot/myapp/myenv/secrets/db-password"}, err.Error())
-		require.Nil(t, got)
-	})
-
-	t.Run("fail to put parameter", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
-		mockSSMClient := mocks.NewMockapi(ctrl)
-		mockSSMClient.EXPECT().PutParameter(gomock.Any()).Return(nil, errors.New("some error"))
-
-		client := SSM{
-			client: mockSSMClient,
-		}
-		got, err := client.PutSecret(PutSecretInput{
-			Name:  "/copilot/myapp/myenv/secrets/db-password",
-			Value: "super secure password",
-			Tags: map[string]string{
-				deploy.AppTagKey: "myapp",
-				deploy.EnvTagKey: "myenv",
+			mockClient: func(m *mocks.Mockapi) {
+				m.EXPECT().PutParameter(&ssm.PutParameterInput{
+					DataType: aws.String("text"),
+					Type:     aws.String("SecureString"),
+					Name:     aws.String(fmt.Sprintf("/copilot/%s/%s/secrets/db-password", mockApp, mockEnv)),
+					Value:    aws.String("super secure password"),
+					Tags: []*ssm.Tag{
+						{
+							Key:   aws.String(deploy.AppTagKey),
+							Value: aws.String(mockApp),
+						},
+						{
+							Key:   aws.String(deploy.EnvTagKey),
+							Value: aws.String(mockEnv),
+						},
+					},
+				}).Return(nil, errors.New("some error"))
 			},
+			wantedError: errors.New("create parameter /copilot/myapp/myenv/secrets/db-password: some error"),
+		},
+		"no overwrite attempt when overwrite is true and creation fails because of other errors": {
+			inPutSecretInput: PutSecretInput{
+				Name:  fmt.Sprintf("/copilot/%s/%s/secrets/db-password", mockApp, mockEnv),
+				Value: "super secure password",
+				Tags: map[string]string{
+					deploy.AppTagKey: mockApp,
+					deploy.EnvTagKey: mockEnv,
+				},
+				Overwrite: true,
+			},
+			mockClient: func(m *mocks.Mockapi) {
+				m.EXPECT().PutParameter(&ssm.PutParameterInput{
+					DataType: aws.String("text"),
+					Type:     aws.String("SecureString"),
+					Name:     aws.String(fmt.Sprintf("/copilot/%s/%s/secrets/db-password", mockApp, mockEnv)),
+					Value:    aws.String("super secure password"),
+					Tags: []*ssm.Tag{
+						{
+							Key:   aws.String(deploy.AppTagKey),
+							Value: aws.String(mockApp),
+						},
+						{
+							Key:   aws.String(deploy.EnvTagKey),
+							Value: aws.String(mockEnv),
+						},
+					},
+				}).Return(nil, errors.New("some error"))
+			},
+			wantedError: errors.New("create parameter /copilot/myapp/myenv/secrets/db-password: some error"),
+		},
+		"attempt to overwrite only when overwrite is true and creation fails because the secret exists": {
+			inPutSecretInput: PutSecretInput{
+				Name:  fmt.Sprintf("/copilot/%s/%s/secrets/db-password", mockApp, mockEnv),
+				Value: "super secure password",
+				Tags: map[string]string{
+					deploy.AppTagKey: mockApp,
+					deploy.EnvTagKey: mockEnv,
+				},
+				Overwrite: true,
+			},
+			mockClient: func(m *mocks.Mockapi) {
+				gomock.InOrder(
+					m.EXPECT().PutParameter(&ssm.PutParameterInput{
+						DataType: aws.String("text"),
+						Type:     aws.String("SecureString"),
+						Name:     aws.String(fmt.Sprintf("/copilot/%s/%s/secrets/db-password", mockApp, mockEnv)),
+						Value:    aws.String("super secure password"),
+						Tags: []*ssm.Tag{
+							{
+								Key:   aws.String(deploy.AppTagKey),
+								Value: aws.String(mockApp),
+							},
+							{
+								Key:   aws.String(deploy.EnvTagKey),
+								Value: aws.String(mockEnv),
+							},
+						},
+					}).Return(nil, awserr.New(ssm.ErrCodeParameterAlreadyExists, "parameter already exists", fmt.Errorf("parameter already exists"))),
+					m.EXPECT().PutParameter(&ssm.PutParameterInput{
+						DataType:  aws.String("text"),
+						Type:      aws.String("SecureString"),
+						Name:      aws.String(fmt.Sprintf("/copilot/%s/%s/secrets/db-password", mockApp, mockEnv)),
+						Value:     aws.String("super secure password"),
+						Overwrite: aws.Bool(true),
+					}).Return(&ssm.PutParameterOutput{
+						Tier:    aws.String("Standard"),
+						Version: aws.Int64(3),
+					}, nil),
+					m.EXPECT().AddTagsToResource(&ssm.AddTagsToResourceInput{
+						ResourceType: aws.String(ssm.ResourceTypeForTaggingParameter),
+						ResourceId:   aws.String(fmt.Sprintf("/copilot/%s/%s/secrets/db-password", mockApp, mockEnv)),
+						Tags: convertTags(map[string]string{
+							deploy.AppTagKey: mockApp,
+							deploy.EnvTagKey: mockEnv,
+						}),
+					}).Return(nil, nil),
+				)
+			},
+			wantedOut: &PutSecretOutput{
+				Tier:    aws.String("Standard"),
+				Version: aws.Int64(3),
+			},
+		},
+		"failed to add tags during an overwrite operation": {
+			inPutSecretInput: PutSecretInput{
+				Name:  fmt.Sprintf("/copilot/%s/%s/secrets/db-password", mockApp, mockEnv),
+				Value: "super secure password",
+				Tags: map[string]string{
+					deploy.AppTagKey: mockApp,
+					deploy.EnvTagKey: mockEnv,
+				},
+				Overwrite: true,
+			},
+			mockClient: func(m *mocks.Mockapi) {
+				gomock.InOrder(
+					m.EXPECT().PutParameter(&ssm.PutParameterInput{
+						DataType: aws.String("text"),
+						Type:     aws.String("SecureString"),
+						Name:     aws.String(fmt.Sprintf("/copilot/%s/%s/secrets/db-password", mockApp, mockEnv)),
+						Value:    aws.String("super secure password"),
+						Tags: []*ssm.Tag{
+							{
+								Key:   aws.String(deploy.AppTagKey),
+								Value: aws.String(mockApp),
+							},
+							{
+								Key:   aws.String(deploy.EnvTagKey),
+								Value: aws.String(mockEnv),
+							},
+						},
+					}).Return(nil, awserr.New(ssm.ErrCodeParameterAlreadyExists, "parameter already exists", fmt.Errorf("parameter already exists"))),
+					m.EXPECT().PutParameter(&ssm.PutParameterInput{
+						DataType:  aws.String("text"),
+						Type:      aws.String("SecureString"),
+						Name:      aws.String(fmt.Sprintf("/copilot/%s/%s/secrets/db-password", mockApp, mockEnv)),
+						Value:     aws.String("super secure password"),
+						Overwrite: aws.Bool(true),
+					}).Return(&ssm.PutParameterOutput{
+						Tier:    aws.String("Standard"),
+						Version: aws.Int64(3),
+					}, nil),
+					m.EXPECT().AddTagsToResource(&ssm.AddTagsToResourceInput{
+						ResourceType: aws.String(ssm.ResourceTypeForTaggingParameter),
+						ResourceId:   aws.String(fmt.Sprintf("/copilot/%s/%s/secrets/db-password", mockApp, mockEnv)),
+						Tags: convertTags(map[string]string{
+							deploy.AppTagKey: mockApp,
+							deploy.EnvTagKey: mockEnv,
+						}),
+					}).Return(nil, errors.New("some error")),
+				)
+			},
+			wantedError: errors.New("add tags to resource /copilot/myapp/myenv/secrets/db-password: some error"),
+		},
+		"fail to overwrite": {
+			inPutSecretInput: PutSecretInput{
+				Name:  fmt.Sprintf("/copilot/%s/%s/secrets/db-password", mockApp, mockEnv),
+				Value: "super secure password",
+				Tags: map[string]string{
+					deploy.AppTagKey: mockApp,
+					deploy.EnvTagKey: mockEnv,
+				},
+				Overwrite: true,
+			},
+			mockClient: func(m *mocks.Mockapi) {
+				gomock.InOrder(
+					m.EXPECT().PutParameter(&ssm.PutParameterInput{
+						DataType: aws.String("text"),
+						Type:     aws.String("SecureString"),
+						Name:     aws.String(fmt.Sprintf("/copilot/%s/%s/secrets/db-password", mockApp, mockEnv)),
+						Value:    aws.String("super secure password"),
+						Tags: []*ssm.Tag{
+							{
+								Key:   aws.String(deploy.AppTagKey),
+								Value: aws.String(mockApp),
+							},
+							{
+								Key:   aws.String(deploy.EnvTagKey),
+								Value: aws.String(mockEnv),
+							},
+						},
+					}).Return(nil, awserr.New(ssm.ErrCodeParameterAlreadyExists, "parameter already exists", fmt.Errorf("parameter already exists"))),
+					m.EXPECT().PutParameter(&ssm.PutParameterInput{
+						DataType:  aws.String("text"),
+						Type:      aws.String("SecureString"),
+						Name:      aws.String(fmt.Sprintf("/copilot/%s/%s/secrets/db-password", mockApp, mockEnv)),
+						Value:     aws.String("super secure password"),
+						Overwrite: aws.Bool(true),
+					}).Return(nil, errors.New("some error")),
+				)
+			},
+			wantedError: errors.New("update parameter /copilot/myapp/myenv/secrets/db-password: some error"),
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockSSMClient := mocks.NewMockapi(ctrl)
+			client := SSM{
+				client: mockSSMClient,
+			}
+			tc.mockClient(mockSSMClient)
+
+			got, err := client.PutSecret(tc.inPutSecretInput)
+
+			if tc.wantedError != nil {
+				require.EqualError(t, tc.wantedError, err.Error())
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.wantedOut, got)
+			}
+
 		})
-		require.EqualError(t, errors.New("put parameter /copilot/myapp/myenv/secrets/db-password: some error"), err.Error())
-		require.Nil(t, got)
-	})
+	}
 }

--- a/internal/pkg/cli/secret_init.go
+++ b/internal/pkg/cli/secret_init.go
@@ -50,8 +50,6 @@ type secretInitVars struct {
 	values        map[string]string
 	inputFilePath string
 	overwrite     bool
-
-	resourceTags map[string]string
 }
 
 type secretInitOpts struct {
@@ -237,19 +235,15 @@ func (o *secretInitOpts) putSecretInEnv(secretName, envName, value string) error
 		return err
 	}
 
-	tags := make(map[string]string)
-	for k, v := range o.resourceTags {
-		tags[k] = v
-	}
-	tags[deploy.AppTagKey] = o.appName
-	tags[deploy.EnvTagKey] = envName
-
 	name := fmt.Sprintf(fmtSecretParameterName, o.appName, envName, secretName)
 	in := ssm.PutSecretInput{
 		Name:      name,
 		Value:     value,
 		Overwrite: o.overwrite,
-		Tags:      tags,
+		Tags: map[string]string{
+			deploy.AppTagKey: o.appName,
+			deploy.EnvTagKey: envName,
+		},
 	}
 
 	out, err := client.PutSecret(in)
@@ -434,6 +428,5 @@ func BuildSecretInitCmd() *cobra.Command {
 	cmd.Flags().StringToStringVar(&vars.values, valuesFlag, nil, secretValuesFlagDescription)
 	cmd.Flags().BoolVar(&vars.overwrite, overwriteFlag, false, secretOverwriteFlagDescription)
 	cmd.Flags().StringVar(&vars.inputFilePath, inputFilePathFlag, "", secretInputFilePathFlagDescription)
-	cmd.Flags().StringToStringVar(&vars.resourceTags, resourceTagsFlag, nil, resourceTagsFlagDescription)
 	return cmd
 }

--- a/internal/pkg/cli/secret_init.go
+++ b/internal/pkg/cli/secret_init.go
@@ -227,7 +227,7 @@ func (o *secretInitOpts) Execute() error {
 func (o *secretInitOpts) configureClientsAndUpgradeForEnvironments(secrets map[string]map[string]string) error {
 	envNames := make(map[string]struct{})
 	for _, values := range secrets {
-		for envName, _ := range values {
+		for envName := range values {
 			envNames[envName] = struct{}{}
 		}
 	}

--- a/internal/pkg/cli/secret_init.go
+++ b/internal/pkg/cli/secret_init.go
@@ -248,6 +248,11 @@ func (o *secretInitOpts) putSecret(secretName string, values map[string]string) 
 	for env := range values {
 		envs = append(envs, env)
 	}
+
+	if len(envs) == 0 {
+		return nil
+	}
+
 	log.Infof("...Put secret %s to environment %s\n", color.HighlightUserInput(secretName), english.WordSeries(envs, "and"))
 
 	errorsForEnvironments := make(map[string]error)
@@ -379,7 +384,9 @@ func (o *secretInitOpts) askForSecretValues() error {
 			return fmt.Errorf("get secret value for %s in environment %s: %w", color.HighlightUserInput(o.name), env.Name, err)
 		}
 
-		values[env.Name] = value
+		if value != "" {
+			values[env.Name] = value
+		}
 	}
 	o.values = values
 	return nil

--- a/internal/pkg/cli/secret_init_test.go
+++ b/internal/pkg/cli/secret_init_test.go
@@ -582,7 +582,7 @@ db-host:
 			if tc.wantedError == nil {
 				require.NoError(t, err)
 			} else {
-				require.EqualError(t, tc.wantedError, err.Error())
+				require.Equal(t, tc.wantedError, err)
 			}
 		})
 	}

--- a/internal/pkg/cli/secret_init_test.go
+++ b/internal/pkg/cli/secret_init_test.go
@@ -34,7 +34,6 @@ func TestSecretInitOpts_Validate(t *testing.T) {
 		inValues        map[string]string
 		inOverwrite     bool
 		inInputFilePath string
-		inResourceTags  map[string]string
 
 		setupMocks func(m secretInitMocks)
 
@@ -43,9 +42,7 @@ func TestSecretInitOpts_Validate(t *testing.T) {
 		"valid with input file": {
 			inInputFilePath: "./deep/secrets.yml",
 			inOverwrite:     true,
-			inResourceTags: map[string]string{
-				"hide": "yes",
-			},
+
 			setupMocks: func(m secretInitMocks) {
 				m.mockFS.MkdirAll("deep", 0755)
 				afero.WriteFile(m.mockFS, "deep/secrets.yml", []byte("FROM nginx"), 0644)
@@ -59,9 +56,7 @@ func TestSecretInitOpts_Validate(t *testing.T) {
 			},
 			inApp:       "dragon_slaying",
 			inOverwrite: true,
-			inResourceTags: map[string]string{
-				"hide": "yes",
-			},
+
 			setupMocks: func(m secretInitMocks) {
 				m.mockStore.EXPECT().GetApplication("dragon_slaying").Return(&config.Application{}, nil)
 				m.mockStore.EXPECT().GetEnvironment("dragon_slaying", "good_village").Return(&config.Environment{}, nil)
@@ -127,7 +122,6 @@ func TestSecretInitOpts_Validate(t *testing.T) {
 					values:        tc.inValues,
 					inputFilePath: tc.inInputFilePath,
 					overwrite:     tc.inOverwrite,
-					resourceTags:  tc.inResourceTags,
 				},
 				fs:    &afero.Afero{Fs: afero.NewMemMapFs()},
 				store: mockStore,
@@ -365,8 +359,7 @@ func TestSecretInitOpts_Execute(t *testing.T) {
 
 		inInputFilePath string
 
-		inOverwrite    bool
-		inResourceTags map[string]string
+		inOverwrite bool
 
 		mockInputFileContent []byte
 		setupMocks           func(m secretInitExecuteMocks)
@@ -377,9 +370,6 @@ func TestSecretInitOpts_Execute(t *testing.T) {
 			inAppName: testApp,
 			inName:    testName,
 			inValues:  testValues,
-			inResourceTags: map[string]string{
-				"isPassword": "yes",
-			},
 
 			setupMocks: func(m secretInitExecuteMocks) {
 				m.mockSecretPutter.EXPECT().PutSecret(ssm.PutSecretInput{
@@ -389,7 +379,6 @@ func TestSecretInitOpts_Execute(t *testing.T) {
 					Tags: map[string]string{
 						deploy.AppTagKey: "test-app",
 						deploy.EnvTagKey: "test",
-						"isPassword":     "yes",
 					},
 				}).Return(&ssm.PutSecretOutput{
 					Version: aws.Int64(1),
@@ -401,7 +390,6 @@ func TestSecretInitOpts_Execute(t *testing.T) {
 					Tags: map[string]string{
 						deploy.AppTagKey: "test-app",
 						deploy.EnvTagKey: "prod",
-						"isPassword":     "yes",
 					},
 				}).Return(&ssm.PutSecretOutput{
 					Version: aws.Int64(1),
@@ -578,7 +566,6 @@ db-host:
 					appName:       tc.inAppName,
 					name:          tc.inName,
 					values:        tc.inValues,
-					resourceTags:  tc.inResourceTags,
 					overwrite:     tc.inOverwrite,
 					inputFilePath: tc.inInputFilePath,
 				},

--- a/templates/environment/partials/environment-manager-role.yml
+++ b/templates/environment/partials/environment-manager-role.yml
@@ -141,6 +141,14 @@ EnvironmentManagerRole:
             "ssm:GetParametersByPath"
           ]
           Resource: "*"
+        - Sid: SSMSecret
+          Effect: Allow
+          Action: [
+            "ssm:PutParameter",
+            "ssm:AddTagsToResource"
+          ]
+          Resource:
+            - !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/copilot/${AppName}/${EnvironmentName}/secrets/*'
         - Sid: ELBv2
           Effect: Allow
           Action: [


### PR DESCRIPTION
This PR:
1. Removes `--resource-tags` flag from `secret init`
2. Update ssm package to separate API calls for creation and overwriting of secrets. This is because the SSM API does not allow an input to have a non-nil `Tags` field and a `Overwrite` field set true at the same time.
3. Add required IAM policy statement to the environment manager role (ssm:PutParameter and ssm:AddTagsToResource)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
