### PR TITLE
doc: enable `--generate-cmd` and update docs

### DIFF
--- a/internal/pkg/cli/flag.go
+++ b/internal/pkg/cli/flag.go
@@ -239,8 +239,7 @@ Tasks with the same group name share the same set of resources.
 	taskImageTagFlagDescription    = `Optional. The container image tag in addition to "latest".`
 	generateCommandFlagDescription = `Optional. Generate a command with a pre-filled value for each flag.
 To use it for an ECS service, specify --generate-cmd <cluster name>/<service name>.
-Alternatively, if the service is created with Copilot, specify --generate-cmd <application>/<environment>/<service>.
-Similarly, to use it for a job created with Copilot, specify --generate-cmd <application>/<environment>/<job>.
+Alternatively, if the service or job is created with Copilot, specify --generate-cmd <application>/<environment>/<service or job name>.
 Cannot be specified with any other flags.`
 
 	vpcIDFlagDescription          = "Optional. Use an existing VPC ID."

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -887,6 +887,5 @@ Run a task with a command.
 	cmd.Flags().BoolVar(&vars.follow, followFlag, false, followFlagDescription)
 	cmd.Flags().StringVar(&vars.generateCommandTarget, generateCommandFlag, "", generateCommandFlagDescription)
 
-	_ = cmd.Flags().MarkHidden(generateCommandFlag)
 	return cmd
 }

--- a/site/content/docs/commands/task-run.en.md
+++ b/site/content/docs/commands/task-run.en.md
@@ -35,6 +35,11 @@ Generally, the steps involved in task run are:
   --env-vars stringToString        Optional. Environment variables specified by key=value separated by commas. (default [])
   --execution-role string          Optional. The role that grants the container agent permission to make AWS API calls.
   --follow                         Optional. Specifies if the logs should be streamed.
+  --generate-cmd string            Optional. Generate a command with a pre-filled value for each flag.
+                                   To use it for an ECS service, specify --generate-cmd <cluster name>/<service name>.
+                                   Alternatively, if the service is created with Copilot, specify --generate-cmd <application>/<environment>/<service>.
+                                   Similarly, to use it for a job created with Copilot, specify --generate-cmd <application>/<environment>/<job>.
+                                   Cannot be specified with any other flags.
 -h, --help                         help for run
   --image string                   Optional. The image to run instead of building a Dockerfile.
   --memory int                     Optional. The amount of memory to reserve in MiB for each task. (default 512)

--- a/site/content/docs/commands/task-run.en.md
+++ b/site/content/docs/commands/task-run.en.md
@@ -37,8 +37,7 @@ Generally, the steps involved in task run are:
   --follow                         Optional. Specifies if the logs should be streamed.
   --generate-cmd string            Optional. Generate a command with a pre-filled value for each flag.
                                    To use it for an ECS service, specify --generate-cmd <cluster name>/<service name>.
-                                   Alternatively, if the service is created with Copilot, specify --generate-cmd <application>/<environment>/<service>.
-                                   Similarly, to use it for a job created with Copilot, specify --generate-cmd <application>/<environment>/<job>.
+                                   Alternatively, if the service or job is created with Copilot, specify --generate-cmd <application>/<environment>/<service or job name>.
                                    Cannot be specified with any other flags.
 -h, --help                         help for run
   --image string                   Optional. The image to run instead of building a Dockerfile.


### PR DESCRIPTION
This PR enables  `--generate-cmd` for `task run`, as well as update the site docs for it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
