### PR TITLE
chore(pipeline): change error message to use var

### DIFF
--- a/internal/pkg/cli/pipeline_init.go
+++ b/internal/pkg/cli/pipeline_init.go
@@ -218,7 +218,7 @@ func (o *initPipelineOpts) validateURL(url string) error {
 	// Note: no longer calling `validateDomainName` because if users use git-remote-codecommit
 	// (the HTTPS (GRC) protocol) to connect to CodeCommit, the url does not have any periods.
 	if !strings.Contains(url, githubURL) && !strings.Contains(url, ccIdentifier) && !strings.Contains(url, bbURL) {
-		return errors.New("Copilot currently accepts URLs to only GitHub, CodeCommit, and Bitbucket repository sources")
+		return fmt.Errorf("must be a URL to a supported provider: %s", strings.Join(manifest.PipelineProviders, ", "))
 	}
 	return nil
 }

--- a/internal/pkg/cli/pipeline_init.go
+++ b/internal/pkg/cli/pipeline_init.go
@@ -218,7 +218,7 @@ func (o *initPipelineOpts) validateURL(url string) error {
 	// Note: no longer calling `validateDomainName` because if users use git-remote-codecommit
 	// (the HTTPS (GRC) protocol) to connect to CodeCommit, the url does not have any periods.
 	if !strings.Contains(url, githubURL) && !strings.Contains(url, ccIdentifier) && !strings.Contains(url, bbURL) {
-		return fmt.Errorf("must be a URL to a supported provider: %s", strings.Join(manifest.PipelineProviders, ", "))
+		return fmt.Errorf("must be a URL to a supported provider (%s)", strings.Join(manifest.PipelineProviders, ", "))
 	}
 	return nil
 }

--- a/internal/pkg/cli/pipeline_init_test.go
+++ b/internal/pkg/cli/pipeline_init_test.go
@@ -53,7 +53,7 @@ func TestInitPipelineOpts_Validate(t *testing.T) {
 				m.EXPECT().GetApplication("my-app").Return(&config.Application{Name: "my-app"}, nil)
 			},
 
-			expectedError: errors.New("must be a URL to a supported provider: GitHub, CodeCommit, Bitbucket"),
+			expectedError: errors.New("must be a URL to a supported provider (GitHub, CodeCommit, Bitbucket)"),
 		},
 		"invalid environments": {
 			inAppName: "my-app",
@@ -323,7 +323,7 @@ func TestInitPipelineOpts_Ask(t *testing.T) {
 			},
 			mockSessProvider: func(m *mocks.MocksessionProvider) {},
 
-			expectedError: fmt.Errorf("must be a URL to a supported provider: GitHub, CodeCommit, Bitbucket"),
+			expectedError: fmt.Errorf("must be a URL to a supported provider (GitHub, CodeCommit, Bitbucket)"),
 		},
 		"returns error if fail to parse GitHub URL": {
 			inEnvironments:      []string{},

--- a/internal/pkg/cli/pipeline_init_test.go
+++ b/internal/pkg/cli/pipeline_init_test.go
@@ -53,7 +53,7 @@ func TestInitPipelineOpts_Validate(t *testing.T) {
 				m.EXPECT().GetApplication("my-app").Return(&config.Application{Name: "my-app"}, nil)
 			},
 
-			expectedError: errors.New("Copilot currently accepts URLs to only GitHub, CodeCommit, and Bitbucket repository sources"),
+			expectedError: errors.New("must be a URL to a supported provider: GitHub, CodeCommit, Bitbucket"),
 		},
 		"invalid environments": {
 			inAppName: "my-app",
@@ -323,7 +323,7 @@ func TestInitPipelineOpts_Ask(t *testing.T) {
 			},
 			mockSessProvider: func(m *mocks.MocksessionProvider) {},
 
-			expectedError: fmt.Errorf("Copilot currently accepts URLs to only GitHub, CodeCommit, and Bitbucket repository sources"),
+			expectedError: fmt.Errorf("must be a URL to a supported provider: GitHub, CodeCommit, Bitbucket"),
 		},
 		"returns error if fail to parse GitHub URL": {
 			inEnvironments:      []string{},


### PR DESCRIPTION
Just a tiny change to use the var introduced in #2523.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
