### PR TITLE
fix(manifest): preserve default network config on empty env overrides

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/transformers.go
+++ b/internal/pkg/deploy/cloudformation/stack/transformers.go
@@ -533,7 +533,13 @@ func convertEFSConfiguration(in manifest.EFSVolumeConfiguration) *template.EFSVo
 	}
 }
 
-func convertNetworkConfig(network manifest.NetworkConfig) *template.NetworkOpts {
+func convertNetworkConfig(network *manifest.NetworkConfig) *template.NetworkOpts {
+	if network == nil || network.VPC == nil {
+		return &template.NetworkOpts{
+			AssignPublicIP: template.EnablePublicIP,
+			SubnetsType:    template.PublicSubnetsPlacement,
+		}
+	}
 	opts := &template.NetworkOpts{
 		AssignPublicIP: template.EnablePublicIP,
 		SubnetsType:    template.PublicSubnetsPlacement,

--- a/internal/pkg/manifest/backend_svc.go
+++ b/internal/pkg/manifest/backend_svc.go
@@ -40,7 +40,7 @@ type BackendServiceConfig struct {
 	TaskConfig    `yaml:",inline"`
 	*Logging      `yaml:"logging,flow"`
 	Sidecars      map[string]*SidecarConfig `yaml:"sidecars"`
-	Network       NetworkConfig             `yaml:"network"`
+	Network       *NetworkConfig            `yaml:"network"`
 }
 
 type imageWithPortAndHealthcheck struct {
@@ -149,8 +149,8 @@ func newDefaultBackendService() *BackendService {
 					Enable: aws.Bool(false),
 				},
 			},
-			Network: NetworkConfig{
-				VPC: vpcConfig{
+			Network: &NetworkConfig{
+				VPC: &vpcConfig{
 					Placement: stringP(PublicSubnetPlacement),
 				},
 			},

--- a/internal/pkg/manifest/backend_svc_test.go
+++ b/internal/pkg/manifest/backend_svc_test.go
@@ -54,8 +54,8 @@ func TestNewBackendSvc(t *testing.T) {
 							Enable: aws.Bool(false),
 						},
 					},
-					Network: NetworkConfig{
-						VPC: vpcConfig{
+					Network: &NetworkConfig{
+						VPC: &vpcConfig{
 							Placement: stringP("public"),
 						},
 					},
@@ -104,8 +104,8 @@ func TestNewBackendSvc(t *testing.T) {
 							Enable: aws.Bool(false),
 						},
 					},
-					Network: NetworkConfig{
-						VPC: vpcConfig{
+					Network: &NetworkConfig{
+						VPC: &vpcConfig{
 							Placement: stringP("public"),
 						},
 					},

--- a/internal/pkg/manifest/job.go
+++ b/internal/pkg/manifest/job.go
@@ -43,7 +43,7 @@ type ScheduledJobConfig struct {
 	Sidecars                map[string]*SidecarConfig `yaml:"sidecars"`
 	On                      JobTriggerConfig          `yaml:"on,flow"`
 	JobFailureHandlerConfig `yaml:",inline"`
-	Network                 NetworkConfig `yaml:"network"`
+	Network                 *NetworkConfig `yaml:"network"`
 }
 
 // JobTriggerConfig represents the configuration for the event that triggers the job.
@@ -80,8 +80,8 @@ func newDefaultScheduledJob() *ScheduledJob {
 					Value: aws.Int(1),
 				},
 			},
-			Network: NetworkConfig{
-				VPC: vpcConfig{
+			Network: &NetworkConfig{
+				VPC: &vpcConfig{
 					Placement: stringP(PublicSubnetPlacement),
 				},
 			},

--- a/internal/pkg/manifest/job_test.go
+++ b/internal/pkg/manifest/job_test.go
@@ -122,8 +122,8 @@ func TestScheduledJob_ApplyEnv(t *testing.T) {
 							Value: aws.Int(1),
 						},
 					},
-					Network: NetworkConfig{
-						VPC: vpcConfig{
+					Network: &NetworkConfig{
+						VPC: &vpcConfig{
 							Placement: stringP(PublicSubnetPlacement),
 						},
 					},
@@ -166,8 +166,8 @@ func TestScheduledJob_ApplyEnv(t *testing.T) {
 							"LOG_LEVEL": "prod",
 						},
 					},
-					Network: NetworkConfig{
-						VPC: vpcConfig{
+					Network: &NetworkConfig{
+						VPC: &vpcConfig{
 							Placement: stringP(PublicSubnetPlacement),
 						},
 					},

--- a/internal/pkg/manifest/lb_web_svc.go
+++ b/internal/pkg/manifest/lb_web_svc.go
@@ -51,7 +51,7 @@ type LoadBalancedWebServiceConfig struct {
 	TaskConfig    `yaml:",inline"`
 	*Logging      `yaml:"logging,flow"`
 	Sidecars      map[string]*SidecarConfig `yaml:"sidecars"`
-	Network       NetworkConfig             `yaml:"network"`
+	Network       *NetworkConfig            `yaml:"network"`
 
 	// Fields that are used while marshaling the template for additional clarifications,
 	// but don't correspond to a field in the manifests.
@@ -116,8 +116,8 @@ func newDefaultLoadBalancedWebService() *LoadBalancedWebService {
 					Enable: aws.Bool(false),
 				},
 			},
-			Network: NetworkConfig{
-				VPC: vpcConfig{
+			Network: &NetworkConfig{
+				VPC: &vpcConfig{
 					Placement: stringP(PublicSubnetPlacement),
 				},
 			},

--- a/internal/pkg/manifest/lb_web_svc_test.go
+++ b/internal/pkg/manifest/lb_web_svc_test.go
@@ -65,8 +65,8 @@ func TestNewLoadBalancedWebService(t *testing.T) {
 							Enable: aws.Bool(false),
 						},
 					},
-					Network: NetworkConfig{
-						VPC: vpcConfig{
+					Network: &NetworkConfig{
+						VPC: &vpcConfig{
 							Placement: stringP("public"),
 						},
 					},
@@ -352,8 +352,8 @@ func TestLoadBalancedWebService_ApplyEnv(t *testing.T) {
 					Logging: &Logging{
 						ConfigFile: aws.String("mockConfigFile"),
 					},
-					Network: NetworkConfig{
-						VPC: vpcConfig{
+					Network: &NetworkConfig{
+						VPC: &vpcConfig{
 							Placement:      stringP("public"),
 							SecurityGroups: []string{"sg-123"},
 						},
@@ -416,8 +416,8 @@ func TestLoadBalancedWebService_ApplyEnv(t *testing.T) {
 								"FOO": "BAR",
 							},
 						},
-						Network: NetworkConfig{
-							VPC: vpcConfig{
+						Network: &NetworkConfig{
+							VPC: &vpcConfig{
 								SecurityGroups: []string{"sg-456", "sg-789"},
 							},
 						},
@@ -505,8 +505,8 @@ func TestLoadBalancedWebService_ApplyEnv(t *testing.T) {
 							"FOO": "BAR",
 						},
 					},
-					Network: NetworkConfig{
-						VPC: vpcConfig{
+					Network: &NetworkConfig{
+						VPC: &vpcConfig{
 							Placement:      stringP("public"),
 							SecurityGroups: []string{"sg-456", "sg-789"},
 						},
@@ -549,7 +549,7 @@ func TestLoadBalancedWebService_ApplyEnv(t *testing.T) {
 				},
 			},
 		},
-		"with range override": {
+		"with range override and preserving network config": {
 			in: &LoadBalancedWebService{
 				LoadBalancedWebServiceConfig: LoadBalancedWebServiceConfig{
 					TaskConfig: TaskConfig{
@@ -558,6 +558,12 @@ func TestLoadBalancedWebService_ApplyEnv(t *testing.T) {
 								Range: &Range{Value: &mockRange},
 								CPU:   aws.Int(80),
 							},
+						},
+					},
+					Network: &NetworkConfig{
+						VPC: &vpcConfig{
+							Placement:      stringP("public"),
+							SecurityGroups: []string{"sg-456", "sg-789"},
 						},
 					},
 				},
@@ -576,6 +582,12 @@ func TestLoadBalancedWebService_ApplyEnv(t *testing.T) {
 								Range: &Range{Value: &mockRange},
 								CPU:   aws.Int(80),
 							},
+						},
+					},
+					Network: &NetworkConfig{
+						VPC: &vpcConfig{
+							Placement:      stringP("public"),
+							SecurityGroups: []string{"sg-456", "sg-789"},
 						},
 					},
 				},

--- a/internal/pkg/manifest/svc_test.go
+++ b/internal/pkg/manifest/svc_test.go
@@ -122,8 +122,8 @@ environments:
 								"LOG_TOKEN": "LOG_TOKEN",
 							},
 						},
-						Network: NetworkConfig{
-							VPC: vpcConfig{
+						Network: &NetworkConfig{
+							VPC: &vpcConfig{
 								Placement: stringP("public"),
 							},
 						},
@@ -229,8 +229,8 @@ secrets:
 								"API_TOKEN": "SUBS_API_TOKEN",
 							},
 						},
-						Network: NetworkConfig{
-							VPC: vpcConfig{
+						Network: &NetworkConfig{
+							VPC: &vpcConfig{
 								Placement: stringP("public"),
 							},
 						},

--- a/internal/pkg/manifest/workload.go
+++ b/internal/pkg/manifest/workload.go
@@ -454,7 +454,7 @@ func (c *NetworkConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	if err := unmarshal(&conf); err != nil {
 		return err
 	}
-	if conf.VPC == nil { // If after unmarshaling the user didnot specify VPC configuration then reset it to public.
+	if conf.VPC == nil { // If after unmarshaling the user did not specify VPC configuration then reset it to public.
 		conf.VPC = defaultVPCConf
 	}
 	if !conf.VPC.isValidPlacement() {

--- a/internal/pkg/manifest/workload_test.go
+++ b/internal/pkg/manifest/workload_test.go
@@ -518,7 +518,7 @@ func TestNetworkConfig_UnmarshalYAML(t *testing.T) {
 	testCases := map[string]struct {
 		data string
 
-		wantedConfig NetworkConfig
+		wantedConfig *NetworkConfig
 		wantedErr    error
 	}{
 		"defaults to public placement if vpc is empty": {
@@ -526,8 +526,8 @@ func TestNetworkConfig_UnmarshalYAML(t *testing.T) {
 network:
   vpc:
 `,
-			wantedConfig: NetworkConfig{
-				VPC: vpcConfig{
+			wantedConfig: &NetworkConfig{
+				VPC: &vpcConfig{
 					Placement: stringP(PublicSubnetPlacement),
 				},
 			},
@@ -549,8 +549,8 @@ network:
     - 'sg-1234'
     - 'sg-4567'
 `,
-			wantedConfig: NetworkConfig{
-				VPC: vpcConfig{
+			wantedConfig: &NetworkConfig{
+				VPC: &vpcConfig{
 					Placement:      stringP(PublicSubnetPlacement),
 					SecurityGroups: []string{"sg-1234", "sg-4567"},
 				},
@@ -562,7 +562,7 @@ network:
 		t.Run(name, func(t *testing.T) {
 			// GIVEN
 			type manifest struct {
-				Network NetworkConfig `yaml:"network"`
+				Network *NetworkConfig `yaml:"network"`
 			}
 			var m manifest
 


### PR DESCRIPTION
Fixes #2420

Previously, when a user provided a network config and an env override:
```yaml
network:
  vpc:
    security_groups: ['sg-123123']
environments:
  dev:
    count: 2
```
The network config for the "dev" environment got overriden to an empty
struct{}.

This change ensures that the default entry is preserved for network
config is preserved for the "dev" environment.
This is done by changing the type for the Network field to a pointer so
that mergo does not overwrite it.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
