### PR TITLE
fix(addons): support empty addon dirs

### DIFF
--- a/internal/pkg/addon/addons.go
+++ b/internal/pkg/addon/addons.go
@@ -52,14 +52,21 @@ func New(wlName string) (*Addons, error) {
 func (a *Addons) Template() (string, error) {
 	fnames, err := a.ws.ReadAddonsDir(a.wlName)
 	if err != nil {
-		return "", &ErrAddonsDirNotExist{
+		return "", &ErrAddonsNotFound{
 			WlName:    a.wlName,
 			ParentErr: err,
 		}
 	}
 
+	yamlFiles := filterYAMLfiles(fnames)
+	if len(yamlFiles) == 0 {
+		return "", &ErrAddonsNotFound{
+			WlName: a.wlName,
+		}
+	}
+
 	mergedTemplate := newCFNTemplate("merged")
-	for _, fname := range filterYAMLfiles(fnames) {
+	for _, fname := range yamlFiles {
 		out, err := a.ws.ReadAddon(a.wlName, fname)
 		if err != nil {
 			return "", fmt.Errorf("read addon %s under %s: %w", fname, a.wlName, err)

--- a/internal/pkg/addon/addons_test.go
+++ b/internal/pkg/addon/addons_test.go
@@ -71,21 +71,6 @@ func TestAddons_Template(t *testing.T) {
 				ParentErr: nil,
 			},
 		},
-		"return ErrAddonsNotFound if addons directory is empty in a job": {
-			mockAddons: func(ctrl *gomock.Controller) *Addons {
-				ws := mocks.NewMockworkspaceReader(ctrl)
-				ws.EXPECT().ReadAddonsDir(testJobName).
-					Return([]string{}, nil)
-				return &Addons{
-					wlName: testJobName,
-					ws:     ws,
-				}
-			},
-			wantedErr: &ErrAddonsNotFound{
-				WlName:    testJobName,
-				ParentErr: nil,
-			},
-		},
 		"return ErrAddonsNotFound if addons directory does not contain yaml files in a service": {
 			mockAddons: func(ctrl *gomock.Controller) *Addons {
 				ws := mocks.NewMockworkspaceReader(ctrl)
@@ -98,21 +83,6 @@ func TestAddons_Template(t *testing.T) {
 			},
 			wantedErr: &ErrAddonsNotFound{
 				WlName:    testSvcName,
-				ParentErr: nil,
-			},
-		},
-		"return ErrAddonsNotFound if addons directory does not contain yaml files in a job": {
-			mockAddons: func(ctrl *gomock.Controller) *Addons {
-				ws := mocks.NewMockworkspaceReader(ctrl)
-				ws.EXPECT().ReadAddonsDir(testJobName).
-					Return([]string{".gitkeep"}, nil)
-				return &Addons{
-					wlName: testJobName,
-					ws:     ws,
-				}
-			},
-			wantedErr: &ErrAddonsNotFound{
-				WlName:    testJobName,
 				ParentErr: nil,
 			},
 		},

--- a/internal/pkg/addon/addons_test.go
+++ b/internal/pkg/addon/addons_test.go
@@ -26,7 +26,7 @@ func TestAddons_Template(t *testing.T) {
 		wantedTemplate string
 		wantedErr      error
 	}{
-		"return ErrAddonsDirNotExist if addons doesn't exist in a service": {
+		"return ErrAddonsNotFound if addons doesn't exist in a service": {
 			mockAddons: func(ctrl *gomock.Controller) *Addons {
 				ws := mocks.NewMockworkspaceReader(ctrl)
 				ws.EXPECT().ReadAddonsDir(testSvcName).
@@ -36,12 +36,12 @@ func TestAddons_Template(t *testing.T) {
 					ws:     ws,
 				}
 			},
-			wantedErr: &ErrAddonsDirNotExist{
+			wantedErr: &ErrAddonsNotFound{
 				WlName:    testSvcName,
 				ParentErr: testErr,
 			},
 		},
-		"return ErrAddonsDirNotExist if addons doesn't exist in a job": {
+		"return ErrAddonsNotFound if addons doesn't exist in a job": {
 			mockAddons: func(ctrl *gomock.Controller) *Addons {
 				ws := mocks.NewMockworkspaceReader(ctrl)
 				ws.EXPECT().ReadAddonsDir(testJobName).
@@ -51,12 +51,72 @@ func TestAddons_Template(t *testing.T) {
 					ws:     ws,
 				}
 			},
-			wantedErr: &ErrAddonsDirNotExist{
+			wantedErr: &ErrAddonsNotFound{
 				WlName:    testJobName,
 				ParentErr: testErr,
 			},
 		},
-		"print correct error message for ErrAddonsDirNotExist": {
+		"return ErrAddonsNotFound if addons directory is empty in a service": {
+			mockAddons: func(ctrl *gomock.Controller) *Addons {
+				ws := mocks.NewMockworkspaceReader(ctrl)
+				ws.EXPECT().ReadAddonsDir(testSvcName).
+					Return([]string{}, nil)
+				return &Addons{
+					wlName: testSvcName,
+					ws:     ws,
+				}
+			},
+			wantedErr: &ErrAddonsNotFound{
+				WlName:    testSvcName,
+				ParentErr: nil,
+			},
+		},
+		"return ErrAddonsNotFound if addons directory is empty in a job": {
+			mockAddons: func(ctrl *gomock.Controller) *Addons {
+				ws := mocks.NewMockworkspaceReader(ctrl)
+				ws.EXPECT().ReadAddonsDir(testJobName).
+					Return([]string{}, nil)
+				return &Addons{
+					wlName: testJobName,
+					ws:     ws,
+				}
+			},
+			wantedErr: &ErrAddonsNotFound{
+				WlName:    testJobName,
+				ParentErr: nil,
+			},
+		},
+		"return ErrAddonsNotFound if addons directory does not contain yaml files in a service": {
+			mockAddons: func(ctrl *gomock.Controller) *Addons {
+				ws := mocks.NewMockworkspaceReader(ctrl)
+				ws.EXPECT().ReadAddonsDir(testSvcName).
+					Return([]string{".gitkeep"}, nil)
+				return &Addons{
+					wlName: testSvcName,
+					ws:     ws,
+				}
+			},
+			wantedErr: &ErrAddonsNotFound{
+				WlName:    testSvcName,
+				ParentErr: nil,
+			},
+		},
+		"return ErrAddonsNotFound if addons directory does not contain yaml files in a job": {
+			mockAddons: func(ctrl *gomock.Controller) *Addons {
+				ws := mocks.NewMockworkspaceReader(ctrl)
+				ws.EXPECT().ReadAddonsDir(testJobName).
+					Return([]string{".gitkeep"}, nil)
+				return &Addons{
+					wlName: testJobName,
+					ws:     ws,
+				}
+			},
+			wantedErr: &ErrAddonsNotFound{
+				WlName:    testJobName,
+				ParentErr: nil,
+			},
+		},
+		"print correct error message for ErrAddonsNotFound": {
 			mockAddons: func(ctrl *gomock.Controller) *Addons {
 				ws := mocks.NewMockworkspaceReader(ctrl)
 				ws.EXPECT().ReadAddonsDir(testJobName).

--- a/internal/pkg/addon/errors.go
+++ b/internal/pkg/addon/errors.go
@@ -10,13 +10,13 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// ErrAddonsDirNotExist occurs when an addons directory for a workload does not exist.
-type ErrAddonsDirNotExist struct {
+// ErrAddonsNotFound occurs when an addons directory for a workload is either not found or empty.
+type ErrAddonsNotFound struct {
 	WlName    string
 	ParentErr error
 }
 
-func (e *ErrAddonsDirNotExist) Error() string {
+func (e *ErrAddonsNotFound) Error() string {
 	return fmt.Sprintf("read addons directory for %s: %v", e.WlName, e.ParentErr)
 }
 

--- a/internal/pkg/addon/errors.go
+++ b/internal/pkg/addon/errors.go
@@ -17,7 +17,10 @@ type ErrAddonsNotFound struct {
 }
 
 func (e *ErrAddonsNotFound) Error() string {
-	return fmt.Sprintf("read addons directory for %s: %v", e.WlName, e.ParentErr)
+	if e.ParentErr != nil {
+		return fmt.Sprintf("read addons directory for %s: %v", e.WlName, e.ParentErr)
+	}
+	return fmt.Sprintf("read addons directory for %s: no addons found", e.WlName)
 }
 
 type errKeyAlreadyExists struct {

--- a/internal/pkg/cli/job_deploy.go
+++ b/internal/pkg/cli/job_deploy.go
@@ -163,8 +163,8 @@ func (o *deployJobOpts) Execute() error {
 func (o *deployJobOpts) pushAddonsTemplateToS3Bucket() (string, error) {
 	template, err := o.addons.Template()
 	if err != nil {
-		var notExistErr *addon.ErrAddonsDirNotExist
-		if errors.As(err, &notExistErr) {
+		var notFoundErr *addon.ErrAddonsNotFound
+		if errors.As(err, &notFoundErr) {
 			// addons doesn't exist for job, the url is empty.
 			return "", nil
 		}

--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -346,8 +346,8 @@ func buildArgs(name, imageTag, copilotDir string, unmarshaledManifest interface{
 func (o *deploySvcOpts) pushAddonsTemplateToS3Bucket() (string, error) {
 	template, err := o.addons.Template()
 	if err != nil {
-		var notExistErr *addon.ErrAddonsDirNotExist
-		if errors.As(err, &notExistErr) {
+		var notFoundErr *addon.ErrAddonsNotFound
+		if errors.As(err, &notFoundErr) {
 			// addons doesn't exist for service, the url is empty.
 			return "", nil
 		}

--- a/internal/pkg/cli/svc_deploy_test.go
+++ b/internal/pkg/cli/svc_deploy_test.go
@@ -437,7 +437,7 @@ func TestSvcDeployOpts_pushAddonsTemplateToS3Bucket(t *testing.T) {
 		"should return empty url if the service doesn't have any addons": {
 			inputSvc: "mockSvc",
 			mockAddons: func(m *mocks.Mocktemplater) {
-				m.EXPECT().Template().Return("", &addon.ErrAddonsDirNotExist{
+				m.EXPECT().Template().Return("", &addon.ErrAddonsNotFound{
 					WlName: "mockSvc",
 				})
 			},

--- a/internal/pkg/cli/svc_package.go
+++ b/internal/pkg/cli/svc_package.go
@@ -192,9 +192,9 @@ func (o *packageSvcOpts) Execute() error {
 	}
 
 	addonsTemplate, err := o.getAddonsTemplate()
-	// return nil if addons dir doesn't exist.
-	var notExistErr *addon.ErrAddonsDirNotExist
-	if errors.As(err, &notExistErr) {
+	// return nil if addons not found.
+	var notFoundErr *addon.ErrAddonsNotFound
+	if errors.As(err, &notFoundErr) {
 		return nil
 	}
 	if err != nil {

--- a/internal/pkg/cli/svc_package_test.go
+++ b/internal/pkg/cli/svc_package_test.go
@@ -273,7 +273,7 @@ count: 1`), nil)
 
 				mockAddons := mocks.NewMocktemplater(ctrl)
 				mockAddons.EXPECT().Template().
-					Return("", &addon.ErrAddonsDirNotExist{})
+					Return("", &addon.ErrAddonsNotFound{})
 
 				opts.store = mockStore
 				opts.ws = mockWs

--- a/internal/pkg/deploy/cloudformation/stack/lb_web_svc_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/lb_web_svc_test.go
@@ -209,7 +209,7 @@ Outputs:
 					Command:    []string{"world"},
 				}).Return(&template.Content{Buffer: bytes.NewBufferString("template")}, nil)
 
-				addons := mockTemplater{err: &addon.ErrAddonsDirNotExist{}}
+				addons := mockTemplater{err: &addon.ErrAddonsNotFound{}}
 				c.parser = m
 				c.wkld.addons = addons
 			},

--- a/internal/pkg/deploy/cloudformation/stack/rd_web_svc_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/rd_web_svc_test.go
@@ -172,7 +172,7 @@ Outputs:
 		"should return parsing error": {
 			mockDependencies: func(t *testing.T, ctrl *gomock.Controller, c *RequestDrivenWebService) {
 				mockParser := mocks.NewMockrequestDrivenWebSvcReadParser(ctrl)
-				addons := mockTemplater{err: &addon.ErrAddonsDirNotExist{}}
+				addons := mockTemplater{err: &addon.ErrAddonsNotFound{}}
 				mockParser.EXPECT().ParseRequestDrivenWebService(template.ParseRequestDrivenWebServiceInput{
 					Variables:         c.manifest.Variables,
 					Tags:              c.manifest.Tags,

--- a/internal/pkg/deploy/cloudformation/stack/scheduled_job_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/scheduled_job_test.go
@@ -70,7 +70,7 @@ func TestScheduledJob_Template(t *testing.T) {
 					Command:             []string{"world"},
 					EnvControllerLambda: "something",
 				})).Return(&template.Content{Buffer: bytes.NewBufferString("template")}, nil)
-				addons := mockTemplater{err: &addon.ErrAddonsDirNotExist{}}
+				addons := mockTemplater{err: &addon.ErrAddonsNotFound{}}
 				j.parser = m
 				j.wkld.addons = addons
 			},
@@ -146,7 +146,7 @@ Outputs:
 				m := mocks.NewMockscheduledJobReadParser(ctrl)
 				m.EXPECT().Read(envControllerPath).Return(&template.Content{Buffer: bytes.NewBufferString("something")}, nil)
 				m.EXPECT().ParseScheduledJob(gomock.Any()).Return(nil, errors.New("some error"))
-				addons := mockTemplater{err: &addon.ErrAddonsDirNotExist{}}
+				addons := mockTemplater{err: &addon.ErrAddonsNotFound{}}
 				j.parser = m
 				j.wkld.addons = addons
 			},

--- a/internal/pkg/deploy/cloudformation/stack/workload.go
+++ b/internal/pkg/deploy/cloudformation/stack/workload.go
@@ -191,11 +191,11 @@ func (w *wkld) templateConfiguration(tc templateConfigurer) (string, error) {
 func (w *wkld) addonsOutputs() (*template.WorkloadNestedStackOpts, error) {
 	stack, err := w.addons.Template()
 	if err != nil {
-		var noAddonsErr *addon.ErrAddonsDirNotExist
-		if !errors.As(err, &noAddonsErr) {
+		var notFoundErr *addon.ErrAddonsNotFound
+		if !errors.As(err, &notFoundErr){
 			return nil, fmt.Errorf("generate addons template for %s: %w", w.name, err)
 		}
-		return nil, nil // Addons directory does not exist, so there are no outputs and error.
+		return nil, nil // No addons found, so there are no outputs and error.
 	}
 
 	out, err := addon.Outputs(stack)


### PR DESCRIPTION
This is achieved by turning `ErrAddonsDirNotExist` into
a more general purpose one called `ErrAddonsNotFound`.

It's hard to think of a use-case that different failure
reasons for gathering addons have to be treated differently.

Fixes #2502

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
