### PR TITLE
style: ensure every prompt in the CLI has a FinalMessage 

### DIFF
--- a/internal/pkg/cli/app_delete.go
+++ b/internal/pkg/cli/app_delete.go
@@ -167,7 +167,8 @@ func (o *deleteAppOpts) Ask() error {
 	manualConfirm, err := o.prompt.Confirm(
 		fmt.Sprintf(fmtDeleteAppConfirmPrompt, o.name),
 		deleteAppConfirmHelp,
-		prompt.WithTrueDefault())
+		prompt.WithTrueDefault(),
+		prompt.WithConfirmFinalMessage())
 	if err != nil {
 		return fmt.Errorf("confirm app deletion: %w", err)
 	}

--- a/internal/pkg/cli/env_delete.go
+++ b/internal/pkg/cli/env_delete.go
@@ -127,7 +127,7 @@ func (o *deleteEnvOpts) Ask() error {
 	if o.skipConfirmation {
 		return nil
 	}
-	deleteConfirmed, err := o.prompt.Confirm(fmt.Sprintf(fmtDeleteEnvPrompt, o.name, o.appName), "")
+	deleteConfirmed, err := o.prompt.Confirm(fmt.Sprintf(fmtDeleteEnvPrompt, o.name, o.appName), "", prompt.WithConfirmFinalMessage())
 	if err != nil {
 		return fmt.Errorf("confirm to delete environment %s: %w", o.name, err)
 	}

--- a/internal/pkg/cli/env_delete_test.go
+++ b/internal/pkg/cli/env_delete_test.go
@@ -103,7 +103,7 @@ func TestDeleteEnvOpts_Ask(t *testing.T) {
 				mockSelector.EXPECT().Environment(envDeleteNamePrompt, "", testApp).Return(testEnv, nil)
 
 				mockPrompter := mocks.NewMockprompter(ctrl)
-				mockPrompter.EXPECT().Confirm(fmt.Sprintf(fmtDeleteEnvPrompt, testEnv, testApp), gomock.Any()).Return(true, nil)
+				mockPrompter.EXPECT().Confirm(fmt.Sprintf(fmtDeleteEnvPrompt, testEnv, testApp), gomock.Any(), gomock.Any()).Return(true, nil)
 
 				o.sel = mockSelector
 				o.prompt = mockPrompter
@@ -127,7 +127,7 @@ func TestDeleteEnvOpts_Ask(t *testing.T) {
 			mockDependencies: func(ctrl *gomock.Controller, o *deleteEnvOpts) {
 
 				mockPrompter := mocks.NewMockprompter(ctrl)
-				mockPrompter.EXPECT().Confirm(fmt.Sprintf(fmtDeleteEnvPrompt, testEnv, testApp), gomock.Any()).Return(false, errors.New("some error"))
+				mockPrompter.EXPECT().Confirm(fmt.Sprintf(fmtDeleteEnvPrompt, testEnv, testApp), gomock.Any(), gomock.Any()).Return(false, errors.New("some error"))
 
 				o.prompt = mockPrompter
 			},

--- a/internal/pkg/cli/env_init.go
+++ b/internal/pkg/cli/env_init.go
@@ -359,7 +359,7 @@ func (o *initEnvOpts) askEnvName() error {
 		return nil
 	}
 
-	envName, err := o.prompt.Get(envInitNamePrompt, envInitNameHelpPrompt, validateEnvironmentName)
+	envName, err := o.prompt.Get(envInitNamePrompt, envInitNameHelpPrompt, validateEnvironmentName, prompt.WithFinalMessage("Environment name:"))
 	if err != nil {
 		return fmt.Errorf("get environment name: %w", err)
 	}
@@ -398,7 +398,7 @@ func (o *initEnvOpts) askEnvRegion() error {
 		region = o.region
 	}
 	if region == "" {
-		v, err := o.prompt.Get(envInitRegionPrompt, "", nil, prompt.WithDefaultInput(envInitDefaultRegionOption))
+		v, err := o.prompt.Get(envInitRegionPrompt, "", nil, prompt.WithDefaultInput(envInitDefaultRegionOption), prompt.WithFinalMessage("Region:"))
 		if err != nil {
 			return fmt.Errorf("get environment region: %w", err)
 		}
@@ -420,7 +420,8 @@ func (o *initEnvOpts) askCustomizedResources() error {
 	}
 	adjustOrImport, err := o.prompt.SelectOne(
 		envInitDefaultEnvConfirmPrompt, "",
-		envInitCustomizedEnvTypes)
+		envInitCustomizedEnvTypes,
+		prompt.WithFinalMessage("Default environment configuration?"))
 	if err != nil {
 		return fmt.Errorf("select adjusting or importing resources: %w", err)
 	}
@@ -503,7 +504,7 @@ If you proceed without at least two public subnets, you will not be able to depl
 func (o *initEnvOpts) askAdjustResources() error {
 	if o.adjustVPC.CIDR.String() == emptyIPNet.String() {
 		vpcCIDRString, err := o.prompt.Get(envInitVPCCIDRPrompt, envInitVPCCIDRPromptHelp, validateCIDR,
-			prompt.WithDefaultInput(stack.DefaultVPCCIDR))
+			prompt.WithDefaultInput(stack.DefaultVPCCIDR), prompt.WithFinalMessage("VPC CIDR:"))
 		if err != nil {
 			return fmt.Errorf("get VPC CIDR: %w", err)
 		}
@@ -515,7 +516,7 @@ func (o *initEnvOpts) askAdjustResources() error {
 	}
 	if o.adjustVPC.PublicSubnetCIDRs == nil {
 		publicCIDR, err := o.prompt.Get(envInitPublicCIDRPrompt, envInitPublicCIDRPromptHelp, validateCIDRSlice,
-			prompt.WithDefaultInput(stack.DefaultPublicSubnetCIDRs))
+			prompt.WithDefaultInput(stack.DefaultPublicSubnetCIDRs), prompt.WithFinalMessage("Public subnets CIDR:"))
 		if err != nil {
 			return fmt.Errorf("get public subnet CIDRs: %w", err)
 		}
@@ -523,7 +524,7 @@ func (o *initEnvOpts) askAdjustResources() error {
 	}
 	if o.adjustVPC.PrivateSubnetCIDRs == nil {
 		privateCIDR, err := o.prompt.Get(envInitPrivateCIDRPrompt, envInitPrivateCIDRPromptHelp, validateCIDRSlice,
-			prompt.WithDefaultInput(stack.DefaultPrivateSubnetCIDRs))
+			prompt.WithDefaultInput(stack.DefaultPrivateSubnetCIDRs), prompt.WithFinalMessage("Private subnets CIDR:"))
 		if err != nil {
 			return fmt.Errorf("get private subnet CIDRs: %w", err)
 		}

--- a/internal/pkg/cli/env_init_test.go
+++ b/internal/pkg/cli/env_init_test.go
@@ -236,7 +236,7 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 			setupMocks: func(m initEnvMocks) {
 				gomock.InOrder(
 					m.prompt.EXPECT().
-						Get(envInitNamePrompt, envInitNameHelpPrompt, gomock.Any()).
+						Get(envInitNamePrompt, envInitNameHelpPrompt, gomock.Any(), gomock.Any()).
 						Return("", mockErr),
 				)
 			},
@@ -284,7 +284,7 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(&session.Session{
 					Config: &aws.Config{},
 				}, nil)
-				m.prompt.EXPECT().Get("Which region?", gomock.Any(), nil, gomock.Any()).Return("us-west-2", nil)
+				m.prompt.EXPECT().Get("Which region?", gomock.Any(), nil, gomock.Any(), gomock.Any()).Return("us-west-2", nil)
 			},
 		},
 		"should skip prompting for region if flag is provided": {
@@ -297,7 +297,7 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(&session.Session{
 					Config: &aws.Config{},
 				}, nil)
-				m.prompt.EXPECT().Get("Which region?", gomock.Any(), nil, gomock.Any()).Times(0)
+				m.prompt.EXPECT().Get("Which region?", gomock.Any(), nil, gomock.Any(), gomock.Any()).Times(0)
 			},
 		},
 		"should not prompt for configuring environment if default config flag is true": {
@@ -307,7 +307,7 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 			inDefault: true,
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(mockSession, nil)
-				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, gomock.Any(), gomock.Any()).Times(0)
+				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 			},
 		},
 		"fail to select whether to adjust or import resources": {
@@ -316,7 +316,7 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 			inProfile: mockProfile,
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(mockSession, nil)
-				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, "", envInitCustomizedEnvTypes).
+				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, "", envInitCustomizedEnvTypes, gomock.Any()).
 					Return("", mockErr)
 			},
 			wantedError: fmt.Errorf("select adjusting or importing resources: some error"),
@@ -327,7 +327,7 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 			inProfile: mockProfile,
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(mockSession, nil)
-				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, "", envInitCustomizedEnvTypes).
+				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, "", envInitCustomizedEnvTypes, gomock.Any()).
 					Return(envInitDefaultConfigSelectOption, nil)
 			},
 		},
