### PR TITLE
chore: expose internet gateway in environment stack outputs

### DIFF
--- a/internal/pkg/deploy/cloudformation/cloudformation_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/cloudformation_integration_test.go
@@ -522,6 +522,16 @@ func Test_Environment_Deployment_Integration(t *testing.T) {
 					output.OutputValue,
 					"ServiceDiscoveryNamespaceID value should not be nil")
 			},
+			"InternetGatewayID": func(output *awsCF.Output) {
+				require.Equal(t,
+					fmt.Sprintf("%s-InternetGatewayID", envStackName),
+					*output.ExportName,
+					"Should export InternetGatewayID as stackname-InternetGatewayID")
+
+				require.NotNil(t,
+					output.OutputValue,
+					"InternetGatewayID value should not be nil")
+			},
 			"EnvironmentSecurityGroup": func(output *awsCF.Output) {
 				require.Equal(t,
 					fmt.Sprintf("%s-EnvironmentSecurityGroup", envStackName),

--- a/internal/pkg/deploy/env.go
+++ b/internal/pkg/deploy/env.go
@@ -13,7 +13,7 @@ const (
 	// LegacyEnvTemplateVersion is the version associated with the environment template before we started versioning.
 	LegacyEnvTemplateVersion = "v0.0.0"
 	// LatestEnvTemplateVersion is the latest version number available for environment templates.
-	LatestEnvTemplateVersion = "v1.5.1"
+	LatestEnvTemplateVersion = "v1.6.0"
 )
 
 // CreateEnvironmentInput holds the fields required to deploy an environment.

--- a/internal/pkg/template/templates/environment/cf.yml
+++ b/internal/pkg/template/templates/environment/cf.yml
@@ -311,6 +311,12 @@ Outputs:
     Export:
       Name: !Sub ${AWS::StackName}-PrivateSubnets
 {{- end}}
+{{- if not .ImportVPC}}
+  InternetGatewayID:
+    Value: !Ref InternetGateway
+    Export:
+      Name: !Sub ${AWS::StackName}-InternetGatewayID
+{{- end}}
   ServiceDiscoveryNamespaceID:
     Value: !GetAtt ServiceDiscoveryNamespace.Id
     Export:


### PR DESCRIPTION
<!-- When Copilot VPC is used (instead of importing existing VPC), expose internet gateway created in VPC by copilot in environment stack outputs -->

<!-- Addresses #2724 -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
