### PR TITLE
build: use go v1.16.6 while building binaries

### DIFF
--- a/.release/buildspec.yml
+++ b/.release/buildspec.yml
@@ -3,8 +3,11 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      golang: 1.15
       nodejs: 12
+    commands:
+      - 'cd $HOME/.goenv && git pull --ff-only && cd -'
+      - 'goenv install 1.16.6'
+      - 'goenv global 1.16.6'
   pre_build:
     commands:
       - echo "cd into $CODEBUILD_SRC_DIR"

--- a/.release/buildspec_e2e.yml
+++ b/.release/buildspec_e2e.yml
@@ -125,8 +125,11 @@ batch:
 phases:
   install:
     runtime-versions:
-      golang: 1.15
       nodejs: 12
+    commands:
+      - 'cd $HOME/.goenv && git pull --ff-only && cd -'
+      - 'goenv install 1.16.6'
+      - 'goenv global 1.16.6'
   pre_build:
     commands:
        - docker login -u ${DOCKERHUB_USERNAME} -p ${DOCKERHUB_TOKEN}

--- a/.release/buildspec_integ.yml
+++ b/.release/buildspec_integ.yml
@@ -12,8 +12,11 @@ env:
 phases:
   install:
     runtime-versions:
-      golang: 1.15
       nodejs: 12
+    commands:
+      - 'cd $HOME/.goenv && git pull --ff-only && cd -'
+      - 'goenv install 1.16.6'
+      - 'goenv global 1.16.6'
   build:
     commands:
       - echo `git rev-parse HEAD` # Do not delete; for pipeline logging purposes


### PR DESCRIPTION
_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
