### PR TITLE
chore(cli): add alias validation for app version

### DIFF
--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -422,7 +422,7 @@ func (o *deploySvcOpts) stackConfiguration(addonsURL string) (cloudformation.Sta
 	case *manifest.LoadBalancedWebService:
 		if err := o.validateAppVersion(t); err != nil {
 			log.Errorf(`Cannot deploy service %s because the application version is incompatible.
-To upgrade the application, please use the application credentials to run %s first (see https://aws.github.io/copilot-cli/docs/credentials/#application-credentials).
+To upgrade the application, please run %s first (see https://aws.github.io/copilot-cli/docs/credentials/#application-credentials).
 `, aws.StringValue(t.Name),
 				color.HighlightCode("copilot app upgrade"))
 			return nil, err
@@ -467,7 +467,7 @@ func (o *deploySvcOpts) validateAppVersion(svc *manifest.LoadBalancedWebService)
 		}
 		diff := semver.Compare(appVersion, deploy.AliasLeastAppTemplateVersion)
 		if diff < 0 {
-			return fmt.Errorf("cannot enable https alias: the application version should be at least %s", deploy.AliasLeastAppTemplateVersion)
+			return fmt.Errorf(`enable "http.alias": the application version should be at least %s`, deploy.AliasLeastAppTemplateVersion)
 		}
 	}
 	return nil

--- a/internal/pkg/cli/svc_deploy_test.go
+++ b/internal/pkg/cli/svc_deploy_test.go
@@ -9,8 +9,10 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
 	addon "github.com/aws/copilot-cli/internal/pkg/addon"
 	"github.com/aws/copilot-cli/internal/pkg/config"
+	"github.com/aws/copilot-cli/internal/pkg/deploy"
 	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation/stack"
 	"github.com/aws/copilot-cli/internal/pkg/exec"
 	"github.com/aws/copilot-cli/internal/pkg/manifest"
