### PR TITLE
chore(lambda): fix svc delete failure if alias enabled for multiple deployments

### DIFF
--- a/cf-custom-resources/lib/dns-cert-validator.js
+++ b/cf-custom-resources/lib/dns-cert-validator.js
@@ -14,6 +14,7 @@ let waiter;
 let sleep = defaultSleep;
 let random = Math.random;
 let maxAttempts = 10;
+let domainTypes;
 
 /**
  * Upload a CloudFormation response object to S3.
@@ -85,36 +86,33 @@ let report = function (
  * Lastly, the function exits until the certificate is validated.
  *
  * @param {string} requestId the CloudFormation request ID
- * @param {string} appName the name of the application
- * @param {string} envName the name of the environment
- * @param {string} domainName the Common Name (CN) field for the requested certificate
- * @param {string} subjectAlternativeNames additional FQDNs to be included in the
- * Subject Alternative Name extension of the requested certificate
+ * @param {string} appName the application name
+ * @param {string} envName the environment name
+ * @param {string} certDomain the domain of the certificate
+ * @param {string} aliases the custom domain aliases
  * @param {string} envHostedZoneId the environment Route53 Hosted Zone ID
  * @param {string} rootDnsRole the IAM role ARN that can manage domainName
- * @param {string} isAliasEnabled whether alias is enabled
  * @returns {string} Validated certificate ARN
  */
 const requestCertificate = async function (
   requestId,
   appName,
   envName,
-  domainName,
-  subjectAlternativeNames,
+  certDomain,
+  aliases,
   envHostedZoneId,
   rootDnsRole,
-  isAliasEnabled,
   region
 ) {
   const crypto = require("crypto");
   const [acm, envRoute53, appRoute53] = clients(region, rootDnsRole);
-  var sansToUse =
-    isAliasEnabled === "false"
-      ? [`*.${envName}.${appName}.${domainName}`]
-      : subjectAlternativeNames;
+  const sansToUse = [`*.${certDomain}`];
+  for (const alias of aliases) {
+    sansToUse.push(alias);
+  }
   const reqCertResponse = await acm
     .requestCertificate({
-      DomainName: `${envName}.${appName}.${domainName}`,
+      DomainName: certDomain,
       SubjectAlternativeNames: sansToUse,
       IdempotencyToken: crypto
         .createHash("sha256")
@@ -170,9 +168,6 @@ const requestCertificate = async function (
   await updateHostedZoneRecords(
     "UPSERT",
     options,
-    envName,
-    appName,
-    domainName,
     envRoute53,
     appRoute53,
     envHostedZoneId
@@ -195,17 +190,15 @@ const requestCertificate = async function (
 const updateHostedZoneRecords = async function (
   action,
   options,
-  envName,
-  appName,
-  domainName,
   envRoute53,
   appRoute53,
   envHostedZoneId
 ) {
   const promises = [];
   for (const option of options) {
-    switch (option.DomainName) {
-      case `${envName}.${appName}.${domainName}`:
+    const domainType = await getDomainType(option.DomainName);
+    switch (domainType) {
+      case domainTypes.EnvDomainZone:
         promises.push(
           validateDomain({
             route53: envRoute53,
@@ -216,23 +209,23 @@ const updateHostedZoneRecords = async function (
           })
         );
         break;
-      case `${appName}.${domainName}`:
+      case domainTypes.AppDomainZone:
         promises.push(
           validateDomain({
             route53: appRoute53,
             record: option.ResourceRecord,
             action: action,
-            domainName: `${appName}.${domainName}`,
+            domainName: domainType.domain,
           })
         );
         break;
-      case domainName:
+      case domainTypes.RootDomainZone:
         promises.push(
           validateDomain({
             route53: appRoute53,
             record: option.ResourceRecord,
             action: action,
-            domainName: domainName,
+            domainName: domainType.domain,
           })
         );
         break;
@@ -250,9 +243,7 @@ const updateHostedZoneRecords = async function (
 // if there is no other certificate using the record.
 const deleteHostedZoneRecords = async function (
   options,
-  envName,
-  appName,
-  domainName,
+  certDomain,
   envRoute53,
   appRoute53,
   acm,
@@ -265,10 +256,7 @@ const deleteHostedZoneRecords = async function (
     isLegacyCert = true;
   }
 
-  const certsWithEnvDomain = await numOfGeneratedCertificates(
-    acm,
-    `${envName}.${appName}.${domainName}`
-  );
+  const certsWithEnvDomain = await numOfGeneratedCertificates(acm, certDomain);
   const isLastOne = certsWithEnvDomain === 1;
 
   const newOptions = [];
@@ -293,19 +281,28 @@ const deleteHostedZoneRecords = async function (
       // we'll remove validation CNAME records only for app and root hosted zone,
       // since the legacy cert still needs the validation record in the env hosted zone.
       for (const option of options) {
-        if (option.DomainName === `${envName}.${appName}.${domainName}`) {
+        if (option.DomainName === certDomain || option.DomainName === `*.${certDomain}`) {
           continue;
         }
         newOptions.push(option);
       }
       break;
   }
+  // Make sure DNS validation records are unique. For example: "example.com" and "*.example.com"
+  // might have the same DNS validation record.
+  const filteredOption = [];
+  var uniqueValidateRecordNames = new Set();
+  for (const option of newOptions) {
+    var id = `${option.ResourceRecord.Name} ${option.ResourceRecord.Value}`;
+    if (uniqueValidateRecordNames.has(id)) {
+      continue;
+    }
+    uniqueValidateRecordNames.add(id);
+    filteredOption.push(option);
+  }
   await updateHostedZoneRecords(
     "DELETE",
-    newOptions,
-    envName,
-    appName,
-    domainName,
+    filteredOption,
     envRoute53,
     appRoute53,
     envHostedZoneId
@@ -380,12 +377,13 @@ const validateDomain = async function ({
  * If the certificate does not exist, the function will return normally.
  *
  * @param {string} arn The certificate ARN
+ * @param {string} certDomain the domain of the certificate
+ * @param {string} envHostedZoneId the environment Route53 Hosted Zone ID
+ * @param {string} rootDnsRole the IAM role ARN that can manage domainName
  */
 const deleteCertificate = async function (
   arn,
-  appName,
-  envName,
-  domainName,
+  certDomain,
   region,
   envHostedZoneId,
   rootDnsRole
@@ -421,7 +419,6 @@ const deleteCertificate = async function (
         break;
       }
     }
-
     if (inUseByResources.length) {
       throw new Error(
         `Certificate still in use after checking for ${maxAttempts} attempts.`
@@ -430,9 +427,7 @@ const deleteCertificate = async function (
 
     await deleteHostedZoneRecords(
       options,
-      envName,
-      appName,
-      domainName,
+      certDomain,
       envRoute53,
       appRoute53,
       acm,
@@ -496,6 +491,38 @@ const updateRecords = function (
     .promise();
 };
 
+// getAllAliases gets all aliases out from a string. For example:
+// {"frontend": ["test.foobar.com", "foobar.com"], "api": ["api.foobar.com"]} will return
+// ["test.foobar.com", "foobar.com", "api.foobar.com"].
+const getAllAliases = function (aliases) {
+  let obj;
+  try {
+    obj = JSON.parse(aliases || "{}");
+  } catch (error) {
+    throw new Error(`Cannot parse ${aliases} into JSON format.`);
+  }
+  var aliasList = [];
+  for (var m in obj) {
+    aliasList.push(...obj[m]);
+  }
+  return new Set(aliasList.filter(function (itm) {
+    return getDomainType(itm) != domainTypes.OtherDomainZone;
+  }));
+};
+
+const getDomainType = function (alias) {
+  switch (true) {
+    case domainTypes.EnvDomainZone.regex.test(alias):
+      return domainTypes.EnvDomainZone;
+    case domainTypes.AppDomainZone.regex.test(alias):
+      return domainTypes.AppDomainZone;
+    case domainTypes.RootDomainZone.regex.test(alias):
+      return domainTypes.RootDomainZone;
+    default:
+      return domainTypes.OtherDomainZone;
+  }
+};
+
 const clients = function (region, rootDnsRole) {
   const acm = new aws.ACM({
     region,
@@ -522,8 +549,26 @@ exports.certificateRequestHandler = async function (event, context) {
   var physicalResourceId;
   var certificateArn;
   const props = event.ResourceProperties;
+  const [app, env, domain] = [props.AppName, props.EnvName, props.DomainName];
+  domainTypes = {
+    EnvDomainZone: {
+      regex: new RegExp(`^([^\.]+\.)?${env}.${app}.${domain}`),
+      domain: `${env}.${app}.${domain}`,
+    },
+    AppDomainZone: {
+      regex: new RegExp(`^([^\.]+\.)?${app}.${domain}`),
+      domain: `${app}.${domain}`,
+    },
+    RootDomainZone: {
+      regex: new RegExp(`^([^\.]+\.)?${domain}`),
+      domain: `${domain}`,
+    },
+    OtherDomainZone: { regex: new RegExp(`.*`) },
+  };
 
   try {
+    var certDomain = `${props.EnvName}.${props.AppName}.${props.DomainName}`;
+    var aliases = await getAllAliases(props.Aliases);
     switch (event.RequestType) {
       case "Create":
       case "Update":
@@ -531,11 +576,10 @@ exports.certificateRequestHandler = async function (event, context) {
           event.RequestId,
           props.AppName,
           props.EnvName,
-          props.DomainName,
-          props.SubjectAlternativeNames,
+          certDomain,
+          [...aliases],
           props.EnvHostedZoneId,
           props.RootDNSRole,
-          props.IsAliasEnabled,
           props.Region
         );
         responseData.Arn = physicalResourceId = certificateArn;
@@ -547,9 +591,7 @@ exports.certificateRequestHandler = async function (event, context) {
         if (physicalResourceId.startsWith("arn:")) {
           await deleteCertificate(
             physicalResourceId,
-            props.AppName,
-            props.EnvName,
-            props.DomainName,
+            certDomain,
             props.Region,
             props.EnvHostedZoneId,
             props.RootDNSRole
@@ -559,7 +601,6 @@ exports.certificateRequestHandler = async function (event, context) {
       default:
         throw new Error(`Unsupported request type ${event.RequestType}`);
     }
-
     await report(event, context, "SUCCESS", physicalResourceId, responseData);
   } catch (err) {
     console.log(`Caught error ${err}.`);

--- a/cf-custom-resources/lib/dns-cert-validator.js
+++ b/cf-custom-resources/lib/dns-cert-validator.js
@@ -564,7 +564,7 @@ exports.certificateRequestHandler = async function (event, context) {
       regex: new RegExp(`^([^\.]+\.)?${domain}`),
       domain: `${domain}`,
     },
-    OtherDomainZone: { regex: new RegExp(`.*`) },
+    OtherDomainZone: {},
   };
 
   try {
@@ -577,7 +577,7 @@ exports.certificateRequestHandler = async function (event, context) {
           props.AppName,
           props.EnvName,
           certDomain,
-          [...aliases],
+          aliases,
           props.EnvHostedZoneId,
           props.RootDNSRole,
           props.Region
@@ -605,7 +605,7 @@ exports.certificateRequestHandler = async function (event, context) {
           props.AppName,
           props.EnvName,
           certDomain,
-          [...aliases],
+          aliases,
           props.EnvHostedZoneId,
           props.RootDNSRole,
           props.Region

--- a/cf-custom-resources/test/dns-cert-validator-test.js
+++ b/cf-custom-resources/test/dns-cert-validator-test.js
@@ -18,13 +18,11 @@ describe("DNS Validated Certificate Handler", () => {
   const testHostedZoneId = "Z3P5QSUBK4POTI";
   const testAppHostedZoneId = "K4POTIZ3P5QSUB";
   const testRootDNSRole = "mockRole";
-  const testSubjectAlternativeNames = [
-    "example.com",
-    "*.example.com",
-    "myapp.example.com",
-    "*.myapp.example.com",
-    "*.test.myapp.example.com",
-  ];
+  const testAliases = `{
+    "frontend": ["v1.${testAppName}.${testDomainName}", "foobar.com"],
+    "backend": ["v2.${testDomainName}"]
+  }`;
+  const testSANs = ["*.test.myapp.example.com", "v1.myapp.example.com", "v2.example.com"];
   const testCopilotTags = [
     { Key: "copilot-application", Value: testAppName },
     { Key: "copilot-environment", Value: testEnvName },
@@ -32,11 +30,13 @@ describe("DNS Validated Certificate Handler", () => {
   const testCertificateArn =
     "arn:aws:acm:region:123456789012:certificate/12345678-1234-1234-1234-123456789012";
   const testRRName = "_3639ac514e785e898d2646601fa951d5.example.com";
-  const testRRValue = "_x2.acm-validations.aws";
+  const testRRValue1 = "_x1.acm-validations.aws";
+  const testRRValue2 = "_x2.acm-validations.aws";
+  const testRRValue3 = "_x3.acm-validations.aws";
   const spySleep = sinon.spy(function (ms) {
     return Promise.resolve();
   });
-  const testDeleteRecordChangebatch = {
+  const testDeleteRecordChangebatch1 = {
     Changes: [
       {
         Action: "DELETE",
@@ -46,14 +46,48 @@ describe("DNS Validated Certificate Handler", () => {
           TTL: 60,
           ResourceRecords: [
             {
-              Value: testRRValue,
+              Value: testRRValue1,
             },
           ],
         },
       },
     ],
   };
-  const testUpsertRecordChangebatch = {
+  const testDeleteRecordChangebatch2 = {
+    Changes: [
+      {
+        Action: "DELETE",
+        ResourceRecordSet: {
+          Name: testRRName,
+          Type: "CNAME",
+          TTL: 60,
+          ResourceRecords: [
+            {
+              Value: testRRValue2,
+            },
+          ],
+        },
+      },
+    ],
+  };
+  const testDeleteRecordChangebatch3 = {
+    Changes: [
+      {
+        Action: "DELETE",
+        ResourceRecordSet: {
+          Name: testRRName,
+          Type: "CNAME",
+          TTL: 60,
+          ResourceRecords: [
+            {
+              Value: testRRValue3,
+            },
+          ],
+        },
+      },
+    ],
+  };
+  const testUpsertRecordChangebatch1 = {
     Changes: [
       {
         Action: "UPSERT",
@@ -63,7 +97,41 @@ describe("DNS Validated Certificate Handler", () => {
           TTL: 60,
           ResourceRecords: [
             {
-              Value: testRRValue,
+              Value: testRRValue1,
+            },
+          ],
+        },
+      },
+    ],
+  };
+  const testUpsertRecordChangebatch2 = {
+    Changes: [
+      {
+        Action: "UPSERT",
+        ResourceRecordSet: {
+          Name: testRRName,
+          Type: "CNAME",
+          TTL: 60,
+          ResourceRecords: [
+            {
+              Value: testRRValue2,
+            },
+          ],
+        },
+      },
+    ],
+  };
+  const testUpsertRecordChangebatch3 = {
+    Changes: [
+      {
+        Action: "UPSERT",
+        ResourceRecordSet: {
+          Name: testRRName,
+          Type: "CNAME",
+          TTL: 60,
+          ResourceRecords: [
+            {
+              Value: testRRValue3,
             },
           ],
         },
@@ -77,7 +145,7 @@ describe("DNS Validated Certificate Handler", () => {
       ResourceRecord: {
         Name: testRRName,
         Type: "CNAME",
-        Value: testRRValue,
+        Value: testRRValue1,
       },
     },
     {
@@ -86,63 +154,45 @@ describe("DNS Validated Certificate Handler", () => {
       ResourceRecord: {
         Name: testRRName,
         Type: "CNAME",
-        Value: testRRValue,
+        Value: testRRValue1,
       },
     },
   ];
   const newCertValidateOptions = [
     {
       DomainName: `${testEnvName}.${testAppName}.${testDomainName}`,
-      ValidationStatus: "SUCCESS",
+      ValidationStatus: "PENDING_VALIDATION",
       ResourceRecord: {
         Name: testRRName,
         Type: "CNAME",
-        Value: testRRValue,
+        Value: testRRValue1,
       },
     },
     {
       DomainName: `*.${testEnvName}.${testAppName}.${testDomainName}`,
-      ValidationStatus: "SUCCESS",
+      ValidationStatus: "PENDING_VALIDATION",
       ResourceRecord: {
         Name: testRRName,
         Type: "CNAME",
-        Value: testRRValue,
+        Value: testRRValue1,
       },
     },
     {
-      DomainName: `${testAppName}.${testDomainName}`,
-      ValidationStatus: "SUCCESS",
+      DomainName: `v1.${testAppName}.${testDomainName}`,
+      ValidationStatus: "PENDING_VALIDATION",
       ResourceRecord: {
         Name: testRRName,
         Type: "CNAME",
-        Value: testRRValue,
+        Value: testRRValue2,
       },
     },
     {
-      DomainName: `*.${testAppName}.${testDomainName}`,
-      ValidationStatus: "SUCCESS",
+      DomainName: `v2.${testDomainName}`,
+      ValidationStatus: "PENDING_VALIDATION",
       ResourceRecord: {
         Name: testRRName,
         Type: "CNAME",
-        Value: testRRValue,
-      },
-    },
-    {
-      DomainName: `${testDomainName}`,
-      ValidationStatus: "SUCCESS",
-      ResourceRecord: {
-        Name: testRRName,
-        Type: "CNAME",
-        Value: testRRValue,
-      },
-    },
-    {
-      DomainName: `*.${testDomainName}`,
-      ValidationStatus: "SUCCESS",
-      ResourceRecord: {
-        Name: testRRName,
-        Type: "CNAME",
-        Value: testRRValue,
+        Value: testRRValue3,
       },
     },
   ];
@@ -170,7 +220,7 @@ describe("DNS Validated Certificate Handler", () => {
     spySleep.resetHistory();
   });
 
-  test("Empty event payload fails", () => {
+  test("Empty event payload type fails", () => {
     const request = nock(ResponseURL)
       .put("/", (body) => {
         return (
@@ -180,7 +230,18 @@ describe("DNS Validated Certificate Handler", () => {
       })
       .reply(200);
     return LambdaTester(handler.certificateRequestHandler)
-      .event({})
+      .event({
+        RequestId: testRequestId,
+        ResourceProperties: {
+          AppName: testAppName,
+          EnvName: testEnvName,
+          DomainName: testDomainName,
+          EnvHostedZoneId: testHostedZoneId,
+          Aliases: testAliases,
+          Region: "us-east-1",
+          RootDNSRole: testRootDNSRole,
+        },
+      })
       .expectResolve(() => {
         expect(request.isDone()).toBe(true);
       });
@@ -199,6 +260,16 @@ describe("DNS Validated Certificate Handler", () => {
     return LambdaTester(handler.certificateRequestHandler)
       .event({
         RequestType: bogusType,
+        RequestId: testRequestId,
+        ResourceProperties: {
+          AppName: testAppName,
+          EnvName: testEnvName,
+          DomainName: testDomainName,
+          EnvHostedZoneId: testHostedZoneId,
+          Aliases: testAliases,
+          Region: "us-east-1",
+          RootDNSRole: testRootDNSRole,
+        },
       })
       .expectResolve(() => {
         expect(request.isDone()).toBe(true);
@@ -261,10 +332,9 @@ describe("DNS Validated Certificate Handler", () => {
           EnvName: testEnvName,
           DomainName: testDomainName,
           EnvHostedZoneId: testHostedZoneId,
-          IsAliasEnabled: "true",
+          Aliases: testAliases,
           Region: "us-east-1",
           RootDNSRole: testRootDNSRole,
-          SubjectAlternativeNames: testSubjectAlternativeNames,
         },
       })
       .expectResolve(() => {
@@ -278,7 +348,7 @@ describe("DNS Validated Certificate Handler", () => {
           requestCertificateFake,
           sinon.match({
             DomainName: `${testEnvName}.${testAppName}.${testDomainName}`,
-            SubjectAlternativeNames: testSubjectAlternativeNames,
+            SubjectAlternativeNames: testSANs,
             ValidationMethod: "DNS",
             Tags: testCopilotTags,
           })
@@ -286,21 +356,35 @@ describe("DNS Validated Certificate Handler", () => {
         sinon.assert.calledWith(
           changeResourceRecordSetsFake,
           sinon.match({
-            ChangeBatch: testUpsertRecordChangebatch,
+            ChangeBatch: testUpsertRecordChangebatch1,
+            HostedZoneId: testHostedZoneId,
+          })
+        );
+        sinon.assert.calledWith(
+          changeResourceRecordSetsFake,
+          sinon.match({
+            ChangeBatch: testUpsertRecordChangebatch2,
+            HostedZoneId: testHostedZoneId,
+          })
+        );
+        sinon.assert.calledWith(
+          changeResourceRecordSetsFake,
+          sinon.match({
+            ChangeBatch: testUpsertRecordChangebatch3,
             HostedZoneId: testHostedZoneId,
           })
         );
         sinon.assert.calledWith(
           listHostedZonesByNameFake,
           sinon.match({
-            DNSName: `${testAppName}.${testDomainName}`,
+            DNSName: `${testDomainName}`,
             MaxItems: "1",
           })
         );
         sinon.assert.calledWith(
           listHostedZonesByNameFake,
           sinon.match({
-            DNSName: `${testDomainName}`,
+            DNSName: `${testAppName}.${testDomainName}`,
             MaxItems: "1",
           })
         );
@@ -355,10 +439,8 @@ describe("DNS Validated Certificate Handler", () => {
           EnvName: testEnvName,
           DomainName: testDomainName,
           EnvHostedZoneId: testHostedZoneId,
-          IsAliasEnabled: "false",
           Region: "us-east-1",
           RootDNSRole: testRootDNSRole,
-          SubjectAlternativeNames: testSubjectAlternativeNames,
         },
       })
       .expectResolve(() => {
@@ -382,7 +464,7 @@ describe("DNS Validated Certificate Handler", () => {
         sinon.assert.calledWith(
           changeResourceRecordSetsFake,
           sinon.match({
-            ChangeBatch: testUpsertRecordChangebatch,
+            ChangeBatch: testUpsertRecordChangebatch1,
             HostedZoneId: testHostedZoneId,
           })
         );
@@ -426,10 +508,9 @@ describe("DNS Validated Certificate Handler", () => {
           EnvName: testEnvName,
           DomainName: testDomainName,
           EnvHostedZoneId: testHostedZoneId,
-          IsAliasEnabled: "true",
+          Aliases: testAliases,
           Region: "us-east-1",
           RootDNSRole: testRootDNSRole,
-          SubjectAlternativeNames: testSubjectAlternativeNames,
         },
       })
       .expectResolve(() => {
@@ -437,7 +518,7 @@ describe("DNS Validated Certificate Handler", () => {
           requestCertificateFake,
           sinon.match({
             DomainName: `${testEnvName}.${testAppName}.${testDomainName}`,
-            SubjectAlternativeNames: testSubjectAlternativeNames,
+            SubjectAlternativeNames: testSANs,
             ValidationMethod: "DNS",
           })
         );
@@ -485,11 +566,10 @@ describe("DNS Validated Certificate Handler", () => {
           AppName: testAppName,
           EnvName: testEnvName,
           DomainName: testDomainName,
-          IsAliasEnabled: "true",
+          Aliases: testAliases,
           EnvHostedZoneId: testHostedZoneId,
           Region: "us-east-1",
           RootDNSRole: testRootDNSRole,
-          SubjectAlternativeNames: testSubjectAlternativeNames,
         },
       })
       .expectResolve(() => {
@@ -497,7 +577,7 @@ describe("DNS Validated Certificate Handler", () => {
           requestCertificateFake,
           sinon.match({
             DomainName: `${testEnvName}.${testAppName}.${testDomainName}`,
-            SubjectAlternativeNames: testSubjectAlternativeNames,
+            SubjectAlternativeNames: testSANs,
             ValidationMethod: "DNS",
           })
         );
@@ -566,10 +646,9 @@ describe("DNS Validated Certificate Handler", () => {
           EnvName: testEnvName,
           DomainName: testDomainName,
           EnvHostedZoneId: testHostedZoneId,
-          IsAliasEnabled: "true",
+          Aliases: testAliases,
           Region: "us-east-1",
           RootDNSRole: testRootDNSRole,
-          SubjectAlternativeNames: testSubjectAlternativeNames,
         },
       })
       .expectResolve(() => {
@@ -577,7 +656,7 @@ describe("DNS Validated Certificate Handler", () => {
           requestCertificateFake,
           sinon.match({
             DomainName: `${testEnvName}.${testAppName}.${testDomainName}`,
-            SubjectAlternativeNames: testSubjectAlternativeNames,
+            SubjectAlternativeNames: testSANs,
             ValidationMethod: "DNS",
           })
         );
@@ -634,10 +713,8 @@ describe("DNS Validated Certificate Handler", () => {
           EnvName: testEnvName,
           DomainName: testDomainName,
           EnvHostedZoneId: testHostedZoneId,
-          IsAliasEnabled: "false",
           Region: "us-east-1",
           RootDNSRole: testRootDNSRole,
-          SubjectAlternativeNames: testSubjectAlternativeNames,
         },
       })
       .expectResolve(() => {
@@ -730,7 +807,7 @@ describe("DNS Validated Certificate Handler", () => {
         sinon.assert.calledWith(
           changeResourceRecordSetsFake,
           sinon.match({
-            ChangeBatch: testDeleteRecordChangebatch,
+            ChangeBatch: testDeleteRecordChangebatch1,
             HostedZoneId: testHostedZoneId,
           })
         );
@@ -880,14 +957,21 @@ describe("DNS Validated Certificate Handler", () => {
         sinon.assert.calledWith(
           changeResourceRecordSetsFake,
           sinon.match({
-            ChangeBatch: testDeleteRecordChangebatch,
+            ChangeBatch: testDeleteRecordChangebatch1,
             HostedZoneId: testHostedZoneId,
           })
         );
         sinon.assert.calledWith(
           changeResourceRecordSetsFake,
           sinon.match({
-            ChangeBatch: testDeleteRecordChangebatch,
+            ChangeBatch: testDeleteRecordChangebatch2,
+            HostedZoneId: testAppHostedZoneId,
+          })
+        );
+        sinon.assert.calledWith(
+          changeResourceRecordSetsFake,
+          sinon.match({
+            ChangeBatch: testDeleteRecordChangebatch3,
             HostedZoneId: testAppHostedZoneId,
           })
         );
@@ -915,7 +999,7 @@ describe("DNS Validated Certificate Handler", () => {
       });
   });
 
-  test("Delete operation deletes the last new cert but not the last", () => {
+  test("Delete operation deletes the new cert but not the last", () => {
     const describeCertificateFake = sinon.fake.resolves({
       Certificate: {
         CertificateArn: testCertificateArn,
@@ -991,7 +1075,14 @@ describe("DNS Validated Certificate Handler", () => {
         sinon.assert.calledWith(
           changeResourceRecordSetsFake,
           sinon.match({
-            ChangeBatch: testDeleteRecordChangebatch,
+            ChangeBatch: testDeleteRecordChangebatch2,
+            HostedZoneId: testAppHostedZoneId,
+          })
+        );
+        sinon.assert.calledWith(
+          changeResourceRecordSetsFake,
+          sinon.match({
+            ChangeBatch: testDeleteRecordChangebatch3,
             HostedZoneId: testAppHostedZoneId,
           })
         );

--- a/templates/environment/partials/custom-resources.yml
+++ b/templates/environment/partials/custom-resources.yml
@@ -33,20 +33,13 @@ HTTPSCert:
   - DelegateDNSAction
   Properties:
     ServiceToken: !GetAtt CertificateValidationFunction.Arn
-    HostedZoneId: !Ref EnvironmentHostedZone
     AppName: !Ref AppName
     EnvName: !Ref EnvironmentName
     DomainName: !Ref AppDNSName
+    Aliases: !Ref Aliases
     EnvHostedZoneId: !Ref EnvironmentHostedZone
     Region: !Ref AWS::Region
     RootDNSRole: !Ref AppDNSDelegationRole
-    IsAliasEnabled: !If [HasAliases, true, false]
-    SubjectAlternativeNames:
-    - !Sub "${AppDNSName}"
-    - !Sub "*.${AppDNSName}"
-    - !Sub "${AppName}.${AppDNSName}"
-    - !Sub "*.${AppName}.${AppDNSName}"
-    - !Sub "*.${EnvironmentName}.${AppName}.${AppDNSName}"
 
 CustomDomainAction:
   Metadata:


### PR DESCRIPTION
Previously if multiple LB service deployments enable alias in the same app, it starts to fail from the second deployment deletion. It is because previously the cert by default we create includes
```yaml
- !Sub "${AppDNSName}"
- !Sub "*.${AppDNSName}"
- !Sub "${AppName}.${AppDNSName}"
- !Sub "*.${AppName}.${AppDNSName}"
- !Sub "*.${EnvironmentName}.${AppName}.${AppDNSName}"
```
as subject alternative names for the cert, resulting multiple certs share the same DNS validation record in app hosted zone and root hosted zone. This PR fixes this behavior by making the new cert specifically for their aliases.
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
