### PR TITLE
chore(e2e): use image from ecr for pipeline e2e test

### DIFF
--- a/e2e/pipeline/frontend/Dockerfile
+++ b/e2e/pipeline/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx
+FROM public.ecr.aws/nginx/nginx:latest
 
 COPY nginx.conf /etc/nginx/nginx.conf
 


### PR DESCRIPTION
There is a 100 pull limit / 6 hours for Docker Hub images, which may cause our e2e test to fail. This PR fixes it by using the image from ECR instead.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