@@ -337,7 +337,7 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 			inProfile: mockProfile,
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(mockSession, nil)
-				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, "", envInitCustomizedEnvTypes).
+				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, "", envInitCustomizedEnvTypes, gomock.Any()).
 					Return(envInitImportEnvResourcesSelectOption, nil)
 				m.selVPC.EXPECT().VPC(envInitVPCSelectPrompt, "").Return("", mockErr)
 			},
@@ -349,7 +349,7 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 			inProfile: mockProfile,
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(mockSession, nil)
-				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, "", envInitCustomizedEnvTypes).
+				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, "", envInitCustomizedEnvTypes, gomock.Any()).
 					Return(envInitImportEnvResourcesSelectOption, nil)
 				m.selVPC.EXPECT().VPC(envInitVPCSelectPrompt, "").Return("mockVPC", nil)
 				m.ec2Client.EXPECT().HasDNSSupport("mockVPC").Return(false, mockErr)
@@ -362,7 +362,7 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 			inProfile: mockProfile,
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(mockSession, nil)
-				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, "", envInitCustomizedEnvTypes).
+				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, "", envInitCustomizedEnvTypes, gomock.Any()).
 					Return(envInitImportEnvResourcesSelectOption, nil)
 				m.selVPC.EXPECT().VPC(envInitVPCSelectPrompt, "").Return("mockVPC", nil)
 				m.ec2Client.EXPECT().HasDNSSupport("mockVPC").Return(false, nil)
@@ -375,7 +375,7 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 			inProfile: mockProfile,
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(mockSession, nil)
-				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, "", envInitCustomizedEnvTypes).
+				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, "", envInitCustomizedEnvTypes, gomock.Any()).
 					Return(envInitImportEnvResourcesSelectOption, nil)
 				m.selVPC.EXPECT().VPC(envInitVPCSelectPrompt, "").Return("mockVPC", nil)
 				m.ec2Client.EXPECT().HasDNSSupport("mockVPC").Return(true, nil)
@@ -390,7 +390,7 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 			inProfile: mockProfile,
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(mockSession, nil)
-				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, "", envInitCustomizedEnvTypes).
+				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, "", envInitCustomizedEnvTypes, gomock.Any()).
 					Return(envInitImportEnvResourcesSelectOption, nil)
 				m.selVPC.EXPECT().VPC(envInitVPCSelectPrompt, "").Return("mockVPC", nil)
 				m.ec2Client.EXPECT().HasDNSSupport("mockVPC").Return(true, nil)
@@ -405,7 +405,7 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 			inProfile: mockProfile,
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(mockSession, nil)
-				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, "", envInitCustomizedEnvTypes).
+				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, "", envInitCustomizedEnvTypes, gomock.Any()).
 					Return(envInitImportEnvResourcesSelectOption, nil)
 				m.selVPC.EXPECT().VPC(envInitVPCSelectPrompt, "").Return("mockVPC", nil)
 				m.ec2Client.EXPECT().HasDNSSupport("mockVPC").Return(true, nil)
@@ -422,7 +422,7 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 			inProfile: mockProfile,
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(mockSession, nil)
-				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, "", envInitCustomizedEnvTypes).
+				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, "", envInitCustomizedEnvTypes, gomock.Any()).
 					Return(envInitImportEnvResourcesSelectOption, nil)
 				m.selVPC.EXPECT().VPC(envInitVPCSelectPrompt, "").Return("mockVPC", nil)
 				m.ec2Client.EXPECT().HasDNSSupport("mockVPC").Return(true, nil)
@@ -439,7 +439,7 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 			inProfile: mockProfile,
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(mockSession, nil)
-				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, "", envInitCustomizedEnvTypes).
+				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, "", envInitCustomizedEnvTypes, gomock.Any()).
 					Return(envInitImportEnvResourcesSelectOption, nil)
 				m.selVPC.EXPECT().VPC(envInitVPCSelectPrompt, "").Return("mockVPC", nil)
 				m.ec2Client.EXPECT().HasDNSSupport("mockVPC").Return(true, nil)
@@ -455,7 +455,7 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 			inProfile: mockProfile,
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(mockSession, nil)
-				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, "", envInitCustomizedEnvTypes).
+				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, "", envInitCustomizedEnvTypes, gomock.Any()).
 					Return(envInitImportEnvResourcesSelectOption, nil)
 				m.selVPC.EXPECT().VPC(envInitVPCSelectPrompt, "").Return("mockVPC", nil)
 				m.ec2Client.EXPECT().HasDNSSupport("mockVPC").Return(true, nil)
@@ -476,7 +476,7 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 			},
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(mockSession, nil)
-				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, gomock.Any(), gomock.Any()).Times(0)
+				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 				m.ec2Client.EXPECT().HasDNSSupport("mockVPCID").Return(true, nil)
 			},
 		},
@@ -486,7 +486,7 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 			inProfile: mockProfile,
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(mockSession, nil)
-				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, "", envInitCustomizedEnvTypes).
+				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, "", envInitCustomizedEnvTypes, gomock.Any()).
 					Return(envInitAdjustEnvResourcesSelectOption, nil)
 				m.prompt.EXPECT().Get(envInitVPCCIDRPrompt, envInitVPCCIDRPromptHelp, gomock.Any(), gomock.Any()).
 					Return("", mockErr)
@@ -499,7 +499,7 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 			inProfile: mockProfile,
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(mockSession, nil)
-				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, "", envInitCustomizedEnvTypes).
+				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, "", envInitCustomizedEnvTypes, gomock.Any()).
 					Return(envInitAdjustEnvResourcesSelectOption, nil)
 				m.prompt.EXPECT().Get(envInitVPCCIDRPrompt, envInitVPCCIDRPromptHelp, gomock.Any(), gomock.Any()).
 					Return(mockVPCCIDR, nil)
@@ -514,7 +514,7 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 			inProfile: mockProfile,
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(mockSession, nil)
-				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, "", envInitCustomizedEnvTypes).
+				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, "", envInitCustomizedEnvTypes, gomock.Any()).
 					Return(envInitAdjustEnvResourcesSelectOption, nil)
 				m.prompt.EXPECT().Get(envInitVPCCIDRPrompt, envInitVPCCIDRPromptHelp, gomock.Any(), gomock.Any()).
 					Return(mockVPCCIDR, nil)
@@ -531,7 +531,7 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 			inProfile: mockProfile,
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(mockSession, nil)
-				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, "", envInitCustomizedEnvTypes).
+				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, "", envInitCustomizedEnvTypes, gomock.Any()).
 					Return(envInitAdjustEnvResourcesSelectOption, nil)
 				m.prompt.EXPECT().Get(envInitVPCCIDRPrompt, envInitVPCCIDRPromptHelp, gomock.Any(), gomock.Any()).
 					Return(mockVPCCIDR, nil)
@@ -555,7 +555,7 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 			},
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(mockSession, nil)
-				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, gomock.Any(), gomock.Any()).Times(0)
+				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 			},
 		},
 	}

