### PR TITLE
chore: adds worker service converters/validators

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/transformers.go
+++ b/internal/pkg/deploy/cloudformation/stack/transformers.go
@@ -630,14 +630,14 @@ func convertTopic(t manifest.Topic, accountID, partition, region, app, env, svc 
 	}, nil
 }
 
-func convertSubscribe(s *manifest.SubscribeConfig) (*template.SubscribeOpts, error) {
+func convertSubscribe(s *manifest.SubscribeConfig, validTopicARNs []string) (*template.SubscribeOpts, error) {
 	if s == nil || s.Topics == nil {
 		return nil, nil
 	}
 
-	subscriptions := template.SubscribeOpts{}
+	var subscriptions template.SubscribeOpts
 	for _, sb := range *s.Topics {
-		ts, err := convertTopicSubscription(sb)
+		ts, err := convertTopicSubscription(sb, validTopicARNs)
 		if err != nil {
 			return nil, err
 		}
@@ -648,10 +648,10 @@ func convertSubscribe(s *manifest.SubscribeConfig) (*template.SubscribeOpts, err
 	return &subscriptions, nil
 }
 
-func convertTopicSubscription(t manifest.TopicSubscription) (*template.TopicSubscription, error) {
-	err := validateTopicSubscription(t)
+func convertTopicSubscription(t manifest.TopicSubscription, validTopicARNs []string) (*template.TopicSubscription, error) {
+	err := validateTopicSubscription(t, validTopicARNs)
 	if err != nil {
-		return nil, fmt.Errorf(`invalid topic subscription %s: %w`, t.Name, err)
+		return nil, fmt.Errorf(`invalid topic subscription "%s": %w`, t.Name, err)
 	}
 
 	return &template.TopicSubscription{

--- a/internal/pkg/deploy/cloudformation/stack/transformers.go
+++ b/internal/pkg/deploy/cloudformation/stack/transformers.go
@@ -595,7 +595,7 @@ func convertPublish(p *manifest.PublishConfig, accountID, region, app, env, svc 
 	if !ok {
 		return nil, fmt.Errorf("find the partition for region %s", region)
 	}
-	publishers := template.PublishOpts{}
+	var publishers template.PublishOpts
 	// convert the topics to template Topics
 	for _, topic := range p.Topics {
 		t, err := convertTopic(topic, accountID, partition.ID(), region, app, env, svc)
@@ -611,7 +611,7 @@ func convertPublish(p *manifest.PublishConfig, accountID, region, app, env, svc 
 
 func convertTopic(t manifest.Topic, accountID, partition, region, app, env, svc string) (*template.Topic, error) {
 	// topic should have a valid name and valid service worker names
-	if err := validatePubSubName(t.Name); err != nil {
+	if err := validatePubSubName(aws.StringValue(t.Name)); err != nil {
 		return nil, err
 	}
 	if err := validateWorkerNames(t.AllowedWorkers); err != nil {

--- a/internal/pkg/deploy/cloudformation/stack/transformers.go
+++ b/internal/pkg/deploy/cloudformation/stack/transformers.go
@@ -629,3 +629,33 @@ func convertTopic(t manifest.Topic, accountID, partition, region, app, env, svc 
 		Svc:            svc,
 	}, nil
 }
+
+func convertSubscribe(s *manifest.SubscribeConfig) (*template.SubscribeOpts, error) {
+	if s == nil || s.Topics == nil {
+		return nil, nil
+	}
+
+	subscriptions := template.SubscribeOpts{}
+	for _, sb := range *s.Topics {
+		ts, err := convertTopicSubscription(sb)
+		if err != nil {
+			return nil, err
+		}
+
+		subscriptions.Topics = append(subscriptions.Topics, ts)
+	}
+
+	return &subscriptions, nil
+}
+
+func convertTopicSubscription(t manifest.TopicSubscription) (*template.TopicSubscription, error) {
+	err := validateTopicSubscription(t)
+	if err != nil {
+		return nil, fmt.Errorf(`invalid topic subscription %s: %w`, t.Name, err)
+	}
+
+	return &template.TopicSubscription{
+		Name:    aws.String(t.Name),
+		Service: aws.String(t.Service),
+	}, nil
+}

--- a/internal/pkg/deploy/cloudformation/stack/transformers_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/transformers_test.go
@@ -1481,7 +1481,7 @@ func Test_convertPublish(t *testing.T) {
 					{},
 				},
 			},
-			wantedError: errMissingPubSubTopicField,
+			wantedError: errMissingPublishTopicField,
 		},
 		"publish with no workers": {
 			inPublish: &manifest.PublishConfig{
@@ -1582,7 +1582,7 @@ func Test_convertSubscribe(t *testing.T) {
 					{},
 				},
 			},
-			wantedError: fmt.Errorf(`invalid topic subscription "": %w`, errMissingPubSubTopicField),
+			wantedError: fmt.Errorf(`invalid topic subscription "": %w`, errMissingPublishTopicField),
 		},
 		"valid publish": {
 			inSubscribe: &manifest.SubscribeConfig{

--- a/internal/pkg/deploy/cloudformation/stack/validate.go
+++ b/internal/pkg/deploy/cloudformation/stack/validate.go
@@ -47,7 +47,7 @@ var (
 	errInvalidSvcName                = errors.New("service names cannot be empty")
 	errSvcNameTooLong                = errors.New("service names must not exceed 255 characters")
 	errSvcNameBadFormat              = errors.New("service names must start with a letter, contain only lower-case letters, numbers, and hyphens, and have no consecutive or trailing hyphen")
-	errTopicSubscriptionNotAllowed   = errors.New("topic not in valid list of topics to subscribe to")
+	errTopicSubscriptionNotAllowed   = errors.New("topic not in list of topics available to subscribe to")
 )
 
 // Container dependency status options
@@ -413,7 +413,7 @@ func validateContainerPath(input string) error {
 // SNS Topic intended for a publisher.
 func validatePubSubName(name string) error {
 	if len(name) == 0 {
-		return errMissingPubSubTopicField
+		return errMissingPublishTopicField
 	}
 
 	// Name must contain letters, numbers, and can't use special characters besides underscores and hyphens.

--- a/internal/pkg/deploy/cloudformation/stack/validate.go
+++ b/internal/pkg/deploy/cloudformation/stack/validate.go
@@ -487,12 +487,3 @@ func validateTopicSubscription(ts manifest.TopicSubscription, validTopicARNs []s
 
 	return errTopicSubscriptionNotAllowed
 }
-
-func contains(s string, items []string) bool {
-	for _, item := range items {
-		if s == item {
-			return true
-		}
-	}
-	return false
-}

--- a/internal/pkg/deploy/cloudformation/stack/validate_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/validate_test.go
@@ -510,7 +510,7 @@ func Test_validatePubSubTopicName(t *testing.T) {
 		},
 		"error when no topic name": {
 			inName:  nil,
-			wantErr: errMissingPublishTopicField,
+			wantErr: errMissingPubSubTopicField,
 		},
 		"error when invalid topic name": {
 			inName:  aws.String("OHNO~/`...,"),
@@ -541,15 +541,15 @@ func TestValidateWorkerName(t *testing.T) {
 		},
 		"empty name": {
 			inName:  []string{""},
-			wantErr: fmt.Errorf("worker name `` is invalid: %s", errInvalidName),
+			wantErr: fmt.Errorf("worker name `` is invalid: %s", errInvalidSvcName),
 		},
 		"contains spaces": {
 			inName:  []string{"a re@!!y b#d n&me"},
-			wantErr: fmt.Errorf("worker name `a re@!!y b#d n&me` is invalid: %s", errNameBadFormat),
+			wantErr: fmt.Errorf("worker name `a re@!!y b#d n&me` is invalid: %s", errSvcNameBadFormat),
 		},
 		"too long": {
 			inName:  []string{"this-is-the-name-that-goes-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-until-it-is-too-long"},
-			wantErr: fmt.Errorf("worker name `this-is-the-name-that-goes-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-until-it-is-too-long` is invalid: %s", errNameTooLong),
+			wantErr: fmt.Errorf("worker name `this-is-the-name-that-goes-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-and-on-until-it-is-too-long` is invalid: %s", errSvcNameTooLong),
 		},
 	}
 

--- a/internal/pkg/deploy/cloudformation/stack/validate_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/validate_test.go
@@ -501,19 +501,19 @@ func TestValidateImageDependsOn(t *testing.T) {
 
 func Test_validatePubSubTopicName(t *testing.T) {
 	testCases := map[string]struct {
-		inName *string
+		inName string
 
 		wantErr error
 	}{
 		"valid topic name": {
-			inName: aws.String("a-Perfectly_V4l1dString"),
+			inName: "a-Perfectly_V4l1dString",
 		},
 		"error when no topic name": {
-			inName:  nil,
+			inName:  "",
 			wantErr: errMissingPubSubTopicField,
 		},
 		"error when invalid topic name": {
-			inName:  aws.String("OHNO~/`...,"),
+			inName:  "OHNO~/`...,",
 			wantErr: errInvalidPubSubTopicName,
 		},
 	}
@@ -556,6 +556,54 @@ func TestValidateWorkerName(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			err := validateWorkerNames(tc.inName)
+
+			if tc.wantErr == nil {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, tc.wantErr.Error())
+			}
+		})
+	}
+}
+
+func TestValidateTopicSubscription(t *testing.T) {
+	validTopics := []string{"arn:aws:us-east-1:123456789012:app-env-svc-name", "arn:aws:us-east-1:123456789012:app-env-svc-name2"}
+	testCases := map[string]struct {
+		inTS manifest.TopicSubscription
+
+		wantErr error
+	}{
+		"good case": {
+			inTS: manifest.TopicSubscription{
+				Name:    "name2",
+				Service: "svc",
+			},
+			wantErr: nil,
+		},
+		"empty name": {
+			inTS: manifest.TopicSubscription{
+				Service: "svc",
+			},
+			wantErr: errMissingPubSubTopicField,
+		},
+		"empty svc name": {
+			inTS: manifest.TopicSubscription{
+				Name: "theName",
+			},
+			wantErr: errInvalidSvcName,
+		},
+		"topic not in list of valid topics": {
+			inTS: manifest.TopicSubscription{
+				Name:    "badName",
+				Service: "svc",
+			},
+			wantErr: errTopicSubscriptionNotAllowed,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			err := validateTopicSubscription(tc.inTS, validTopics)
 
 			if tc.wantErr == nil {
 				require.NoError(t, err)

--- a/internal/pkg/deploy/cloudformation/stack/validate_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/validate_test.go
@@ -510,7 +510,7 @@ func Test_validatePubSubTopicName(t *testing.T) {
 		},
 		"error when no topic name": {
 			inName:  "",
-			wantErr: errMissingPubSubTopicField,
+			wantErr: errMissingPublishTopicField,
 		},
 		"error when invalid topic name": {
 			inName:  "OHNO~/`...,",
@@ -584,7 +584,7 @@ func TestValidateTopicSubscription(t *testing.T) {
 			inTS: manifest.TopicSubscription{
 				Service: "svc",
 			},
-			wantErr: errMissingPubSubTopicField,
+			wantErr: errMissingPublishTopicField,
 		},
 		"empty svc name": {
 			inTS: manifest.TopicSubscription{

--- a/internal/pkg/template/workload.go
+++ b/internal/pkg/template/workload.go
@@ -28,6 +28,7 @@ const (
 	lbWebSvcTplName     = "lb-web"
 	rdWebSvcTplName     = "rd-web"
 	backendSvcTplName   = "backend"
+	workerSvcTplName    = "worker"
 	scheduledJobTplName = "scheduled-job"
 )
 
@@ -233,6 +234,17 @@ type Topic struct {
 	Svc       string
 }
 
+// SubscribeOpts holds configuration needed if the service has subscriptions.
+type SubscribeOpts struct {
+	Topics []*TopicSubscription
+}
+
+// TopicSubscription holds information needed to render a SNS Topic Subscription in a container definition.
+type TopicSubscription struct {
+	Name    *string
+	Service *string
+}
+
 // NetworkOpts holds AWS networking configuration for the workloads.
 type NetworkOpts struct {
 	AssignPublicIP string
@@ -281,6 +293,7 @@ type WorkloadOpts struct {
 	DesiredCountLambda   string
 	EnvControllerLambda  string
 	CredentialsParameter string
+	Subscribe            SubscribeOpts
 
 	// Additional options for job templates.
 	ScheduleExpression string
@@ -326,6 +339,14 @@ func (t *Template) ParseBackendService(data WorkloadOpts) (*Content, error) {
 		data.Network = defaultNetworkOpts()
 	}
 	return t.parseSvc(backendSvcTplName, data, withSvcParsingFuncs())
+}
+
+// ParseWorkerService parses a backend service's CloudFormation template with the specified data object and returns its content.
+func (t *Template) ParseWorkerService(data WorkloadOpts) (*Content, error) {
+	if data.Network == nil {
+		data.Network = defaultNetworkOpts()
+	}
+	return t.parseSvc(workerSvcTplName, data, withSvcParsingFuncs())
 }
 
 // ParseScheduledJob parses a scheduled job's Cloudformation Template

--- a/internal/pkg/template/workload.go
+++ b/internal/pkg/template/workload.go
@@ -293,11 +293,13 @@ type WorkloadOpts struct {
 	DesiredCountLambda   string
 	EnvControllerLambda  string
 	CredentialsParameter string
-	Subscribe            SubscribeOpts
 
 	// Additional options for job templates.
 	ScheduleExpression string
 	StateMachine       *StateMachineOpts
+
+	// Additional options for worker service templates.
+	Subscribe SubscribeOpts
 }
 
 // ParseRequestDrivenWebServiceInput holds data that can be provided to enable features for a request-driven web service stack.

--- a/internal/pkg/template/workload.go
+++ b/internal/pkg/template/workload.go
@@ -341,7 +341,7 @@ func (t *Template) ParseBackendService(data WorkloadOpts) (*Content, error) {
 	return t.parseSvc(backendSvcTplName, data, withSvcParsingFuncs())
 }
 
-// ParseWorkerService parses a backend service's CloudFormation template with the specified data object and returns its content.
+// ParseWorkerService parses a worker service's CloudFormation template with the specified data object and returns its content.
 func (t *Template) ParseWorkerService(data WorkloadOpts) (*Content, error) {
 	if data.Network == nil {
 		data.Network = defaultNetworkOpts()


### PR DESCRIPTION
Adds basic worker service converters/validators with the exception of init/deploy validations

Addresses #2550

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