@@ -467,11 +469,11 @@ func TestSvcDeployOpts_pushAddonsTemplateToS3Bucket(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
-			mockProjectSvc := mocks.NewMockstore(ctrl)
-			mockProjectResourcesGetter := mocks.NewMockappResourcesGetter(ctrl)
+			mockAppSvc := mocks.NewMockstore(ctrl)
+			mockAppResourcesGetter := mocks.NewMockappResourcesGetter(ctrl)
 			mockS3Svc := mocks.NewMockartifactUploader(ctrl)
 			mockAddons := mocks.NewMocktemplater(ctrl)
-			tc.mockAppResourcesGetter(mockProjectResourcesGetter)
+			tc.mockAppResourcesGetter(mockAppResourcesGetter)
 			tc.mockS3Svc(mockS3Svc)
 			tc.mockAddons(mockAddons)
 
@@ -479,8 +481,8 @@ func TestSvcDeployOpts_pushAddonsTemplateToS3Bucket(t *testing.T) {
 				deployWkldVars: deployWkldVars{
 					name: tc.inputSvc,
 				},
-				store:             mockProjectSvc,
-				appCFN:            mockProjectResourcesGetter,
+				store:             mockAppSvc,
+				appCFN:            mockAppResourcesGetter,
 				addons:            mockAddons,
 				s3:                mockS3Svc,
 				targetEnvironment: tc.inEnvironment,
@@ -493,6 +495,181 @@ func TestSvcDeployOpts_pushAddonsTemplateToS3Bucket(t *testing.T) {
 				require.EqualError(t, gotErr, tc.wantErr.Error())
 			} else {
 				require.Equal(t, tc.wantPath, gotPath)
+			}
+		})
+	}
+}
+
+func TestSvcDeployOpts_stackConfiguration(t *testing.T) {
+	mockError := errors.New("some error")
+	const (
+		mockAppName   = "mockApp"
+		mockEnvName   = "mockEnv"
+		mockSvcName   = "mockSvc"
+		mockAddonsURL = "mockAddonsURL"
+	)
+	tests := map[string]struct {
+		inAlias        string
+		inApp          *config.Application
+		inEnvironment  *config.Environment
+		inBuildRequire bool
+
+		mockWorkspace          func(m *mocks.MockwsSvcDirReader)
+		mockAppResourcesGetter func(m *mocks.MockappResourcesGetter)
+		mockAppVersionGetter   func(m *mocks.MockversionGetter)
+
+		wantErr error
+	}{
+		"fail to read service manifest": {
+			mockWorkspace: func(m *mocks.MockwsSvcDirReader) {
+				m.EXPECT().ReadServiceManifest(mockSvcName).Return(nil, mockError)
+			},
+			mockAppResourcesGetter: func(m *mocks.MockappResourcesGetter) {},
+			mockAppVersionGetter:   func(m *mocks.MockversionGetter) {},
+			wantErr:                fmt.Errorf("read service %s manifest file: %w", mockSvcName, mockError),
+		},
+		"fail to get app resources": {
+			inBuildRequire: true,
+			inEnvironment: &config.Environment{
+				Name:   mockEnvName,
+				Region: "us-west-2",
+			},
+			inApp: &config.Application{
+				Name: mockAppName,
+			},
+			mockWorkspace: func(m *mocks.MockwsSvcDirReader) {
+				m.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
+			},
+			mockAppResourcesGetter: func(m *mocks.MockappResourcesGetter) {
+				m.EXPECT().GetAppResourcesByRegion(&config.Application{
+					Name: mockAppName,
+				}, "us-west-2").Return(nil, mockError)
+			},
+			mockAppVersionGetter: func(m *mocks.MockversionGetter) {},
+			wantErr:              fmt.Errorf("get application %s resources from region us-west-2: %w", mockAppName, mockError),
+		},
+		"cannot to find ECR repo": {
+			inBuildRequire: true,
+			inEnvironment: &config.Environment{
+				Name:   mockEnvName,
+				Region: "us-west-2",
+			},
+			inApp: &config.Application{
+				Name:      mockAppName,
+				AccountID: "1234567890",
+			},
+			mockWorkspace: func(m *mocks.MockwsSvcDirReader) {
+				m.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
+			},
+			mockAppResourcesGetter: func(m *mocks.MockappResourcesGetter) {
+				m.EXPECT().GetAppResourcesByRegion(&config.Application{
+					Name:      mockAppName,
+					AccountID: "1234567890",
+				}, "us-west-2").Return(&stack.AppRegionalResources{
+					RepositoryURLs: map[string]string{},
+				}, nil)
+			},
+			mockAppVersionGetter: func(m *mocks.MockversionGetter) {},
+			wantErr:              fmt.Errorf("ECR repository not found for service mockSvc in region us-west-2 and account 1234567890"),
+		},
+		"fail to get app version": {
+			inEnvironment: &config.Environment{
+				Name:   mockEnvName,
+				Region: "us-west-2",
+			},
+			inApp: &config.Application{
+				Name: mockAppName,
+			},
+			mockWorkspace: func(m *mocks.MockwsSvcDirReader) {
+				m.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
+			},
+			mockAppResourcesGetter: func(m *mocks.MockappResourcesGetter) {},
+			mockAppVersionGetter: func(m *mocks.MockversionGetter) {
+				m.EXPECT().Version().Return("", mockError)
+			},
+			wantErr: fmt.Errorf("get version for app %s: %w", mockAppName, mockError),
+		},
+		"fail to enable https alias because of incompatible app version": {
+			inAlias: "mockAlias",
+			inEnvironment: &config.Environment{
+				Name:   mockEnvName,
+				Region: "us-west-2",
+			},
+			inApp: &config.Application{
+				Name:   mockAppName,
+				Domain: "mockDomain",
+			},
+			mockWorkspace: func(m *mocks.MockwsSvcDirReader) {
+				m.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
+			},
+			mockAppResourcesGetter: func(m *mocks.MockappResourcesGetter) {},
+			mockAppVersionGetter: func(m *mocks.MockversionGetter) {
+				m.EXPECT().Version().Return("v0.0.0", nil)
+			},
+			wantErr: fmt.Errorf("enabling https alias requires the application version to be at least %s", deploy.AliasLeastAppTemplateVersion),
+		},
+		"success": {
+			inEnvironment: &config.Environment{
+				Name:   mockEnvName,
+				Region: "us-west-2",
+			},
+			inApp: &config.Application{
+				Name: mockAppName,
+			},
+			mockWorkspace: func(m *mocks.MockwsSvcDirReader) {
+				m.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
+			},
+			mockAppResourcesGetter: func(m *mocks.MockappResourcesGetter) {},
+			mockAppVersionGetter: func(m *mocks.MockversionGetter) {
+				m.EXPECT().Version().Return("v1.0.0", nil)
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockWorkspace := mocks.NewMockwsSvcDirReader(ctrl)
+			mockAppResourcesGetter := mocks.NewMockappResourcesGetter(ctrl)
+			mockAppVersionGetter := mocks.NewMockversionGetter(ctrl)
+			tc.mockWorkspace(mockWorkspace)
+			tc.mockAppResourcesGetter(mockAppResourcesGetter)
+			tc.mockAppVersionGetter(mockAppVersionGetter)
+
+			opts := deploySvcOpts{
+				deployWkldVars: deployWkldVars{
+					name:    mockSvcName,
+					appName: mockAppName,
+					envName: mockEnvName,
+				},
+				ws:                mockWorkspace,
+				buildRequired:     tc.inBuildRequire,
+				appCFN:            mockAppResourcesGetter,
+				appVersionGetter:  mockAppVersionGetter,
+				targetApp:         tc.inApp,
+				targetEnvironment: tc.inEnvironment,
+				unmarshal: func(b []byte) (interface{}, error) {
+					return &manifest.LoadBalancedWebService{
+						Workload: manifest.Workload{
+							Name: aws.String(mockSvcName),
+						},
+						LoadBalancedWebServiceConfig: manifest.LoadBalancedWebServiceConfig{
+							RoutingRule: manifest.RoutingRule{
+								Alias: aws.String(tc.inAlias),
+							},
+						},
+					}, nil
+				},
+			}
+
+			_, gotErr := opts.stackConfiguration(mockAddonsURL)
+
+			if gotErr != nil {
+				require.EqualError(t, gotErr, tc.wantErr.Error())
+			} else {
+				require.Equal(t, tc.wantErr, gotErr)
 			}
 		})
 	}

--- a/internal/pkg/cli/svc_deploy_test.go
+++ b/internal/pkg/cli/svc_deploy_test.go
@@ -608,7 +608,7 @@ func TestSvcDeployOpts_stackConfiguration(t *testing.T) {
 			mockAppVersionGetter: func(m *mocks.MockversionGetter) {
 				m.EXPECT().Version().Return("v0.0.0", nil)
 			},
-			wantErr: fmt.Errorf("cannot enable https alias: the application version should be at least %s", deploy.AliasLeastAppTemplateVersion),
+			wantErr: fmt.Errorf(`enable "http.alias": the application version should be at least %s`, deploy.AliasLeastAppTemplateVersion),
 		},
 		"success": {
 			inEnvironment: &config.Environment{

--- a/internal/pkg/cli/svc_deploy_test.go
+++ b/internal/pkg/cli/svc_deploy_test.go
@@ -573,12 +573,14 @@ func TestSvcDeployOpts_stackConfiguration(t *testing.T) {
 			wantErr:              fmt.Errorf("ECR repository not found for service mockSvc in region us-west-2 and account 1234567890"),
 		},
 		"fail to get app version": {
+			inAlias: "mockAlias",
 			inEnvironment: &config.Environment{
 				Name:   mockEnvName,
 				Region: "us-west-2",
 			},
 			inApp: &config.Application{
-				Name: mockAppName,
+				Name:   mockAppName,
+				Domain: "mockDomain",
 			},
 			mockWorkspace: func(m *mocks.MockwsSvcDirReader) {
 				m.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
@@ -606,7 +608,7 @@ func TestSvcDeployOpts_stackConfiguration(t *testing.T) {
 			mockAppVersionGetter: func(m *mocks.MockversionGetter) {
 				m.EXPECT().Version().Return("v0.0.0", nil)
 			},
-			wantErr: fmt.Errorf("enabling https alias requires the application version to be at least %s", deploy.AliasLeastAppTemplateVersion),
+			wantErr: fmt.Errorf("cannot enable https alias: the application version should be at least %s", deploy.AliasLeastAppTemplateVersion),
 		},
 		"success": {
 			inEnvironment: &config.Environment{
@@ -614,15 +616,14 @@ func TestSvcDeployOpts_stackConfiguration(t *testing.T) {
 				Region: "us-west-2",
 			},
 			inApp: &config.Application{
-				Name: mockAppName,
+				Name:   mockAppName,
+				Domain: "mockDomain",
 			},
 			mockWorkspace: func(m *mocks.MockwsSvcDirReader) {
 				m.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
 			},
 			mockAppResourcesGetter: func(m *mocks.MockappResourcesGetter) {},
-			mockAppVersionGetter: func(m *mocks.MockversionGetter) {
-				m.EXPECT().Version().Return("v1.0.0", nil)
-			},
+			mockAppVersionGetter:   func(m *mocks.MockversionGetter) {},
 		},
 	}
 

--- a/internal/pkg/deploy/app.go
+++ b/internal/pkg/deploy/app.go
@@ -21,4 +21,6 @@ const (
 	LegacyAppTemplateVersion = "v0.0.0"
 	// LatestAppTemplateVersion is the latest version number available for application templates.
 	LatestAppTemplateVersion = "v1.0.1"
+	// AliasLeastAppTemplateVersion is the least version number available for HTTPS alias.
+	AliasLeastAppTemplateVersion = "v1.0.0"
 )


### PR DESCRIPTION
<!-- Provide summary of changes -->
Part of #1188. Add alias validation for `svc deploy`, making sure the app version is compatible before deploying the service.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
