### PR TITLE
docs: add mutual links to concept and manifest pages

### DIFF
--- a/site/content/docs/concepts/pipelines.en.md
+++ b/site/content/docs/concepts/pipelines.en.md
@@ -89,7 +89,7 @@ stages:
       name: prod
       # requires_approval: true
 ```
-To learn about the specification of `pipeline.yml`, see the [pipeline manifest](../manifest/pipeline.en.md) page.
+You can see every available configuration option for `pipeline.yml` on the [pipeline manifest](../manifest/pipeline.en.md) page.
 
 There are 3 main parts of this file: the `name` field, which is the name of your CodePipeline, the `source` section, which details the repository and branch to track, and the `stages` section, which lists the environments you want this pipeline to deploy to. You can update this anytime, but you must run `copilot pipeline update` afterwards.
 

--- a/site/content/docs/concepts/pipelines.en.md
+++ b/site/content/docs/concepts/pipelines.en.md
@@ -89,6 +89,7 @@ stages:
       name: prod
       # requires_approval: true
 ```
+To learn about the specification of `pipeline.yml`, see the [pipeline manifest](../manifest/pipeline.en.md) page.
 
 There are 3 main parts of this file: the `name` field, which is the name of your CodePipeline, the `source` section, which details the repository and branch to track, and the `stages` section, which lists the environments you want this pipeline to deploy to. You can update this anytime, but you must run `copilot pipeline update` afterwards.
 

--- a/site/content/docs/manifest/backend-service.en.md
+++ b/site/content/docs/manifest/backend-service.en.md
@@ -1,4 +1,4 @@
-List of all available properties for a `'Backend Service'` manifest. To learn about its concept, see the [Services](../concepts/services.en.md) page.
+List of all available properties for a `'Backend Service'` manifest. To learn about Copilot services, see the [Services](../concepts/services.en.md) concept page.
 
 ???+ note "Sample manifest for an api service"
 

--- a/site/content/docs/manifest/backend-service.en.md
+++ b/site/content/docs/manifest/backend-service.en.md
@@ -1,4 +1,4 @@
-List of all available properties for a `'Backend Service'` manifest.
+List of all available properties for a `'Backend Service'` manifest. To learn about its concept, see the [Services](../concepts/services.en.md) page.
 
 ???+ note "Sample manifest for an api service"
 

--- a/site/content/docs/manifest/lb-web-service.en.md
+++ b/site/content/docs/manifest/lb-web-service.en.md
@@ -1,4 +1,4 @@
-List of all available properties for a `'Load Balanced Web Service'` manifest.
+List of all available properties for a `'Load Balanced Web Service'` manifest. To learn about its concept, see the [Services](../concepts/services.en.md) page.
 
 ???+ note "Sample manifest for a frontend service"
 

--- a/site/content/docs/manifest/lb-web-service.en.md
+++ b/site/content/docs/manifest/lb-web-service.en.md
@@ -1,4 +1,4 @@
-List of all available properties for a `'Load Balanced Web Service'` manifest. To learn about its concept, see the [Services](../concepts/services.en.md) page.
+List of all available properties for a `'Load Balanced Web Service'` manifest. To learn about Copilot services, see the [Services](../concepts/services.en.md) concept page.
 
 ???+ note "Sample manifest for a frontend service"
 

--- a/site/content/docs/manifest/pipeline.en.md
+++ b/site/content/docs/manifest/pipeline.en.md
@@ -1,4 +1,4 @@
-List of all available properties for a Copilot pipeline manifest.
+List of all available properties for a Copilot pipeline manifest. To learn about its concept, see the [Pipelines](../concepts/pipelines.en.md) page.
 
 ???+ note "Sample manifest for a pipeline triggered from a GitHub repo"
 

--- a/site/content/docs/manifest/pipeline.en.md
+++ b/site/content/docs/manifest/pipeline.en.md
@@ -1,4 +1,4 @@
-List of all available properties for a Copilot pipeline manifest. To learn about its concept, see the [Pipelines](../concepts/pipelines.en.md) page.
+List of all available properties for a Copilot pipeline manifest. To learn more about pipelines, see the [Pipelines](../concepts/pipelines.en.md) concept page.
 
 ???+ note "Sample manifest for a pipeline triggered from a GitHub repo"
 

--- a/site/content/docs/manifest/scheduled-job.en.md
+++ b/site/content/docs/manifest/scheduled-job.en.md
@@ -1,4 +1,4 @@
-List of all available properties for a `'Scheduled Job'` manifest.
+List of all available properties for a `'Scheduled Job'` manifest. To learn about its concept, see the [Jobs](../concepts/jobs.en.md) page.
 
 ???+ note "Sample manifest for a report generator cronjob"
 

--- a/site/content/docs/manifest/scheduled-job.en.md
+++ b/site/content/docs/manifest/scheduled-job.en.md
@@ -1,4 +1,4 @@
-List of all available properties for a `'Scheduled Job'` manifest. To learn about its concept, see the [Jobs](../concepts/jobs.en.md) page.
+List of all available properties for a `'Scheduled Job'` manifest. To learn about Copilot jobs, see the [Jobs](../concepts/jobs.en.md) concept page.
 
 ???+ note "Sample manifest for a report generator cronjob"
 


### PR DESCRIPTION
This PR adds mutual links to the concept and manifest pages to make it easy to reference for users (especially for people visit our docs via search engines).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