--- a/internal/pkg/cli/job_delete.go
+++ b/internal/pkg/cli/job_delete.go
@@ -145,7 +145,8 @@ func (o *deleteJobOpts) Ask() error {
 
 	deleteConfirmed, err := o.prompt.Confirm(
 		deletePrompt,
-		deleteConfirmHelp)
+		deleteConfirmHelp,
+		prompt.WithConfirmFinalMessage())
 
 	if err != nil {
 		return fmt.Errorf("job delete confirmation prompt: %w", err)

--- a/internal/pkg/cli/job_delete_test.go
+++ b/internal/pkg/cli/job_delete_test.go
@@ -197,6 +197,7 @@ func TestDeleteJobOpts_Ask(t *testing.T) {
 				m.EXPECT().Confirm(
 					fmt.Sprintf(fmtJobDeleteConfirmPrompt, testJobName, testAppName),
 					jobDeleteConfirmHelp,
+					gomock.Any(),
 				).Times(1).Return(true, mockError)
 			},
 
@@ -213,6 +214,7 @@ func TestDeleteJobOpts_Ask(t *testing.T) {
 				m.EXPECT().Confirm(
 					fmt.Sprintf(fmtJobDeleteConfirmPrompt, testJobName, testAppName),
 					jobDeleteConfirmHelp,
+					gomock.Any(),
 				).Times(1).Return(false, nil)
 			},
 
@@ -229,6 +231,7 @@ func TestDeleteJobOpts_Ask(t *testing.T) {
 				m.EXPECT().Confirm(
 					fmt.Sprintf(fmtJobDeleteConfirmPrompt, testJobName, testAppName),
 					jobDeleteConfirmHelp,
+					gomock.Any(),
 				).Times(1).Return(true, nil)
 			},
 
@@ -246,6 +249,7 @@ func TestDeleteJobOpts_Ask(t *testing.T) {
 				m.EXPECT().Confirm(
 					fmt.Sprintf(fmtJobDeleteFromEnvConfirmPrompt, testJobName, "test"),
 					fmt.Sprintf(fmtJobDeleteFromEnvConfirmHelp, "test"),
+					gomock.Any(),
 				).Times(1).Return(true, nil)
 			},
 

--- a/internal/pkg/cli/pipeline_delete.go
+++ b/internal/pkg/cli/pipeline_delete.go
@@ -103,7 +103,8 @@ func (o *deletePipelineOpts) Ask() error {
 
 	deleteConfirmed, err := o.prompt.Confirm(
 		fmt.Sprintf(pipelineDeleteConfirmPrompt, o.PipelineName, o.appName),
-		pipelineDeleteConfirmHelp)
+		pipelineDeleteConfirmHelp,
+		prompt.WithConfirmFinalMessage())
 
 	if err != nil {
 		return fmt.Errorf("pipeline delete confirmation prompt: %w", err)

--- a/internal/pkg/cli/pipeline_delete_test.go
+++ b/internal/pkg/cli/pipeline_delete_test.go
@@ -139,6 +139,7 @@ func TestDeletePipelineOpts_Ask(t *testing.T) {
 				m.prompt.EXPECT().Confirm(
 					fmt.Sprintf(pipelineDeleteConfirmPrompt, testPipelineName, testAppName),
 					pipelineDeleteConfirmHelp,
+					gomock.Any(),
 				).Times(1).Return(true, nil)
 			},
 			wantedError: nil,

--- a/internal/pkg/cli/pipeline_init.go
+++ b/internal/pkg/cli/pipeline_init.go
@@ -344,6 +344,7 @@ func (o *initPipelineOpts) selectURL() error {
 		pipelineSelectURLPrompt,
 		pipelineSelectURLHelpPrompt,
 		urls,
+		prompt.WithFinalMessage("Repository URL:"),
 	)
 	if err != nil {
 		return fmt.Errorf("select URL: %w", err)

--- a/internal/pkg/cli/pipeline_init_test.go
+++ b/internal/pkg/cli/pipeline_init_test.go
@@ -199,7 +199,7 @@ func TestInitPipelineOpts_Ask(t *testing.T) {
 				m.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			},
 			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().SelectOne(pipelineSelectURLPrompt, gomock.Any(), gomock.Any()).Return(githubAnotherURL, nil).Times(1)
+				m.EXPECT().SelectOne(pipelineSelectURLPrompt, gomock.Any(), gomock.Any(), gomock.Any()).Return(githubAnotherURL, nil).Times(1)
 			},
 			mockSessProvider: func(m *mocks.MocksessionProvider) {},
 
@@ -233,7 +233,7 @@ func TestInitPipelineOpts_Ask(t *testing.T) {
 				m.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			},
 			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().SelectOne(pipelineSelectURLPrompt, gomock.Any(), gomock.Any()).Return(codecommitSSHURL, nil).Times(1)
+				m.EXPECT().SelectOne(pipelineSelectURLPrompt, gomock.Any(), gomock.Any(), gomock.Any()).Return(codecommitSSHURL, nil).Times(1)
 			},
 			mockSessProvider: func(m *mocks.MocksessionProvider) {
 				m.EXPECT().Default().Return(&session.Session{
@@ -287,7 +287,7 @@ func TestInitPipelineOpts_Ask(t *testing.T) {
 				m.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			},
 			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().SelectOne(pipelineSelectURLPrompt, gomock.Any(), gomock.Any()).Return("", errors.New("some error")).Times(1)
+				m.EXPECT().SelectOne(pipelineSelectURLPrompt, gomock.Any(), gomock.Any(), gomock.Any()).Return("", errors.New("some error")).Times(1)
 			},
 			mockSessProvider: func(m *mocks.MocksessionProvider) {},
 
@@ -319,7 +319,7 @@ func TestInitPipelineOpts_Ask(t *testing.T) {
 				m.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			},
 			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().SelectOne(pipelineSelectURLPrompt, gomock.Any(), gomock.Any()).Return("https://bitbub.com/badGoose/chaOS", nil).Times(1)
+				m.EXPECT().SelectOne(pipelineSelectURLPrompt, gomock.Any(), gomock.Any(), gomock.Any()).Return("https://bitbub.com/badGoose/chaOS", nil).Times(1)
 			},
 			mockSessProvider: func(m *mocks.MocksessionProvider) {},
 
@@ -349,7 +349,7 @@ func TestInitPipelineOpts_Ask(t *testing.T) {
 				m.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			},
 			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().SelectOne(pipelineSelectURLPrompt, gomock.Any(), []string{githubReallyBadURL}).Return(githubReallyBadURL, nil).Times(1)
+				m.EXPECT().SelectOne(pipelineSelectURLPrompt, gomock.Any(), []string{githubReallyBadURL}, gomock.Any()).Return(githubReallyBadURL, nil).Times(1)
 			},
 			mockSessProvider: func(m *mocks.MocksessionProvider) {},
 
@@ -382,7 +382,7 @@ func TestInitPipelineOpts_Ask(t *testing.T) {
 				m.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			},
 			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().SelectOne(pipelineSelectURLPrompt, gomock.Any(), gomock.Any()).Return(codecommitBadURL, nil).Times(1)
+				m.EXPECT().SelectOne(pipelineSelectURLPrompt, gomock.Any(), gomock.Any(), gomock.Any()).Return(codecommitBadURL, nil).Times(1)
 			},
 			mockSessProvider: func(m *mocks.MocksessionProvider) {},
 
@@ -410,7 +410,7 @@ func TestInitPipelineOpts_Ask(t *testing.T) {
 				m.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			},
 			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().SelectOne(pipelineSelectURLPrompt, gomock.Any(), gomock.Any()).Return(codecommitBadRegion, nil).Times(1)
+				m.EXPECT().SelectOne(pipelineSelectURLPrompt, gomock.Any(), gomock.Any(), gomock.Any()).Return(codecommitBadRegion, nil).Times(1)
 			},
 			mockSessProvider: func(m *mocks.MocksessionProvider) {},
 
@@ -441,7 +441,7 @@ func TestInitPipelineOpts_Ask(t *testing.T) {
 				m.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			},
 			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().SelectOne(pipelineSelectURLPrompt, gomock.Any(), gomock.Any()).Return(codecommitFedURL, nil).Times(1)
