### PR TITLE
chore: update UX for rd web service alias

### DIFF
--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -711,6 +711,9 @@ func (o *deploySvcOpts) showSvcURI() error {
 			msg = fmt.Sprintf("Deployed %s, its service discovery endpoint is %s.\n", color.HighlightUserInput(o.name), color.HighlightResource(uri))
 		}
 		log.Success(msg)
+	case manifest.RequestDrivenWebServiceType:
+		log.Successf("Deployed %s, you can access it at %s.\n", color.HighlightUserInput(o.name), color.HighlightResource(uri))
+		log.Infof("If you are using an alias, the validation process can take more than 15 minutes. Please visit %s to check the validation status.\n", color.Emphasize("https://console.aws.amazon.com/apprunner/home"))
 	default:
 		log.Successf("Deployed %s, you can access it at %s.\n", color.HighlightUserInput(o.name), color.HighlightResource(uri))
 	}

--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -610,15 +610,15 @@ func checkUnsupportedAlias(alias, envName string, app *config.Application) error
 	}
 
 	if regEnvHostedZone.MatchString(alias) {
-		return errors.New("environment-level alias is not supported yet")
+		return fmt.Errorf("%s is an environment-level alias, which is not supported yet", alias)
 	}
 
 	if regAppHostedZone.MatchString(alias) {
-		return errors.New("application-level alias is not supported yet")
+		return fmt.Errorf("%s is an application-level alias, which is not supported yet", alias)
 	}
 
 	if alias == app.Domain {
-		return errors.New("root domain alias is not supported yet")
+		return fmt.Errorf("%s is a root domain alias, which is not supported yet", alias)
 	}
 
 	return nil
@@ -633,9 +633,9 @@ func validateRDSvcAliasAndAppVersion(svcName, alias, envName string, app *config
 		return err
 	}
 	// Alias should be within root hosted zone.
-	aliasInvalidLog := fmt.Sprintf(`%s should match the pattern <subdomain>.%s 
+	aliasInvalidLog := fmt.Sprintf(`%s of %s field should match the pattern <subdomain>.%s 
 Where <subdomain> cannot be the application name.
-`, color.HighlightCode("http.alias"), app.Domain)
+`, color.HighlightUserInput(alias), color.HighlightCode("http.alias"), app.Domain)
 	if err := checkUnsupportedAlias(alias, envName, app); err != nil {
 		log.Errorf(aliasInvalidLog)
 		return err

--- a/internal/pkg/cli/svc_deploy_test.go
+++ b/internal/pkg/cli/svc_deploy_test.go
@@ -877,7 +877,7 @@ func TestSvcDeployOpts_rdWebServiceStackConfiguration(t *testing.T) {
 				}, nil)
 			},
 
-			wantErr: fmt.Errorf("environment-level alias is not supported yet"),
+			wantErr: fmt.Errorf("mockEnv.mockApp.mockDomain is an environment-level alias, which is not supported yet"),
 		},
 		"invalid application level alias": {
 			inAlias: "someSub.mockApp.mockDomain",
@@ -898,7 +898,7 @@ func TestSvcDeployOpts_rdWebServiceStackConfiguration(t *testing.T) {
 				}, nil)
 			},
 
-			wantErr: fmt.Errorf("application-level alias is not supported yet"),
+			wantErr: fmt.Errorf("someSub.mockApp.mockDomain is an application-level alias, which is not supported yet"),
 		},
 		"invalid root level alias": {
 			inAlias: "mockDomain",
@@ -919,7 +919,7 @@ func TestSvcDeployOpts_rdWebServiceStackConfiguration(t *testing.T) {
 				}, nil)
 			},
 
