### PR TITLE
chore: fix svc show should list proper endpoint under "service discovery" section

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ gen-mocks: tools
 	${GOBIN}/mockgen -package=mocks -destination=./internal/pkg/describe/mocks/mock_describe.go -source=./internal/pkg/describe/describe.go
 	${GOBIN}/mockgen -package=mocks -destination=./internal/pkg/describe/stack/mocks/mock_stack.go -source=./internal/pkg/describe/stack/stack.go
 	${GOBIN}/mockgen -package=mocks -destination=./internal/pkg/describe/mocks/mock_status.go -source=./internal/pkg/describe/status.go
-	${GOBIN}/mockgen -package=mocks -destination=./internal/pkg/describe/mocks/mock_status_describe.go -source=./internal/pkg/describe/status_descirbe.go
+	${GOBIN}/mockgen -package=mocks -destination=./internal/pkg/describe/mocks/mock_status_describe.go -source=./internal/pkg/describe/status_describe.go
 	${GOBIN}/mockgen -package=mocks -destination=./internal/pkg/describe/mocks/mock_pipeline_show.go -source=./internal/pkg/describe/pipeline_show.go
 	${GOBIN}/mockgen -package=mocks -destination=./internal/pkg/describe/mocks/mock_pipeline_status.go -source=./internal/pkg/describe/pipeline_status.go
 	${GOBIN}/mockgen -package=mocks -destination=./internal/pkg/aws/ecr/mocks/mock_ecr.go -source=./internal/pkg/aws/ecr/ecr.go

--- a/go.sum
+++ b/go.sum
@@ -1325,6 +1325,7 @@ golang.org/x/tools v0.0.0-20210105154028-b0ab187a4818/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+golang.org/x/tools v0.1.2 h1:kRBLX7v7Af8W7Gdbbc908OJcdgtK8bOz9Uaj8/F1ACA=
 golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/pkg/describe/backend_service.go
+++ b/internal/pkg/describe/backend_service.go
@@ -75,7 +75,6 @@ func NewBackendServiceDescriber(opt NewBackendServiceConfig) (*BackendServiceDes
 		}
 		describer.envDescriber[env] = envDescr
 		return nil
-		return nil
 	}
 	return describer, nil
 }
