### PR TITLE
fix(lambda): handle gracefully for same alias default domain

### DIFF
--- a/cf-custom-resources/test/dns-cert-validator-test.js
+++ b/cf-custom-resources/test/dns-cert-validator-test.js
@@ -22,13 +22,14 @@ describe("DNS Validated Certificate Handler", () => {
   const testRootDNSRole = "mockRole";
   const testAliases = `{
     "frontend": ["v1.${testAppName}.${testDomainName}", "foobar.com"],
-    "backend": ["v2.${testDomainName}"]
+    "backend": ["v2.${testDomainName}", "${testEnvName}.${testAppName}.${testDomainName}"]
   }`;
   const testUpdatedAliases = `{
     "frontend": ["v1.${testAppName}.${testDomainName}"],
-    "backend": ["v2.${testDomainName}"]
+    "backend": ["v2.${testDomainName}", "${testEnvName}.${testAppName}.${testDomainName}"]
   }`;
   const testSANs = [
+    "test.myapp.example.com",
     "*.test.myapp.example.com",
     "v1.myapp.example.com",
     "v2.example.com",
@@ -518,6 +519,7 @@ describe("DNS Validated Certificate Handler", () => {
           sinon.match({
             DomainName: `${testEnvName}.${testAppName}.${testDomainName}`,
             SubjectAlternativeNames: [
+              `${testEnvName}.${testAppName}.${testDomainName}`,
               `*.${testEnvName}.${testAppName}.${testDomainName}`,
             ],
             ValidationMethod: "DNS",

--- a/templates/environment/cf.yml
+++ b/templates/environment/cf.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT-0
 Description: CloudFormation environment template for infrastructure shared among Copilot workloads.
 Metadata:
-  Version: 'v1.5.0'
+  Version: 'v1.5.1'
 Parameters:
   AppName:
     Type: String


### PR DESCRIPTION
<!-- Provide summary of changes -->
fixes #2602. Currently Copilot fails if users set the `alias` to be the same as the default domain name we assign them. Though this is not a very common behavior, we should handle this edge case gracefully. 
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
