### PR TITLE
docs: fix rendering issue in depends_on docs

### DIFF
--- a/site/content/docs/include/common-svc-fields.en.md
+++ b/site/content/docs/include/common-svc-fields.en.md
@@ -134,9 +134,6 @@ Key-value pairs that represent environment variables that will be passed to your
 <a id="secrets" href="#secrets" class="field">`secrets`</a> <span class="type">Map</span>  
 Key-value pairs that represent secret values from [AWS Systems Manager Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html) that will be securely passed to your service as environment variables.
 
-<a id="depends-on" href="#depends-on" class="field">`depends_on`</a> <span class="type">Map</span> 
-An optional key/value map of [Container Dependencies](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ContainerDependency.html) to add to the container.
-
 <div class="separator"></div>  
 
 <a id="storage" href="#storage" class="field">`storage`</a> <span class="type">Map</span>  

--- a/site/content/docs/include/image-config.en.md
+++ b/site/content/docs/include/image-config.en.md
@@ -39,3 +39,19 @@ The port exposed in your Dockerfile. Copilot should parse this value for you fro
 
 <span class="parent-field">image.</span><a id="image-labels" href="#image-labels" class="field">`labels`</a><span class="type">Map</span>  
 An optional key/value map of [Docker labels](https://docs.docker.com/config/labels-custom-metadata/) to add to the container.
+
+<span class="parent-field">image.</span><a id="image-depends-on" href="#image-depends-on" class="field">`depends_on`</a><span class="type">Map</span>  
+An optional key/value map of [Container Dependencies](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ContainerDependency.html) to add to the container. The key of the map is a container name and the value is the condition to depend on. Valid conditions are: `start`, `healthy`, `complete`, and `success`. You cannot specify a `complete` or `success` dependency on an essential container.
+
+!!! note
+    Container health checks for sidecars are not currently supported in Copilot. This means that `healthy` is not a valid sidecar dependency condition.
+
+For example:
+```yaml
+image:
+  build: ./Dockerfile
+  depends_on:
+    nginx: start
+    startup: success
+```
+In the above example, the task's main container will only start after the `nginx` sidecar has started and the `startup` container has completed successfully.  

--- a/site/content/docs/manifest/scheduled-job.en.md
+++ b/site/content/docs/manifest/scheduled-job.en.md
@@ -94,7 +94,20 @@ The `location` field follows the same definition as the [`image` parameter](http
 An optional key/value map of [Docker labels](https://docs.docker.com/config/labels-custom-metadata/) to add to the container.
 
 <span class="parent-field">image.</span><a id="image-depends-on" href="#image-depends-on" class="field">`depends_on`</a><span class="type">Map</span>  
-An optional key/value map of [Container Dependencies](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ContainerDependency.html) to add to the container.
+An optional key/value map of [Container Dependencies](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ContainerDependency.html) to add to the container. The key of the map is a container name and the value is the condition to depend on. Valid conditions are: `start`, `healthy`, `complete`, and `success`. You cannot specify a `complete` or `success` dependency on an essential container.
+
+!!! note
+    Container health checks for sidecars are not currently supported in Copilot. This means that `healthy` is not a valid sidecar dependency condition.
+
+For example:
+```yaml
+image:
+  build: ./Dockerfile
+  depends_on:
+    nginx: start
+    startup: success
+```
+In the above example, the task's main container will only start after the `nginx` sidecar has started and the `startup` container has completed successfully.  
 
 <div class="separator"></div>  
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
Fixes a line break issue due to markdown shenanigans in depends_on docs. Also adds detail to dependency documentation.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
