### PR TITLE
feat(cli): add --force for svc deploy

### DIFF
--- a/internal/pkg/aws/cloudformation/errors.go
+++ b/internal/pkg/aws/cloudformation/errors.go
@@ -19,6 +19,16 @@ func (e *ErrChangeSetEmpty) Error() string {
 	return fmt.Sprintf("change set with name %s for stack %s has no changes", e.cs.name, e.cs.stackName)
 }
 
+// NewMockErrChangeSetEmpty creates a mock ErrChangeSetEmpty.
+func NewMockErrChangeSetEmpty() *ErrChangeSetEmpty {
+	return &ErrChangeSetEmpty{
+		cs: &changeSet{
+			name:      "mockChangeSet",
+			stackName: "mockStack",
+		},
+	}
+}
+
 // ErrStackAlreadyExists occurs when a CloudFormation stack already exists with a given name.
 type ErrStackAlreadyExists struct {
 	Name  string

--- a/internal/pkg/aws/ecs/ecs.go
+++ b/internal/pkg/aws/ecs/ecs.go
@@ -149,6 +149,8 @@ func (e *ECS) waitUntilServiceStable(svc *Service) error {
 	for {
 		if len(svc.Deployments) == stableServiceDeploymentNum &&
 			aws.Int64Value(svc.DesiredCount) == aws.Int64Value(svc.RunningCount) {
+			// We can safely assume the service has been successfully updated, because before
+			// the circuit breaker is triggered to use the previous deployment, it should have timed out already.
 			return nil
 		}
 		if tryNum >= e.maxForceDeploymentTries {

--- a/internal/pkg/aws/ecs/ecs_test.go
+++ b/internal/pkg/aws/ecs/ecs_test.go
@@ -239,7 +239,7 @@ func TestECS_UpdateService(t *testing.T) {
 					},
 				}, nil).Times(2)
 			},
-			wantErr: fmt.Errorf("wait until service mockService becomes stable: max retries %v exceeded", waitServiceStableMaxTry),
+			wantErr: fmt.Errorf("wait until service mockService becomes stable: max retries 2 exceeded"),
 		},
 		"errors if failed to describe service": {
 			mockECSClient: func(m *mocks.Mockapi) {
@@ -320,9 +320,9 @@ func TestECS_UpdateService(t *testing.T) {
 			tc.mockECSClient(mockECSClient)
 
 			service := ECS{
-				client:                  mockECSClient,
-				maxForceDeploymentTries: 2,
-				pollIntervalDuration:    0,
+				client:                mockECSClient,
+				maxServiceStableTries: 2,
+				pollIntervalDuration:  0,
 			}
 			var opts []UpdateServiceOpts
 			if tc.forceUpdate {

--- a/internal/pkg/aws/ecs/ecs_test.go
+++ b/internal/pkg/aws/ecs/ecs_test.go
@@ -181,6 +181,132 @@ func TestECS_Service(t *testing.T) {
 				require.EqualError(t, tc.wantErr, gotErr.Error())
 			} else {
 				require.Equal(t, tc.wantSvc, gotSvc)
+				require.NoError(t, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestECS_UpdateService(t *testing.T) {
+	const (
+		clusterName = "mockCluster"
+		serviceName = "mockService"
+	)
+	testCases := map[string]struct {
+		forceUpdate   bool
+		tryNum        int
+		mockECSClient func(m *mocks.Mockapi)
+
+		wantErr error
+		wantSvc *Service
+	}{
+		"errors if failed to update service": {
+
+			mockECSClient: func(m *mocks.Mockapi) {
+				m.EXPECT().UpdateService(&ecs.UpdateServiceInput{
+					Cluster: aws.String(clusterName),
+					Service: aws.String(serviceName),
+				}).Return(nil, errors.New("some error"))
+			},
+			wantErr: fmt.Errorf("update service mockService from cluster mockCluster: some error"),
+		},
+		"errors if max retries exceeded": {
+			tryNum: waitServiceStableMaxTry,
+			mockECSClient: func(m *mocks.Mockapi) {
+				m.EXPECT().UpdateService(&ecs.UpdateServiceInput{
+					Cluster: aws.String(clusterName),
+					Service: aws.String(serviceName),
+				}).Return(&ecs.UpdateServiceOutput{
+					Service: &ecs.Service{
+						Deployments:  []*ecs.Deployment{{}, {}},
+						DesiredCount: aws.Int64(1),
+						RunningCount: aws.Int64(2),
+						ClusterArn:   aws.String(clusterName),
+						ServiceName:  aws.String(serviceName),
+					},
+				}, nil)
+			},
+			wantErr: fmt.Errorf("wait until service mockService becomes stable: max retries %v exceeded", waitServiceStableMaxTry),
+		},
+		"errors if failed to describe service": {
+			mockECSClient: func(m *mocks.Mockapi) {
+				m.EXPECT().UpdateService(&ecs.UpdateServiceInput{
+					Cluster: aws.String(clusterName),
+					Service: aws.String(serviceName),
+				}).Return(&ecs.UpdateServiceOutput{
+					Service: &ecs.Service{
+						Deployments:  []*ecs.Deployment{{}, {}},
+						DesiredCount: aws.Int64(1),
+						RunningCount: aws.Int64(2),
+						ClusterArn:   aws.String(clusterName),
+						ServiceName:  aws.String(serviceName),
+					},
+				}, nil)
+				m.EXPECT().DescribeServices(&ecs.DescribeServicesInput{
+					Cluster:  aws.String(clusterName),
+					Services: aws.StringSlice([]string{serviceName}),
+				}).Return(nil, errors.New("some error"))
+			},
+			wantErr: fmt.Errorf("wait until service mockService becomes stable: describe service mockService: some error"),
+		},
+		"success": {
+			forceUpdate: true,
+			mockECSClient: func(m *mocks.Mockapi) {
+				m.EXPECT().UpdateService(&ecs.UpdateServiceInput{
+					Cluster:            aws.String(clusterName),
+					Service:            aws.String(serviceName),
+					ForceNewDeployment: aws.Bool(true),
+				}).Return(&ecs.UpdateServiceOutput{
+					Service: &ecs.Service{
+						Deployments:  []*ecs.Deployment{{}, {}},
+						DesiredCount: aws.Int64(1),
+						RunningCount: aws.Int64(2),
+						ClusterArn:   aws.String(clusterName),
+						ServiceName:  aws.String(serviceName),
+					},
+				}, nil)
+				m.EXPECT().DescribeServices(&ecs.DescribeServicesInput{
+					Cluster:  aws.String(clusterName),
+					Services: aws.StringSlice([]string{serviceName}),
+				}).Return(&ecs.DescribeServicesOutput{
+					Services: []*ecs.Service{
+						{
+							Deployments:  []*ecs.Deployment{{}},
+							DesiredCount: aws.Int64(1),
+							RunningCount: aws.Int64(1),
+							ClusterArn:   aws.String(clusterName),
+							ServiceName:  aws.String(serviceName),
+						},
+					},
+				}, nil)
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// GIVEN
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockECSClient := mocks.NewMockapi(ctrl)
+			tc.mockECSClient(mockECSClient)
+
+			service := ECS{
+				client: mockECSClient,
+				tryNum: tc.tryNum,
+			}
+			var opts []UpdateServiceOpts
+			if tc.forceUpdate {
+				opts = append(opts, WithForceUpdate())
+			}
+
+			gotErr := service.UpdateService(clusterName, serviceName, opts...)
+
+			if tc.wantErr != nil {
+				require.EqualError(t, tc.wantErr, gotErr.Error())
+			} else {
+				require.NoError(t, gotErr)
 			}
 		})
 

--- a/internal/pkg/aws/ecs/errors.go
+++ b/internal/pkg/aws/ecs/errors.go
@@ -18,6 +18,15 @@ const (
 	fmtErrTaskStopped = "task %s: %s"
 )
 
+// ErrWaitServiceStableTimeout occurs when the max retries number waiting for the service to be stable exceeded the limit.
+type ErrWaitServiceStableTimeout struct {
+	maxRetries int
+}
+
+func (e *ErrWaitServiceStableTimeout) Error() string {
+	return fmt.Sprintf("max retries %v exceeded", e.maxRetries)
+}
+
 // ErrNoDefaultCluster occurs when the default cluster is not found.
 var ErrNoDefaultCluster = errors.New("default cluster does not exist")
 

--- a/internal/pkg/aws/ecs/mocks/mock_ecs.go
+++ b/internal/pkg/aws/ecs/mocks/mock_ecs.go
@@ -154,6 +154,21 @@ func (mr *MockapiMockRecorder) StopTask(input interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopTask", reflect.TypeOf((*Mockapi)(nil).StopTask), input)
 }
 
+// UpdateService mocks base method.
+func (m *Mockapi) UpdateService(input *ecs.UpdateServiceInput) (*ecs.UpdateServiceOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateService", input)
+	ret0, _ := ret[0].(*ecs.UpdateServiceOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateService indicates an expected call of UpdateService.
+func (mr *MockapiMockRecorder) UpdateService(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateService", reflect.TypeOf((*Mockapi)(nil).UpdateService), input)
+}
+
 // WaitUntilTasksRunning mocks base method.
 func (m *Mockapi) WaitUntilTasksRunning(input *ecs.DescribeTasksInput) error {
 	m.ctrl.T.Helper()

--- a/internal/pkg/cli/deploy.go
+++ b/internal/pkg/cli/deploy.go
@@ -178,6 +178,7 @@ func BuildDeployCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&vars.envName, envFlag, envFlagShort, "", envFlagDescription)
 	cmd.Flags().StringVar(&vars.imageTag, imageTagFlag, "", imageTagFlagDescription)
 	cmd.Flags().StringToStringVar(&vars.resourceTags, resourceTagsFlag, nil, resourceTagsFlagDescription)
+	cmd.Flags().BoolVar(&vars.forceNewUpdate, forceFlag, false, forceFlagDescription)
 
 	cmd.SetUsageTemplate(template.Usage)
 	cmd.Annotations = map[string]string{

--- a/internal/pkg/cli/flag.go
+++ b/internal/pkg/cli/flag.go
@@ -183,7 +183,7 @@ const (
 	yesFlagDescription      = "Skips confirmation prompt."
 	execYesFlagDescription  = "Optional. Whether to update the Session Manager Plugin."
 	jsonFlagDescription     = "Optional. Outputs in JSON format."
-	forceFlagDescription    = "Optional. Whether to force a new deployment of the ECS service. Default is false."
+	forceFlagDescription    = "Optional. Force a new ECS service deployment using the existing image."
 
 	imageTagFlagDescription     = `Optional. The container image tag.`
 	resourceTagsFlagDescription = `Optional. Labels with a key and value separated by commas.

--- a/internal/pkg/cli/flag.go
+++ b/internal/pkg/cli/flag.go
@@ -25,6 +25,7 @@ const (
 	yesFlag      = "yes"
 	jsonFlag     = "json"
 	allFlag      = "all"
+	forceFlag    = "force"
 
 	// Command specific flags.
 	dockerFileFlag        = "dockerfile"
@@ -182,6 +183,7 @@ const (
 	yesFlagDescription      = "Skips confirmation prompt."
 	execYesFlagDescription  = "Optional. Whether to update the Session Manager Plugin."
 	jsonFlagDescription     = "Optional. Outputs in JSON format."
+	forceFlagDescription    = "Optional. Whether to force a new deployment of the ECS service. Default is false."
 
 	imageTagFlagDescription     = `Optional. The container image tag.`
 	resourceTagsFlagDescription = `Optional. Labels with a key and value separated by commas.

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -540,6 +540,14 @@ type serviceDescriber interface {
 	DescribeService(app, env, svc string) (*ecs.ServiceDesc, error)
 }
 
+type serviceUpdater interface {
+	ForceUpdateService(app, env, svc string) error
+}
+
+type serviceDeployer interface {
+	DeployService(out termprogress.FileWriter, conf cloudformation.StackConfiguration, opts ...awscloudformation.StackOption) error
+}
+
 type apprunnerServiceDescriber interface {
 	ServiceARN() (string, error)
 }

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -5717,6 +5717,85 @@ func (mr *MockserviceDescriberMockRecorder) DescribeService(app, env, svc interf
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeService", reflect.TypeOf((*MockserviceDescriber)(nil).DescribeService), app, env, svc)
 }
 
+// MockserviceUpdater is a mock of serviceUpdater interface.
+type MockserviceUpdater struct {
+	ctrl     *gomock.Controller
+	recorder *MockserviceUpdaterMockRecorder
+}
+
+// MockserviceUpdaterMockRecorder is the mock recorder for MockserviceUpdater.
+type MockserviceUpdaterMockRecorder struct {
+	mock *MockserviceUpdater
+}
+
+// NewMockserviceUpdater creates a new mock instance.
+func NewMockserviceUpdater(ctrl *gomock.Controller) *MockserviceUpdater {
+	mock := &MockserviceUpdater{ctrl: ctrl}
+	mock.recorder = &MockserviceUpdaterMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockserviceUpdater) EXPECT() *MockserviceUpdaterMockRecorder {
+	return m.recorder
+}
+
+// ForceUpdateService mocks base method.
+func (m *MockserviceUpdater) ForceUpdateService(app, env, svc string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ForceUpdateService", app, env, svc)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ForceUpdateService indicates an expected call of ForceUpdateService.
+func (mr *MockserviceUpdaterMockRecorder) ForceUpdateService(app, env, svc interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForceUpdateService", reflect.TypeOf((*MockserviceUpdater)(nil).ForceUpdateService), app, env, svc)
+}
+
+// MockserviceDeployer is a mock of serviceDeployer interface.
+type MockserviceDeployer struct {
+	ctrl     *gomock.Controller
+	recorder *MockserviceDeployerMockRecorder
+}
+
+// MockserviceDeployerMockRecorder is the mock recorder for MockserviceDeployer.
+type MockserviceDeployerMockRecorder struct {
+	mock *MockserviceDeployer
+}
+
+// NewMockserviceDeployer creates a new mock instance.
+func NewMockserviceDeployer(ctrl *gomock.Controller) *MockserviceDeployer {
+	mock := &MockserviceDeployer{ctrl: ctrl}
+	mock.recorder = &MockserviceDeployerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockserviceDeployer) EXPECT() *MockserviceDeployerMockRecorder {
+	return m.recorder
+}
+
+// DeployService mocks base method.
+func (m *MockserviceDeployer) DeployService(out progress.FileWriter, conf cloudformation0.StackConfiguration, opts ...cloudformation.StackOption) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{out, conf}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DeployService", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeployService indicates an expected call of DeployService.
+func (mr *MockserviceDeployerMockRecorder) DeployService(out, conf interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{out, conf}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeployService", reflect.TypeOf((*MockserviceDeployer)(nil).DeployService), varargs...)
+}
+
 // MockapprunnerServiceDescriber is a mock of apprunnerServiceDescriber interface.
 type MockapprunnerServiceDescriber struct {
 	ctrl     *gomock.Controller

--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -566,7 +566,8 @@ func (o *deploySvcOpts) deploySvc(addonsURL string) error {
 	}
 
 	if err := o.svcCFN.DeployService(os.Stderr, conf, awscloudformation.WithRoleARN(o.targetEnvironment.ExecutionRoleARN)); err != nil {
-		if _, ok := err.(*awscloudformation.ErrChangeSetEmpty); ok {
+		var errEmptyCS *awscloudformation.ErrChangeSetEmpty
+		if errors.As(err, &errEmptyCS) {
 			if o.forceNewUpdate {
 				// Force update ECS service if --force is set and change set is empty.
 				o.spinner.Start(fmt.Sprintf(fmtForceUpdateSvcStart, color.HighlightUserInput(o.name), color.HighlightUserInput(o.envName)))

--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -45,8 +45,10 @@ import (
 )
 
 const (
-	fmtForceUpdateSvcStart    = "Forcing an update for service %s from environment %s"
-	fmtForceUpdateSvcFailed   = "Failed to force an update for service %s from environment %s: %v.\n"
+	fmtForceUpdateSvcStart  = "Forcing an update for service %s from environment %s"
+	fmtForceUpdateSvcFailed = `Failed to force an update for service %s from environment %s: %v.
+  Run %s to check for the fail reason.
+`
 	fmtForceUpdateSvcComplete = "Forced an update for service %s from environment %s.\n"
 )
 
@@ -572,7 +574,9 @@ func (o *deploySvcOpts) deploySvc(addonsURL string) error {
 				// Force update ECS service if --force is set and change set is empty.
 				o.spinner.Start(fmt.Sprintf(fmtForceUpdateSvcStart, color.HighlightUserInput(o.name), color.HighlightUserInput(o.envName)))
 				if err = o.svcUpdater.ForceUpdateService(o.appName, o.envName, o.name); err != nil {
-					o.spinner.Stop(log.Serrorf(fmtForceUpdateSvcFailed, color.HighlightUserInput(o.name), color.HighlightUserInput(o.envName), err))
+					o.spinner.Stop(log.Serrorf(fmtForceUpdateSvcFailed, color.HighlightUserInput(o.name),
+						color.HighlightUserInput(o.envName), err,
+						color.HighlightCode(fmt.Sprintf("copilot svc status --name %s --env %s", o.name, o.envName))))
 					return fmt.Errorf("force an update for service %s: %w", o.name, err)
 				}
 				o.spinner.Stop(log.Ssuccessf(fmtForceUpdateSvcComplete, color.HighlightUserInput(o.name), color.HighlightUserInput(o.envName)))

--- a/internal/pkg/cli/svc_deploy_test.go
+++ b/internal/pkg/cli/svc_deploy_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/aws/copilot-cli/internal/pkg/docker/dockerengine"
+	"github.com/aws/copilot-cli/internal/pkg/term/color"
 	"github.com/aws/copilot-cli/internal/pkg/term/log"
 
 	"github.com/aws/copilot-cli/internal/pkg/aws/identity"
@@ -713,10 +714,12 @@ func TestSvcDeployOpts_deploySvc(t *testing.T) {
 			mock: func(m *deploySvcMocks) {
 				m.mockWs.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
 				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
-				m.mockServiceDeployer.EXPECT().DeployService(gomock.Any(), gomock.Any(), gomock.Any()).Return(cloudformation.NewMockErrChangeSetEmpty())
+				m.mockServiceDeployer.EXPECT().DeployService(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(cloudformation.NewMockErrChangeSetEmpty())
 				m.mockSpinner.EXPECT().Start(fmt.Sprintf(fmtForceUpdateSvcStart, mockSvcName, mockEnvName))
 				m.mockServiceUpdater.EXPECT().ForceUpdateService(mockAppName, mockEnvName, mockSvcName).Return(mockError)
-				m.mockSpinner.EXPECT().Stop(log.Serrorf(fmtForceUpdateSvcFailed, mockSvcName, mockEnvName, mockError))
+				m.mockSpinner.EXPECT().Stop(log.Serrorf(fmtForceUpdateSvcFailed, mockSvcName, mockEnvName, mockError,
+					color.HighlightCode(fmt.Sprintf("copilot svc status --name %s --env %s", mockSvcName, mockEnvName))))
 			},
 			wantErr: fmt.Errorf("force an update for service mockSvc: some error"),
 		},

--- a/internal/pkg/cli/svc_deploy_test.go
+++ b/internal/pkg/cli/svc_deploy_test.go
@@ -10,11 +10,13 @@ import (
 	"testing"
 
 	"github.com/aws/copilot-cli/internal/pkg/docker/dockerengine"
+	"github.com/aws/copilot-cli/internal/pkg/term/log"
 
 	"github.com/aws/copilot-cli/internal/pkg/aws/identity"
 
 	"github.com/aws/aws-sdk-go/aws"
 	addon "github.com/aws/copilot-cli/internal/pkg/addon"
+	"github.com/aws/copilot-cli/internal/pkg/aws/cloudformation"
 	"github.com/aws/copilot-cli/internal/pkg/config"
 	"github.com/aws/copilot-cli/internal/pkg/deploy"
 	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation/stack"
@@ -28,6 +30,12 @@ import (
 type deploySvcMocks struct {
 	mockWs                 *mocks.MockwsSvcDirReader
 	mockimageBuilderPusher *mocks.MockimageBuilderPusher
+	mockAppResourcesGetter *mocks.MockappResourcesGetter
+	mockAppVersionGetter   *mocks.MockversionGetter
+	mockEndpointGetter     *mocks.MockendpointGetter
+	mockServiceDeployer    *mocks.MockserviceDeployer
+	mockSpinner            *mocks.Mockprogress
+	mockServiceUpdater     *mocks.MockserviceUpdater
 }
 
 func TestSvcDeployOpts_Validate(t *testing.T) {
@@ -543,7 +551,7 @@ func TestSvcDeployOpts_pushAddonsTemplateToS3Bucket(t *testing.T) {
 	}
 }
 
-func TestSvcDeployOpts_stackConfiguration(t *testing.T) {
+func TestSvcDeployOpts_deploySvc(t *testing.T) {
 	mockError := errors.New("some error")
 	const (
 		mockAppName   = "mockApp"
@@ -556,23 +564,17 @@ func TestSvcDeployOpts_stackConfiguration(t *testing.T) {
 		inApp          *config.Application
 		inEnvironment  *config.Environment
 		inBuildRequire bool
+		inForceDeploy  bool
 
-		mockWorkspace          func(m *mocks.MockwsSvcDirReader)
-		mockAppResourcesGetter func(m *mocks.MockappResourcesGetter)
-		mockAppVersionGetter   func(m *mocks.MockversionGetter)
-		mockEndpointGetter     func(m *mocks.MockendpointGetter)
-		mockIdentity           func(m *mocks.MockidentityService)
+		mock func(m *deploySvcMocks)
 
 		wantErr error
 	}{
 		"fail to read service manifest": {
-			mockWorkspace: func(m *mocks.MockwsSvcDirReader) {
-				m.EXPECT().ReadServiceManifest(mockSvcName).Return(nil, mockError)
+			mock: func(m *deploySvcMocks) {
+				m.mockWs.EXPECT().ReadServiceManifest(mockSvcName).Return(nil, mockError)
 			},
-			mockAppResourcesGetter: func(m *mocks.MockappResourcesGetter) {},
-			mockAppVersionGetter:   func(m *mocks.MockversionGetter) {},
-			mockEndpointGetter:     func(m *mocks.MockendpointGetter) {},
-			wantErr:                fmt.Errorf("read service %s manifest file: %w", mockSvcName, mockError),
+			wantErr: fmt.Errorf("read service %s manifest file: %w", mockSvcName, mockError),
 		},
 		"fail to get app resources": {
 			inBuildRequire: true,
@@ -583,19 +585,14 @@ func TestSvcDeployOpts_stackConfiguration(t *testing.T) {
 			inApp: &config.Application{
 				Name: mockAppName,
 			},
-			mockWorkspace: func(m *mocks.MockwsSvcDirReader) {
-				m.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
-			},
-			mockAppResourcesGetter: func(m *mocks.MockappResourcesGetter) {
-				m.EXPECT().GetAppResourcesByRegion(&config.Application{
+			mock: func(m *deploySvcMocks) {
+				m.mockWs.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
+				m.mockAppResourcesGetter.EXPECT().GetAppResourcesByRegion(&config.Application{
 					Name: mockAppName,
 				}, "us-west-2").Return(nil, mockError)
+				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
 			},
-			mockEndpointGetter: func(m *mocks.MockendpointGetter) {
-				m.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
-			},
-			mockAppVersionGetter: func(m *mocks.MockversionGetter) {},
-			wantErr:              fmt.Errorf("get application %s resources from region us-west-2: %w", mockAppName, mockError),
+			wantErr: fmt.Errorf("get application %s resources from region us-west-2: %w", mockAppName, mockError),
 		},
 		"cannot to find ECR repo": {
 			inBuildRequire: true,
@@ -607,22 +604,17 @@ func TestSvcDeployOpts_stackConfiguration(t *testing.T) {
 				Name:      mockAppName,
 				AccountID: "1234567890",
 			},
-			mockWorkspace: func(m *mocks.MockwsSvcDirReader) {
-				m.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
-			},
-			mockAppResourcesGetter: func(m *mocks.MockappResourcesGetter) {
-				m.EXPECT().GetAppResourcesByRegion(&config.Application{
+			mock: func(m *deploySvcMocks) {
+				m.mockWs.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
+				m.mockAppResourcesGetter.EXPECT().GetAppResourcesByRegion(&config.Application{
 					Name:      mockAppName,
 					AccountID: "1234567890",
 				}, "us-west-2").Return(&stack.AppRegionalResources{
 					RepositoryURLs: map[string]string{},
 				}, nil)
+				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
 			},
-			mockEndpointGetter: func(m *mocks.MockendpointGetter) {
-				m.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
-			},
-			mockAppVersionGetter: func(m *mocks.MockversionGetter) {},
-			wantErr:              fmt.Errorf("ECR repository not found for service mockSvc in region us-west-2 and account 1234567890"),
+			wantErr: fmt.Errorf("ECR repository not found for service mockSvc in region us-west-2 and account 1234567890"),
 		},
 		"fail to get app version": {
 			inAliases: &manifest.Alias{String: aws.String("mockAlias")},
@@ -634,15 +626,10 @@ func TestSvcDeployOpts_stackConfiguration(t *testing.T) {
 				Name:   mockAppName,
 				Domain: "mockDomain",
 			},
-			mockWorkspace: func(m *mocks.MockwsSvcDirReader) {
-				m.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
-			},
-			mockAppResourcesGetter: func(m *mocks.MockappResourcesGetter) {},
-			mockAppVersionGetter: func(m *mocks.MockversionGetter) {
-				m.EXPECT().Version().Return("", mockError)
-			},
-			mockEndpointGetter: func(m *mocks.MockendpointGetter) {
-				m.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
+			mock: func(m *deploySvcMocks) {
+				m.mockWs.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
+				m.mockAppVersionGetter.EXPECT().Version().Return("", mockError)
+				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
 			},
 			wantErr: fmt.Errorf("get version for app %s: %w", mockAppName, mockError),
 		},
@@ -656,15 +643,10 @@ func TestSvcDeployOpts_stackConfiguration(t *testing.T) {
 				Name:   mockAppName,
 				Domain: "mockDomain",
 			},
-			mockWorkspace: func(m *mocks.MockwsSvcDirReader) {
-				m.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
-			},
-			mockAppResourcesGetter: func(m *mocks.MockappResourcesGetter) {},
-			mockAppVersionGetter: func(m *mocks.MockversionGetter) {
-				m.EXPECT().Version().Return("v0.0.0", nil)
-			},
-			mockEndpointGetter: func(m *mocks.MockendpointGetter) {
-				m.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
+			mock: func(m *deploySvcMocks) {
+				m.mockWs.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
+				m.mockAppVersionGetter.EXPECT().Version().Return("v0.0.0", nil)
+				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
 			},
 			wantErr: fmt.Errorf("alias is not compatible with application versions below %s", deploy.AliasLeastAppTemplateVersion),
 		},
@@ -678,17 +660,65 @@ func TestSvcDeployOpts_stackConfiguration(t *testing.T) {
 				Name:   mockAppName,
 				Domain: "mockDomain",
 			},
-			mockWorkspace: func(m *mocks.MockwsSvcDirReader) {
-				m.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
-			},
-			mockAppResourcesGetter: func(m *mocks.MockappResourcesGetter) {},
-			mockAppVersionGetter: func(m *mocks.MockversionGetter) {
-				m.EXPECT().Version().Return("v1.0.0", nil)
-			},
-			mockEndpointGetter: func(m *mocks.MockendpointGetter) {
-				m.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
+			mock: func(m *deploySvcMocks) {
+				m.mockWs.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
+				m.mockAppVersionGetter.EXPECT().Version().Return("v1.0.0", nil)
+				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
+
 			},
 			wantErr: fmt.Errorf(`alias "v1.v2.mockDomain" is not supported in hosted zones managed by Copilot`),
+		},
+		"error if fail to deploy service": {
+			inEnvironment: &config.Environment{
+				Name:   mockEnvName,
+				Region: "us-west-2",
+			},
+			inApp: &config.Application{
+				Name:   mockAppName,
+				Domain: "mockDomain",
+			},
+			mock: func(m *deploySvcMocks) {
+				m.mockWs.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
+				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
+				m.mockServiceDeployer.EXPECT().DeployService(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("some error"))
+			},
+			wantErr: fmt.Errorf("deploy service: some error"),
+		},
+		"error if fail to deploy service if change set is empty but force flag is not set": {
+			inEnvironment: &config.Environment{
+				Name:   mockEnvName,
+				Region: "us-west-2",
+			},
+			inApp: &config.Application{
+				Name:   mockAppName,
+				Domain: "mockDomain",
+			},
+			mock: func(m *deploySvcMocks) {
+				m.mockWs.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
+				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
+				m.mockServiceDeployer.EXPECT().DeployService(gomock.Any(), gomock.Any(), gomock.Any()).Return(cloudformation.NewMockErrChangeSetEmpty())
+			},
+			wantErr: fmt.Errorf("deploy service: change set with name mockChangeSet for stack mockStack has no changes"),
+		},
+		"error if fail to force an update": {
+			inForceDeploy: true,
+			inEnvironment: &config.Environment{
+				Name:   mockEnvName,
+				Region: "us-west-2",
+			},
+			inApp: &config.Application{
+				Name:   mockAppName,
+				Domain: "mockDomain",
+			},
+			mock: func(m *deploySvcMocks) {
+				m.mockWs.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
+				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
+				m.mockServiceDeployer.EXPECT().DeployService(gomock.Any(), gomock.Any(), gomock.Any()).Return(cloudformation.NewMockErrChangeSetEmpty())
+				m.mockSpinner.EXPECT().Start(fmt.Sprintf(fmtForceUpdateSvcStart, mockSvcName, mockEnvName))
+				m.mockServiceUpdater.EXPECT().ForceUpdateService(mockAppName, mockEnvName, mockSvcName).Return(mockError)
+				m.mockSpinner.EXPECT().Stop(log.Serrorf(fmtForceUpdateSvcFailed, mockSvcName, mockEnvName, mockError))
+			},
+			wantErr: fmt.Errorf("force an update for service mockSvc: some error"),
 		},
 		"success": {
 			inAliases: &manifest.Alias{
@@ -705,15 +735,30 @@ func TestSvcDeployOpts_stackConfiguration(t *testing.T) {
 				Name:   mockAppName,
 				Domain: "mockDomain",
 			},
-			mockWorkspace: func(m *mocks.MockwsSvcDirReader) {
-				m.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
+			mock: func(m *deploySvcMocks) {
+				m.mockWs.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
+				m.mockAppVersionGetter.EXPECT().Version().Return("v1.0.0", nil)
+				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
+				m.mockServiceDeployer.EXPECT().DeployService(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			},
-			mockAppResourcesGetter: func(m *mocks.MockappResourcesGetter) {},
-			mockAppVersionGetter: func(m *mocks.MockversionGetter) {
-				m.EXPECT().Version().Return("v1.0.0", nil)
+		},
+		"success with force update": {
+			inForceDeploy: true,
+			inEnvironment: &config.Environment{
+				Name:   mockEnvName,
+				Region: "us-west-2",
 			},
-			mockEndpointGetter: func(m *mocks.MockendpointGetter) {
-				m.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
+			inApp: &config.Application{
+				Name:   mockAppName,
+				Domain: "mockDomain",
+			},
+			mock: func(m *deploySvcMocks) {
+				m.mockWs.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
+				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
+				m.mockServiceDeployer.EXPECT().DeployService(gomock.Any(), gomock.Any(), gomock.Any()).Return(cloudformation.NewMockErrChangeSetEmpty())
+				m.mockSpinner.EXPECT().Start(fmt.Sprintf(fmtForceUpdateSvcStart, mockSvcName, mockEnvName))
+				m.mockServiceUpdater.EXPECT().ForceUpdateService(mockAppName, mockEnvName, mockSvcName).Return(nil)
+				m.mockSpinner.EXPECT().Stop(log.Ssuccessf(fmtForceUpdateSvcComplete, mockSvcName, mockEnvName))
 			},
 		},
 	}
@@ -723,28 +768,31 @@ func TestSvcDeployOpts_stackConfiguration(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
-			mockWorkspace := mocks.NewMockwsSvcDirReader(ctrl)
-			mockAppResourcesGetter := mocks.NewMockappResourcesGetter(ctrl)
-			mockAppVersionGetter := mocks.NewMockversionGetter(ctrl)
-			mockEndpointGetter := mocks.NewMockendpointGetter(ctrl)
-			tc.mockWorkspace(mockWorkspace)
-			tc.mockAppResourcesGetter(mockAppResourcesGetter)
-			tc.mockAppVersionGetter(mockAppVersionGetter)
-			tc.mockEndpointGetter(mockEndpointGetter)
+			m := &deploySvcMocks{
+				mockWs:                 mocks.NewMockwsSvcDirReader(ctrl),
+				mockAppResourcesGetter: mocks.NewMockappResourcesGetter(ctrl),
+				mockAppVersionGetter:   mocks.NewMockversionGetter(ctrl),
+				mockEndpointGetter:     mocks.NewMockendpointGetter(ctrl),
+				mockServiceDeployer:    mocks.NewMockserviceDeployer(ctrl),
+				mockServiceUpdater:     mocks.NewMockserviceUpdater(ctrl),
+				mockSpinner:            mocks.NewMockprogress(ctrl),
+			}
+			tc.mock(m)
 
 			opts := deploySvcOpts{
 				deployWkldVars: deployWkldVars{
-					name:    mockSvcName,
-					appName: mockAppName,
-					envName: mockEnvName,
+					name:           mockSvcName,
+					appName:        mockAppName,
+					envName:        mockEnvName,
+					forceNewUpdate: tc.inForceDeploy,
 				},
-				ws:            mockWorkspace,
+				ws:            m.mockWs,
 				buildRequired: tc.inBuildRequire,
-				appCFN:        mockAppResourcesGetter,
+				appCFN:        m.mockAppResourcesGetter,
 				newAppVersionGetter: func(s string) (versionGetter, error) {
-					return mockAppVersionGetter, nil
+					return m.mockAppVersionGetter, nil
 				},
-				endpointGetter:    mockEndpointGetter,
+				endpointGetter:    m.mockEndpointGetter,
 				targetApp:         tc.inApp,
 				targetEnvironment: tc.inEnvironment,
 				unmarshal: func(b []byte) (manifest.WorkloadManifest, error) {
@@ -759,9 +807,12 @@ func TestSvcDeployOpts_stackConfiguration(t *testing.T) {
 						},
 					}, nil
 				},
+				svcCFN:     m.mockServiceDeployer,
+				svcUpdater: m.mockServiceUpdater,
+				spinner:    m.mockSpinner,
 			}
 
-			_, gotErr := opts.stackConfiguration(mockAddonsURL)
+			gotErr := opts.deploySvc(mockAddonsURL)
 
 			if tc.wantErr != nil {
 				require.EqualError(t, gotErr, tc.wantErr.Error())
@@ -1047,5 +1098,4 @@ func TestSvcDeployOpts_rdWebServiceStackConfiguration(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/internal/pkg/cli/svc_deploy_test.go
+++ b/internal/pkg/cli/svc_deploy_test.go
@@ -684,7 +684,7 @@ func TestSvcDeployOpts_deploySvc(t *testing.T) {
 			},
 			wantErr: fmt.Errorf("deploy service: some error"),
 		},
-		"error if fail to deploy service if change set is empty but force flag is not set": {
+		"error if change set is empty but force flag is not set": {
 			inEnvironment: &config.Environment{
 				Name:   mockEnvName,
 				Region: "us-west-2",

--- a/internal/pkg/ecs/ecs.go
+++ b/internal/pkg/ecs/ecs.go
@@ -79,7 +79,7 @@ func (c Client) ClusterARN(app, env string) (string, error) {
 
 // ForceUpdateService forces a new update for an ECS service given Copilot service info.
 func (c Client) ForceUpdateService(app, env, svc string) error {
-	clusterName, serviceName, err := c.clusterServiceName(app, env, svc)
+	clusterName, serviceName, err := c.fetchAndParseServiceARN(app, env, svc)
 	if err != nil {
 		return err
 	}
@@ -88,7 +88,7 @@ func (c Client) ForceUpdateService(app, env, svc string) error {
 
 // DescribeService returns the description of an ECS service given Copilot service info.
 func (c Client) DescribeService(app, env, svc string) (*ServiceDesc, error) {
-	clusterName, serviceName, err := c.clusterServiceName(app, env, svc)
+	clusterName, serviceName, err := c.fetchAndParseServiceARN(app, env, svc)
 	if err != nil {
 		return nil, err
 	}
@@ -383,7 +383,7 @@ func (c Client) clusterARN(app, env string) (string, error) {
 	return clusters[0].ARN, nil
 }
 
-func (c Client) clusterServiceName(app, env, svc string) (cluster, service string, err error) {
+func (c Client) fetchAndParseServiceARN(app, env, svc string) (cluster, service string, err error) {
 	svcARN, err := c.serviceARN(app, env, svc)
 	if err != nil {
 		return "", "", err

--- a/internal/pkg/ecs/ecs_test.go
+++ b/internal/pkg/ecs/ecs_test.go
@@ -348,7 +348,7 @@ func TestClient_ForceUpdateService(t *testing.T) {
 
 		wantedError error
 	}{
-		"return error if failed to get service tasks": {
+		"return error if failed to update service": {
 			setupMocks: func(m clientMocks) {
 				gomock.InOrder(
 					m.resourceGetter.EXPECT().GetResourcesByTags(serviceResourceType, getRgInput).

--- a/internal/pkg/ecs/ecs_test.go
+++ b/internal/pkg/ecs/ecs_test.go
@@ -114,7 +114,7 @@ func TestClient_ClusterARN(t *testing.T) {
 	}
 }
 
-func TestClient_ServiceARN(t *testing.T) {
+func TestClient_serviceARN(t *testing.T) {
 	const (
 		mockApp = "mockApp"
 		mockEnv = "mockEnv"
@@ -193,7 +193,7 @@ func TestClient_ServiceARN(t *testing.T) {
 			}
 
 			// WHEN
-			get, err := client.ServiceARN(mockApp, mockEnv, mockSvc)
+			get, err := client.serviceARN(mockApp, mockEnv, mockSvc)
 
 			// THEN
 			if test.wantedError != nil {
@@ -323,6 +323,84 @@ func TestClient_DescribeService(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, get, test.wanted)
+			}
+		})
+	}
+}
+
+func TestClient_ForceUpdateService(t *testing.T) {
+	const (
+		mockApp     = "mockApp"
+		mockEnv     = "mockEnv"
+		mockSvc     = "mockSvc"
+		mockSvcARN  = "arn:aws:ecs:us-west-2:1234567890:service/mockCluster/mockService"
+		mockCluster = "mockCluster"
+		mockService = "mockService"
+	)
+	getRgInput := map[string]string{
+		deploy.AppTagKey:     mockApp,
+		deploy.EnvTagKey:     mockEnv,
+		deploy.ServiceTagKey: mockSvc,
+	}
+
+	tests := map[string]struct {
+		setupMocks func(mocks clientMocks)
+
+		wantedError error
+	}{
+		"return error if failed to get service tasks": {
+			setupMocks: func(m clientMocks) {
+				gomock.InOrder(
+					m.resourceGetter.EXPECT().GetResourcesByTags(serviceResourceType, getRgInput).
+						Return([]*resourcegroups.Resource{
+							{ARN: mockSvcARN},
+						}, nil),
+					m.ecsClient.EXPECT().UpdateService(mockCluster, mockService, gomock.Any()).Return(errors.New("some error")),
+				)
+			},
+			wantedError: fmt.Errorf("some error"),
+		},
+		"success": {
+			setupMocks: func(m clientMocks) {
+				gomock.InOrder(
+					m.resourceGetter.EXPECT().GetResourcesByTags(serviceResourceType, getRgInput).
+						Return([]*resourcegroups.Resource{
+							{ARN: mockSvcARN},
+						}, nil),
+					m.ecsClient.EXPECT().UpdateService(mockCluster, mockService, gomock.Any()).Return(nil),
+				)
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			// GIVEN
+			mockRgGetter := mocks.NewMockresourceGetter(ctrl)
+			mockECSClient := mocks.NewMockecsClient(ctrl)
+			mocks := clientMocks{
+				resourceGetter: mockRgGetter,
+				ecsClient:      mockECSClient,
+			}
+
+			test.setupMocks(mocks)
+
+			client := Client{
+				rgGetter:  mockRgGetter,
+				ecsClient: mockECSClient,
+			}
+
+			// WHEN
+			err := client.ForceUpdateService(mockApp, mockEnv, mockSvc)
+
+			// THEN
+			if test.wantedError != nil {
+				require.EqualError(t, err, test.wantedError.Error())
+			} else {
+				require.NoError(t, err)
 			}
 		})
 	}

--- a/internal/pkg/ecs/mocks/mock_ecs.go
+++ b/internal/pkg/ecs/mocks/mock_ecs.go
@@ -197,6 +197,25 @@ func (mr *MockecsClientMockRecorder) TaskDefinition(taskDefName interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TaskDefinition", reflect.TypeOf((*MockecsClient)(nil).TaskDefinition), taskDefName)
 }
 
+// UpdateService mocks base method.
+func (m *MockecsClient) UpdateService(clusterName, serviceName string, opts ...ecs.UpdateServiceOpts) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{clusterName, serviceName}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "UpdateService", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateService indicates an expected call of UpdateService.
+func (mr *MockecsClientMockRecorder) UpdateService(clusterName, serviceName interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{clusterName, serviceName}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateService", reflect.TypeOf((*MockecsClient)(nil).UpdateService), varargs...)
+}
+
 // MockstepFunctionsClient is a mock of stepFunctionsClient interface.
 type MockstepFunctionsClient struct {
 	ctrl     *gomock.Controller


### PR DESCRIPTION
<!-- Provide summary of changes -->
Add `--force` flag for `svc deploy` and `deploy`, allowing users to force deploy their ECS service. Fixes #2597. E2E test and doc will be added in an upcoming PR.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
