### PR TITLE
chore: run ci action on all branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@ name: ci
 
 on:
   pull_request:
-    branches:
-      - '*'
 
 jobs:
   build:


### PR DESCRIPTION
Right now if the branch contains a "/" the CI action does not run: https://stackoverflow.com/a/64635612/1201381


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