@@ -129,8 +128,9 @@ func (d *BackendServiceDescriber) Describe() (HumanJSONStringer, error) {
 		port := blankContainerPort
 		if svcParams[cfnstack.LBWebServiceContainerPortParamKey] != cfnstack.NoExposedContainerPort {
 			endpoint, err := d.envDescriber[env].ServiceDiscoveryEndpoint()
+			// This error is descriptive and doesn't need to be wrapped.
 			if err != nil {
-				return nil, fmt.Errorf("get service discovery endpoint for environment %s: %w", env, err)
+				return nil, err
 			}
 			port = svcParams[cfnstack.LBWebServiceContainerPortParamKey]
 			services = appendServiceDiscovery(services, serviceDiscovery{

--- a/internal/pkg/describe/backend_service.go
+++ b/internal/pkg/describe/backend_service.go
@@ -28,9 +28,10 @@ type BackendServiceDescriber struct {
 	svc             string
 	enableResources bool
 
-	store                DeployedEnvServicesLister
-	svcDescriber         map[string]ecsSvcDescriber
-	initServiceDescriber func(string) error
+	store         DeployedEnvServicesLister
+	svcDescriber  map[string]ecsSvcDescriber
+	envDescriber  map[string]envDescriber
+	initDescriber func(string) error
 }
 
 // NewBackendServiceConfig contains fields that initiates BackendServiceDescriber struct.
@@ -48,8 +49,9 @@ func NewBackendServiceDescriber(opt NewBackendServiceConfig) (*BackendServiceDes
 		enableResources: opt.EnableResources,
 		store:           opt.DeployStore,
 		svcDescriber:    make(map[string]ecsSvcDescriber),
+		envDescriber:    make(map[string]envDescriber),
 	}
-	describer.initServiceDescriber = func(env string) error {
+	describer.initDescriber = func(env string) error {
 		if _, ok := describer.svcDescriber[env]; ok {
 			return nil
 		}
@@ -63,6 +65,16 @@ func NewBackendServiceDescriber(opt NewBackendServiceConfig) (*BackendServiceDes
 			return err
 		}
 		describer.svcDescriber[env] = d
+		envDescr, err := NewEnvDescriber(NewEnvDescriberConfig{
+			App:         opt.App,
+			Env:         env,
+			ConfigStore: opt.ConfigStore,
+		})
+		if err != nil {
+			return err
+		}
+		describer.envDescriber[env] = envDescr
+		return nil
 		return nil
 	}
 	return describer, nil
@@ -71,7 +83,7 @@ func NewBackendServiceDescriber(opt NewBackendServiceConfig) (*BackendServiceDes
 // URI returns the service discovery namespace and is used to make
 // BackendServiceDescriber have the same signature as WebServiceDescriber.
 func (d *BackendServiceDescriber) URI(envName string) (string, error) {
-	if err := d.initServiceDescriber(envName); err != nil {
+	if err := d.initDescriber(envName); err != nil {
 		return "", err
 	}
 	svcStackParams, err := d.svcDescriber[envName].Params()
@@ -82,10 +94,14 @@ func (d *BackendServiceDescriber) URI(envName string) (string, error) {
 	if port == cfnstack.NoExposedContainerPort {
 		return BlankServiceDiscoveryURI, nil
 	}
+	envEndpoint, err := d.envDescriber[envName].ServiceDiscoveryEndpoint()
+	if err != nil {
+		return "nil", fmt.Errorf("retrieve service discovery endpoint for environment %s: %w", envName, err)
+	}
 	s := serviceDiscovery{
-		Service: d.svc,
-		Port:    port,
-		App:     d.app,
+		Service:  d.svc,
+		Port:     port,
+		Endpoint: envEndpoint,
 	}
 	return s.String(), nil
 }
@@ -102,7 +118,7 @@ func (d *BackendServiceDescriber) Describe() (HumanJSONStringer, error) {
 	var envVars []*containerEnvVar
 	var secrets []*secret
 	for _, env := range environments {
-		err := d.initServiceDescriber(env)
+		err := d.initDescriber(env)
 		if err != nil {
 			return nil, err
 		}
@@ -112,12 +128,15 @@ func (d *BackendServiceDescriber) Describe() (HumanJSONStringer, error) {
 		}
 		port := blankContainerPort
 		if svcParams[cfnstack.LBWebServiceContainerPortParamKey] != cfnstack.NoExposedContainerPort {
+			endpoint, err := d.envDescriber[env].ServiceDiscoveryEndpoint()
+			if err != nil {
+				return nil, fmt.Errorf("get service discovery endpoint for environment %s: %w", env, err)
+			}
 			port = svcParams[cfnstack.LBWebServiceContainerPortParamKey]
 			services = appendServiceDiscovery(services, serviceDiscovery{
-				Service: d.svc,
-				Port:    port,
-				Env:     env,
-				App:     d.app,
+				Service:  d.svc,
+				Port:     port,
+				Endpoint: endpoint,
 			}, env)
 		}
 		configs = append(configs, &ECSServiceConfig{
@@ -144,7 +163,7 @@ func (d *BackendServiceDescriber) Describe() (HumanJSONStringer, error) {
 	resources := make(map[string][]*stack.Resource)
 	if d.enableResources {
 		for _, env := range environments {
-			err := d.initServiceDescriber(env)
+			err := d.initDescriber(env)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/pkg/describe/backend_service_test.go
+++ b/internal/pkg/describe/backend_service_test.go
@@ -328,7 +328,7 @@ func TestBackendServiceDescriber_Describe(t *testing.T) {
 					"prod":    mockEnvDescriber,
 					"mockEnv": mockEnvDescriber,
 				},
-				initDescriber: func(string) error { return nil },
+				initDescribers: func(string) error { return nil },
 			}
 
 			// WHEN

--- a/internal/pkg/describe/lb_web_service.go
+++ b/internal/pkg/describe/lb_web_service.go
@@ -164,8 +164,9 @@ func (d *LBWebServiceDescriber) Describe() (HumanJSONStringer, error) {
 			Tasks: d.svcParams[cfnstack.WorkloadTaskCountParamKey],
 		})
 		envEndpoint, err := d.envDescriber[env].ServiceDiscoveryEndpoint()
+		// This error is descriptive and doesn't need to be wrapped.
 		if err != nil {
-			return nil, fmt.Errorf("retrieve service discovery endpoint: %w", err)
+			return nil, err
 		}
 		serviceDiscoveries = appendServiceDiscovery(serviceDiscoveries, serviceDiscovery{
 			Service:  d.svc,

--- a/internal/pkg/describe/lb_web_service.go
+++ b/internal/pkg/describe/lb_web_service.go
@@ -28,6 +28,8 @@ const (
 	envOutputSubdomain                 = "EnvironmentSubdomain"
 )
 
+var fmtSvcDiscoveryEndpointWithPort = "%s.%s:%s" // Format string of the form {svc}.{endpoint}:{port}
+
 // LBWebServiceURI represents the unique identifier to access a load balanced web service.
 type LBWebServiceURI struct {
 	HTTPS    bool
@@ -52,17 +54,17 @@ func (u *LBWebServiceURI) String() string {
 }
 
 type serviceDiscovery struct {
-	Service string
-	App     string
-	Env     string
-	Port    string
+	Service  string
+	Endpoint string
+	Port     string
 }
 
 func (s *serviceDiscovery) String() string {
-	return fmt.Sprintf("%s.%s.%s.local:%s", s.Service, s.Env, s.App, s.Port)
+	return fmt.Sprintf(fmtSvcDiscoveryEndpointWithPort, s.Service, s.Endpoint, s.Port)
 }
 
 type envDescriber interface {
+	ServiceDiscoveryEndpoint() (string, error)
 	Params() (map[string]string, error)
 	Outputs() (map[string]string, error)
 }
@@ -161,11 +163,14 @@ func (d *LBWebServiceDescriber) Describe() (HumanJSONStringer, error) {
 			},
 			Tasks: d.svcParams[cfnstack.WorkloadTaskCountParamKey],
 		})
+		envEndpoint, err := d.envDescriber[env].ServiceDiscoveryEndpoint()
+		if err != nil {
+			return nil, fmt.Errorf("retrieve service discovery endpoint: %w", err)
+		}
 		serviceDiscoveries = appendServiceDiscovery(serviceDiscoveries, serviceDiscovery{
-			Service: d.svc,
-			Port:    d.svcParams[cfnstack.LBWebServiceContainerPortParamKey],
-			Env:     env,
-			App:     d.app,
+			Service:  d.svc,
+			Port:     d.svcParams[cfnstack.LBWebServiceContainerPortParamKey],
+			Endpoint: envEndpoint,
 		}, env)
 		webSvcEnvVars, err := d.svcDescriber[env].EnvVars()
 		if err != nil {

--- a/internal/pkg/describe/lb_web_service.go
+++ b/internal/pkg/describe/lb_web_service.go
@@ -163,15 +163,14 @@ func (d *LBWebServiceDescriber) Describe() (HumanJSONStringer, error) {
 			},
 			Tasks: d.svcParams[cfnstack.WorkloadTaskCountParamKey],
 		})
-		envEndpoint, err := d.envDescriber[env].ServiceDiscoveryEndpoint()
-		// This error is descriptive and doesn't need to be wrapped.
+		endpoint, err := d.envDescriber[env].ServiceDiscoveryEndpoint()
 		if err != nil {
 			return nil, err
 		}
 		serviceDiscoveries = appendServiceDiscovery(serviceDiscoveries, serviceDiscovery{
 			Service:  d.svc,
 			Port:     d.svcParams[cfnstack.LBWebServiceContainerPortParamKey],
-			Endpoint: envEndpoint,
+			Endpoint: endpoint,
 		}, env)
 		webSvcEnvVars, err := d.svcDescriber[env].EnvVars()
 		if err != nil {

--- a/internal/pkg/describe/lb_web_service_test.go
+++ b/internal/pkg/describe/lb_web_service_test.go
@@ -246,7 +246,7 @@ func TestLBWebServiceDescriber_Describe(t *testing.T) {
 			},
 			wantedError: fmt.Errorf("retrieve service URI: get stack parameters for environment test: some error"),
 		},
-		"return error if fail to retrieve service deployment configuration": {
+		"return error if fail to retrieve service discovery endpoint": {
 			setupMocks: func(m lbWebSvcDescriberMocks) {
 				gomock.InOrder(
 					m.storeSvc.EXPECT().ListEnvironmentsDeployedTo(testApp, testSvc).Return([]string{testEnv}, nil),
@@ -261,10 +261,10 @@ func TestLBWebServiceDescriber_Describe(t *testing.T) {
 						cfnstack.WorkloadTaskMemoryParamKey:        "512",
 						cfnstack.LBWebServiceRulePathParamKey:      testSvcPath,
 					}, nil),
-					m.ecsSvcDescriber.EXPECT().EnvVars().Return(nil, mockErr),
+					m.envDescriber.EXPECT().ServiceDiscoveryEndpoint().Return("", errors.New("some error")),
 				)
 			},
-			wantedError: fmt.Errorf("retrieve environment variables: some error"),
+			wantedError: fmt.Errorf("some error"),
 		},
 		"return error if fail to retrieve environment variables": {
 			setupMocks: func(m lbWebSvcDescriberMocks) {
@@ -281,6 +281,7 @@ func TestLBWebServiceDescriber_Describe(t *testing.T) {
 						cfnstack.WorkloadTaskMemoryParamKey:        "512",
 						cfnstack.LBWebServiceRulePathParamKey:      testSvcPath,
 					}, nil),
+					m.envDescriber.EXPECT().ServiceDiscoveryEndpoint().Return("test.phonetool.local", nil),
 					m.ecsSvcDescriber.EXPECT().EnvVars().Return(nil, mockErr),
 				)
 			},
@@ -301,6 +302,7 @@ func TestLBWebServiceDescriber_Describe(t *testing.T) {
 						cfnstack.WorkloadTaskMemoryParamKey:        "512",
 						cfnstack.LBWebServiceRulePathParamKey:      testSvcPath,
 					}, nil),
+					m.envDescriber.EXPECT().ServiceDiscoveryEndpoint().Return("test.phonetool.local", nil),
 					m.ecsSvcDescriber.EXPECT().EnvVars().Return([]*ecs.ContainerEnvVar{
 						{
 							Name:      "COPILOT_ENVIRONMENT_NAME",
@@ -330,6 +332,7 @@ func TestLBWebServiceDescriber_Describe(t *testing.T) {
 						cfnstack.WorkloadTaskMemoryParamKey:        "512",
 						cfnstack.LBWebServiceRulePathParamKey:      testSvcPath,
 					}, nil),
+					m.envDescriber.EXPECT().ServiceDiscoveryEndpoint().Return("test.phonetool.local", nil),
 					m.ecsSvcDescriber.EXPECT().EnvVars().Return([]*ecs.ContainerEnvVar{
 						{
 							Name:      "COPILOT_ENVIRONMENT_NAME",
@@ -371,6 +374,7 @@ func TestLBWebServiceDescriber_Describe(t *testing.T) {
 						cfnstack.WorkloadTaskMemoryParamKey:        "512",
 						cfnstack.LBWebServiceRulePathParamKey:      testSvcPath,
 					}, nil),
+					m.envDescriber.EXPECT().ServiceDiscoveryEndpoint().Return("test.phonetool.local", nil),
 					m.ecsSvcDescriber.EXPECT().EnvVars().Return([]*ecs.ContainerEnvVar{
 						{
 							Name:      "COPILOT_ENVIRONMENT_NAME",
@@ -396,6 +400,7 @@ func TestLBWebServiceDescriber_Describe(t *testing.T) {
 						cfnstack.WorkloadTaskMemoryParamKey:        "1024",
 						cfnstack.LBWebServiceRulePathParamKey:      prodSvcPath,
 					}, nil),
+					m.envDescriber.EXPECT().ServiceDiscoveryEndpoint().Return("prod.phonetool.local", nil),
 					m.ecsSvcDescriber.EXPECT().EnvVars().Return([]*ecs.ContainerEnvVar{
 						{
 							Name:      "COPILOT_ENVIRONMENT_NAME",

--- a/internal/pkg/describe/mocks/mock_lb_web_service.go
+++ b/internal/pkg/describe/mocks/mock_lb_web_service.go
@@ -62,3 +62,18 @@ func (mr *MockenvDescriberMockRecorder) Params() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Params", reflect.TypeOf((*MockenvDescriber)(nil).Params))
 }
+
+// ServiceDiscoveryEndpoint mocks base method.
+func (m *MockenvDescriber) ServiceDiscoveryEndpoint() (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ServiceDiscoveryEndpoint")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ServiceDiscoveryEndpoint indicates an expected call of ServiceDiscoveryEndpoint.
+func (mr *MockenvDescriberMockRecorder) ServiceDiscoveryEndpoint() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceDiscoveryEndpoint", reflect.TypeOf((*MockenvDescriber)(nil).ServiceDiscoveryEndpoint))
+}


### PR DESCRIPTION
<!-- Provide summary of changes -->
UI bug. svc show should display the env var as well as the "Service Discovery" section correctly. 

This PR adds a call to the env describer under the hood of the service describer clients to get the correct endpoint for the environment, service, and port. 

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<img width="970" alt="Screen Shot 2021-07-28 at 8 57 06 PM" src="https://user-images.githubusercontent.com/25392995/127429366-73caaad1-24d3-4311-9d88-3e1e7a33d1e0.png">
