### PR TITLE
chore(custom-resources): create a partial cfn template that adds an alias to rd-service

### DIFF
--- a/cf-custom-resources/lib/custom-domain-app-runner.js
+++ b/cf-custom-resources/lib/custom-domain-app-runner.js
@@ -84,8 +84,7 @@ function report (
 
 exports.handler = async function (event, context) {
     const props = event.ResourceProperties;
-    const [serviceARN, appDNSRole, customDomain] = [props.ServiceARN, props.AppDNSRole, props.CustomDomain,];
-    appHostedZoneID = props.HostedZoneID;
+    const [serviceARN, appDNSRole, customDomain, appDNSName] = [props.ServiceARN, props.AppDNSRole, props.CustomDomain, props.AppDNSName, ];
     const physicalResourceID = `/associate-domain-app-runner/${customDomain}`;
     let handler = async function () {
         // Configure clients.
@@ -96,7 +95,7 @@ exports.handler = async function (event, context) {
             }),
         });
         appRunnerClient = new AWS.AppRunner();
-
+        appHostedZoneID = await domainHostedZoneID(appDNSName);
         switch (event.RequestType) {
             case "Create":
             case "Update":
@@ -110,7 +109,6 @@ exports.handler = async function (event, context) {
                 throw new Error(`Unsupported request type ${event.RequestType}`);
         }
     };
-
     try {
         await Promise.race([exports.deadlineExpired(), handler(),]);
         await report(event, context, "SUCCESS", physicalResourceID);
@@ -129,6 +127,23 @@ exports.deadlineExpired = function () {
         );
     });
 };