-			wantErr: fmt.Errorf("root domain alias is not supported yet"),
+			wantErr: fmt.Errorf("mockDomain is a root domain alias, which is not supported yet"),
 		},
 		"fail to upload custom resource scripts": {
 			inAlias: "v1.mockDomain",

--- a/internal/pkg/cli/svc_deploy_test.go
+++ b/internal/pkg/cli/svc_deploy_test.go
@@ -837,6 +837,90 @@ func TestSvcDeployOpts_rdWebServiceStackConfiguration(t *testing.T) {
 
 			wantErr: fmt.Errorf("get application mockApp resources from region us-west-2: some error"),
 		},
+		"invalid alias with unknown domain": {
+			inAlias: "v1.someRandomDomain",
+			inEnvironment: &config.Environment{
+				Name:   mockEnvName,
+				Region: "us-west-2",
+			},
+			inApp: &config.Application{
+				Name:   mockAppName,
+				Domain: "mockDomain",
+			},
+			mock: func(m *deployRDSvcMocks) {
+				m.mockWorkspace.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
+				m.mockAppVersionGetter.EXPECT().Version().Return("v1.0.0", nil)
+				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
+				m.mockIdentity.EXPECT().Get().Return(identity.Caller{
+					RootUserARN: "1234",
+				}, nil)
+			},
+
+			wantErr: fmt.Errorf("alias is not supported in hosted zones that are not managed by Copilot"),
+		},
+		"invalid environment level alias": {
+			inAlias: "mockEnv.mockApp.mockDomain",
+			inEnvironment: &config.Environment{
+				Name:   mockEnvName,
+				Region: "us-west-2",
+			},
+			inApp: &config.Application{
+				Name:   mockAppName,
+				Domain: "mockDomain",
+			},
+			mock: func(m *deployRDSvcMocks) {
+				m.mockWorkspace.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
+				m.mockAppVersionGetter.EXPECT().Version().Return("v1.0.0", nil)
+				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
+				m.mockIdentity.EXPECT().Get().Return(identity.Caller{
+					RootUserARN: "1234",
+				}, nil)
+			},
+
+			wantErr: fmt.Errorf("environment-level alias is not supported yet"),
+		},
+		"invalid application level alias": {
+			inAlias: "someSub.mockApp.mockDomain",
+			inEnvironment: &config.Environment{
+				Name:   mockEnvName,
+				Region: "us-west-2",
+			},
+			inApp: &config.Application{
+				Name:   mockAppName,
+				Domain: "mockDomain",
+			},
+			mock: func(m *deployRDSvcMocks) {
+				m.mockWorkspace.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
+				m.mockAppVersionGetter.EXPECT().Version().Return("v1.0.0", nil)
+				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
+				m.mockIdentity.EXPECT().Get().Return(identity.Caller{
+					RootUserARN: "1234",
+				}, nil)
+			},
+
+			wantErr: fmt.Errorf("application-level alias is not supported yet"),
+		},
+		"invalid root level alias": {
+			inAlias: "mockDomain",
+			inEnvironment: &config.Environment{
+				Name:   mockEnvName,
+				Region: "us-west-2",
+			},
+			inApp: &config.Application{
+				Name:   mockAppName,
+				Domain: "mockDomain",
+			},
+			mock: func(m *deployRDSvcMocks) {
+				m.mockWorkspace.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
+				m.mockAppVersionGetter.EXPECT().Version().Return("v1.0.0", nil)
+				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
+				m.mockIdentity.EXPECT().Get().Return(identity.Caller{
+					RootUserARN: "1234",
+				}, nil)
+			},
+
+			wantErr: fmt.Errorf("root domain alias is not supported yet"),
+		},
 		"fail to upload custom resource scripts": {
 			inAlias: "v1.mockDomain",
 			inEnvironment: &config.Environment{

--- a/internal/pkg/cli/svc_deploy_test.go
+++ b/internal/pkg/cli/svc_deploy_test.go
@@ -688,7 +688,7 @@ func TestSvcDeployOpts_stackConfiguration(t *testing.T) {
 			mockEndpointGetter: func(m *mocks.MockendpointGetter) {
 				m.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
 			},
-			wantErr: fmt.Errorf("alias is not supported in hosted zones not managed by Copilot"),
+			wantErr: fmt.Errorf("alias is not supported in hosted zones that are not managed by Copilot"),
 		},
 		"success": {
 			inAlias: "v1.mockDomain",

--- a/internal/pkg/cli/svc_package.go
+++ b/internal/pkg/cli/svc_package.go
@@ -147,6 +147,10 @@ func newPackageSvcOpts(vars packageSvcVars) (*packageSvcOpts, error) {
 				break
 			}
 
+			if err = validateRDSvcAlias(opts.name, aws.StringValue(t.Alias), env.Name, app, appVersionGetter); err != nil {
+				return nil, err
+			}
+
 			resources, err := opts.appCFN.GetAppResourcesByRegion(app, env.Region)
 			if err != nil {
 				return nil, fmt.Errorf("get application %s resources from region %s: %w", app.Name, env.Region, err)

--- a/internal/pkg/cli/svc_package.go
+++ b/internal/pkg/cli/svc_package.go
@@ -116,7 +116,7 @@ func newPackageSvcOpts(vars packageSvcVars) (*packageSvcOpts, error) {
 		switch t := mft.(type) {
 		case *manifest.LoadBalancedWebService:
 			if app.RequiresDNSDelegation() {
-				if err := validateAlias(aws.StringValue(t.Name), aws.StringValue(t.Alias), app, env.Name, appVersionGetter); err != nil {
+				if err := validateAliasAndAppVersion(aws.StringValue(t.Name), aws.StringValue(t.Alias), app, env.Name, appVersionGetter); err != nil {
 					return nil, err
 				}
 				serializer, err = stack.NewHTTPSLoadBalancedWebService(t, env.Name, app.Name, rc)
@@ -147,7 +147,7 @@ func newPackageSvcOpts(vars packageSvcVars) (*packageSvcOpts, error) {
 				break
 			}
 
-			if err = validateRDSvcAlias(opts.name, aws.StringValue(t.Alias), env.Name, app, appVersionGetter); err != nil {
+			if err = validateRDSvcAliasAndAppVersion(opts.name, aws.StringValue(t.Alias), env.Name, app, appVersionGetter); err != nil {
 				return nil, err
 			}
 


### PR DESCRIPTION
This PR adds validation for `http.alias` for request-driven web service, as well as updating the follow-up instruction.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
