### PR TITLE
docs: update frontpage and subpages for AWS App Runner

### DIFF
--- a/Dockerfile.site
+++ b/Dockerfile.site
@@ -1,0 +1,10 @@
+FROM squidfunk/mkdocs-material:7.1.3
+WORKDIR /website
+COPY mkdocs.yml /website
+COPY requirements.txt /website
+ADD site /website/site
+RUN ["pip", "install", "-r", "requirements.txt"]
+
+ENTRYPOINT ["mkdocs"]
+CMD ["serve", "--dev-addr=0.0.0.0:8000"]
+EXPOSE 8000

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ tools:
 .PHONY: site-local
 site-local:
 	docker build . -f Dockerfile.site -t site:latest
-	docker run -p 8000:8000 -it site:latest
+	docker run -p 8000:8000 -v `pwd`/site:/website/site -it site:latest
 
 .PHONY: gen-mocks
 gen-mocks: tools

--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,11 @@ tools:
 	@echo "Installing custom resource dependencies" &&\
 	cd ${SOURCE_CUSTOM_RESOURCES} && npm ci
 
+.PHONY: site-local
+site-local:
+	docker build . -f Dockerfile.site -t site:latest
+	docker run -p 8000:8000 -it site:latest
+
 .PHONY: gen-mocks
 gen-mocks: tools
 	# TODO: make this more extensible?

--- a/site/content/docs/concepts/services.en.md
+++ b/site/content/docs/concepts/services.en.md
@@ -22,12 +22,13 @@ When you're setting up a service, Copilot will ask you about what kind of servic
 
 ### Internet-facing services
 
-If you want your service to serve internet traffic then you have two options: 
+If you want your service to serve internet traffic then you have two options:
+
 * "Request-Driven Web Service" will provision an AWS App Runner Service to run your service. 
 * "Load Balanced Web Service" will provision an Application Load Balancer, security groups, an ECS service on Fargate to run your service.
 
 #### Request-Driven Web Service
-An AWS App Runner service that autoscales your services based on incoming traffic and scales down to a baseline instance when there's no traffic. This option is more cost effective for HTTP services with sudden bursts in request volumes or low request volumes.
+An AWS App Runner service that autoscales your instances based on incoming traffic and scales down to a baseline instance when there's no traffic. This option is more cost effective for HTTP services with sudden bursts in request volumes or low request volumes.
 
 #### Load Balanced Web Service
 An ECS Service running tasks on Fargate with an Application Load Balancer as ingress. This option is suitable for HTTP services with steady request volumes that need to access resources in a VPC or require advanced configuration.

--- a/site/content/docs/manifest/rd-web-service.en.md
+++ b/site/content/docs/manifest/rd-web-service.en.md
@@ -80,7 +80,46 @@ The approximate amount of time, in seconds, between health checks of an individu
 <span class="parent-field">http.healthcheck.</span><a id="http-healthcheck-timeout" href="#http-healthcheck-timeout" class="field">`timeout`</a> <span class="type">Duration</span>  
 The amount of time, in seconds, during which no response from a target means a failed health check. The default is 2s. Range 1s-20s.
 
