### PR TITLE
test(e2e): add pipeline test

### DIFF
--- a/e2e/internal/client/cli.go
+++ b/e2e/internal/client/cli.go
@@ -643,10 +643,15 @@ func (cli *CLI) PipelineInit(app, url, branch string, envs []string) (string, er
 			"-e", strings.Join(envs, ",")))
 }
 
+// PipelineUpdate runs "copilot pipeline update".
+func (cli *CLI) PipelineUpdate(app string) (string, error) {
+	return cli.exec(exec.Command(cli.path, "pipeline", "update", "-a", app, "--yes"))
+}
+
 // PipelineShow runs "copilot pipeline show --json"
-func (cli *CLI) PipelineShow() (*PipelineShowOutput, error) {
+func (cli *CLI) PipelineShow(app string) (*PipelineShowOutput, error) {
 	text, err := cli.exec(
-		exec.Command(cli.path, "pipeline", "show", "--json"))
+		exec.Command(cli.path, "pipeline", "show", "-a", app, "--json"))
 	if err != nil {
 		return nil, err
 	}
@@ -658,9 +663,9 @@ func (cli *CLI) PipelineShow() (*PipelineShowOutput, error) {
 }
 
 // PipelineStatus runs "copilot pipeline status --json"
-func (cli *CLI) PipelineStatus() (*PipelineStatusOutput, error) {
+func (cli *CLI) PipelineStatus(app string) (*PipelineStatusOutput, error) {
 	text, err := cli.exec(
-		exec.Command(cli.path, "pipeline", "status", "--json"))
+		exec.Command(cli.path, "pipeline", "status", "-a", app, "--json"))
 	if err != nil {
 		return nil, err
 	}

--- a/e2e/internal/client/outputs.go
+++ b/e2e/internal/client/outputs.go
@@ -220,7 +220,7 @@ type PipelineShowOutput struct {
 
 // PipelineStatusOutput represents the JSON output of the "pipeline status" command.
 type PipelineStatusOutput struct {
-	States struct {
+	States []struct {
 		Name    string `json:"stageName"`
 		Actions []struct {
 			Name   string `json:"name"`

--- a/e2e/pipeline/pipeline_test.go
+++ b/e2e/pipeline/pipeline_test.go
@@ -5,6 +5,7 @@ package pipeline_test
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"os/exec"
@@ -41,26 +42,6 @@ var _ = Describe("pipeline flow", func() {
 			cmd := exec.Command("cp", "-r", "frontend", repoName)
 			cmd.Stdout = os.Stdout
 			cmd.Stderr = os.Stderr
-			Expect(cmd.Run()).NotTo(HaveOccurred())
-		})
-
-		It("should push upstream", func() {
-			cmd := exec.Command("git", "add", ".")
-			cmd.Stdout = os.Stdout
-			cmd.Stderr = os.Stderr
-			cmd.Dir = repoName
-			Expect(cmd.Run()).NotTo(HaveOccurred())
-
-			cmd = exec.Command("git", "commit", "-m", "first commit")
-			cmd.Stdout = os.Stdout
-			cmd.Stderr = os.Stderr
-			cmd.Dir = repoName
-			Expect(cmd.Run()).NotTo(HaveOccurred())
-
-			cmd = exec.Command("git", "push")
-			cmd.Stdout = os.Stdout
-			cmd.Stderr = os.Stderr
-			cmd.Dir = repoName
 			Expect(cmd.Run()).NotTo(HaveOccurred())
 		})
 	})
@@ -148,9 +129,172 @@ var _ = Describe("pipeline flow", func() {
 			_, err := copilot.PipelineInit(appName, repoURL, "master", []string{"test", "prod"})
 			Expect(err).NotTo(HaveOccurred())
 		})
+
 		It("should generate pipeline artifacts", func() {
 			Expect(filepath.Join(repoName, "copilot", "pipeline.yml")).Should(BeAnExistingFile())
 			Expect(filepath.Join(repoName, "copilot", "buildspec.yml")).Should(BeAnExistingFile())
+		})
+
+		It("should push repo changes upstream", func() {
+			cmd := exec.Command("git", "config", "user.email", "e2etest@amazon.com")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			cmd.Dir = repoName
+			Expect(cmd.Run()).NotTo(HaveOccurred())
+
+			cmd = exec.Command("git", "config", "user.name", "e2etest")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			cmd.Dir = repoName
+			Expect(cmd.Run()).NotTo(HaveOccurred())
+
+			cmd = exec.Command("git", "add", ".")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			cmd.Dir = repoName
+			Expect(cmd.Run()).NotTo(HaveOccurred())
+
+			cmd = exec.Command("git", "commit", "-m", "first commit")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			cmd.Dir = repoName
+			Expect(cmd.Run()).NotTo(HaveOccurred())
+
+			cmd = exec.Command("git", "push")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			cmd.Dir = repoName
+			Expect(cmd.Run()).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("when creating the pipeline stack", func() {
+		It("should start creating the pipeline stack", func() {
+			_, err := copilot.PipelineUpdate(appName)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should show pipeline details once the stack is created", func() {
+			type stage struct {
+				Name     string
+				Category string
+			}
+			wantedStages := []stage{
+				{
+					Name:     "Source",
+					Category: "Source",
+				},
+				{
+					Name:     "Build",
+					Category: "Build",
+				},
+				{
+					Name:     "DeployTo-test",
+					Category: "Deploy",
+				},
+				{
+					Name:     "DeployTo-prod",
+					Category: "Deploy",
+				},
+			}
+
+			Eventually(func() error {
+				out, err := copilot.PipelineShow(appName)
+				if err != nil {
+					return err
+				}
+				if out.Name == "" {
+					return fmt.Errorf("pipeline name is empty: %v", out)
+				}
+				if len(wantedStages) != len(out.Stages) {
+					return fmt.Errorf("pipeline stages do not match: %v", out.Stages)
+				}
+				for idx, actualStage := range out.Stages {
+					if wantedStages[idx].Name != actualStage.Name {
+						return fmt.Errorf("stage name %s at index %d does not match", actualStage.Name, idx)
+					}
+					if wantedStages[idx].Category != actualStage.Category {
+						return fmt.Errorf("stage category %s at index %d does not match", actualStage.Category, idx)
+					}
+				}
+				return nil
+			}, "600s", "10s").Should(BeNil())
+		})
+
+		It("should deploy the services to both environments", func() {
+			type state struct {
+				Name         string
+				ActionName   string
+				ActionStatus string
+			}
+			wantedStates := []state{
+				{
+					Name:         "Source",
+					ActionName:   fmt.Sprintf("SourceCodeFor-%s", appName),
+					ActionStatus: "Succeeded",
+				},
+				{
+					Name:         "Build",
+					ActionName:   "Build",
+					ActionStatus: "Succeeded",
+				},
+				{
+					Name:         "DeployTo-test",
+					ActionName:   "CreateOrUpdate-frontend-test",
+					ActionStatus: "Succeeded",
+				},
+				{
+					Name:         "DeployTo-prod",
+					ActionName:   "CreateOrUpdate-frontend-prod",
+					ActionStatus: "Succeeded",
+				},
+			}
+
+			Eventually(func() error {
+				out, err := copilot.PipelineStatus(appName)
+				if err != nil {
+					return err
+				}
+				if len(wantedStates) != len(out.States) {
+					return fmt.Errorf("len of pipeline states do not match: %v", out.States)
+				}
+				for idx, actualState := range out.States {
+					if wantedStates[idx].Name != actualState.Name {
+						return fmt.Errorf("state name %s at index %d does not match", actualState.Name, idx)
+					}
+					if len(actualState.Actions) != 1 {
+						return fmt.Errorf("no action yet for state name %s", actualState.Name)
+					}
+					if wantedStates[idx].ActionName != actualState.Actions[0].Name {
+						return fmt.Errorf("action name %v for state %s does not match at index %d", actualState.Actions[0], actualState.Name, idx)
+					}
+					if wantedStates[idx].ActionStatus != actualState.Actions[0].Status {
+						return fmt.Errorf("action status %v for state %s does not match at index %d", actualState.Actions[0], actualState.Name, idx)
+					}
+				}
+				return nil
+			}, "1200s", "15s").Should(BeNil())
+		})
+	})
+
+	Context("services should be queryable post-release", func() {
+		It("services should include a valid URL", func() {
+			out, err := copilot.SvcShow(&client.SvcShowRequest{
+				AppName: appName,
+				Name:    "frontend",
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			routes := make(map[string]string)
+			for _, route := range out.Routes {
+				routes[route.Environment] = route.URL
+			}
+			for _, env := range []string{"test", "prod"} {
+				Eventually(func() (int, error) {
+					resp, fetchErr := http.Get(routes[env])
+					return resp.StatusCode, fetchErr
+				}, "30s", "1s").Should(Equal(200))
+			}
 		})
 	})
 })


### PR DESCRIPTION
The test flow for pipelines:
1. Create and clone a CodeCommit repo
2. Create an application with a single service "frontend" on two environments ("test" and "prod") in different AWS acc and regions.
3. Create a pipeline and validate with `pipeline show`
4. Push the artifacts to the repo and validate that the service is deployed with `pipeline status`
5. Finally validate that the endpoints are live with a GET request from `svc show`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
