### PR TITLE
docs: match 'environments' explanations and sample manifests

### DIFF
--- a/site/content/docs/include/common-svc-fields.en.md
+++ b/site/content/docs/include/common-svc-fields.en.md
@@ -236,4 +236,4 @@ Optional. The full config file path in your custom Fluent Bit image.
 <div class="separator"></div>
 
 <a id="environments" href="#environments" class="field">`environments`</a> <span class="type">Map</span>  
-The environment section lets you override any value in your manifest based on the environment you're in. In the example manifest above, we're overriding the count parameter so that we can run 2 copies of our service in our prod environment.
+The environment section lets you override any value in your manifest based on the environment you're in. In the example manifest above, we're overriding the count parameter so that we can run 2 copies of our service in our 'prod' environment, and 2 copies using Fargate Spot capacity in our 'staging' environment.

--- a/site/content/docs/manifest/rd-web-service.en.md
+++ b/site/content/docs/manifest/rd-web-service.en.md
@@ -139,5 +139,5 @@ Key-value pairs that represent environment variables that will be passed to your
 <div class="separator"></div>
 
 <a id="environments" href="#environments" class="field">`environments`</a> <span class="type">Map</span>  
-The environment section lets you override any value in your manifest based on the environment you're in. In the example manifest above, we're overriding the count parameter so that we can run 2 copies of our service in our prod environment.
+The environment section lets you override any value in your manifest based on the environment you're in. In the example manifest above, we're overriding the `LOG_LEVEL` environment variable in our 'test' environment.
 

--- a/site/content/docs/manifest/scheduled-job.en.md
+++ b/site/content/docs/manifest/scheduled-job.en.md
@@ -22,6 +22,11 @@ List of all available properties for a `'Scheduled Job'` manifest. To learn abou
       LOG_LEVEL: info
     secrets:
       GITHUB_TOKEN: GITHUB_TOKEN
+      
+    # You can override any of the values defined above by environment.
+    environments:
+      prod:
+        cpu: 2048               # Larger CPU value for prod environment 
     ```
 
 <a id="name" href="#name" class="field">`name`</a> <span class="type">String</span>  

--- a/site/content/docs/manifest/scheduled-job.en.md
+++ b/site/content/docs/manifest/scheduled-job.en.md
@@ -27,6 +27,7 @@ List of all available properties for a `'Scheduled Job'` manifest. To learn abou
     environments:
       prod:
         cpu: 2048               # Larger CPU value for prod environment 
+        memory: 4096
     ```
 
 <a id="name" href="#name" class="field">`name`</a> <span class="type">String</span>  


### PR DESCRIPTION
As we have added new workload types and new fields to our manifests, our docs have become a little clunky. This is just a quick fix to make the `environments` description for each manifest page match the sample manifest at top, but we should do a more comprehensive fix-up soon.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
