### PR TITLE
docs: Fix sidecars admonitions format

### DIFF
--- a/site/content/docs/developing/sidecars.en.md
+++ b/site/content/docs/developing/sidecars.en.md
@@ -9,7 +9,7 @@ If you have defined an EFS volume for your main container through the [`storage`
 There are two ways of adding sidecars using the Copilot manifest: by specifying [general sidecars](#general-sidecars) or by using [sidecar patterns](#sidecar-patterns).
 
 !!! Attention
-  Sidecars are not supported for Request-Driven Web Services
+    Sidecars are not supported for Request-Driven Web Services
 
 ### General sidecars
 You'll need to provide the URL for the sidecar image. Optionally, you can specify the port you'd like to expose and the credential parameter for [private registry](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/private-auth.html).


### PR DESCRIPTION
This PR fix admonition format in sidercar page.
https://aws.github.io/copilot-cli/en/docs/developing/sidecars/

| Before | After |
| --- | --- |
| ![スクリーンショット 2021-05-26 23 26 10](https://user-images.githubusercontent.com/5207601/119678944-ef98fb00-be7a-11eb-98a5-09edab277583.png) | ![スクリーンショット 2021-05-26 23 30 53](https://user-images.githubusercontent.com/5207601/119678956-f293eb80-be7a-11eb-878a-0bb948a2e4ae.png) |


> The content of the block then follows on the next line, indented by four spaces.
> ref: https://squidfunk.github.io/mkdocs-material/reference/admonitions/

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
