### PR TITLE
chore(deps): bump go to 1.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
 
       - name: Set up Node
         uses: actions/setup-node@v1
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
 
       - name: Set up Node
         uses: actions/setup-node@v1
@@ -59,7 +59,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
 
       - name: Set up Node
         uses: actions/setup-node@v1
@@ -78,7 +78,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
 
       - name: Check out code
         uses: actions/checkout@v2
@@ -95,7 +95,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
 
       - name: Check out code
         uses: actions/checkout@v2

--- a/.release/buildspec.yml
+++ b/.release/buildspec.yml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      golang: 1.15
+      golang: 1.16
       nodejs: 12
   pre_build:
     commands:

--- a/.release/buildspec_e2e.yml
+++ b/.release/buildspec_e2e.yml
@@ -125,7 +125,7 @@ batch:
 phases:
   install:
     runtime-versions:
-      golang: 1.15
+      golang: 1.16
       nodejs: 12
   pre_build:
     commands:

--- a/.release/buildspec_integ.yml
+++ b/.release/buildspec_integ.yml
@@ -2,7 +2,7 @@ version: 0.2
 env:
   parameter-store:
     NEUTRAL_BUILD_RELEASE_ROLE: COPILOT_NEUTRAL_BUILD_RELEASE_ROLE_ARN
-  variables: 
+  variables:
     NEUTRAL_BUILD_RELEASE_BUCKET_NAME: ecs-cli-v2-release
     AWS_STS_REGIONAL_ENDPOINTS: regional
     INTEG_TEST_SESSION_NAME: aws_copilot_cli_integ_test
@@ -12,7 +12,7 @@ env:
 phases:
   install:
     runtime-versions:
-      golang: 1.15
+      golang: 1.16
       nodejs: 12
   build:
     commands:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Please read it over and let us know if it's not up-to-date (or, even better, sub
 
 ### Environment
 
-- Make sure you are using Go 1.15 (`go version`).
+- Make sure you are using Go 1.16 (`go version`).
 - Fork the repository.
 - Clone your forked repository locally.
 - We use Go Modules to manage dependencies, so you can develop outside of your $GOPATH.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15
+FROM golang:1.16
 # We need to have both nodejs and go to build the binaries.
 # We could use multi-stage builds but that would require significantly changing our Makefile.
 RUN apt-get update

--- a/e2e/multi-svc-app/back-end/Dockerfile
+++ b/e2e/multi-svc-app/back-end/Dockerfile
@@ -1,6 +1,6 @@
 # We specify the base image we need for our
 # go application
-FROM golang:1.15 AS builder
+FROM golang:1.16 AS builder
 # We create an /app directory within our
 # image that will hold our application source
 # files

--- a/e2e/multi-svc-app/back-end/go.mod
+++ b/e2e/multi-svc-app/back-end/go.mod
@@ -1,5 +1,5 @@
 module github.com/aws/copilot-cli/e2e/multi-app-project/back-end
 
-go 1.15
+go 1.16
 
 require github.com/julienschmidt/httprouter v1.3.0 // indirect

--- a/e2e/multi-svc-app/front-end/Dockerfile
+++ b/e2e/multi-svc-app/front-end/Dockerfile
@@ -1,6 +1,6 @@
 # We specify the base image we need for our
 # go application
-FROM golang:1.15 AS builder
+FROM golang:1.16 AS builder
 # We create an /app directory within our
 # image that will hold our application source
 # files

--- a/e2e/multi-svc-app/front-end/go.mod
+++ b/e2e/multi-svc-app/front-end/go.mod
@@ -1,5 +1,5 @@
 module github.com/aws/copilot-cli/e2e/multi-app-project/front-end
 
-go 1.15
+go 1.16
 
 require github.com/julienschmidt/httprouter v1.3.0

--- a/e2e/multi-svc-app/www/Dockerfile
+++ b/e2e/multi-svc-app/www/Dockerfile
@@ -1,6 +1,6 @@
 # We specify the base image we need for our
 # go application
-FROM golang:1.15 AS builder
+FROM golang:1.16 AS builder
 # We create an /app directory within our
 # image that will hold our application source
 # files

--- a/e2e/multi-svc-app/www/go.mod
+++ b/e2e/multi-svc-app/www/go.mod
@@ -1,5 +1,5 @@
 module github.com/aws/copilot-cli/e2e/multi-app-project/www
 
-go 1.15
+go 1.16
 
 require github.com/julienschmidt/httprouter v1.3.0

--- a/e2e/sidecars/nginx/Dockerfile
+++ b/e2e/sidecars/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.15-alpine
+FROM nginx:1.16-alpine
 
 COPY nginx-default.conf.template /etc/nginx/conf.d/default.conf.template
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/copilot-cli
 
-go 1.15
+go 1.16
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.2.12


### PR DESCRIPTION
Update to go 1.16. Since go 1.16 adds support for darwin/arm64 this PR will make it possible to
run this provider on ARM-based Macs.