-{% include 'image-config.md' %}
+<div class="separator"></div>
+
+<a id="image" href="#image" class="field">`image`</a> <span class="type">Map</span>  
+The image section contains parameters relating to the Docker build configuration and exposed port.
+
+<span class="parent-field">image.</span><a id="image-build" href="#image-build" class="field">`build`</a> <span class="type">String or Map</span>  
+If you specify a string, Copilot interprets it as the path to your Dockerfile. It will assume that the dirname of the string you specify should be the build context. The manifest:
+```yaml
+image:
+  build: path/to/dockerfile
+```
+will result in the following call to docker build: `$ docker build --file path/to/dockerfile path/to`
+
+You can also specify build as a map:
+```yaml
+image:
+  build:
+    dockerfile: path/to/dockerfile
+    context: context/dir
+    target: build-stage
+    cache_from:
+      - image:tag
+    args:
+      key: value
+```
+In this case, Copilot will use the context directory you specified and convert the key-value pairs under args to --build-arg overrides. The equivalent docker build call will be:
+`$ docker build --file path/to/dockerfile --target build-stage --cache-from image:tag --build-arg key=value context/dir`.
+
+You can omit fields and Copilot will do its best to understand what you mean. For example, if you specify `context` but not `dockerfile`, Copilot will run Docker in the context directory and assume that your Dockerfile is named "Dockerfile." If you specify `dockerfile` but no `context`, Copilot assumes you want to run Docker in the directory that contains `dockerfile`.
+
+All paths are relative to your workspace root.
+
+<span class="parent-field">image.</span><a id="image-location" href="#image-location" class="field">`location`</a> <span class="type">String</span>  
+Instead of building a container from a Dockerfile, you can specify an existing image name. Mutually exclusive with [`image.build`](#image-build).
+
+!!! note
+    Only public images stored in [Amazon ECR Public](https://docs.aws.amazon.com/AmazonECR/latest/public/public-repositories.html) is available with AWS App Runner.
+
+<span class="parent-field">image.</span><a id="image-port" href="#image-port" class="field">`port`</a> <span class="type">Integer</span>  
+The port exposed in your Dockerfile. Copilot should parse this value for you from your `EXPOSE` instruction.
 
 <div class="separator"></div>  
 

--- a/site/content/docs/overview.en.md
+++ b/site/content/docs/overview.en.md
@@ -1,6 +1,7 @@
 Welcome to the AWS Copilot CLI 🎉
 
-The Copilot CLI is a tool for developers to build, release, and operate production-ready containerized applications on Amazon ECS and AWS Fargate.   
+The Copilot CLI is a tool for developers to build, release, and operate production-ready containerized applications on 
+AWS App Runner, Amazon ECS, and AWS Fargate.   
 From getting started, pushing to staging, and releasing to production, Copilot can help manage the entire lifecycle of your application development.
 
 ## Installing

--- a/site/overrides/layouts/home.html
+++ b/site/overrides/layouts/home.html
@@ -309,7 +309,7 @@
         <div>
           <h1>Your toolkit for containerized applications on AWS</h1>
           <p>AWS Copilot is an open source command line interface that makes it easy for developers to <span class="em">build</span>, 
-            <span class="em">release</span>, and <span class="em">operate</span> production ready containerized applications on Amazon ECS and AWS Fargate.
+            <span class="em">release</span>, and <span class="em">operate</span> production ready containerized applications on AWS App Runner, Amazon ECS, and AWS Fargate.
           </p>
           <a
             href="docs/overview/"
@@ -346,7 +346,9 @@
               application using best practices on AWS from a Dockerfile. 
             </p>
             <p>
-              Instead of modeling individual resources, Copilot provides common cloud architectures: <a href="docs/concepts/services/#load-balanced-web-service">Load Balanced Web Service</a>, 
+              Instead of modeling individual resources, Copilot provides common cloud architectures:
+              <a href="docs/concepts/services/#request-driven-web-service">Request-Driven Web Service</a>,
+              <a href="docs/concepts/services/#load-balanced-web-service">Load Balanced Web Service</a>,
               <a href="docs/concepts/services/#backend-service">Backend Service</a>, <a href="docs/concepts/jobs/">Scheduled Job</a> and generates the necessary infrastructure from that.
               Focus your time on writing business logic instead of connecting AWS resources.
             </p>
@@ -507,7 +509,7 @@
             <p>
               Modeling, provisioning, and deploying services are only part of the application lifecycle for the developer. 
               Copilot also supports workflows around troubleshooting and debugging to help when things go wrong. <a href="docs/commands/svc-logs/">Tail
-              your logs</a> or <a href="docs/commands/svc-status/">view the health</a> of your services 
+              your logs</a>, <a href="docs/commands/svc-exec">get a shell</a> to a running container, <a href="docs/commands/svc-status/">view the health</a> of your services
               from the comfort of your terminal.
             </p>
           </div>
@@ -537,6 +539,22 @@
                   <h5>Run tasks</h5>
                   <p>
                     Run one-off tasks for operational workloads.
+                  </p>
+                </div>
+              </div>
+            </a>
+
+            <a class="card-wrapper" href="docs/commands/svc-exec/">
+              <div class="card">
+                <div class="logo">
+                  <span class="twemoji">
+                    {% include ".icons/octicons/terminal-24.svg" %}
+                  </span>
+                </div>
+                <div class="card-content">
+                  <h5>Exec</h5>
+                  <p>
+                    Run commands in or get a shell to a container running on AWS Fargate.
                   </p>
                 </div>
               </div>


### PR DESCRIPTION
We also add a Dockerfile and a make target: `make site-local` so that everyone on the team can easily spin up the website locally.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
