### PR TITLE
chore: quick fix to env controller

### DIFF
--- a/cf-custom-resources/test/env-controller-test.js
+++ b/cf-custom-resources/test/env-controller-test.js
@@ -178,11 +178,19 @@ describe("Env Controller Handler", () => {
           Parameters: [
             {
               ParameterKey: "ALBWorkloads",
-              ParameterValue: "my-svc,my-other-svc",
+              ParameterValue: "",
             },
             {
               ParameterKey: "Aliases",
-              ParameterValue: '{"my-other-svc": ["v1.example.com"]}',
+              ParameterValue: "",
+            },
+            {
+              ParameterKey: "EFSWorkloads",
+              ParameterValue: "",
+            },
+            {
+              ParameterKey: "NATWorkloads",
+              ParameterValue: "",
             },
           ],
           Outputs: testOutputs,
@@ -211,7 +219,7 @@ describe("Env Controller Handler", () => {
         ResourceProperties: {
           EnvStack: testEnvStack,
           Workload: "my-svc",
-          Parameters: ["ALBWorkloads", "Aliases"],
+          Parameters: ["Aliases"],
         },
       })
       .expectResolve(() => {


### PR DESCRIPTION
<!-- Provide summary of changes -->
#2315 breaks the workflow for creating a backend service or job because when creating them, the parameters will be empty if they are not using EFS or NAT. However, the [`envSet`](https://github.com/aws/copilot-cli/pull/2315/files#diff-b621c635b9a10aa2d00aed9f1d821e89d21e681ed568f21adab987358621fd24R105) always has `Aliases` to be a param which causing the env controller doesn't quit early when there's no change and the env stack update fails because the update is empty. This PR fixes this issue.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