+				m.EXPECT().SelectOne(pipelineSelectURLPrompt, gomock.Any(), gomock.Any(), gomock.Any()).Return(codecommitFedURL, nil).Times(1)
 			},
 			mockSessProvider: func(m *mocks.MocksessionProvider) {
 				m.EXPECT().Default().Return(nil, errors.New("some error"))
@@ -471,7 +471,7 @@ func TestInitPipelineOpts_Ask(t *testing.T) {
 				m.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			},
 			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().SelectOne(pipelineSelectURLPrompt, gomock.Any(), gomock.Any()).Return(codecommitFedURL, nil).Times(1)
+				m.EXPECT().SelectOne(pipelineSelectURLPrompt, gomock.Any(), gomock.Any(), gomock.Any()).Return(codecommitFedURL, nil).Times(1)
 			},
 			mockSessProvider: func(m *mocks.MocksessionProvider) {
 				m.EXPECT().Default().Return(&session.Session{

--- a/internal/pkg/cli/pipeline_show.go
+++ b/internal/pkg/cli/pipeline_show.go
@@ -163,7 +163,10 @@ func (o *showPipelineOpts) askPipelineName() error {
 
 	// select from list of deployed pipelines
 	pipelineName, err = o.prompt.SelectOne(
-		fmt.Sprintf(fmtPipelineShowPipelineNamePrompt, color.HighlightUserInput(o.appName)), pipelineShowPipelineNameHelpPrompt, pipelineNames,
+		fmt.Sprintf(fmtPipelineShowPipelineNamePrompt, color.HighlightUserInput(o.appName)),
+		pipelineShowPipelineNameHelpPrompt,
+		pipelineNames,
+		prompt.WithFinalMessage("Pipeline:"),
 	)
 	if err != nil {
 		return fmt.Errorf("select pipeline for application %s: %w", o.appName, err)

--- a/internal/pkg/cli/pipeline_show_test.go
+++ b/internal/pkg/cli/pipeline_show_test.go
@@ -177,7 +177,7 @@ stages:
 				gomock.InOrder(
 					mocks.ws.EXPECT().ReadPipelineManifest().Return(nil, workspace.ErrNoPipelineInWorkspace),
 					mocks.pipelineSvc.EXPECT().ListPipelineNamesByTags(testTags).Return(mockPipelines, nil),
-					mocks.prompt.EXPECT().SelectOne(fmt.Sprintf(fmtPipelineShowPipelineNamePrompt, color.HighlightUserInput(mockAppName)), pipelineShowPipelineNameHelpPrompt, mockPipelines).Return(mockPipelineName, nil),
+					mocks.prompt.EXPECT().SelectOne(fmt.Sprintf(fmtPipelineShowPipelineNamePrompt, color.HighlightUserInput(mockAppName)), pipelineShowPipelineNameHelpPrompt, mockPipelines, gomock.Any()).Return(mockPipelineName, nil),
 				)
 			},
 			expectedApp:      mockAppName,
@@ -239,7 +239,7 @@ stages:
 				gomock.InOrder(
 					mocks.ws.EXPECT().ReadPipelineManifest().Return(nil, workspace.ErrNoPipelineInWorkspace),
 					mocks.pipelineSvc.EXPECT().ListPipelineNamesByTags(testTags).Return(mockPipelines, nil),
-					mocks.prompt.EXPECT().SelectOne(fmt.Sprintf(fmtPipelineShowPipelineNamePrompt, color.HighlightUserInput(mockAppName)), pipelineShowPipelineNameHelpPrompt, mockPipelines).Return("", mockError),
+					mocks.prompt.EXPECT().SelectOne(fmt.Sprintf(fmtPipelineShowPipelineNamePrompt, color.HighlightUserInput(mockAppName)), pipelineShowPipelineNameHelpPrompt, mockPipelines, gomock.Any()).Return("", mockError),
 				)
 			},
 			expectedApp:      mockAppName,

--- a/internal/pkg/cli/pipeline_status.go
+++ b/internal/pkg/cli/pipeline_status.go
@@ -181,7 +181,10 @@ func (o *pipelineStatusOpts) askPipelineName() error {
 
 	// select from list of deployed pipelines
 	pipelineName, err = o.prompt.SelectOne(
-		fmt.Sprintf(fmtPipelineStatusPipelineNamePrompt, color.HighlightUserInput(o.appName)), pipelineStatusPipelineNameHelpPrompt, pipelineNames,
+		fmt.Sprintf(fmtPipelineStatusPipelineNamePrompt, color.HighlightUserInput(o.appName)),
+		pipelineStatusPipelineNameHelpPrompt,
+		pipelineNames,
+		prompt.WithFinalMessage("Pipeline:"),
 	)
 	if err != nil {
 		return fmt.Errorf("select pipeline for application %s: %w", o.appName, err)

--- a/internal/pkg/cli/pipeline_status_test.go
+++ b/internal/pkg/cli/pipeline_status_test.go
@@ -175,7 +175,7 @@ stages:
 				gomock.InOrder(
 					mocks.ws.EXPECT().ReadPipelineManifest().Return(nil, workspace.ErrNoPipelineInWorkspace),
 					mocks.pipelineSvc.EXPECT().ListPipelineNamesByTags(testTags).Return(mockPipelines, nil),
-					mocks.prompt.EXPECT().SelectOne(fmt.Sprintf(fmtPipelineStatusPipelineNamePrompt, color.HighlightUserInput(mockAppName)), pipelineStatusPipelineNameHelpPrompt, mockPipelines).Return(mockPipelineName, nil),
+					mocks.prompt.EXPECT().SelectOne(fmt.Sprintf(fmtPipelineStatusPipelineNamePrompt, color.HighlightUserInput(mockAppName)), pipelineStatusPipelineNameHelpPrompt, mockPipelines, gomock.Any()).Return(mockPipelineName, nil),
 				)
 			},
 			expectedApp:      mockAppName,
@@ -221,7 +221,7 @@ stages:
 				gomock.InOrder(
 					mocks.ws.EXPECT().ReadPipelineManifest().Return(nil, workspace.ErrNoPipelineInWorkspace),
 					mocks.pipelineSvc.EXPECT().ListPipelineNamesByTags(testTags).Return(mockPipelines, nil),
-					mocks.prompt.EXPECT().SelectOne(fmt.Sprintf(fmtPipelineStatusPipelineNamePrompt, color.HighlightUserInput(mockAppName)), pipelineStatusPipelineNameHelpPrompt, mockPipelines).Return("", mockError),
+					mocks.prompt.EXPECT().SelectOne(fmt.Sprintf(fmtPipelineStatusPipelineNamePrompt, color.HighlightUserInput(mockAppName)), pipelineStatusPipelineNameHelpPrompt, mockPipelines, gomock.Any()).Return("", mockError),
 				)
 			},
 			expectedApp:      mockAppName,

--- a/internal/pkg/cli/secret_init.go
+++ b/internal/pkg/cli/secret_init.go
@@ -357,7 +357,7 @@ func (o *secretInitOpts) askForSecretName() error {
 	name, err := o.prompter.Get(secretInitSecretNamePrompt,
 		secretInitSecretNamePromptHelp,
 		validateSecretName,
-		prompt.WithFinalMessage("secret name: "))
+		prompt.WithFinalMessage("Secret name: "))
 	if err != nil {
 		return fmt.Errorf("ask for the secret name: %w", err)
 	}
@@ -387,7 +387,9 @@ func (o *secretInitOpts) askForSecretValues() error {
 	for _, env := range envs {
 		value, err := o.prompter.GetSecret(
 			fmt.Sprintf(fmtSecretInitSecretValuePrompt, color.HighlightUserInput(o.name), env.Name),
-			fmt.Sprintf(fmtSecretInitSecretValuePromptHelp, color.HighlightUserInput(o.name), env.Name))
+			fmt.Sprintf(fmtSecretInitSecretValuePromptHelp, color.HighlightUserInput(o.name), env.Name),
+			prompt.WithFinalMessage(fmt.Sprintf("%s secret value:", strings.Title(env.Name))),
+		)
 		if err != nil {
 			return fmt.Errorf("get secret value for %s in environment %s: %w", color.HighlightUserInput(o.name), env.Name, err)
 		}

--- a/internal/pkg/cli/secret_init_test.go
+++ b/internal/pkg/cli/secret_init_test.go
@@ -246,11 +246,11 @@ func TestSecretInitOpts_Ask(t *testing.T) {
 						Name: "prod",
 					},
 				}, nil)
-				m.mockPrompter.EXPECT().GetSecret(fmt.Sprintf(fmtSecretInitSecretValuePrompt, "db-password", "test"), gomock.Any()).
+				m.mockPrompter.EXPECT().GetSecret(fmt.Sprintf(fmtSecretInitSecretValuePrompt, "db-password", "test"), gomock.Any(), gomock.Any()).
 					Return("test-password", nil)
-				m.mockPrompter.EXPECT().GetSecret(fmt.Sprintf(fmtSecretInitSecretValuePrompt, "db-password", "dev"), gomock.Any()).
+				m.mockPrompter.EXPECT().GetSecret(fmt.Sprintf(fmtSecretInitSecretValuePrompt, "db-password", "dev"), gomock.Any(), gomock.Any()).
 					Return("dev-password", nil)
-				m.mockPrompter.EXPECT().GetSecret(fmt.Sprintf(fmtSecretInitSecretValuePrompt, "db-password", "prod"), gomock.Any()).
+				m.mockPrompter.EXPECT().GetSecret(fmt.Sprintf(fmtSecretInitSecretValuePrompt, "db-password", "prod"), gomock.Any(), gomock.Any()).
 					Return("prod-password", nil)
 			},
 			wantedVars: wantedVars,
@@ -278,10 +278,10 @@ func TestSecretInitOpts_Ask(t *testing.T) {
 						Name: "prod",
 					},
 				}, nil)
-				m.mockPrompter.EXPECT().GetSecret(fmt.Sprintf(fmtSecretInitSecretValuePrompt, "db-password", "test"), gomock.Any()).
+				m.mockPrompter.EXPECT().GetSecret(fmt.Sprintf(fmtSecretInitSecretValuePrompt, "db-password", "test"), gomock.Any(), gomock.Any()).
 					Return("", errors.New("some error"))
-				m.mockPrompter.EXPECT().GetSecret(fmt.Sprintf(fmtSecretInitSecretValuePrompt, "db-password", "dev"), gomock.Any()).MinTimes(0).MaxTimes(1)
-				m.mockPrompter.EXPECT().GetSecret(fmt.Sprintf(fmtSecretInitSecretValuePrompt, "db-password", "prod"), gomock.Any()).MinTimes(0).MaxTimes(1)
+				m.mockPrompter.EXPECT().GetSecret(fmt.Sprintf(fmtSecretInitSecretValuePrompt, "db-password", "dev"), gomock.Any(), gomock.Any()).MinTimes(0).MaxTimes(1)
+				m.mockPrompter.EXPECT().GetSecret(fmt.Sprintf(fmtSecretInitSecretValuePrompt, "db-password", "prod"), gomock.Any(), gomock.Any()).MinTimes(0).MaxTimes(1)
 			},
 			wantedError: errors.New("get secret value for db-password in environment test: some error"),
 		},

