### PR TITLE
chore: move CI=true inside e2e tests to actually use the env var

### DIFF
--- a/.release/buildspec_e2e.yml
+++ b/.release/buildspec_e2e.yml
@@ -156,5 +156,4 @@ phases:
          -e "TEST_SUITE=$TEST_SUITE"
          -e "DOCKERHUB_USERNAME=$DOCKERHUB_USERNAME"
          -e "DOCKERHUB_TOKEN=$DOCKERHUB_TOKEN"
-         -e "CI=true"
          copilot-cli/e2e:latest

--- a/e2e/internal/client/cli.go
+++ b/e2e/internal/client/cli.go
@@ -905,7 +905,7 @@ func (cli *CLI) SvcPackage(opts *PackageInput) (string, error) {
 
 func (cli *CLI) exec(command *exec.Cmd) (string, error) {
 	// Turn off colors
-	command.Env = append(os.Environ(), "COLOR=false")
+	command.Env = append(os.Environ(), "COLOR=false", "CI=true")
 	command.Dir = cli.workingDir
 	sess, err := gexec.Start(command, ginkgo.GinkgoWriter, ginkgo.GinkgoWriter)
 	if err != nil {


### PR DESCRIPTION

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