+
+/**
+ * Get the hosted zone ID of the domain name from the app account.
+ * @param {string} domainName
+ * @returns {Promise<void>}
+ */
+async function domainHostedZoneID(domainName) {
+    const data = await appRoute53Client.listHostedZonesByName({
+        DNSName: domainName,
+        MaxItems: "1",
+    }).promise();
+
+    if (!data.HostedZones || data.HostedZones.length === 0) {
+        throw new Error(`couldn't find any Hosted Zone with DNS name ${domainName}`);
+    }
+    return data.HostedZones[0].Id.split("/").pop();
+}
 
 /**
  * Add custom domain for service by associating and adding records for both the domain and the validation.

--- a/cf-custom-resources/lib/custom-domain-app-runner.js
+++ b/cf-custom-resources/lib/custom-domain-app-runner.js
@@ -131,7 +131,6 @@ exports.deadlineExpired = function () {
 /**
  * Get the hosted zone ID of the domain name from the app account.
  * @param {string} domainName
- * @returns {Promise<void>}
  */
 async function domainHostedZoneID(domainName) {
     const data = await appRoute53Client.listHostedZonesByName({

--- a/templates/workloads/services/rd-web/cf.yml
+++ b/templates/workloads/services/rd-web/cf.yml
@@ -38,15 +38,6 @@ Parameters:
     Description: 'URL of the addons nested stack template within the S3 bucket.'
     Type: String
     Default: ''
-  Alias:
-    Type: String
-    Default: ""
-  AppDNSDelegationRole:
-    Type: String
-    Default: ""
-  AppDNSName:
-    Type: String
-    Default: ""
 
 Conditions:
   # App Runner will not accept an AccessRole for ImageRepositoryTypes other than ECR.
@@ -65,8 +56,6 @@ Conditions:
     !Not [!Equals [!Ref HealthCheckUnhealthyThreshold, '']]
   HasAddons: # If a bucket URL is specified, that means the template exists.
     !Not [!Equals [!Ref AddonsTemplateURL, '']]
-  HasAlias:
-    !Not [!Equals [!Ref Alias, '']]
 
 Resources:
 {{include "accessrole" . | indent 2}}
@@ -133,9 +122,9 @@ Resources:
 
 {{include "addons" . | indent 2}}
 
+{{- if .Alias}}
   CustomDomainFunctionAWSSDKLayer:
     Type: AWS::Lambda::LayerVersion
-    Condition: HasAlias
     Properties:
       CompatibleRuntimes:
         - nodejs14.x
@@ -148,7 +137,6 @@ Resources:
 
   CustomDomainFunction:
     Type: AWS::Lambda::Function
-    Condition: HasAlias
     Properties:
       Code:
         S3Bucket: {{ .ScriptBucketName }}
@@ -164,19 +152,17 @@ Resources:
   CustomDomainAction:
       Metadata:
         'aws:copilot:description': 'Associate the domain with the service as well as upserting the domain record and validation records'
-      Condition: HasAlias
       DependsOn: CustomDomainFunction
       Type: Custom::CustomDomainFunction
       Properties:
         ServiceToken: !GetAtt CustomDomainFunction.Arn
         ServiceARN: !GetAtt Service.ServiceArn
-        CustomDomain: !Ref Alias
-        AppDNSRole: !Ref AppDNSDelegationRole
-        AppDNSName: !Ref AppDNSName
+        CustomDomain: {{ .Alias }}
+        AppDNSRole: {{ .AppDNSRole }}
+        AppDNSName: {{ .AppDNSName }
 
   CustomResourceRole:
     Type: AWS::IAM::Role
-    Condition: HasAlias
     Properties:
       AssumeRolePolicyDocument:
         Version: 2012-10-17
@@ -206,3 +192,4 @@ Resources:
                   - "route53:ListHostedZonesByName"
                 Resource:
                   - "*"
+{{- end }}

--- a/templates/workloads/services/rd-web/cf.yml
+++ b/templates/workloads/services/rd-web/cf.yml
@@ -38,6 +38,15 @@ Parameters:
     Description: 'URL of the addons nested stack template within the S3 bucket.'
     Type: String
     Default: ''
+  Alias:
+    Type: String
+    Default: ""
+  AppDNSDelegationRole:
+    Type: String
+    Default: ""
+  AppDNSName:
+    Type: String
+    Default: ""
 
 Conditions:
   # App Runner will not accept an AccessRole for ImageRepositoryTypes other than ECR.
@@ -56,6 +65,8 @@ Conditions:
     !Not [!Equals [!Ref HealthCheckUnhealthyThreshold, '']]
   HasAddons: # If a bucket URL is specified, that means the template exists.
     !Not [!Equals [!Ref AddonsTemplateURL, '']]
+  HasAlias:
+    !Not [!Equals [!Ref Alias, '']]
 
 Resources:
 {{include "accessrole" . | indent 2}}
@@ -122,3 +133,76 @@ Resources:
 
 {{include "addons" . | indent 2}}
 
+  CustomDomainFunctionAWSSDKLayer:
+    Type: AWS::Lambda::LayerVersion
+    Condition: HasAlias
+    Properties:
+      CompatibleRuntimes:
+        - nodejs14.x
+      Content:
+        S3Bucket: {{ .ScriptBucketName }}
+        S3Key: {{ .AWSSDKLayer }}
+      Description: "The latest aws-sdk for the custom domain function to use. "
+      LayerName: custom-domain-aws-sdk
+      LicenseInfo: Apache-2.0
+
+  CustomDomainFunction:
+    Type: AWS::Lambda::Function
+    Condition: HasAlias
+    Properties:
+      Code:
+        S3Bucket: {{ .ScriptBucketName }}
+        S3Key: {{ .CustomDomainLambda }}
+      Handler: "index.handler"
+      Timeout: 900
+      MemorySize: 512
+      Role: !GetAtt CustomResourceRole.Arn
+      Runtime: nodejs14.x
+      Layers:
+        - !Ref CustomDomainFunctionAWSSDKLayer
+
+  CustomDomainAction:
+      Metadata:
+        'aws:copilot:description': 'Associate the domain with the service as well as upserting the domain record and validation records'
+      Condition: HasAlias
+      DependsOn: CustomDomainFunction
+      Type: Custom::CustomDomainFunction
+      Properties:
+        ServiceToken: !GetAtt CustomDomainFunction.Arn
+        ServiceARN: !GetAtt Service.ServiceArn
+        CustomDomain: !Ref Alias
+        AppDNSRole: !Ref AppDNSDelegationRole
+        AppDNSName: !Ref AppDNSName
+
+  CustomResourceRole:
+    Type: AWS::IAM::Role
+    Condition: HasAlias
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          -
+            Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Path: /
+      ManagedPolicyArns:
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyName: "DNSandACMAccess"
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "apprunner:AssociateCustomDomain"
+                  - "apprunner:DisassociateCustomDomain"
+                  - "apprunner:DescribeCustomDomains"
+                  - "sts:AssumeRole"
+                  - "route53:ChangeResourceRecordSets"
+                  - "route53:ListHostedZonesByName"
+                Resource:
+                  - "*"


### PR DESCRIPTION
1. Creates a partial cfn template that adds an alias to rd-service
2. Patch to the previous PR #2589: when the lambda tries to delete a non-existent record in response to `DELETE` action, it shouldn't error out.
3. Patch to the previous PR #2589: instead of passing the hosted zone id from CFN, the lambda gets the hosted zone ID by making an API call.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