--- a/internal/pkg/cli/svc_delete.go
+++ b/internal/pkg/cli/svc_delete.go
@@ -138,7 +138,7 @@ func (o *deleteSvcOpts) Ask() error {
 	deleteConfirmed, err := o.prompt.Confirm(
 		deletePrompt,
 		deleteConfirmHelp,
-		prompt.WithFinalMessage("Confirm:"))
+		prompt.WithConfirmFinalMessage())
 
 	if err != nil {
 		return fmt.Errorf("svc delete confirmation prompt: %w", err)

--- a/internal/pkg/cli/svc_delete.go
+++ b/internal/pkg/cli/svc_delete.go
@@ -137,7 +137,8 @@ func (o *deleteSvcOpts) Ask() error {
 
 	deleteConfirmed, err := o.prompt.Confirm(
 		deletePrompt,
-		deleteConfirmHelp)
+		deleteConfirmHelp,
+		prompt.WithFinalMessage("Confirm:"))
 
 	if err != nil {
 		return fmt.Errorf("svc delete confirmation prompt: %w", err)
@@ -177,6 +178,7 @@ func (o *deleteSvcOpts) Execute() error {
 		return err
 	}
 
+	log.Infoln()
 	log.Successf("Deleted service %s from application %s.\n", o.name, o.appName)
 
 	return nil

--- a/internal/pkg/cli/svc_delete_test.go
+++ b/internal/pkg/cli/svc_delete_test.go
@@ -197,6 +197,7 @@ func TestDeleteSvcOpts_Ask(t *testing.T) {
 				m.EXPECT().Confirm(
 					fmt.Sprintf(fmtSvcDeleteConfirmPrompt, testSvcName, testAppName),
 					svcDeleteConfirmHelp,
+					gomock.Any(),
 				).Times(1).Return(true, mockError)
 			},
 
@@ -213,6 +214,7 @@ func TestDeleteSvcOpts_Ask(t *testing.T) {
 				m.EXPECT().Confirm(
 					fmt.Sprintf(fmtSvcDeleteConfirmPrompt, testSvcName, testAppName),
 					svcDeleteConfirmHelp,
+					gomock.Any(),
 				).Times(1).Return(false, nil)
 			},
 
@@ -229,6 +231,7 @@ func TestDeleteSvcOpts_Ask(t *testing.T) {
 				m.EXPECT().Confirm(
 					fmt.Sprintf(fmtSvcDeleteConfirmPrompt, testSvcName, testAppName),
 					svcDeleteConfirmHelp,
+					gomock.Any(),
 				).Times(1).Return(true, nil)
 			},
 
@@ -246,6 +249,7 @@ func TestDeleteSvcOpts_Ask(t *testing.T) {
 				m.EXPECT().Confirm(
 					fmt.Sprintf(fmtSvcDeleteFromEnvConfirmPrompt, testSvcName, "test"),
 					fmt.Sprintf(svcDeleteFromEnvConfirmHelp, "test"),
+					gomock.Any(),
 				).Times(1).Return(true, nil)
 			},
 

--- a/internal/pkg/cli/svc_pause.go
+++ b/internal/pkg/cli/svc_pause.go
@@ -139,7 +139,7 @@ func (o *svcPauseOpts) Ask() error {
 		return nil
 	}
 
-	pauseConfirmed, err := o.prompt.Confirm(fmt.Sprintf(fmtSvcPauseConfirmPrompt, color.HighlightUserInput(o.svcName)), "")
+	pauseConfirmed, err := o.prompt.Confirm(fmt.Sprintf(fmtSvcPauseConfirmPrompt, color.HighlightUserInput(o.svcName)), "", prompt.WithConfirmFinalMessage())
 	if err != nil {
 		return fmt.Errorf("svc pause confirmation prompt: %w", err)
 	}

--- a/internal/pkg/cli/svc_pause_test.go
+++ b/internal/pkg/cli/svc_pause_test.go
@@ -169,7 +169,7 @@ func TestSvcPause_Ask(t *testing.T) {
 					}, nil)
 			},
 			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().Confirm("Are you sure you want to stop processing requests for service mockSvc?", "").Times(1).Return(true, mockError)
+				m.EXPECT().Confirm("Are you sure you want to stop processing requests for service mockSvc?", "", gomock.Any()).Times(1).Return(true, mockError)
 			},
 			wantedError: fmt.Errorf("svc pause confirmation prompt: %w", mockError),
 		},
@@ -186,7 +186,7 @@ func TestSvcPause_Ask(t *testing.T) {
 					}, nil)
 			},
 			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().Confirm("Are you sure you want to stop processing requests for service mockSvc?", "").Times(1).Return(false, nil)
+				m.EXPECT().Confirm("Are you sure you want to stop processing requests for service mockSvc?", "", gomock.Any()).Times(1).Return(false, nil)
 			},
 			wantedError: errors.New("svc pause cancelled - no changes made"),
 		},
@@ -203,7 +203,7 @@ func TestSvcPause_Ask(t *testing.T) {
 					}, nil)
 			},
 			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().Confirm("Are you sure you want to stop processing requests for service mockSvc?", "").Times(1).Return(true, nil)
+				m.EXPECT().Confirm("Are you sure you want to stop processing requests for service mockSvc?", "", gomock.Any()).Times(1).Return(true, nil)
 			},
 			wantedError: nil,
 		},

--- a/internal/pkg/cli/task_delete.go
+++ b/internal/pkg/cli/task_delete.go
@@ -261,7 +261,8 @@ func (o *deleteTaskOpts) Ask() error {
 
 	deleteConfirmed, err := o.prompt.Confirm(
 		deletePrompt,
-		taskDeleteConfirmHelp)
+		taskDeleteConfirmHelp,
+		prompt.WithConfirmFinalMessage())
 
 	if err != nil {
 		return fmt.Errorf("task delete confirmation prompt: %w", err)

--- a/internal/pkg/cli/task_delete_test.go
+++ b/internal/pkg/cli/task_delete_test.go
@@ -190,7 +190,7 @@ func TestDeleteTaskOpts_Ask(t *testing.T) {
 				m.EXPECT().FromRole(gomock.Any(), gomock.Any()).Return(&session.Session{}, nil)
 			},
 			mockPrompter: func(m *mocks.Mockprompter) {
-				m.EXPECT().Confirm("Are you sure you want to delete abc from application phonetool and environment test?", gomock.Any()).Return(true, nil)
+				m.EXPECT().Confirm("Are you sure you want to delete abc from application phonetool and environment test?", gomock.Any(), gomock.Any()).Return(true, nil)
 			},
 		},
 		"name flag not specified and confirm cancelled": {
@@ -209,7 +209,7 @@ func TestDeleteTaskOpts_Ask(t *testing.T) {
 				m.EXPECT().FromRole(gomock.Any(), gomock.Any()).Return(&session.Session{}, nil)
 			},
 			mockPrompter: func(m *mocks.Mockprompter) {
-				m.EXPECT().Confirm("Are you sure you want to delete abc from application phonetool and environment test?", gomock.Any()).Return(false, nil)
+				m.EXPECT().Confirm("Are you sure you want to delete abc from application phonetool and environment test?", gomock.Any(), gomock.Any()).Return(false, nil)
 			},
 			wantErr: "task delete cancelled - no changes made",
 		},
@@ -226,7 +226,7 @@ func TestDeleteTaskOpts_Ask(t *testing.T) {
 				m.EXPECT().Default().Return(&session.Session{}, nil)
 			},
 			mockPrompter: func(m *mocks.Mockprompter) {
-				m.EXPECT().Confirm("Are you sure you want to delete abc from the default cluster?", gomock.Any()).Return(true, nil)
+				m.EXPECT().Confirm("Are you sure you want to delete abc from the default cluster?", gomock.Any(), gomock.Any()).Return(true, nil)
 			},
 		},
 		"no flags specified": {
@@ -245,7 +245,7 @@ func TestDeleteTaskOpts_Ask(t *testing.T) {
 				m.EXPECT().FromRole(gomock.Any(), gomock.Any()).Return(&session.Session{}, nil)
 			},
 			mockPrompter: func(m *mocks.Mockprompter) {
-				m.EXPECT().Confirm("Are you sure you want to delete abc from application phonetool and environment test?", gomock.Any()).Return(true, nil)
+				m.EXPECT().Confirm("Are you sure you want to delete abc from application phonetool and environment test?", gomock.Any(), gomock.Any()).Return(true, nil)
 			},
 		},
 		"no flags specified (default path)": {
@@ -260,7 +260,7 @@ func TestDeleteTaskOpts_Ask(t *testing.T) {
 				m.EXPECT().Default().Return(&session.Session{}, nil)
 			},
 			mockPrompter: func(m *mocks.Mockprompter) {
-				m.EXPECT().Confirm("Are you sure you want to delete abc from the default cluster?", gomock.Any()).Return(true, nil)
+				m.EXPECT().Confirm("Are you sure you want to delete abc from the default cluster?", gomock.Any(), gomock.Any()).Return(true, nil)
 			},
 		},
 	}

--- a/internal/pkg/term/prompt/prompt.go
+++ b/internal/pkg/term/prompt/prompt.go
@@ -292,6 +292,13 @@ func WithFinalMessage(msg string) PromptConfig {
 	}
 }
 
