### PR TITLE
chore(cicd): change CodeCommit default branch to 'main'

### DIFF
--- a/internal/pkg/cli/pipeline_init.go
+++ b/internal/pkg/cli/pipeline_init.go
@@ -55,7 +55,7 @@ const (
 	// For a CodeCommit repository.
 	awsURL          = "aws.amazon.com"
 	ccIdentifier    = "codecommit"
-	defaultCCBranch = "master"
+	defaultCCBranch = "main"
 	fmtCCRepoURL    = "https://%s.console.%s/codesuite/codecommit/repositories/%s/browse" // Ex: "https://region.console.aws.amazon.com/codesuite/codecommit/repositories/repoName/browse"
 	// For a Bitbucket repository.
 	bbURL           = "bitbucket.org"

--- a/internal/pkg/cli/pipeline_init_test.go
+++ b/internal/pkg/cli/pipeline_init_test.go
@@ -245,7 +245,7 @@ func TestInitPipelineOpts_Ask(t *testing.T) {
 
 			expectedRepoURL:          codecommitSSHURL,
 			expectedRepoName:         codecommitAnotherRepoName,
-			expectedRepoBranch:       "master",
+			expectedRepoBranch:       "main",
 			expectedCodeCommitRegion: codecommitRegion,
 			expectedEnvironments:     []string{"test", "prod"},
 			expectedError:            nil,

--- a/internal/pkg/deploy/cloudformation/cc_pipeline_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/cc_pipeline_integration_test.go
@@ -208,7 +208,7 @@ func TestCCPipelineCreation(t *testing.T) {
 			Name:    pipelineStackName,
 			Source: &deploy.CodeCommitSource{
 				ProviderName:  manifest.CodeCommitProviderName,
-				Branch:        "master",
+				Branch:        "main",
 				RepositoryURL: "https://us-west-2.console.aws.amazon.com/codesuite/codecommit/repositories/repo-name/browse",
 			},
 			Build: deploy.PipelineBuildFromManifest(nil),

--- a/internal/pkg/deploy/cloudformation/stack/cc_pipeline_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/cc_pipeline_integration_test.go
@@ -26,7 +26,7 @@ func TestCC_Pipeline_Template(t *testing.T) {
 		Source: &deploy.CodeCommitSource{
 			ProviderName:  manifest.CodeCommitProviderName,
 			RepositoryURL: "https://us-west-2.console.aws.amazon.com/codesuite/codecommit/repositories/aws-sample/browse",
-			Branch:        "master",
+			Branch:        "main",
 		},
 		Build: deploy.PipelineBuildFromManifest(nil),
 		Stages: []deploy.PipelineStage{

--- a/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/cc_template.yaml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/cc_template.yaml
@@ -243,7 +243,7 @@ Resources:
                 Provider: CodeCommit
               Configuration:
                 RepositoryName: aws-sample
-                BranchName: master
+                BranchName: main
               OutputArtifacts:
                 - Name: SCCheckoutArtifact
               RunOrder: 1

--- a/internal/pkg/manifest/pipeline_test.go
+++ b/internal/pkg/manifest/pipeline_test.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	defaultGHBranch = "main"
-	defaultCCBranch = "master"
+	defaultCCBranch = "main"
 )
 
 func TestNewProvider(t *testing.T) {

--- a/site/content/docs/manifest/pipeline.en.md
+++ b/site/content/docs/manifest/pipeline.en.md
@@ -53,7 +53,7 @@ The name of AWS Secrets Manager secret that holds the GitHub access token to tri
     As of AWS Copilot v1.4.0, the access token is no longer needed for GitHub repository sources. Instead, Copilot will trigger the pipeline [using AWS CodeStar connections](https://docs.aws.amazon.com/codepipeline/latest/userguide/update-github-action-connections.html).
 
 <span class="parent-field">source.properties.</span><a id="source-properties-branch" href="#source-properties-branch" class="field">`branch`</a> <span class="type">String</span>  
-The name of the branch in your repository that triggers the pipeline. The default for GitHub is `main`; the default for Bitbucket and CodeCommit is `master`.
+The name of the branch in your repository that triggers the pipeline. The default for GitHub and CodeCommit is `main`; the default for Bitbucket is `master`.
 
 <span class="parent-field">source.properties.</span><a id="source-properties-repository" href="#source-properties-repository" class="field">`repository`</a> <span class="type">String</span>  
 The URL of your repository.

--- a/site/content/docs/manifest/pipeline.ja.md
+++ b/site/content/docs/manifest/pipeline.ja.md
@@ -54,7 +54,7 @@ Pipeline をトリガーするための GitHub アクセストークンを保持
     Copilot v1.4.0 から GitHub リポジトリをソースにする場合のアクセストークンは不要になりました。代わりに Copilot は [AWS CodeStar の GitHub への接続](https://docs.aws.amazon.com/ja_jp/codepipeline/latest/userguide/update-github-action-connections.html)を使って Pipeline をトリガーします。
 
 <span class="parent-field">source.properties.</span><a id="source-properties-branch" href="#source-properties-branch" class="field">`branch`</a> <span class="type">String</span>  
-Pipeline をトリガーするリポジトリのブランチ名。 GitHub の場合デフォルトは `main` で Bitbucket と CodeCommit の場合デフォルトは `master` です。
+Pipeline をトリガーするリポジトリのブランチ名。 GitHub と CodeCommit の場合デフォルトは `main` で Bitbucket の場合デフォルトは `master` です。
 
 <span class="parent-field">source.properties.</span><a id="source-properties-repository" href="#source-properties-repository" class="field">`repository`</a> <span class="type">String</span>  
 リポジトリの URL 。


### PR DESCRIPTION
<!-- Provide summary of changes -->
The default branch for new CodeCommit repositories is 'main'. This PR reflects that.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
