### PR TITLE
docs: fix wrong argument name for svc init command example

### DIFF
--- a/site/content/docs/commands/svc-init.en.md
+++ b/site/content/docs/commands/svc-init.en.md
@@ -26,9 +26,9 @@ Flags
                             "Request-Driven Web Service", "Load Balanced Web Service", "Backend Service".
 ```
 
-To create a "frontend" load balanced web service you could run:  
+To create a "frontend" load balanced web service you could run:
 
-`$ copilot svc init --name frontend --app-type "Load Balanced Web Service" --dockerfile ./frontend/Dockerfile`
+`$ copilot svc init --name frontend --svc-type "Load Balanced Web Service" --dockerfile ./frontend/Dockerfile`
 
 ## What does it look like?
 


### PR DESCRIPTION
Since example command of `copilot svc init` was incorrect, fixed the argument name to the right one.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