+// WithConfirmFinalMessage sets a short final message for to confirm the user's input.
+func WithConfirmFinalMessage() PromptConfig {
+	return func(p *prompt) {
+		p.FinalMessage = color.Emphasize("Sure?")
+	}
+}
+
 // WithTrueDefault sets the default for a confirm prompt to true.
 func WithTrueDefault() PromptConfig {
 	return func(p *prompt) {

--- a/internal/pkg/term/selector/creds_test.go
+++ b/internal/pkg/term/selector/creds_test.go
@@ -51,7 +51,7 @@ func TestCredsSelect_Creds(t *testing.T) {
 					"Enter temporary credentials",
 					"[profile test]",
 					"[profile prod]",
-				}).Return("[profile prod]", nil)
+				}, gomock.Any()).Return("[profile prod]", nil)
 
 				provider := mocks.NewMockSessionProvider(ctrl)
 				provider.EXPECT().FromProfile("prod").Return(&session.Session{}, nil)
@@ -69,7 +69,7 @@ func TestCredsSelect_Creds(t *testing.T) {
 				profile.EXPECT().Names().Return(nil)
 
 				prompter := mocks.NewMockPrompter(ctrl)
-				prompter.EXPECT().SelectOne(gomock.Any(), gomock.Any(), gomock.Any()).Return("Enter temporary credentials", nil)
+				prompter.EXPECT().SelectOne(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("Enter temporary credentials", nil)
 
 				provider := mocks.NewMockSessionProvider(ctrl)
 				provider.EXPECT().Default().Return(&session.Session{

--- a/internal/pkg/term/selector/ec2_test.go
+++ b/internal/pkg/term/selector/ec2_test.go
@@ -55,7 +55,7 @@ func TestEc2Select_VPC(t *testing.T) {
 						},
 					},
 				}, nil)
-				m.prompt.EXPECT().SelectOne("Select a VPC", "Help text", []string{"mockVPC1", "mockVPC2"}).
+				m.prompt.EXPECT().SelectOne("Select a VPC", "Help text", []string{"mockVPC1", "mockVPC2"}, gomock.Any()).
 					Return("", mockErr)
 
 			},
@@ -76,7 +76,7 @@ func TestEc2Select_VPC(t *testing.T) {
 						},
 					},
 				}, nil)
-				m.prompt.EXPECT().SelectOne("Select a VPC", "Help text", []string{"mockVPCID1", "mockVPCID2 (mockVPC2Name)"}).
+				m.prompt.EXPECT().SelectOne("Select a VPC", "Help text", []string{"mockVPCID1", "mockVPCID2 (mockVPC2Name)"}, gomock.Any()).
 					Return("mockVPC1", nil)
 
 			},
@@ -151,7 +151,7 @@ func TestEc2Select_Subnets(t *testing.T) {
 						},
 					},
 				}, nil)
-				m.prompt.EXPECT().MultiSelect("Select a subnet", "Help text", gomock.Any()).
+				m.prompt.EXPECT().MultiSelect("Select a subnet", "Help text", gomock.Any(), gomock.Any()).
 					Return(nil, mockErr)
 			},
 			wantErr: fmt.Errorf("some error"),
@@ -180,7 +180,7 @@ func TestEc2Select_Subnets(t *testing.T) {
 						},
 					},
 				}, nil)
-				m.prompt.EXPECT().MultiSelect("Select a subnet", "Help text", []string{"mockSubnetID2", "mockSubnetID3 (mockSubnetName3)"}).
+				m.prompt.EXPECT().MultiSelect("Select a subnet", "Help text", []string{"mockSubnetID2", "mockSubnetID3 (mockSubnetName3)"}, gomock.Any()).
 					Return([]string{"mockSubnetID2", "mockSubnetID3 (mockSubnetName3)"}, nil)
 			},
 			wantSubnets: []string{"mockSubnetID2", "mockSubnetID3"},

--- a/internal/pkg/term/selector/selector.go
+++ b/internal/pkg/term/selector/selector.go
@@ -769,7 +769,7 @@ func (s *Select) Environments(prompt, help, app string, finalMsgFunc func(int) p
 }
 
 // Application fetches all the apps in an account/region and prompts the user to select one.
