### PR TITLE
fix(addons): fix typo to allow secondary indices for ddb tables

### DIFF
--- a/internal/pkg/addon/testdata/merge/first.yaml
+++ b/internal/pkg/addon/testdata/merge/first.yaml
@@ -75,7 +75,7 @@ Resources:
                           - dynamodb:Query
                           - dynamodb:Scan
                       Effect: Allow
-                      Resource: !Sub ${ MyTable.Arn}/Index/*
+                      Resource: !Sub ${ MyTable.Arn}/index/*
 
 Outputs:
     MyTableName:

--- a/internal/pkg/addon/testdata/merge/wanted.yaml
+++ b/internal/pkg/addon/testdata/merge/wanted.yaml
@@ -94,7 +94,7 @@ Resources:
                         - dynamodb:Query
                         - dynamodb:Scan
                       Effect: Allow
-                      Resource: !Sub ${ MyTable.Arn}/Index/*
+                      Resource: !Sub ${ MyTable.Arn}/index/*
     MyBucket:
         Type: AWS::S3::Bucket
         DeletionPolicy: Retain

--- a/templates/addons/ddb/cf.yml
+++ b/templates/addons/ddb/cf.yml
@@ -65,7 +65,7 @@ Resources:
               - dynamodb:Query
               - dynamodb:Scan
             Effect: Allow
-            Resource: !Sub ${ {{logicalIDSafe .Name}}.Arn}/Index/*
+            Resource: !Sub ${ {{logicalIDSafe .Name}}.Arn}/index/*
 
 Outputs:
   {{envVarName .Name}}:


### PR DESCRIPTION
Fix case in templates/addons/ddb/cf.yml
Also fix test cases in internal/pkg/addon/testdata/merge/{first,wanted}.yaml

With this mistake, a query with a secondary index does not work.

See https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/access-control-overview.html#access-control-resources

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
