### PR TITLE
chore: produce batch errors with stable orders to prevent test failures

### DIFF
--- a/internal/pkg/cli/secret_init.go
+++ b/internal/pkg/cli/secret_init.go
@@ -182,10 +182,10 @@ func (o *secretInitOpts) Execute() error {
 			return err
 		}
 
-		var errs []errPutSecretFailed
+		var errs []*errSecretFailedInSomeEnvironments
 		for secretName, secretValues := range secrets {
 			if err := o.putSecret(secretName, secretValues); err != nil {
-				errs = append(errs, err)
+				errs = append(errs, err.(*errSecretFailedInSomeEnvironments))
 			}
 		}
 
@@ -200,7 +200,7 @@ func (o *secretInitOpts) Execute() error {
 	return o.putSecret(o.name, o.values)
 }
 
-func (o *secretInitOpts) putSecret(secretName string, values map[string]string) errPutSecretFailed {
+func (o *secretInitOpts) putSecret(secretName string, values map[string]string) error {
 	envs := make([]string, 0)
 	for env := range values {
 		envs = append(envs, env)
@@ -355,18 +355,13 @@ func (o *secretInitOpts) askForSecretValues() error {
 func (o *secretInitOpts) RecommendedActions() {
 }
 
-type errPutSecretFailed interface {
-	SecretName() string
-	Error() string
-}
-
 type errSecretFailedInSomeEnvironments struct {
 	secretName            string
 	errorsForEnvironments map[string]error
 }
 
 type errBatchPutSecretsFailed struct {
-	errors []errPutSecretFailed
+	errors []*errSecretFailedInSomeEnvironments
 }
 
 func (e *errSecretFailedInSomeEnvironments) Error() string {

--- a/internal/pkg/cli/secret_init.go
+++ b/internal/pkg/cli/secret_init.go
@@ -372,8 +372,7 @@ func (e *errSecretFailedInSomeEnvironments) Error() string {
 	return strings.Join(out, "\n")
 }
 
-// SecretName returns the name of the secret of the error.
-func (e *errSecretFailedInSomeEnvironments) SecretName() string {
+func (e *errSecretFailedInSomeEnvironments) name() string {
 	return e.secretName
 }
 
@@ -382,7 +381,7 @@ func (e *errBatchPutSecretsFailed) Error() string {
 		"Batch put secrets failed for some secrets:",
 	}
 	sort.SliceStable(e.errors, func(i, j int) bool {
-		return e.errors[i].SecretName() < e.errors[j].SecretName()
+		return e.errors[i].name() < e.errors[j].name()
 	})
 	for _, err := range e.errors {
 		out = append(out, err.Error())

--- a/internal/pkg/cli/secret_init_test.go
+++ b/internal/pkg/cli/secret_init_test.go
@@ -544,7 +544,7 @@ db-host:
 			},
 
 			wantedError: &errBatchPutSecretsFailed{
-				errors: []errPutSecretFailed{
+				errors: []*errSecretFailedInSomeEnvironments{
 					&errSecretFailedInSomeEnvironments{
 						secretName: "db-password",
 						errorsForEnvironments: map[string]error{

--- a/internal/pkg/cli/secret_init_test.go
+++ b/internal/pkg/cli/secret_init_test.go
@@ -544,7 +544,7 @@ db-host:
 			},
 
 			wantedError: &errBatchPutSecretsFailed{
-				errors: []error{
+				errors: []errPutSecretFailed{
 					&errSecretFailedInSomeEnvironments{
 						secretName: "db-password",
 						errorsForEnvironments: map[string]error{


### PR DESCRIPTION
Previously, the `Error()` produced by `errBatchPutSecretsFailed` often fails unit test because the order of errors inside the member list `errors` is random.

This PR fixes by sorting the errors before producing an aggregated error message.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
