### PR TITLE
docs: link to custom env page from manifest pages and reroute link from commands/env-init

### DIFF
--- a/site/content/docs/commands/env-init.en.md
+++ b/site/content/docs/commands/env-init.en.md
@@ -6,7 +6,7 @@ $ copilot env init [flags]
 ## What does it do?
 `copilot env init` creates a new [environment](../concepts/environments.en.md) where your services will live.
 
-After you answer the questions, the CLI creates the common infrastructure that's shared between your services such as a VPC, an Application Load Balancer, and an ECS Cluster. Additionally, you can [customize your Copilot environment](../concepts/environments.en.md#customize-your-environment) by either configuring the default environment resources or importing existing resources for your environment.
+After you answer the questions, the CLI creates the common infrastructure that's shared between your services such as a VPC, an Application Load Balancer, and an ECS Cluster. Additionally, you can [customize your Copilot environment](../developing/custom-environment-resources.en.md) by either configuring the default environment resources or importing existing resources for your environment.
 
 You create environments using a [named profile](../credentials.en.md#environment-credentials) to specify which AWS account and region you'd like the environment to be in.
 

--- a/site/content/docs/include/common-svc-fields.en.md
+++ b/site/content/docs/include/common-svc-fields.en.md
@@ -118,7 +118,7 @@ Subnets and security groups attached to your tasks.
 Must be one of `'public'` or `'private'`. Defaults to launching your tasks in public subnets.
 
 !!! info
-    If you launch tasks in `'private'` subnets and use a Copilot-generated VPC, Copilot will automatically add NAT Gateways to your environment for internet connectivity. Alternatively, when running `copilot env init`, you can import an existing VPC with NAT Gateways, or one with VPC endpoints for isolated workloads. See our [custom environment resources](../developing/custom-environment-resources.en.md) page for more.
+    If you launch tasks in `'private'` subnets and use a Copilot-generated VPC, Copilot will automatically add NAT Gateways to your environment for internet connectivity. (See [pricing](https://aws.amazon.com/vpc/pricing/).) Alternatively, when running `copilot env init`, you can import an existing VPC with NAT Gateways, or one with VPC endpoints for isolated workloads. See our [custom environment resources](../developing/custom-environment-resources.en.md) page for more.
 
 <span class="parent-field">network.vpc.</span><a id="network-vpc-security-groups" href="#network-vpc-security-groups" class="field">`security_groups`</a> <span class="type">Array of Strings</span>  
 Additional security group IDs associated with your tasks. Copilot always includes a security group so containers within your environment

--- a/site/content/docs/include/common-svc-fields.en.md
+++ b/site/content/docs/include/common-svc-fields.en.md
@@ -118,7 +118,7 @@ Subnets and security groups attached to your tasks.
 Must be one of `'public'` or `'private'`. Defaults to launching your tasks in public subnets.
 
 !!! info
-    If you launch tasks in `'private'` subnets and use a Copilot-generated VPC, Copilot will add NAT Gateways to your environment. Alternatively, you can import a VPC with NAT Gateways when running `copilot env init` for internet connectivity.
+    If you launch tasks in `'private'` subnets and use a Copilot-generated VPC, Copilot will automatically add NAT Gateways to your environment for internet connectivity. Alternatively, when running `copilot env init`, you can import an existing VPC with NAT Gateways, or one with VPC endpoints for isolated workloads. See our [custom environment resources](../developing/custom-environment-resources.en.md) page for more.
 
 <span class="parent-field">network.vpc.</span><a id="network-vpc-security-groups" href="#network-vpc-security-groups" class="field">`security_groups`</a> <span class="type">Array of Strings</span>  
 Additional security group IDs associated with your tasks. Copilot always includes a security group so containers within your environment

--- a/site/content/docs/manifest/scheduled-job.en.md
+++ b/site/content/docs/manifest/scheduled-job.en.md
@@ -148,7 +148,7 @@ Subnets and security groups attached to your tasks.
 Must be one of `'public'` or `'private'`. Defaults to launching your tasks in public subnets.
 
 !!! info
-    If you launch tasks in `'private'` subnets and use a Copilot-generated VPC, Copilot will add NAT Gateways to your environment. Alternatively, you can import a VPC with NAT Gateways when running `copilot env init` for internet connectivity.
+    If you launch tasks in `'private'` subnets and use a Copilot-generated VPC, Copilot will automatically add NAT Gateways to your environment for internet connectivity. Alternatively, when running `copilot env init`, you can import an existing VPC with NAT Gateways, or one with VPC endpoints for isolated workloads. See our [custom environment resources](../developing/custom-environment-resources.en.md) page for more.
 
 <span class="parent-field">network.vpc.</span><a id="network-vpc-security-groups" href="#network-vpc-security-groups" class="field">`security_groups`</a> <span class="type">Array of Strings</span>  
 Additional security group IDs associated with your tasks. Copilot always includes a security group so containers within your environment

--- a/site/content/docs/manifest/scheduled-job.en.md
+++ b/site/content/docs/manifest/scheduled-job.en.md
@@ -148,7 +148,7 @@ Subnets and security groups attached to your tasks.
 Must be one of `'public'` or `'private'`. Defaults to launching your tasks in public subnets.
 
 !!! info
-    If you launch tasks in `'private'` subnets and use a Copilot-generated VPC, Copilot will automatically add NAT Gateways to your environment for internet connectivity. Alternatively, when running `copilot env init`, you can import an existing VPC with NAT Gateways, or one with VPC endpoints for isolated workloads. See our [custom environment resources](../developing/custom-environment-resources.en.md) page for more.
+    If you launch tasks in `'private'` subnets and use a Copilot-generated VPC, Copilot will automatically add NAT Gateways to your environment for internet connectivity. (See [pricing](https://aws.amazon.com/vpc/pricing/).) Alternatively, when running `copilot env init`, you can import an existing VPC with NAT Gateways, or one with VPC endpoints for isolated workloads. See our [custom environment resources](../developing/custom-environment-resources.en.md) page for more.
 
 <span class="parent-field">network.vpc.</span><a id="network-vpc-security-groups" href="#network-vpc-security-groups" class="field">`security_groups`</a> <span class="type">Array of Strings</span>  
 Additional security group IDs associated with your tasks. Copilot always includes a security group so containers within your environment


### PR DESCRIPTION
This links readers straight to the new custom env page from commands/env-init, rather than to concepts/environments, which then links to the custom env page.

This PR also adds links to that page from the relevant manifest pages.

Related #2386.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
