### PR TITLE
fix: get admin role arn from outputs instead of constucting one

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/app.go
+++ b/internal/pkg/deploy/cloudformation/stack/app.go
@@ -64,6 +64,8 @@ const (
 
 	// arn:${partition}:iam::${account}:role/${roleName}
 	fmtStackSetAdminRoleARN = "arn:%s:iam::%s:role/%s"
+
+	AppAdminRoleOutputName = "AdministrationRoleARN"
 )
 
 var cfTemplateFunctions = map[string]interface{}{


### PR DESCRIPTION
This PR fixes the gap between the admin role used to create the app stack set and the admin role created by the app stack. 

Fixes #2563

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
