### PR TITLE
chore: render latest environment template version instead of hardcoding it

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/env.go
+++ b/internal/pkg/deploy/cloudformation/stack/env.go
@@ -102,6 +102,7 @@ func (e *EnvStackConfig) Template() (string, error) {
 		ImportVPC:                 e.in.ImportVPCConfig,
 		VPCConfig:                 vpcConf,
 		Version:                   e.in.Version,
+		LatestVersion:             deploy.LatestEnvTemplateVersion,
 	}, template.WithFuncs(map[string]interface{}{
 		"inc": template.IncFunc,
 	}))

--- a/internal/pkg/deploy/cloudformation/stack/env_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/env_test.go
@@ -41,6 +41,7 @@ func TestEnv_Template(t *testing.T) {
 						PrivateSubnetCIDRs: strings.Split(DefaultPrivateSubnetCIDRs, ","),
 						PublicSubnetCIDRs:  strings.Split(DefaultPublicSubnetCIDRs, ","),
 					},
+					LatestVersion: deploy.LatestEnvTemplateVersion,
 				}, gomock.Any()).Return(&template.Content{Buffer: bytes.NewBufferString("mockTemplate")}, nil)
 				e.parser = m
 			},

--- a/internal/pkg/deploy/env.go
+++ b/internal/pkg/deploy/env.go
@@ -13,7 +13,7 @@ const (
 	// LegacyEnvTemplateVersion is the version associated with the environment template before we started versioning.
 	LegacyEnvTemplateVersion = "v0.0.0"
 	// LatestEnvTemplateVersion is the latest version number available for environment templates.
-	LatestEnvTemplateVersion = "v1.5.0"
+	LatestEnvTemplateVersion = "v1.5.1"
 )
 
 // CreateEnvironmentInput holds the fields required to deploy an environment.

--- a/internal/pkg/template/env.go
+++ b/internal/pkg/template/env.go
@@ -41,6 +41,8 @@ type EnvOpts struct {
 
 	ImportVPC *config.ImportVPC
 	VPCConfig *config.AdjustVPC
+
+	LatestVersion string
 }
 
 // ParseEnv parses an environment's CloudFormation template with the specified data object and returns its content.

--- a/templates/environment/cf.yml
+++ b/templates/environment/cf.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT-0
 Description: CloudFormation environment template for infrastructure shared among Copilot workloads.
 Metadata:
-  Version: 'v1.5.1'
+  Version: {{ .LatestVersion }}
 Parameters:
   AppName:
     Type: String


### PR DESCRIPTION
Previously we have to make changes to two places when we need to update the environment template version, one being the `environment/cf.yml` template, the other being the variable `deploy.LatestEnvTemplateVersion`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
