### PR TITLE
chore(deploy): refactor deployment input so that app-related information is grouped together

### DIFF
--- a/internal/pkg/cli/env_init.go
+++ b/internal/pkg/cli/env_init.go
@@ -560,16 +560,18 @@ func (o *initEnvOpts) deployEnv(app *config.Application, customResourcesURLs map
 		return fmt.Errorf("get identity: %w", err)
 	}
 	deployEnvInput := &deploy.CreateEnvironmentInput{
-		Name:                     o.name,
-		AppName:                  o.appName,
-		Prod:                     o.isProduction,
-		ToolsAccountPrincipalARN: caller.RootUserARN,
-		AppDNSName:               app.Domain,
-		AdditionalTags:           app.Tags,
-		CustomResourcesURLs:      customResourcesURLs,
-		AdjustVPCConfig:          o.adjustVPCConfig(),
-		ImportVPCConfig:          o.importVPCConfig(),
-		Version:                  deploy.LatestEnvTemplateVersion,
+		Name: o.name,
+		App: deploy.AppInformation{
+			Name:                o.appName,
+			DNSName:             app.Domain,
+			AccountPrincipalARN: caller.RootUserARN,
+		},
+		Prod:                o.isProduction,
+		AdditionalTags:      app.Tags,
+		CustomResourcesURLs: customResourcesURLs,
+		AdjustVPCConfig:     o.adjustVPCConfig(),
+		ImportVPCConfig:     o.importVPCConfig(),
+		Version:             deploy.LatestEnvTemplateVersion,
 	}
 
 	if err := o.cleanUpDanglingRoles(o.appName, o.name); err != nil {

--- a/internal/pkg/cli/env_init_test.go
+++ b/internal/pkg/cli/env_init_test.go
@@ -885,11 +885,13 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 			},
 			expectDeployer: func(m *mocks.Mockdeployer) {
 				m.EXPECT().DeployAndRenderEnvironment(gomock.Any(), &deploy.CreateEnvironmentInput{
-					Name:                     "test",
-					AppName:                  "phonetool",
-					ToolsAccountPrincipalARN: "some arn",
-					CustomResourcesURLs:      map[string]string{"mockCustomResource": "mockURL"},
-					Version:                  deploy.LatestEnvTemplateVersion,
+					Name: "test",
+					App: deploy.AppInformation{
+						Name:                "phonetool",
+						AccountPrincipalARN: "some arn",
+					},
+					CustomResourcesURLs: map[string]string{"mockCustomResource": "mockURL"},
+					Version:             deploy.LatestEnvTemplateVersion,
 				}).Return(&cloudformation.ErrStackAlreadyExists{})
 				m.EXPECT().GetEnvironment("phonetool", "test").Return(&config.Environment{
 					AccountID: "1234",

--- a/internal/pkg/cli/env_upgrade.go
+++ b/internal/pkg/cli/env_upgrade.go
@@ -79,7 +79,9 @@ func newEnvUpgradeOpts(vars envUpgradeVars) (*envUpgradeOpts, error) {
 		sel:   selector.NewSelect(prompt.New(), store),
 		legacyEnvTemplater: stack.NewEnvStackConfig(&deploy.CreateEnvironmentInput{
 			Version: deploy.LegacyEnvTemplateVersion,
-			AppName: vars.appName,
+			App: deploy.AppInformation{
+				Name: vars.appName,
+			},
 		}),
 		prog:     termprogress.NewSpinner(log.DiagnosticWriter),
 		uploader: template.New(),
@@ -274,8 +276,10 @@ func (o *envUpgradeOpts) upgradeEnvironment(upgrader envUpgrader, conf *config.E
 	}
 
 	if err := upgrader.UpgradeEnvironment(&deploy.CreateEnvironmentInput{
-		Version:             toVersion,
-		AppName:             conf.App,
+		Version: toVersion,
+		App: deploy.AppInformation{
+			Name: conf.App,
+		},
 		Name:                conf.Name,
 		CustomResourcesURLs: customResourcesURLs,
 		ImportVPCConfig:     importedVPC,
@@ -299,8 +303,10 @@ func (o *envUpgradeOpts) upgradeLegacyEnvironment(upgrader legacyEnvUpgrader, co
 	}
 	if isDefaultEnv {
 		if err := upgrader.UpgradeLegacyEnvironment(&deploy.CreateEnvironmentInput{
-			Version:             toVersion,
-			AppName:             conf.App,
+			Version: toVersion,
+			App: deploy.AppInformation{
+				Name: conf.App,
+			},
 			Name:                conf.Name,
 			CustomResourcesURLs: customResourcesURLs,
 			CFNServiceRoleARN:   conf.ExecutionRoleARN,
@@ -343,8 +349,10 @@ func (o *envUpgradeOpts) upgradeLegacyEnvironmentWithVPCOverrides(upgrader legac
 	fromVersion, toVersion string, albWorkloads []string) error {
 	if conf.CustomConfig != nil {
 		if err := upgrader.UpgradeLegacyEnvironment(&deploy.CreateEnvironmentInput{
-			Version:           toVersion,
-			AppName:           conf.App,
+			Version: toVersion,
+			App: deploy.AppInformation{
+				Name: conf.App,
+			},
 			Name:              conf.Name,
 			ImportVPCConfig:   conf.CustomConfig.ImportVPC,
 			AdjustVPCConfig:   conf.CustomConfig.VPCConfig,

--- a/internal/pkg/cli/env_upgrade_test.go
+++ b/internal/pkg/cli/env_upgrade_test.go
@@ -280,8 +280,10 @@ func TestEnvUpgradeOpts_Execute(t *testing.T) {
 				mockUpgrader := mocks.NewMockenvTemplateUpgrader(ctrl)
 				mockUpgrader.EXPECT().UpgradeEnvironment(&deploy.CreateEnvironmentInput{
 					Version: deploy.LatestEnvTemplateVersion,
-					AppName: "phonetool",
-					Name:    "test",
+					App: deploy.AppInformation{
+						Name: "phonetool",
+					},
+					Name: "test",
 					ImportVPCConfig: &config.ImportVPC{
 						ID: "abc",
 					},
@@ -354,8 +356,10 @@ func TestEnvUpgradeOpts_Execute(t *testing.T) {
 				mockUpgrader := mocks.NewMockenvTemplateUpgrader(ctrl)
 				mockUpgrader.EXPECT().EnvironmentTemplate("phonetool", "test").Return("template", nil)
 				mockUpgrader.EXPECT().UpgradeLegacyEnvironment(&deploy.CreateEnvironmentInput{
-					Version:             deploy.LatestEnvTemplateVersion,
-					AppName:             "phonetool",
+					Version: deploy.LatestEnvTemplateVersion,
+					App: deploy.AppInformation{
+						Name: "phonetool",
+					},
 					Name:                "test",
 					CFNServiceRoleARN:   "execARN",
 					CustomResourcesURLs: map[string]string{"mockCustomResource": "mockURL"},
@@ -421,8 +425,10 @@ func TestEnvUpgradeOpts_Execute(t *testing.T) {
 				mockUpgrader := mocks.NewMockenvTemplateUpgrader(ctrl)
 				mockUpgrader.EXPECT().EnvironmentTemplate("phonetool", "test").Return("modified template", nil)
 				mockUpgrader.EXPECT().UpgradeLegacyEnvironment(&deploy.CreateEnvironmentInput{
-					Version:           deploy.LatestEnvTemplateVersion,
-					AppName:           "phonetool",
+					Version: deploy.LatestEnvTemplateVersion,
+					App: deploy.AppInformation{
+						Name: "phonetool",
+					},
 					Name:              "test",
 					CFNServiceRoleARN: "execARN",
 					ImportVPCConfig: &config.ImportVPC{

--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -49,19 +49,19 @@ type deployWkldVars struct {
 type deploySvcOpts struct {
 	deployWkldVars
 
-	store              store
-	ws                 wsSvcDirReader
-	imageBuilderPusher imageBuilderPusher
-	unmarshal          func([]byte) (manifest.WorkloadManifest, error)
-	s3                 artifactUploader
-	cmd                runner
-	addons             templater
-	appCFN             appResourcesGetter
-	svcCFN             cloudformation.CloudFormation
-	sessProvider       sessionProvider
-	envUpgradeCmd      actionCommand
+	store               store
+	ws                  wsSvcDirReader
+	imageBuilderPusher  imageBuilderPusher
+	unmarshal           func([]byte) (manifest.WorkloadManifest, error)
+	s3                  artifactUploader
+	cmd                 runner
+	addons              templater
+	appCFN              appResourcesGetter
+	svcCFN              cloudformation.CloudFormation
+	sessProvider        sessionProvider
+	envUpgradeCmd       actionCommand
 	newAppVersionGetter func(string) (versionGetter, error)
-	endpointGetter     endpointGetter
+	endpointGetter      endpointGetter
 
 	spinner progress
 	sel     wsSelector
@@ -455,7 +455,12 @@ func (o *deploySvcOpts) stackConfiguration(addonsURL string) (cloudformation.Sta
 			conf, err = stack.NewLoadBalancedWebService(t, o.targetEnvironment.Name, o.targetEnvironment.App, *rc)
 		}
 	case *manifest.RequestDrivenWebService:
-		conf, err = stack.NewRequestDrivenWebService(t, o.targetEnvironment.Name, o.targetEnvironment.App, *rc)
+		appInfo := stack.AppInformation{
+			Name:                o.targetEnvironment.App,
+			DNSName:             o.targetApp.Domain,
+			AccountPrincipalARN: o.targetApp.AccountID,
+		}
+		conf, err = stack.NewRequestDrivenWebService(t, o.targetEnvironment.Name, appInfo, *rc)
 	case *manifest.BackendService:
 		conf, err = stack.NewBackendService(t, o.targetEnvironment.Name, o.targetEnvironment.App, *rc)
 	default:

--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -455,7 +455,7 @@ func (o *deploySvcOpts) stackConfiguration(addonsURL string) (cloudformation.Sta
 			conf, err = stack.NewLoadBalancedWebService(t, o.targetEnvironment.Name, o.targetEnvironment.App, *rc)
 		}
 	case *manifest.RequestDrivenWebService:
-		appInfo := stack.AppInformation{
+		appInfo := deploy.AppInformation{
 			Name:                o.targetEnvironment.App,
 			DNSName:             o.targetApp.Domain,
 			AccountPrincipalARN: o.targetApp.AccountID,

--- a/internal/pkg/cli/svc_package.go
+++ b/internal/pkg/cli/svc_package.go
@@ -125,7 +125,12 @@ func newPackageSvcOpts(vars packageSvcVars) (*packageSvcOpts, error) {
 				}
 			}
 		case *manifest.RequestDrivenWebService:
-			serializer, err = stack.NewRequestDrivenWebService(t, env.Name, app.Name, rc)
+			appInfo := stack.AppInformation{
+				Name:                env.App,
+				DNSName:             app.Domain,
+				AccountPrincipalARN: app.AccountID,
+			}
+			serializer, err = stack.NewRequestDrivenWebService(t, env.Name, appInfo, rc)
 			if err != nil {
 				return nil, fmt.Errorf("init request-driven web service stack serializer: %w", err)
 			}

--- a/internal/pkg/cli/svc_package.go
+++ b/internal/pkg/cli/svc_package.go
@@ -125,7 +125,7 @@ func newPackageSvcOpts(vars packageSvcVars) (*packageSvcOpts, error) {
 				}
 			}
 		case *manifest.RequestDrivenWebService:
-			appInfo := stack.AppInformation{
+			appInfo := deploy.AppInformation{
 				Name:                env.App,
 				DNSName:             app.Domain,
 				AccountPrincipalARN: app.AccountID,

--- a/internal/pkg/deploy/app.go
+++ b/internal/pkg/deploy/app.go
@@ -5,6 +5,14 @@
 // This file defines application deployment resources.
 package deploy
 
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws/arn"
+)
+
+const appDNSDelegationRoleName = "DNSDelegationRole"
+
 // CreateAppInput holds the fields required to create an application stack set.
 type CreateAppInput struct {
 	Name                  string            // Name of the application that needs to be created.
@@ -24,3 +32,28 @@ const (
 	// AliasLeastAppTemplateVersion is the least version number available for HTTPS alias.
 	AliasLeastAppTemplateVersion = "v1.0.0"
 )
+
+// AppInformation holds information about the application that need to be propagated to the env stacks and workload stacks.
+type AppInformation struct {
+	AccountPrincipalARN string
+	DNSName             string
+	Name                string
+}
+
+// DNSDelegationRole returns the ARN of the app's DNS delegation role.
+func (a *AppInformation) DNSDelegationRole() string {
+	if a.AccountPrincipalARN == "" || a.DNSName == "" {
+		return ""
+	}
+
+	appRole, err := arn.Parse(a.AccountPrincipalARN)
+	if err != nil {
+		return ""
+	}
+	return fmt.Sprintf("arn:%s:iam::%s:role/%s", appRole.Partition, appRole.AccountID, DNSDelegationRoleName(a.Name))
+}
+
+// DNSDelegationRoleName returns the DNSDelegation role name of the app.
+func DNSDelegationRoleName(appName string) string {
+	return fmt.Sprintf("%s-%s", appName, appDNSDelegationRoleName)
+}

--- a/internal/pkg/deploy/app_test.go
+++ b/internal/pkg/deploy/app_test.go
@@ -1,0 +1,50 @@
+package deploy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAppInformation_DNSDelegationRole(t *testing.T) {
+	testCases := map[string]struct {
+		in   *AppInformation
+		want string
+	}{
+		"without tools account ARN": {
+			want: "",
+			in: &AppInformation{
+				AccountPrincipalARN: "",
+				DNSName:             "ecs.aws",
+			},
+		},
+		"without DNS": {
+			want: "",
+			in: &AppInformation{
+				AccountPrincipalARN: "",
+				DNSName:             "ecs.aws",
+			},
+		},
+		"with invalid tools principal": {
+			want: "",
+			in: &AppInformation{
+				AccountPrincipalARN: "0000000",
+				DNSName:             "ecs.aws",
+			},
+		},
+		"with dns and tools principal": {
+			want: "arn:aws:iam::0000000:role/-DNSDelegationRole",
+
+			in: &AppInformation{
+				AccountPrincipalARN: "arn:aws:iam::0000000:root",
+				DNSName:             "ecs.aws",
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.want, tc.in.DNSDelegationRole())
+		})
+	}
+}

--- a/internal/pkg/deploy/cloudformation/env.go
+++ b/internal/pkg/deploy/cloudformation/env.go
@@ -52,8 +52,10 @@ func (cf CloudFormation) DeployAndRenderEnvironment(out progress.FileWriter, env
 // DeleteEnvironment deletes the CloudFormation stack of an environment.
 func (cf CloudFormation) DeleteEnvironment(appName, envName, cfnExecRoleARN string) error {
 	conf := stack.NewEnvStackConfig(&deploy.CreateEnvironmentInput{
-		AppName: appName,
-		Name:    envName,
+		App: deploy.AppInformation{
+			Name: appName,
+		},
+		Name: envName,
 	})
 	return cf.cfnClient.DeleteAndWaitWithRoleARN(conf.StackName(), cfnExecRoleARN)
 }
@@ -61,8 +63,10 @@ func (cf CloudFormation) DeleteEnvironment(appName, envName, cfnExecRoleARN stri
 // GetEnvironment returns the Environment metadata from the CloudFormation stack.
 func (cf CloudFormation) GetEnvironment(appName, envName string) (*config.Environment, error) {
 	conf := stack.NewEnvStackConfig(&deploy.CreateEnvironmentInput{
-		AppName: appName,
-		Name:    envName,
+		App: deploy.AppInformation{
+			Name: appName,
+		},
+		Name: envName,
 	})
 	descr, err := cf.cfnClient.Describe(conf.StackName())
 	if err != nil {

--- a/internal/pkg/deploy/cloudformation/env_test.go
+++ b/internal/pkg/deploy/cloudformation/env_test.go
@@ -19,7 +19,9 @@ import (
 )
 
 var mockCreateEnvInput = deploy.CreateEnvironmentInput{
-	AppName: "phonetool",
+	App: deploy.AppInformation{
+		Name: "phonetool",
+	},
 	Name:    "test",
 	Version: "v1.0.0",
 	CustomResourcesURLs: map[string]string{

--- a/internal/pkg/deploy/cloudformation/stack/app.go
+++ b/internal/pkg/deploy/cloudformation/stack/app.go
@@ -8,8 +8,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws/arn"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
@@ -62,7 +60,6 @@ const (
 	appDomainNameKey              = "AppDomainName"
 	appDomainHostedZoneIDKey      = "AppDomainHostedZoneID"
 	appNameKey                    = "AppName"
-	appDNSDelegationRoleName      = "DNSDelegationRole"
 
 	// arn:${partition}:iam::${account}:role/${roleName}
 	fmtStackSetAdminRoleARN = "arn:%s:iam::%s:role/%s"
@@ -154,7 +151,7 @@ func (c *AppStackConfig) Parameters() ([]*cloudformation.Parameter, error) {
 		},
 		{
 			ParameterKey:   aws.String(appDNSDelegationRoleParamName),
-			ParameterValue: aws.String(dnsDelegationRoleName(c.Name)),
+			ParameterValue: aws.String(deploy.DNSDelegationRoleName(c.Name)),
 		},
 	}, nil
 }
@@ -269,27 +266,4 @@ func DNSDelegatedAccountsForStack(stack *cloudformation.Stack) []string {
 	}
 
 	return []string{}
-}
-
-func dnsDelegationRoleName(appName string) string {
-	return fmt.Sprintf("%s-%s", appName, appDNSDelegationRoleName)
-}
-
-// AppInformation holds information about the application that need to be propagated to the env stacks and workload stacks.
-type AppInformation struct {
-	AccountPrincipalARN string
-	DNSName             string
-	Name                string
-}
-
-func (a *AppInformation) dnsDelegationRole() string {
-	if a.AccountPrincipalARN == "" || a.DNSName == "" {
-		return ""
-	}
-
-	appRole, err := arn.Parse(a.AccountPrincipalARN)
-	if err != nil {
-		return ""
-	}
-	return fmt.Sprintf("arn:%s:iam::%s:role/%s", appRole.Partition, appRole.AccountID, dnsDelegationRoleName(a.Name))
 }

--- a/internal/pkg/deploy/cloudformation/stack/env_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/env_test.go
@@ -76,7 +76,7 @@ func TestEnv_Template(t *testing.T) {
 func TestEnv_Parameters(t *testing.T) {
 	deploymentInput := mockDeployEnvironmentInput()
 	deploymentInputWithDNS := mockDeployEnvironmentInput()
-	deploymentInputWithDNS.AppDNSName = "ecs.aws"
+	deploymentInputWithDNS.App.DNSName = "ecs.aws"
 	testCases := map[string]struct {
 		input *deploy.CreateEnvironmentInput
 		want  []*cloudformation.Parameter
@@ -86,7 +86,7 @@ func TestEnv_Parameters(t *testing.T) {
 			want: []*cloudformation.Parameter{
 				{
 					ParameterKey:   aws.String(envParamAppNameKey),
-					ParameterValue: aws.String(deploymentInput.AppName),
+					ParameterValue: aws.String(deploymentInput.App.Name),
 				},
 				{
 					ParameterKey:   aws.String(envParamEnvNameKey),
@@ -94,7 +94,7 @@ func TestEnv_Parameters(t *testing.T) {
 				},
 				{
 					ParameterKey:   aws.String(envParamToolsAccountPrincipalKey),
-					ParameterValue: aws.String(deploymentInput.ToolsAccountPrincipalARN),
+					ParameterValue: aws.String(deploymentInput.App.AccountPrincipalARN),
 				},
 				{
 					ParameterKey:   aws.String(envParamAppDNSKey),
@@ -115,7 +115,7 @@ func TestEnv_Parameters(t *testing.T) {
 			want: []*cloudformation.Parameter{
 				{
 					ParameterKey:   aws.String(envParamAppNameKey),
-					ParameterValue: aws.String(deploymentInputWithDNS.AppName),
+					ParameterValue: aws.String(deploymentInputWithDNS.App.Name),
 				},
 				{
 					ParameterKey:   aws.String(envParamEnvNameKey),
@@ -123,11 +123,11 @@ func TestEnv_Parameters(t *testing.T) {
 				},
 				{
 					ParameterKey:   aws.String(envParamToolsAccountPrincipalKey),
-					ParameterValue: aws.String(deploymentInputWithDNS.ToolsAccountPrincipalARN),
+					ParameterValue: aws.String(deploymentInputWithDNS.App.AccountPrincipalARN),
 				},
 				{
 					ParameterKey:   aws.String(envParamAppDNSKey),
-					ParameterValue: aws.String(deploymentInputWithDNS.AppDNSName),
+					ParameterValue: aws.String(deploymentInputWithDNS.App.DNSName),
 				},
 				{
 					ParameterKey:   aws.String(envParamAppDNSDelegationRoleKey),
@@ -152,61 +152,13 @@ func TestEnv_Parameters(t *testing.T) {
 	}
 }
 
-func TestEnv_DNSDelegationRole(t *testing.T) {
-	testCases := map[string]struct {
-		input *EnvStackConfig
-		want  string
-	}{
-		"without tools account ARN": {
-			want: "",
-			input: &EnvStackConfig{
-				in: &deploy.CreateEnvironmentInput{
-					ToolsAccountPrincipalARN: "",
-					AppDNSName:               "ecs.aws",
-				},
-			},
-		},
-		"without DNS": {
-			want: "",
-			input: &EnvStackConfig{
-				in: &deploy.CreateEnvironmentInput{
-					ToolsAccountPrincipalARN: "arn:aws:iam::0000000:root",
-					AppDNSName:               "",
-				},
-			},
-		},
-		"with invalid tools principal": {
-			want: "",
-			input: &EnvStackConfig{
-				in: &deploy.CreateEnvironmentInput{
-					ToolsAccountPrincipalARN: "0000000",
-					AppDNSName:               "ecs.aws",
-				},
-			},
-		},
-		"with dns and tools principal": {
-			want: "arn:aws:iam::0000000:role/-DNSDelegationRole",
-			input: &EnvStackConfig{
-				in: &deploy.CreateEnvironmentInput{
-					ToolsAccountPrincipalARN: "arn:aws:iam::0000000:root",
-					AppDNSName:               "ecs.aws",
-				},
-			},
-		},
-	}
-
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			require.Equal(t, tc.want, tc.input.dnsDelegationRole())
-		})
-	}
-}
-
 func TestEnv_Tags(t *testing.T) {
 	env := &EnvStackConfig{
 		in: &deploy.CreateEnvironmentInput{
-			Name:    "env",
-			AppName: "project",
+			Name: "env",
+			App: deploy.AppInformation{
+				Name: "project",
+			},
 			AdditionalTags: map[string]string{
 				"owner":          "boss",
 				deploy.AppTagKey: "overrideproject",
@@ -235,7 +187,7 @@ func TestStackName(t *testing.T) {
 	env := &EnvStackConfig{
 		in: deploymentInput,
 	}
-	require.Equal(t, fmt.Sprintf("%s-%s", deploymentInput.AppName, deploymentInput.Name), env.StackName())
+	require.Equal(t, fmt.Sprintf("%s-%s", deploymentInput.App.Name, deploymentInput.Name), env.StackName())
 }
 
 func TestToEnv(t *testing.T) {
@@ -256,7 +208,7 @@ func TestToEnv(t *testing.T) {
 				"arn:aws:iam::902697171733:role/phonetool-test-CFNExecutionRole"),
 			expectedEnv: config.Environment{
 				Name:             mockDeployInput.Name,
-				App:              mockDeployInput.AppName,
+				App:              mockDeployInput.App.Name,
 				Prod:             mockDeployInput.Prod,
 				AccountID:        "902697171733",
 				Region:           "eu-west-3",
@@ -301,10 +253,12 @@ func mockEnvironmentStack(stackArn, managerRoleARN, executionRoleARN string) *cl
 
 func mockDeployEnvironmentInput() *deploy.CreateEnvironmentInput {
 	return &deploy.CreateEnvironmentInput{
-		Name:                     "env",
-		AppName:                  "project",
-		Prod:                     true,
-		ToolsAccountPrincipalARN: "arn:aws:iam::000000000:root",
+		Name: "env",
+		App: deploy.AppInformation{
+			Name:                "project",
+			AccountPrincipalARN: "arn:aws:iam::000000000:root",
+		},
+		Prod: true,
 		CustomResourcesURLs: map[string]string{
 			template.DNSCertValidatorFileName: "https://mockbucket.s3-us-west-2.amazonaws.com/mockkey1",
 			template.DNSDelegationFileName:    "https://mockbucket.s3-us-west-2.amazonaws.com/mockkey2",

--- a/internal/pkg/deploy/cloudformation/stack/rd_web_svc.go
+++ b/internal/pkg/deploy/cloudformation/stack/rd_web_svc.go
@@ -63,20 +63,11 @@ func (s *RequestDrivenWebService) Template() (string, error) {
 		return "", err
 	}
 
-	alias := "" // TODO: parse from manifest
 	content, err := s.parser.ParseRequestDrivenWebService(template.ParseRequestDrivenWebServiceInput{
 		Variables:         s.manifest.Variables,
 		Tags:              s.manifest.Tags,
 		NestedStack:       outputs,
 		EnableHealthCheck: !s.healthCheckConfig.IsEmpty(),
-
-		// TODO: fill these
-		ScriptBucketName:     "",
-		CustomDomainLambda:   "",
-		AWSSDKLayer:          "",
-		Alias:                alias,
-		AppDNSDelegationRole: s.app.DNSDelegationRole(),
-		AppDNSName:           s.app.DNSName, // TODO: is this "" or nil
 	})
 	if err != nil {
 		return "", err

--- a/internal/pkg/deploy/cloudformation/stack/rd_web_svc.go
+++ b/internal/pkg/deploy/cloudformation/stack/rd_web_svc.go
@@ -6,6 +6,8 @@ package stack
 import (
 	"fmt"
 
+	"github.com/aws/copilot-cli/internal/pkg/deploy"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/copilot-cli/internal/pkg/addon"
 	"github.com/aws/copilot-cli/internal/pkg/manifest"
@@ -21,13 +23,13 @@ type requestDrivenWebSvcReadParser interface {
 type RequestDrivenWebService struct {
 	*appRunnerWkld
 	manifest *manifest.RequestDrivenWebService
-	app      AppInformation
+	app      deploy.AppInformation
 
 	parser requestDrivenWebSvcReadParser
 }
 
 // NewRequestDrivenWebService creates a new RequestDrivenWebService stack from a manifest file.
-func NewRequestDrivenWebService(mft *manifest.RequestDrivenWebService, env string, app AppInformation, rc RuntimeConfig) (*RequestDrivenWebService, error) {
+func NewRequestDrivenWebService(mft *manifest.RequestDrivenWebService, env string, app deploy.AppInformation, rc RuntimeConfig) (*RequestDrivenWebService, error) {
 	parser := template.New()
 	addons, err := addon.New(aws.StringValue(mft.Name))
 	if err != nil {
@@ -73,7 +75,7 @@ func (s *RequestDrivenWebService) Template() (string, error) {
 		CustomDomainLambda:   "",
 		AWSSDKLayer:          "",
 		Alias:                alias,
-		AppDNSDelegationRole: s.app.dnsDelegationRole(),
+		AppDNSDelegationRole: s.app.DNSDelegationRole(),
 		AppDNSName:           s.app.DNSName, // TODO: is this "" or nil
 	})
 	if err != nil {

--- a/internal/pkg/deploy/cloudformation/stack/rd_web_svc_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/rd_web_svc_test.go
@@ -49,10 +49,10 @@ var testRDWebServiceManifest = &manifest.RequestDrivenWebService{
 
 func TestRequestDrivenWebService_NewRequestDrivenWebService(t *testing.T) {
 	type testInput struct {
-		mft *manifest.RequestDrivenWebService
-		env string
-		app string
-		rc  RuntimeConfig
+		mft     *manifest.RequestDrivenWebService
+		env     string
+		rc      RuntimeConfig
+		appInfo AppInformation
 	}
 
 	testCases := map[string]struct {
@@ -66,8 +66,10 @@ func TestRequestDrivenWebService_NewRequestDrivenWebService(t *testing.T) {
 			input: testInput{
 				mft: testRDWebServiceManifest,
 				env: testEnvName,
-				app: testAppName,
 				rc:  RuntimeConfig{},
+				appInfo: AppInformation{
+					Name: testAppName,
+				},
 			},
 
 			wantedStack: &RequestDrivenWebService{
@@ -83,6 +85,9 @@ func TestRequestDrivenWebService_NewRequestDrivenWebService(t *testing.T) {
 					imageConfig:    testRDWebServiceManifest.ImageConfig,
 				},
 				manifest: testRDWebServiceManifest,
+				app: AppInformation{
+					Name: testAppName,
+				},
 			},
 		},
 	}
@@ -95,7 +100,7 @@ func TestRequestDrivenWebService_NewRequestDrivenWebService(t *testing.T) {
 			stack, err := NewRequestDrivenWebService(
 				tc.input.mft,
 				tc.input.env,
-				tc.input.app,
+				tc.input.appInfo,
 				tc.input.rc,
 			)
 

--- a/internal/pkg/deploy/cloudformation/stack/rd_web_svc_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/rd_web_svc_test.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/aws/copilot-cli/internal/pkg/deploy"
+
 	"github.com/aws/copilot-cli/internal/pkg/addon"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -52,7 +54,7 @@ func TestRequestDrivenWebService_NewRequestDrivenWebService(t *testing.T) {
 		mft     *manifest.RequestDrivenWebService
 		env     string
 		rc      RuntimeConfig
-		appInfo AppInformation
+		appInfo deploy.AppInformation
 	}
 
 	testCases := map[string]struct {
@@ -67,7 +69,7 @@ func TestRequestDrivenWebService_NewRequestDrivenWebService(t *testing.T) {
 				mft: testRDWebServiceManifest,
 				env: testEnvName,
 				rc:  RuntimeConfig{},
-				appInfo: AppInformation{
+				appInfo: deploy.AppInformation{
 					Name: testAppName,
 				},
 			},
@@ -85,7 +87,7 @@ func TestRequestDrivenWebService_NewRequestDrivenWebService(t *testing.T) {
 					imageConfig:    testRDWebServiceManifest.ImageConfig,
 				},
 				manifest: testRDWebServiceManifest,
-				app: AppInformation{
+				app: deploy.AppInformation{
 					Name: testAppName,
 				},
 			},

--- a/internal/pkg/deploy/cloudformation/stack/workload.go
+++ b/internal/pkg/deploy/cloudformation/stack/workload.go
@@ -43,15 +43,15 @@ const (
 
 // Parameter logical IDs for workloads on App Runner.
 const (
-	WorkloadImageRepositoryType                   = "ImageRepositoryType"
-	WorkloadInstanceCPUParamKey                   = "InstanceCPU"
-	WorkloadInstanceMemoryParamKey                = "InstanceMemory"
-	WorkloadInstanceRoleParamKey                  = "InstanceRole"
-	WorkloadHealthCheckPathParamKey               = "HealthCheckPath"
-	WorkloadHealthCheckIntervalParamKey           = "HealthCheckInterval"
-	WorkloadHealthCheckTimeoutParamKey            = "HealthCheckTimeout"
-	WorkloadHealthCheckHealthyThresholdParamKey   = "HealthCheckHealthyThreshold"
-	WorkloadHealthCheckUnhealthyThresholdParamKey = "HealthCheckUnhealthyThreshold"
+	RDWkldImageRepositoryType                   = "ImageRepositoryType"
+	RDWkldInstanceCPUParamKey                   = "InstanceCPU"
+	RDWkldInstanceMemoryParamKey                = "InstanceMemory"
+	RDWkldInstanceRoleParamKey                  = "InstanceRole"
+	RDWkldHealthCheckPathParamKey               = "HealthCheckPath"
+	RDWkldHealthCheckIntervalParamKey           = "HealthCheckInterval"
+	RDWkldHealthCheckTimeoutParamKey            = "HealthCheckTimeout"
+	RDWkldHealthCheckHealthyThresholdParamKey   = "HealthCheckHealthyThreshold"
+	RDWkldHealthCheckUnhealthyThresholdParamKey = "HealthCheckUnhealthyThreshold"
 )
 
 // Matches alphanumeric characters and -._
@@ -193,7 +193,7 @@ func (w *wkld) addonsOutputs() (*template.WorkloadNestedStackOpts, error) {
 	stack, err := w.addons.Template()
 	if err != nil {
 		var notFoundErr *addon.ErrAddonsNotFound
-		if !errors.As(err, &notFoundErr){
+		if !errors.As(err, &notFoundErr) {
 			return nil, fmt.Errorf("generate addons template for %s: %w", w.name, err)
 		}
 		return nil, nil // No addons found, so there are no outputs and error.
@@ -315,7 +315,7 @@ func (w *appRunnerWkld) Parameters() ([]*cloudformation.Parameter, error) {
 
 	appRunnerParameters := []*cloudformation.Parameter{
 		{
-			ParameterKey:   aws.String(WorkloadImageRepositoryType),
+			ParameterKey:   aws.String(RDWkldImageRepositoryType),
 			ParameterValue: aws.String(imageRepositoryType),
 		},
 		{
@@ -323,11 +323,11 @@ func (w *appRunnerWkld) Parameters() ([]*cloudformation.Parameter, error) {
 			ParameterValue: aws.String(strconv.Itoa(int(*w.imageConfig.Port))),
 		},
 		{
-			ParameterKey:   aws.String(WorkloadInstanceCPUParamKey),
+			ParameterKey:   aws.String(RDWkldInstanceCPUParamKey),
 			ParameterValue: aws.String(strconv.Itoa(*w.instanceConfig.CPU)),
 		},
 		{
-			ParameterKey:   aws.String(WorkloadInstanceMemoryParamKey),
+			ParameterKey:   aws.String(RDWkldInstanceMemoryParamKey),
 			ParameterValue: aws.String(strconv.Itoa(*w.instanceConfig.Memory)),
 		},
 	}
@@ -335,7 +335,7 @@ func (w *appRunnerWkld) Parameters() ([]*cloudformation.Parameter, error) {
 	// Optional HealthCheckPath parameter
 	if w.healthCheckConfig.Path() != nil {
 		appRunnerParameters = append(appRunnerParameters, &cloudformation.Parameter{
-			ParameterKey:   aws.String(WorkloadHealthCheckPathParamKey),
+			ParameterKey:   aws.String(RDWkldHealthCheckPathParamKey),
 			ParameterValue: aws.String(*w.healthCheckConfig.Path()),
 		})
 	}
@@ -343,7 +343,7 @@ func (w *appRunnerWkld) Parameters() ([]*cloudformation.Parameter, error) {
 	// Optional HealthCheckInterval parameter
 	if w.healthCheckConfig.HealthCheckArgs.Interval != nil {
 		appRunnerParameters = append(appRunnerParameters, &cloudformation.Parameter{
-			ParameterKey:   aws.String(WorkloadHealthCheckIntervalParamKey),
+			ParameterKey:   aws.String(RDWkldHealthCheckIntervalParamKey),
 			ParameterValue: aws.String(strconv.Itoa(int(w.healthCheckConfig.HealthCheckArgs.Interval.Seconds()))),
 		})
 	}
@@ -351,7 +351,7 @@ func (w *appRunnerWkld) Parameters() ([]*cloudformation.Parameter, error) {
 	// Optional HealthCheckTimeout parameter
 	if w.healthCheckConfig.HealthCheckArgs.Timeout != nil {
 		appRunnerParameters = append(appRunnerParameters, &cloudformation.Parameter{
-			ParameterKey:   aws.String(WorkloadHealthCheckTimeoutParamKey),
+			ParameterKey:   aws.String(RDWkldHealthCheckTimeoutParamKey),
 			ParameterValue: aws.String(strconv.Itoa(int(w.healthCheckConfig.HealthCheckArgs.Timeout.Seconds()))),
 		})
 	}
@@ -359,7 +359,7 @@ func (w *appRunnerWkld) Parameters() ([]*cloudformation.Parameter, error) {
 	// Optional HealthCheckHealthyThreshold parameter
 	if w.healthCheckConfig.HealthCheckArgs.HealthyThreshold != nil {
 		appRunnerParameters = append(appRunnerParameters, &cloudformation.Parameter{
-			ParameterKey:   aws.String(WorkloadHealthCheckHealthyThresholdParamKey),
+			ParameterKey:   aws.String(RDWkldHealthCheckHealthyThresholdParamKey),
 			ParameterValue: aws.String(strconv.Itoa(int(*w.healthCheckConfig.HealthCheckArgs.HealthyThreshold))),
 		})
 	}
@@ -367,7 +367,7 @@ func (w *appRunnerWkld) Parameters() ([]*cloudformation.Parameter, error) {
 	// Optional HealthCheckUnhealthyThreshold parameter
 	if w.healthCheckConfig.HealthCheckArgs.UnhealthyThreshold != nil {
 		appRunnerParameters = append(appRunnerParameters, &cloudformation.Parameter{
-			ParameterKey:   aws.String(WorkloadHealthCheckUnhealthyThresholdParamKey),
+			ParameterKey:   aws.String(RDWkldHealthCheckUnhealthyThresholdParamKey),
 			ParameterValue: aws.String(strconv.Itoa(int(*w.healthCheckConfig.HealthCheckArgs.UnhealthyThreshold))),
 		})
 	}

--- a/internal/pkg/deploy/env.go
+++ b/internal/pkg/deploy/env.go
@@ -21,15 +21,13 @@ type CreateEnvironmentInput struct {
 	// The version of the environment template to create the stack. If empty, creates the legacy stack.
 	Version string
 
-	AppName                  string            // Name of the application this environment belongs to.
-	Name                     string            // Name of the environment, must be unique within an application.
-	Prod                     bool              // Whether or not this environment is a production environment.
-	ToolsAccountPrincipalARN string            // The Principal ARN of the tools account.
-	AppDNSName               string            // The DNS name of this application, if it exists
-	AdditionalTags           map[string]string // AdditionalTags are labels applied to resources under the application.
-	CustomResourcesURLs      map[string]string // Environment custom resource script S3 object URLs.
-	ImportVPCConfig          *config.ImportVPC // Optional configuration if users have an existing VPC.
-	AdjustVPCConfig          *config.AdjustVPC // Optional configuration if users want to override default VPC configuration.
+	App                 AppInformation    // Information about the application that the environment belongs to, include app name, DNS name, the principal ARN of the account.
+	Name                string            // Name of the environment, must be unique within an application.
+	Prod                bool              // Whether or not this environment is a production environment.
+	AdditionalTags      map[string]string // AdditionalTags are labels applied to resources under the application.
+	CustomResourcesURLs map[string]string // Environment custom resource script S3 object URLs.
+	ImportVPCConfig     *config.ImportVPC // Optional configuration if users have an existing VPC.
+	AdjustVPCConfig     *config.AdjustVPC // Optional configuration if users want to override default VPC configuration.
 
 	CFNServiceRoleARN string // Optional. A service role ARN that CloudFormation should use to make calls to resources in the stack.
 }

--- a/internal/pkg/template/workload.go
+++ b/internal/pkg/template/workload.go
@@ -275,6 +275,14 @@ type ParseRequestDrivenWebServiceInput struct {
 	NestedStack         *WorkloadNestedStackOpts // Outputs from nested stacks such as the addons stack.
 	EnableHealthCheck   bool
 	EnvControllerLambda string
+
+	// Input needed for the custom resource that adds a custom domain to the service.
+	ScriptBucketName     string
+	CustomDomainLambda   string
+	AWSSDKLayer          string
+	Alias                string
+	AppDNSDelegationRole string
+	AppDNSName           string
 }
 
 // ParseLoadBalancedWebService parses a load balanced web service's CloudFormation template


### PR DESCRIPTION
Previously only environment deployment input needs `AppDNSName` and `AppDelegationRole`.  Now in order to enable alias for RD service, these information are needed for RD service deployment as well. 

This PR refactors the `deploy` package to avoid repetitive code that would have been added without the refactoring.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