-func (s *Select) Application(prompt, help string, additionalOpts ...string) (string, error) {
+func (s *Select) Application(msg, help string, additionalOpts ...string) (string, error) {
 	appNames, err := s.retrieveApps()
 	if err != nil {
 		return "", err
@@ -787,7 +787,7 @@ func (s *Select) Application(prompt, help string, additionalOpts ...string) (str
 		return appNames[0], nil
 	}
 
-	app, err := s.prompt.SelectOne(prompt, help, appNames)
+	app, err := s.prompt.SelectOne(msg, help, appNames)
 	if err != nil {
 		return "", fmt.Errorf("select application: %w", err)
 	}

--- a/internal/pkg/term/selector/selector.go
+++ b/internal/pkg/term/selector/selector.go
@@ -787,7 +787,7 @@ func (s *Select) Application(msg, help string, additionalOpts ...string) (string
 		return appNames[0], nil
 	}
 
-	app, err := s.prompt.SelectOne(msg, help, appNames)
+	app, err := s.prompt.SelectOne(msg, help, appNames, prompt.WithConfirmFinalMessage())
 	if err != nil {
 		return "", fmt.Errorf("select application: %w", err)
 	}

--- a/internal/pkg/term/selector/selector.go
+++ b/internal/pkg/term/selector/selector.go
@@ -656,7 +656,7 @@ func filterWlsByName(wls []*config.Workload, wantedNames []string) []string {
 }
 
 // Service fetches all services in an app and prompts the user to select one.
-func (s *ConfigSelect) Service(prompt, help, app string) (string, error) {
+func (s *ConfigSelect) Service(msg, help, app string) (string, error) {
 	services, err := s.retrieveServices(app)
 	if err != nil {
 		return "", err
@@ -671,7 +671,7 @@ func (s *ConfigSelect) Service(prompt, help, app string) (string, error) {
 		log.Infof("Only found one service, defaulting to: %s\n", color.HighlightUserInput(services[0]))
 		return services[0], nil
 	}
-	selectedSvcName, err := s.prompt.SelectOne(prompt, help, services)
+	selectedSvcName, err := s.prompt.SelectOne(msg, help, services, prompt.WithFinalMessage("Service name:"))
 	if err != nil {
 		return "", fmt.Errorf("select service: %w", err)
 	}

--- a/internal/pkg/term/selector/selector.go
+++ b/internal/pkg/term/selector/selector.go
@@ -60,6 +60,18 @@ For example: 0 17 ? * MON-FRI (5 pm on weekdays)
 (Y)es will continue execution. (N)o will allow you to input a different schedule.`
 )
 
+// Final messages displayed after prompting.
+const (
+	appNameFinalMessage = "Application:"
+	envNameFinalMessage = "Environment:"
+	svcNameFinalMsg     = "Service name:"
+	jobNameFinalMsg     = "Job name:"
+	deployedSvcFinalMsg = "Service:"
+	taskFinalMsg        = "Task:"
+	workloadFinalMsg    = "Name:"
+	dockerfileFinalMsg  = "Dockerfile:"
+)
+
 var scheduleTypes = []string{
 	rate,
 	fixedSchedule,
@@ -190,7 +202,7 @@ func TaskWithAppEnv(app, env string) GetDeployedTaskOpts {
 	}
 }
 
-// WithDefaultCluster sets up whether CFTaskSelect should use only the default cluster.
+// TaskWithDefaultCluster sets up whether CFTaskSelect should use only the default cluster.
 func TaskWithDefaultCluster() GetDeployedTaskOpts {
 	return func(in *CFTaskSelect) {
 		in.defaultCluster = true
@@ -285,7 +297,7 @@ func WithTaskID(id string) TaskOpts {
 
 // RunningTask has the user select a running task. Callers can provide either app and env names,
 // or use default cluster.
-func (s *TaskSelect) RunningTask(prompt, help string, opts ...TaskOpts) (*awsecs.Task, error) {
+func (s *TaskSelect) RunningTask(msg, help string, opts ...TaskOpts) (*awsecs.Task, error) {
 	var tasks []*awsecs.Task
 	var err error
 	for _, opt := range opts {
@@ -328,9 +340,10 @@ func (s *TaskSelect) RunningTask(prompt, help string, opts ...TaskOpts) (*awsecs
 		return taskStrMap[taskStrList[0]], nil
 	}
 	task, err := s.prompt.SelectOne(
-		prompt,
+		msg,
 		help,
 		taskStrList,
+		prompt.WithFinalMessage(taskFinalMsg),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("select running task: %w", err)
@@ -391,7 +404,7 @@ func (s *DeployedService) String() string {
 
 // Task has the user select a task. Callers can provide an environment, an app, or a "use default cluster" option
 // to filter the returned tasks.
-func (s *CFTaskSelect) Task(prompt, help string, opts ...GetDeployedTaskOpts) (string, error) {
+func (s *CFTaskSelect) Task(msg, help string, opts ...GetDeployedTaskOpts) (string, error) {
 	for _, opt := range opts {
 		opt(s)
 	}
@@ -432,7 +445,7 @@ func (s *CFTaskSelect) Task(prompt, help string, opts ...GetDeployedTaskOpts) (s
 		log.Infof("Found only one deployed task: %s\n", color.HighlightUserInput(choices[0]))
 		return choices[0], nil
 	}
-	choice, err := s.prompt.SelectOne(prompt, help, choices)
+	choice, err := s.prompt.SelectOne(msg, help, choices, prompt.WithFinalMessage(taskFinalMsg))
 	if err != nil {
 		return "", fmt.Errorf("select task for deletion: %w", err)
 	}
@@ -441,7 +454,7 @@ func (s *CFTaskSelect) Task(prompt, help string, opts ...GetDeployedTaskOpts) (s
 
 // DeployedService has the user select a deployed service. Callers can provide either a particular environment,
 // a particular service to filter on, or both.
-func (s *DeploySelect) DeployedService(prompt, help string, app string, opts ...GetDeployedServiceOpts) (*DeployedService, error) {
+func (s *DeploySelect) DeployedService(msg, help string, app string, opts ...GetDeployedServiceOpts) (*DeployedService, error) {
 	for _, opt := range opts {
 		opt(s)
 	}
@@ -527,9 +540,10 @@ func (s *DeploySelect) DeployedService(prompt, help string, app string, opts ...
 	}
 
 	svcEnvName, err := s.prompt.SelectOne(
-		prompt,
+		msg,
 		help,
 		svcEnvNames,
+		prompt.WithFinalMessage(deployedSvcFinalMsg),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("select deployed services for application %s: %w", app, err)
@@ -574,7 +588,7 @@ func (s *WorkspaceSelect) Service(msg, help string) (string, error) {
 		return serviceNames[0], nil
 	}
 
-	selectedServiceName, err := s.prompt.SelectOne(msg, help, serviceNames, prompt.WithFinalMessage("Service name:"))
+	selectedServiceName, err := s.prompt.SelectOne(msg, help, serviceNames, prompt.WithFinalMessage(svcNameFinalMsg))
 	if err != nil {
 		return "", fmt.Errorf("select service: %w", err)
 	}
@@ -604,7 +618,7 @@ func (s *WorkspaceSelect) Job(msg, help string) (string, error) {
 		return jobNames[0], nil
 	}
 
-	selectedJobName, err := s.prompt.SelectOne(msg, help, jobNames, prompt.WithFinalMessage("Job name:"))
+	selectedJobName, err := s.prompt.SelectOne(msg, help, jobNames, prompt.WithFinalMessage(jobNameFinalMsg))
 	if err != nil {
 		return "", fmt.Errorf("select job: %w", err)
 	}
@@ -633,7 +647,7 @@ func (s *WorkspaceSelect) Workload(msg, help string) (wl string, err error) {
 		log.Infof("Only found one workload, defaulting to: %s\n", color.HighlightUserInput(wlNames[0]))
 		return wlNames[0], nil
 	}
-	selectedWlName, err := s.prompt.SelectOne(msg, help, wlNames, prompt.WithFinalMessage("Name: "))
+	selectedWlName, err := s.prompt.SelectOne(msg, help, wlNames, prompt.WithFinalMessage(workloadFinalMsg))
 	if err != nil {
 		return "", fmt.Errorf("select workload: %w", err)
 	}
@@ -671,7 +685,7 @@ func (s *ConfigSelect) Service(msg, help, app string) (string, error) {
 		log.Infof("Only found one service, defaulting to: %s\n", color.HighlightUserInput(services[0]))
 		return services[0], nil
 	}
-	selectedSvcName, err := s.prompt.SelectOne(msg, help, services, prompt.WithFinalMessage("Service name:"))
+	selectedSvcName, err := s.prompt.SelectOne(msg, help, services, prompt.WithFinalMessage(svcNameFinalMsg))
 	if err != nil {
 		return "", fmt.Errorf("select service: %w", err)
 	}
@@ -679,7 +693,7 @@ func (s *ConfigSelect) Service(msg, help, app string) (string, error) {
 }
 
 // Job fetches all jobs in an app and prompts the user to select one.
-func (s *ConfigSelect) Job(prompt, help, app string) (string, error) {
+func (s *ConfigSelect) Job(msg, help, app string) (string, error) {
 	jobs, err := s.retrieveJobs(app)
 	if err != nil {
 		return "", err
@@ -694,7 +708,7 @@ func (s *ConfigSelect) Job(prompt, help, app string) (string, error) {
 		log.Infof("Only found one job, defaulting to: %s\n", color.HighlightUserInput(jobs[0]))
 		return jobs[0], nil
 	}
-	selectedJobName, err := s.prompt.SelectOne(prompt, help, jobs)
+	selectedJobName, err := s.prompt.SelectOne(msg, help, jobs, prompt.WithFinalMessage(jobNameFinalMsg))
 	if err != nil {
 		return "", fmt.Errorf("select job: %w", err)
 	}
@@ -702,7 +716,7 @@ func (s *ConfigSelect) Job(prompt, help, app string) (string, error) {
 }
 
 // Environment fetches all the environments in an app and prompts the user to select one.
-func (s *Select) Environment(prompt, help, app string, additionalOpts ...string) (string, error) {
+func (s *Select) Environment(msg, help, app string, additionalOpts ...string) (string, error) {
 	envs, err := s.retrieveEnvironments(app)
 	if err != nil {
 		return "", fmt.Errorf("get environments for app %s from metadata store: %w", app, err)
@@ -720,7 +734,7 @@ func (s *Select) Environment(prompt, help, app string, additionalOpts ...string)
 		return envs[0], nil
 	}
 
-	selectedEnvName, err := s.prompt.SelectOne(prompt, help, envs)
+	selectedEnvName, err := s.prompt.SelectOne(msg, help, envs, prompt.WithFinalMessage(envNameFinalMessage))
 	if err != nil {
 		return "", fmt.Errorf("select environment: %w", err)
 	}
@@ -787,7 +801,7 @@ func (s *Select) Application(msg, help string, additionalOpts ...string) (string
 		return appNames[0], nil
 	}
 
-	app, err := s.prompt.SelectOne(msg, help, appNames, prompt.WithConfirmFinalMessage())
+	app, err := s.prompt.SelectOne(msg, help, appNames, prompt.WithFinalMessage(appNameFinalMessage))
 	if err != nil {
 		return "", fmt.Errorf("select application: %w", err)
 	}
@@ -879,7 +893,7 @@ func (s *WorkspaceSelect) Dockerfile(selPrompt, notFoundPrompt, selHelp, notFoun
 		selPrompt,
 		selHelp,
 		dockerfiles,
-		prompt.WithFinalMessage("Dockerfile:"),
+		prompt.WithFinalMessage(dockerfileFinalMsg),
 	)
 	if err != nil {
 		return "", fmt.Errorf("select Dockerfile: %w", err)
@@ -891,7 +905,7 @@ func (s *WorkspaceSelect) Dockerfile(selPrompt, notFoundPrompt, selHelp, notFoun
 		notFoundPrompt,
 		notFoundHelp,
 		pathValidator,
-		prompt.WithFinalMessage("Dockerfile:"))
+		prompt.WithFinalMessage(dockerfileFinalMsg))
 	if err != nil {
 		return "", fmt.Errorf("get custom Dockerfile path: %w", err)
 	}
@@ -938,7 +952,7 @@ func (s *WorkspaceSelect) askCron(scheduleValidator prompt.ValidatorFunc) (strin
 		schedulePrompt,
 		scheduleHelp,
 		presetSchedules,
-		prompt.WithFinalMessage("Fixed Schedule:"),
+		prompt.WithFinalMessage("Fixed schedule:"),
 	)
 	if err != nil {
 		return "", fmt.Errorf("get preset schedule: %w", err)
@@ -957,7 +971,7 @@ func (s *WorkspaceSelect) askCron(scheduleValidator prompt.ValidatorFunc) (strin
 			customScheduleHelp,
 			scheduleValidator,
 			prompt.WithDefaultInput("0 * * * *"),
-			prompt.WithFinalMessage("Custom Schedule:"),
+			prompt.WithFinalMessage("Custom schedule:"),
 		)
 		if err != nil {
 			return "", fmt.Errorf("get custom schedule: %w", err)

--- a/internal/pkg/term/selector/selector_test.go
+++ b/internal/pkg/term/selector/selector_test.go
@@ -1557,7 +1557,7 @@ func TestSelect_Application(t *testing.T) {
 					Times(1)
 				m.prompt.
 					EXPECT().
-					SelectOne(gomock.Any(), gomock.Any(), gomock.Any()).
+					SelectOne(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Times(0)
 
 			},
@@ -1576,7 +1576,7 @@ func TestSelect_Application(t *testing.T) {
 					Times(1)
 				m.prompt.
 					EXPECT().
-					SelectOne(gomock.Any(), gomock.Any(), gomock.Any()).
+					SelectOne(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Times(0)
 
 			},
@@ -1601,7 +1601,8 @@ func TestSelect_Application(t *testing.T) {
 					SelectOne(
 						gomock.Eq("Select an app"),
 						gomock.Eq("Help text"),
-						gomock.Eq([]string{"app1", "app2"})).
+						gomock.Eq([]string{"app1", "app2"}),
+						gomock.Any()).
 					Return("app2", nil).
 					Times(1)
 			},
@@ -1623,7 +1624,7 @@ func TestSelect_Application(t *testing.T) {
 					Times(1)
 				m.prompt.
 					EXPECT().
-					SelectOne(gomock.Any(), gomock.Any(), gomock.Eq([]string{"app1", "app2"})).
+					SelectOne(gomock.Any(), gomock.Any(), gomock.Eq([]string{"app1", "app2"}), gomock.Any()).
 					Return("", fmt.Errorf("error selecting")).
 					Times(1)
 			},

--- a/internal/pkg/term/selector/selector_test.go
+++ b/internal/pkg/term/selector/selector_test.go
@@ -918,7 +918,7 @@ func TestConfigSelect_Service(t *testing.T) {
 					Times(1)
 				m.prompt.
 					EXPECT().
-					SelectOne(gomock.Any(), gomock.Any(), gomock.Any()).
+					SelectOne(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Times(0)
 
 			},
@@ -939,7 +939,7 @@ func TestConfigSelect_Service(t *testing.T) {
 					Times(1)
 				m.prompt.
 					EXPECT().
-					SelectOne(gomock.Any(), gomock.Any(), gomock.Any()).
+					SelectOne(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Times(0)
 
 			},
@@ -968,7 +968,8 @@ func TestConfigSelect_Service(t *testing.T) {
 					SelectOne(
 						gomock.Eq("Select a service"),
 						gomock.Eq("Help text"),
-						gomock.Eq([]string{"service1", "service2"})).
+						gomock.Eq([]string{"service1", "service2"}),
+						gomock.Any()).
 					Return("service2", nil).
 					Times(1)
 			},
@@ -994,7 +995,7 @@ func TestConfigSelect_Service(t *testing.T) {
 					Times(1)
 				m.prompt.
 					EXPECT().
-					SelectOne(gomock.Any(), gomock.Any(), gomock.Eq([]string{"service1", "service2"})).
+					SelectOne(gomock.Any(), gomock.Any(), gomock.Eq([]string{"service1", "service2"}), gomock.Any()).
 					Return("", fmt.Errorf("error selecting")).
 					Times(1)
 			},

--- a/internal/pkg/term/selector/selector_test.go
+++ b/internal/pkg/term/selector/selector_test.go
@@ -105,7 +105,7 @@ func TestDeploySelect_Service(t *testing.T) {
 
 				m.prompt.
 					EXPECT().
-					SelectOne("Select a deployed service", "Help text", []string{"mockSvc1 (test)", "mockSvc2 (test)"}).
+					SelectOne("Select a deployed service", "Help text", []string{"mockSvc1 (test)", "mockSvc2 (test)"}, gomock.Any()).
 					Return("", errors.New("some error"))
 			},
 			wantErr: fmt.Errorf("select deployed services for application %s: some error", testApp),
@@ -128,7 +128,7 @@ func TestDeploySelect_Service(t *testing.T) {
 
 				m.prompt.
 					EXPECT().
-					SelectOne("Select a deployed service", "Help text", []string{"mockSvc1 (test)", "mockSvc2 (test)"}).
+					SelectOne("Select a deployed service", "Help text", []string{"mockSvc1 (test)", "mockSvc2 (test)"}, gomock.Any()).
 					Return("mockSvc1 (test)", nil)
 			},
 			wantEnv: "test",
@@ -225,7 +225,7 @@ func TestDeploySelect_Service(t *testing.T) {
 
 				m.prompt.
 					EXPECT().
-					SelectOne("Select a deployed service", "Help text", []string{"mockSvc1 (test1)", "mockSvc2 (test1)"}).
+					SelectOne("Select a deployed service", "Help text", []string{"mockSvc1 (test1)", "mockSvc2 (test1)"}, gomock.Any()).
 					Return("mockSvc1 (test1)", nil)
 			},
 			wantEnv: "test1",
@@ -1049,7 +1049,7 @@ func TestConfigSelect_Job(t *testing.T) {
 					Times(1)
 				m.prompt.
 					EXPECT().
-					SelectOne(gomock.Any(), gomock.Any(), gomock.Any()).
+					SelectOne(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Times(0)
 
 			},
@@ -1070,7 +1070,7 @@ func TestConfigSelect_Job(t *testing.T) {
 					Times(1)
 				m.prompt.
 					EXPECT().
-					SelectOne(gomock.Any(), gomock.Any(), gomock.Any()).
+					SelectOne(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Times(0)
 
 			},
@@ -1099,7 +1099,8 @@ func TestConfigSelect_Job(t *testing.T) {
 					SelectOne(
 						gomock.Eq("Select a job"),
 						gomock.Eq("Help text"),
-						gomock.Eq([]string{"job1", "job2"})).
+						gomock.Eq([]string{"job1", "job2"}),
+						gomock.Any()).
 					Return("job2", nil).
 					Times(1)
 			},
@@ -1125,7 +1126,7 @@ func TestConfigSelect_Job(t *testing.T) {
 					Times(1)
 				m.prompt.
 					EXPECT().
-					SelectOne(gomock.Any(), gomock.Any(), gomock.Eq([]string{"job1", "job2"})).
+					SelectOne(gomock.Any(), gomock.Any(), gomock.Eq([]string{"job1", "job2"}), gomock.Any()).
 					Return("", fmt.Errorf("error selecting")).
 					Times(1)
 			},
@@ -1188,7 +1189,7 @@ func TestSelect_Environment(t *testing.T) {
 					Times(1)
 				m.prompt.
 					EXPECT().
-					SelectOne(gomock.Any(), gomock.Any(), gomock.Any()).
+					SelectOne(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Times(0)
 
 			},
@@ -1208,7 +1209,7 @@ func TestSelect_Environment(t *testing.T) {
 					Times(1)
 				m.prompt.
 					EXPECT().
-					SelectOne(gomock.Any(), gomock.Any(), gomock.Any()).
+					SelectOne(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Times(0)
 
 			},
@@ -1235,7 +1236,8 @@ func TestSelect_Environment(t *testing.T) {
 					SelectOne(
 						gomock.Eq("Select an environment"),
 						gomock.Eq("Help text"),
-						gomock.Eq([]string{"env1", "env2"})).
+						gomock.Eq([]string{"env1", "env2"}),
+						gomock.Any()).
 					Return("env2", nil).
 					Times(1)
 			},
@@ -1259,7 +1261,7 @@ func TestSelect_Environment(t *testing.T) {
 					Times(1)
 				m.prompt.
 					EXPECT().
-					SelectOne(gomock.Any(), gomock.Any(), gomock.Eq([]string{"env1", "env2"})).
+					SelectOne(gomock.Any(), gomock.Any(), gomock.Eq([]string{"env1", "env2"}), gomock.Any()).
 					Return("", fmt.Errorf("error selecting")).
 					Times(1)
 			},
@@ -1275,7 +1277,7 @@ func TestSelect_Environment(t *testing.T) {
 					Times(1)
 				m.prompt.
 					EXPECT().
-					SelectOne(gomock.Any(), gomock.Any(), gomock.Any()).
+					SelectOne(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Times(0)
 			},
 
@@ -1291,7 +1293,7 @@ func TestSelect_Environment(t *testing.T) {
 					Times(1)
 				m.prompt.
 					EXPECT().
-					SelectOne(gomock.Any(), gomock.Any(), []string{additionalOpt1, additionalOpt2}).
+					SelectOne(gomock.Any(), gomock.Any(), []string{additionalOpt1, additionalOpt2}, gomock.Any()).
 					Times(1).
 					Return(additionalOpt2, nil)
 			},
@@ -1972,6 +1974,7 @@ func TestSelect_CFTask(t *testing.T) {
 						"abc",
 						"db-migrate",
 					},
+					gomock.Any(),
 				).Return("abc", nil)
 			},
 			wantedErr:  nil,
@@ -2010,6 +2013,7 @@ func TestSelect_CFTask(t *testing.T) {
 						"oneoff",
 						"db-migrate",
 					},
+					gomock.Any(),
 				).Return("db-migrate", nil)
 			},
 			wantedErr:  nil,
@@ -2139,7 +2143,7 @@ func TestTaskSelect_Task(t *testing.T) {
 				m.prompt.EXPECT().SelectOne(mockPromptText, mockHelpText, []string{
 					"4082490e (sample-fargate:2)",
 					"0aa1ba8d (sample-fargate:3)",
-				}).Return("", mockErr)
+				}, gomock.Any()).Return("", mockErr)
 			},
 			wantErr: fmt.Errorf("select running task: some error"),
 		},
@@ -2171,7 +2175,7 @@ func TestTaskSelect_Task(t *testing.T) {
 				m.prompt.EXPECT().SelectOne(mockPromptText, mockHelpText, []string{
 					"4082490e (sample-fargate:2)",
 					"0aa1ba8d (sample-fargate:3)",
-				}).Return("0aa1ba8d (sample-fargate:3)", nil)
+				}, gomock.Any()).Return("0aa1ba8d (sample-fargate:3)", nil)
 			},
 			wantTask: mockTask2,
 		},


### PR DESCRIPTION
We now have every prompt give a short final message after a response is entered making our UX consistent.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
