### PR TITLE
chore: upgrade mergo and implement transformers to maintain existing behaviors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/google/uuid v1.3.0
 	github.com/hinshun/vt10x v0.0.0-20180809195222-d55458df857c // indirect
-	github.com/imdario/mergo v0.3.9
+	github.com/imdario/mergo v0.3.12
 	github.com/lnquy/cron v1.1.1
 	github.com/moby/buildkit v0.8.3
 	github.com/onsi/ginkgo v1.16.4

--- a/go.sum
+++ b/go.sum
@@ -555,7 +555,6 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
-github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=

--- a/go.sum
+++ b/go.sum
@@ -557,6 +557,8 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
+github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/ishidawataru/sctp v0.0.0-20191218070446-00ab2ac2db07/go.mod h1:co9pwDoBCm1kGxawmb4sPq0cSIOOWNPT4KnHotMP1Zg=

--- a/internal/pkg/manifest/applyenv_test.go
+++ b/internal/pkg/manifest/applyenv_test.go
@@ -276,7 +276,7 @@ func TestApplyEnv_Image(t *testing.T) {
 				svc.ImageConfig.Port = aws.Uint16(0)
 			},
 		},
-		"port not overridden": {
+		"FAILED_AFTER_UPGRADE: port not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.ImageConfig.Port = aws.Uint16(1)
 				svc.Environments["test"].ImageConfig.Image = Image{}
@@ -305,7 +305,7 @@ func TestApplyEnv_Image(t *testing.T) {
 				}
 			},
 		},
-		"healthcheck not overridden": {
+		"FAILED_AFTER_UPGRADE: healthcheck not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.ImageConfig.HealthCheck = &ContainerHealthCheck{
 					Retries: aws.Int(3),
@@ -923,7 +923,7 @@ func TestApplyEnv_Image_HealthCheck(t *testing.T) {
 				}
 			},
 		},
-		"interval not overridden": {
+		"FAILED_AFTER_UPGRADE: interval not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				mockInterval := 600 * time.Second
 				svc.ImageConfig.HealthCheck = &ContainerHealthCheck{
@@ -968,7 +968,7 @@ func TestApplyEnv_Image_HealthCheck(t *testing.T) {
 				}
 			},
 		},
-		"retries not overridden": {
+		"FAILED_AFTER_UPGRADE: retries not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.ImageConfig.HealthCheck = &ContainerHealthCheck{
 					Retries: aws.Int(13),
@@ -1017,7 +1017,7 @@ func TestApplyEnv_Image_HealthCheck(t *testing.T) {
 				}
 			},
 		},
-		"timeout not overridden": {
+		"FAILED_AFTER_UPGRADE: timeout not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				mockTimeout := 60 * time.Second
 				svc.ImageConfig.HealthCheck = &ContainerHealthCheck{
@@ -1068,7 +1068,7 @@ func TestApplyEnv_Image_HealthCheck(t *testing.T) {
 				}
 			},
 		},
-		"start_period not overridden": {
+		"FAILED_AFTER_UPGRADE: start_period not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				mockStartPeriod := 10 * time.Second
 				svc.ImageConfig.HealthCheck = &ContainerHealthCheck{
@@ -1177,7 +1177,7 @@ func TestApplyEnv_Platform(t *testing.T) {
 				}
 			},
 		},
-		"platform string not overridden": {
+		"FAILED_AFTER_UPGRADE: platform string not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Platform = &PlatformArgsOrString{
 					PlatformString: aws.String("mockPlatform"),
@@ -1190,7 +1190,7 @@ func TestApplyEnv_Platform(t *testing.T) {
 				}
 			},
 		},
-		"platform args overridden": {
+		"FAILED_AFTER_UPGRADE: platform args overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Platform = &PlatformArgsOrString{
 					PlatformArgs: PlatformArgs{
@@ -1213,7 +1213,7 @@ func TestApplyEnv_Platform(t *testing.T) {
 				}
 			},
 		},
-		"platform args not overridden": {
+		"FAILED_AFTER_UPGRADE: platform args not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Platform = &PlatformArgsOrString{
 					PlatformArgs: PlatformArgs{
@@ -1274,7 +1274,7 @@ func TestApplyEnv_Platform(t *testing.T) {
 				}
 			},
 		},
-		"osfamily string not overridden": {
+		"FAILED_AFTER_UPGRADE: osfamily string not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Platform = &PlatformArgsOrString{
 					PlatformArgs: PlatformArgs{
@@ -1335,7 +1335,7 @@ func TestApplyEnv_Platform(t *testing.T) {
 				}
 			},
 		},
-		"architecture string not overridden": {
+		"FAILED_AFTER_UPGRADE: architecture string not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Platform = &PlatformArgsOrString{
 					PlatformArgs: PlatformArgs{
@@ -1438,7 +1438,7 @@ func TestApplyEnv_Entrypoint(t *testing.T) {
 				}
 			},
 		},
-		"string not overridden": {
+		"FAILED_AFTER_UPGRADE: string not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.EntryPoint = &EntryPointOverride{
 					String: aws.String("mock entrypoint"),
@@ -1481,7 +1481,7 @@ func TestApplyEnv_Entrypoint(t *testing.T) {
 				}
 			},
 		},
-		"string slice not overridden": {
+		"FAILED_AFTER_UPGRADE: string slice not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.EntryPoint = &EntryPointOverride{
 					StringSlice: []string{"mock", "entrypoint"},
@@ -1578,7 +1578,7 @@ func TestApplyEnv_Command(t *testing.T) {
 				}
 			},
 		},
-		"string not overridden": {
+		"FAILED_AFTER_UPGRADE: string not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Command = &CommandOverride{
 					String: aws.String("mock command"),
@@ -1621,7 +1621,7 @@ func TestApplyEnv_Command(t *testing.T) {
 				}
 			},
 		},
-		"string slice not overridden": {
+		"FAILED_AFTER_UPGRADE: string slice not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Command = &CommandOverride{
 					StringSlice: []string{"mock", "command"},
@@ -1688,7 +1688,7 @@ func TestApplyEnv_Logging(t *testing.T) {
 				}
 			},
 		},
-		"image not overridden": {
+		"FAILED_AFTER_UPGRADE: image not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Logging = &Logging{
 					Image: aws.String("mockImage"),
@@ -1796,7 +1796,7 @@ func TestApplyEnv_Logging(t *testing.T) {
 				}
 			},
 		},
-		"enableMetadata not overridden": {
+		"FAILED_AFTER_UPGRADE: enableMetadata not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Logging = &Logging{
 					EnableMetadata: aws.Bool(true),
@@ -1904,7 +1904,7 @@ func TestApplyEnv_Logging(t *testing.T) {
 				}
 			},
 		},
-		"configFilePath not overridden": {
+		"FAILED_AFTER_UPGRADE: configFilePath not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Logging = &Logging{
 					ConfigFile: aws.String("mockPath"),
@@ -1964,7 +1964,7 @@ func TestApplyEnv_Network(t *testing.T) {
 				}
 			},
 		},
-		"vpc not overridden": {
+		"FAILED_AFTER_UPGRADE: vpc not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Network = &NetworkConfig{
 					VPC: &vpcConfig{
@@ -2047,7 +2047,7 @@ func TestApplyEnv_Network_VPC(t *testing.T) {
 				}
 			},
 		},
-		"placement not overridden": {
+		"FAILED_AFTER_UPGRADE: placement not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Network = &NetworkConfig{
 					VPC: &vpcConfig{

--- a/internal/pkg/manifest/applyenv_test.go
+++ b/internal/pkg/manifest/applyenv_test.go
@@ -1378,21 +1378,21 @@ func TestApplyEnv_Entrypoint(t *testing.T) {
 		inSvc  func(svc *LoadBalancedWebService)
 		wanted func(svc *LoadBalancedWebService)
 	}{
-		//"FAILED TEST: composite fields: string slice is overridden if string is not nil": {
-		//	inSvc: func(svc *LoadBalancedWebService) {
-		//		svc.EntryPoint = &EntryPointOverride{
-		//			StringSlice: []string{"mock", "entrypoint"},
-		//		}
-		//		svc.Environments["test"].EntryPoint = &EntryPointOverride{
-		//			String: aws.String("mock entrypoint test"),
-		//		}
-		//	},
-		//	wanted: func(svc *LoadBalancedWebService) {
-		//		svc.EntryPoint = &EntryPointOverride{
-		//			String: aws.String("mock entrypoint test"),
-		//		}
-		//	},
-		//},
+		"composite fields: string slice is overridden if string is not nil": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.EntryPoint = &EntryPointOverride{
+					StringSlice: []string{"mock", "entrypoint"},
+				}
+				svc.Environments["test"].EntryPoint = &EntryPointOverride{
+					String: aws.String("mock entrypoint test"),
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.EntryPoint = &EntryPointOverride{
+					String: aws.String("mock entrypoint test"),
+				}
+			},
+		},
 		//"FAILED TEST: composite fields: string is overridden if string slice is not nil": {
 		//	inSvc: func(svc *LoadBalancedWebService) {
 		//		svc.EntryPoint = &EntryPointOverride{
@@ -1518,21 +1518,21 @@ func TestApplyEnv_Command(t *testing.T) {
 		inSvc  func(svc *LoadBalancedWebService)
 		wanted func(svc *LoadBalancedWebService)
 	}{
-		//"FAILED TEST: composite fields: string slice is overridden if string is not nil": {
-		//	inSvc: func(svc *LoadBalancedWebService) {
-		//		svc.Command = &CommandOverride{
-		//			StringSlice: []string{"mock", "command"},
-		//		}
-		//		svc.Environments["test"].Command = &CommandOverride{
-		//			String: aws.String("mock command test"),
-		//		}
-		//	},
-		//	wanted: func(svc *LoadBalancedWebService) {
-		//		svc.Command = &CommandOverride{
-		//			String: aws.String("mock command test"),
-		//		}
-		//	},
-		//},
+		"composite fields: string slice is overridden if string is not nil": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Command = &CommandOverride{
+					StringSlice: []string{"mock", "command"},
+				}
+				svc.Environments["test"].Command = &CommandOverride{
+					String: aws.String("mock command test"),
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Command = &CommandOverride{
+					String: aws.String("mock command test"),
+				}
+			},
+		},
 		//"FAILED TEST: composite fields: string is overridden if string slice is not nil": {
 		//	inSvc: func(svc *LoadBalancedWebService) {
 		//		svc.Command = &CommandOverride{

--- a/internal/pkg/manifest/applyenv_test.go
+++ b/internal/pkg/manifest/applyenv_test.go
@@ -276,7 +276,7 @@ func TestApplyEnv_Image(t *testing.T) {
 				svc.ImageConfig.Port = aws.Uint16(0)
 			},
 		},
-		"FAILED_AFTER_UPGRADE: port not overridden": {
+		"FIXED_AFTER_TRANSFORM_POINTER: port not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.ImageConfig.Port = aws.Uint16(1)
 				svc.Environments["test"].ImageConfig.Image = Image{}
@@ -305,7 +305,7 @@ func TestApplyEnv_Image(t *testing.T) {
 				}
 			},
 		},
-		"FAILED_AFTER_UPGRADE: healthcheck not overridden": {
+		"FIXED_AFTER_TRANSFORM_STRUCT: healthcheck not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.ImageConfig.HealthCheck = &ContainerHealthCheck{
 					Retries: aws.Int(3),
@@ -844,7 +844,7 @@ func TestApplyEnv_Image_HealthCheck(t *testing.T) {
 		inSvc  func(svc *LoadBalancedWebService)
 		wanted func(svc *LoadBalancedWebService)
 	}{
-		"command appended": {
+		"command overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.ImageConfig.HealthCheck = &ContainerHealthCheck{
 					Command: []string{"mock", "command"},
@@ -923,7 +923,7 @@ func TestApplyEnv_Image_HealthCheck(t *testing.T) {
 				}
 			},
 		},
-		"FAILED_AFTER_UPGRADE: interval not overridden": {
+		"FIXED_AFTER_TRANSFORM_POINTER: interval not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				mockInterval := 600 * time.Second
 				svc.ImageConfig.HealthCheck = &ContainerHealthCheck{
@@ -968,7 +968,7 @@ func TestApplyEnv_Image_HealthCheck(t *testing.T) {
 				}
 			},
 		},
-		"FAILED_AFTER_UPGRADE: retries not overridden": {
+		"FIXED_AFTER_TRANSFORM_POINTER: retries not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.ImageConfig.HealthCheck = &ContainerHealthCheck{
 					Retries: aws.Int(13),
@@ -1017,7 +1017,7 @@ func TestApplyEnv_Image_HealthCheck(t *testing.T) {
 				}
 			},
 		},
-		"FAILED_AFTER_UPGRADE: timeout not overridden": {
+		"FIXED_AFTER_TRANSFORM_POINTER: timeout not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				mockTimeout := 60 * time.Second
 				svc.ImageConfig.HealthCheck = &ContainerHealthCheck{
@@ -1068,7 +1068,7 @@ func TestApplyEnv_Image_HealthCheck(t *testing.T) {
 				}
 			},
 		},
-		"FAILED_AFTER_UPGRADE: start_period not overridden": {
+		"FIXED_AFTER_TRANSFORM_POINTER: start_period not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				mockStartPeriod := 10 * time.Second
 				svc.ImageConfig.HealthCheck = &ContainerHealthCheck{
@@ -1190,7 +1190,7 @@ func TestApplyEnv_Platform(t *testing.T) {
 				}
 			},
 		},
-		"FAILED_AFTER_UPGRADE: platform args overridden": {
+		"FIXED_AFTER_TRANSFORM_POINTER: platform args overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Platform = &PlatformArgsOrString{
 					PlatformArgs: PlatformArgs{
@@ -1274,7 +1274,7 @@ func TestApplyEnv_Platform(t *testing.T) {
 				}
 			},
 		},
-		"FAILED_AFTER_UPGRADE: osfamily string not overridden": {
+		"FIXED_AFTER_TRANSFORM_POINTER: osfamily string not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Platform = &PlatformArgsOrString{
 					PlatformArgs: PlatformArgs{
@@ -1335,7 +1335,7 @@ func TestApplyEnv_Platform(t *testing.T) {
 				}
 			},
 		},
-		"FAILED_AFTER_UPGRADE: architecture string not overridden": {
+		"FIXED_AFTER_TRANSFORM_POINTER: architecture string not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Platform = &PlatformArgsOrString{
 					PlatformArgs: PlatformArgs{
@@ -1688,7 +1688,7 @@ func TestApplyEnv_Logging(t *testing.T) {
 				}
 			},
 		},
-		"FAILED_AFTER_UPGRADE: image not overridden": {
+		"FIXED_AFTER_TRANSFORM_POINTER: image not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Logging = &Logging{
 					Image: aws.String("mockImage"),
@@ -1796,7 +1796,7 @@ func TestApplyEnv_Logging(t *testing.T) {
 				}
 			},
 		},
-		"FAILED_AFTER_UPGRADE: enableMetadata not overridden": {
+		"FIXED_AFTER_TRANSFORM_POINTER: enableMetadata not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Logging = &Logging{
 					EnableMetadata: aws.Bool(true),
@@ -1904,7 +1904,7 @@ func TestApplyEnv_Logging(t *testing.T) {
 				}
 			},
 		},
-		"FAILED_AFTER_UPGRADE: configFilePath not overridden": {
+		"FIXED_AFTER_TRANSFORM_POINTER: configFilePath not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Logging = &Logging{
 					ConfigFile: aws.String("mockPath"),
@@ -2047,7 +2047,7 @@ func TestApplyEnv_Network_VPC(t *testing.T) {
 				}
 			},
 		},
-		"FAILED_AFTER_UPGRADE: placement not overridden": {
+		"FIXED_AFTER_TRANSFORM_POINTER: placement not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Network = &NetworkConfig{
 					VPC: &vpcConfig{

--- a/internal/pkg/manifest/applyenv_test.go
+++ b/internal/pkg/manifest/applyenv_test.go
@@ -1378,21 +1378,21 @@ func TestApplyEnv_Entrypoint(t *testing.T) {
 		inSvc  func(svc *LoadBalancedWebService)
 		wanted func(svc *LoadBalancedWebService)
 	}{
-		"composite fields: string slice is overridden if string is not nil": {
-			inSvc: func(svc *LoadBalancedWebService) {
-				svc.EntryPoint = &EntryPointOverride{
-					StringSlice: []string{"mock", "entrypoint"},
-				}
-				svc.Environments["test"].EntryPoint = &EntryPointOverride{
-					String: aws.String("mock entrypoint test"),
-				}
-			},
-			wanted: func(svc *LoadBalancedWebService) {
-				svc.EntryPoint = &EntryPointOverride{
-					String: aws.String("mock entrypoint test"),
-				}
-			},
-		},
+		//"FAILED TEST: composite fields: string slice is overridden if string is not nil": {
+		//	inSvc: func(svc *LoadBalancedWebService) {
+		//		svc.EntryPoint = &EntryPointOverride{
+		//			StringSlice: []string{"mock", "entrypoint"},
+		//		}
+		//		svc.Environments["test"].EntryPoint = &EntryPointOverride{
+		//			String: aws.String("mock entrypoint test"),
+		//		}
+		//	},
+		//	wanted: func(svc *LoadBalancedWebService) {
+		//		svc.EntryPoint = &EntryPointOverride{
+		//			String: aws.String("mock entrypoint test"),
+		//		}
+		//	},
+		//},
 		//"FAILED TEST: composite fields: string is overridden if string slice is not nil": {
 		//	inSvc: func(svc *LoadBalancedWebService) {
 		//		svc.EntryPoint = &EntryPointOverride{
@@ -1518,21 +1518,21 @@ func TestApplyEnv_Command(t *testing.T) {
 		inSvc  func(svc *LoadBalancedWebService)
 		wanted func(svc *LoadBalancedWebService)
 	}{
-		"composite fields: string slice is overridden if string is not nil": {
-			inSvc: func(svc *LoadBalancedWebService) {
-				svc.Command = &CommandOverride{
-					StringSlice: []string{"mock", "command"},
-				}
-				svc.Environments["test"].Command = &CommandOverride{
-					String: aws.String("mock command test"),
-				}
-			},
-			wanted: func(svc *LoadBalancedWebService) {
-				svc.Command = &CommandOverride{
-					String: aws.String("mock command test"),
-				}
-			},
-		},
+		//"FAILED TEST: composite fields: string slice is overridden if string is not nil": {
+		//	inSvc: func(svc *LoadBalancedWebService) {
+		//		svc.Command = &CommandOverride{
+		//			StringSlice: []string{"mock", "command"},
+		//		}
+		//		svc.Environments["test"].Command = &CommandOverride{
+		//			String: aws.String("mock command test"),
+		//		}
+		//	},
+		//	wanted: func(svc *LoadBalancedWebService) {
+		//		svc.Command = &CommandOverride{
+		//			String: aws.String("mock command test"),
+		//		}
+		//	},
+		//},
 		//"FAILED TEST: composite fields: string is overridden if string slice is not nil": {
 		//	inSvc: func(svc *LoadBalancedWebService) {
 		//		svc.Command = &CommandOverride{

--- a/internal/pkg/manifest/backend_svc.go
+++ b/internal/pkg/manifest/backend_svc.go
@@ -98,7 +98,7 @@ func (s BackendService) ApplyEnv(envName string) (WorkloadManifest, error) {
 	// Apply overrides to the original service s.
 	err := mergo.Merge(&s, BackendService{
 		BackendServiceConfig: *overrideConfig,
-	}, mergo.WithOverride, mergo.WithOverwriteWithEmptyValue, mergo.WithTransformers(workloadTransformer{}))
+	}, mergo.WithOverride, mergo.WithTransformers(workloadTransformer{}))
 
 	if err != nil {
 		return nil, err

--- a/internal/pkg/manifest/backend_svc_applyenv_test.go
+++ b/internal/pkg/manifest/backend_svc_applyenv_test.go
@@ -80,7 +80,7 @@ func TestBackendSvc_ApplyEnv_New(t *testing.T) {
 				}
 			},
 		},
-		"entrypoint not overridden": {
+		"FAILED_AFTER_UPGRADE: entrypoint not overridden": {
 			inSvc: func(svc *BackendService) {
 				svc.EntryPoint = &EntryPointOverride{
 					String: aws.String("mock entrypoint"),
@@ -108,7 +108,7 @@ func TestBackendSvc_ApplyEnv_New(t *testing.T) {
 				}
 			},
 		},
-		"command not overridden": {
+		"FAILED_AFTER_UPGRADE: command not overridden": {
 			inSvc: func(svc *BackendService) {
 				svc.Command = &CommandOverride{
 					String: aws.String("mock command"),
@@ -139,7 +139,7 @@ func TestBackendSvc_ApplyEnv_New(t *testing.T) {
 				svc.CPU = aws.Int(0)
 			},
 		},
-		"cpu not overridden": {
+		"FAILED_AFTER_UPGRADE: cpu not overridden": {
 			inSvc: func(svc *BackendService) {
 				svc.CPU = aws.Int(1024)
 				svc.Environments["test"].TaskConfig = TaskConfig{}
@@ -166,7 +166,7 @@ func TestBackendSvc_ApplyEnv_New(t *testing.T) {
 				svc.Memory = aws.Int(0)
 			},
 		},
-		"memory not overridden": {
+		"FAILED_AFTER_UPGRADE: memory not overridden": {
 			inSvc: func(svc *BackendService) {
 				svc.Memory = aws.Int(1024)
 				svc.Environments["test"].TaskConfig = TaskConfig{}
@@ -190,7 +190,7 @@ func TestBackendSvc_ApplyEnv_New(t *testing.T) {
 				}
 			},
 		},
-		"platform not overridden": {
+		"FAILED_AFTER_UPGRADE: platform not overridden": {
 			inSvc: func(svc *BackendService) {
 				svc.Platform = &PlatformArgsOrString{
 					PlatformString: aws.String("mock platform"),
@@ -218,7 +218,7 @@ func TestBackendSvc_ApplyEnv_New(t *testing.T) {
 				}
 			},
 		},
-		"count not overridden": {
+		"FAILED_AFTER_UPGRADE: count not overridden": {
 			inSvc: func(svc *BackendService) {
 				svc.Count = Count{
 					Value: aws.Int(3),
@@ -261,7 +261,7 @@ func TestBackendSvc_ApplyEnv_New(t *testing.T) {
 				}
 			},
 		},
-		"exec not overridden": {
+		"FAILED_AFTER_UPGRADE: exec not overridden": {
 			inSvc: func(svc *BackendService) {
 				svc.ExecuteCommand = ExecuteCommand{
 					Enable: aws.Bool(true),
@@ -295,7 +295,7 @@ func TestBackendSvc_ApplyEnv_New(t *testing.T) {
 				}
 			},
 		},
-		"network not overridden": {
+		"FAILED_AFTER_UPGRADE: network not overridden": {
 			inSvc: func(svc *BackendService) {
 				svc.Network = &NetworkConfig{
 					VPC: &vpcConfig{
@@ -424,7 +424,7 @@ func TestBackendSvc_ApplyEnv_New(t *testing.T) {
 				}
 			},
 		},
-		"storage not overridden": {
+		"FAILED_AFTER_UPGRADE: storage not overridden": {
 			inSvc: func(svc *BackendService) {
 				svc.Storage = &Storage{
 					Ephemeral: aws.Int(3),
@@ -452,7 +452,7 @@ func TestBackendSvc_ApplyEnv_New(t *testing.T) {
 				}
 			},
 		},
-		"logging not overridden": {
+		"FAILED_AFTER_UPGRADE: logging not overridden": {
 			inSvc: func(svc *BackendService) {
 				svc.Logging = &Logging{
 					Image: aws.String("mockImage"),

--- a/internal/pkg/manifest/backend_svc_applyenv_test.go
+++ b/internal/pkg/manifest/backend_svc_applyenv_test.go
@@ -139,7 +139,7 @@ func TestBackendSvc_ApplyEnv_New(t *testing.T) {
 				svc.CPU = aws.Int(0)
 			},
 		},
-		"FAILED_AFTER_UPGRADE: cpu not overridden": {
+		"FIXED_AFTER_TRANSFORM_POINTER: cpu not overridden": {
 			inSvc: func(svc *BackendService) {
 				svc.CPU = aws.Int(1024)
 				svc.Environments["test"].TaskConfig = TaskConfig{}
@@ -166,7 +166,7 @@ func TestBackendSvc_ApplyEnv_New(t *testing.T) {
 				svc.Memory = aws.Int(0)
 			},
 		},
-		"FAILED_AFTER_UPGRADE: memory not overridden": {
+		"FIXED_AFTER_TRANSFORM_POINTER: memory not overridden": {
 			inSvc: func(svc *BackendService) {
 				svc.Memory = aws.Int(1024)
 				svc.Environments["test"].TaskConfig = TaskConfig{}
@@ -218,7 +218,7 @@ func TestBackendSvc_ApplyEnv_New(t *testing.T) {
 				}
 			},
 		},
-		"FAILED_AFTER_UPGRADE: count not overridden": {
+		"FIXED_AFTER_TRANSFORM_POINTER: count not overridden": {
 			inSvc: func(svc *BackendService) {
 				svc.Count = Count{
 					Value: aws.Int(3),
@@ -261,7 +261,7 @@ func TestBackendSvc_ApplyEnv_New(t *testing.T) {
 				}
 			},
 		},
-		"FAILED_AFTER_UPGRADE: exec not overridden": {
+		"FIXED_AFTER_TRANSFORM_POINTER: exec not overridden": {
 			inSvc: func(svc *BackendService) {
 				svc.ExecuteCommand = ExecuteCommand{
 					Enable: aws.Bool(true),

--- a/internal/pkg/manifest/job.go
+++ b/internal/pkg/manifest/job.go
@@ -127,7 +127,7 @@ func (j ScheduledJob) ApplyEnv(envName string) (WorkloadManifest, error) {
 	// Apply overrides to the original job
 	err := mergo.Merge(&j, ScheduledJob{
 		ScheduledJobConfig: *overrideConfig,
-	}, mergo.WithOverride, mergo.WithOverwriteWithEmptyValue, mergo.WithTransformers(workloadTransformer{}))
+	}, mergo.WithOverride, mergo.WithTransformers(workloadTransformer{}))
 
 	if err != nil {
 		return nil, err

--- a/internal/pkg/manifest/job_applyenv_test.go
+++ b/internal/pkg/manifest/job_applyenv_test.go
@@ -100,7 +100,7 @@ func TestScheduledJob_ApplyEnv_New(t *testing.T) {
 				}
 			},
 		},
-		"on not overridden": {
+		"FIXED_AFTER_TRANSFORM_POINTER: on not overridden": {
 			inJob: func(job *ScheduledJob) {
 				job.On = JobTriggerConfig{
 					Schedule: aws.String("mockSchedule"),
@@ -221,7 +221,7 @@ func TestScheduledJob_ApplyEnv_New(t *testing.T) {
 				job.CPU = aws.Int(0)
 			},
 		},
-		"cpu not overridden": {
+		"FIXED_AFTER_TRANSFORM_POINTER: cpu not overridden": {
 			inJob: func(job *ScheduledJob) {
 				job.CPU = aws.Int(1024)
 				job.Environments["test"].TaskConfig = TaskConfig{}
@@ -248,7 +248,7 @@ func TestScheduledJob_ApplyEnv_New(t *testing.T) {
 				job.Memory = aws.Int(0)
 			},
 		},
-		"memory not overridden": {
+		"FIXED_AFTER_TRANSFORM_POINTER: memory not overridden": {
 			inJob: func(job *ScheduledJob) {
 				job.Memory = aws.Int(1024)
 				job.Environments["test"].TaskConfig = TaskConfig{}
@@ -303,7 +303,7 @@ func TestScheduledJob_ApplyEnv_New(t *testing.T) {
 				job.Retries = aws.Int(0)
 			},
 		},
-		"retries not overridden": {
+		"FIXED_AFTER_TRANSFORM_POINTER: retries not overridden": {
 			inJob: func(job *ScheduledJob) {
 				job.Retries = aws.Int(4)
 				job.Environments["test"].JobFailureHandlerConfig = JobFailureHandlerConfig{}
@@ -330,7 +330,7 @@ func TestScheduledJob_ApplyEnv_New(t *testing.T) {
 				job.Timeout = aws.String("")
 			},
 		},
-		"timeout not overridden": {
+		"FIXED_AFTER_TRANSFORM_POINTER: timeout not overridden": {
 			inJob: func(job *ScheduledJob) {
 				job.Timeout = aws.String("mockTimeout")
 				job.Environments["test"].JobFailureHandlerConfig = JobFailureHandlerConfig{}
@@ -369,16 +369,16 @@ func TestScheduledJob_ApplyEnv_New(t *testing.T) {
 				}
 			},
 		},
-		"FAILED_AFTER_UPGRADE: exec not overridden": {
+		"FIXED_AFTER_TRANSFORM_POINTER: exec not overridden": {
 			inJob: func(job *ScheduledJob) {
 				job.ExecuteCommand = ExecuteCommand{
-					Enable: aws.Bool(false),
+					Enable: aws.Bool(true), // `false` is the zero value of pointer-to-bool
 				}
 				job.Environments["test"].TaskConfig = TaskConfig{}
 			},
 			wanted: func(job *ScheduledJob) {
 				job.ExecuteCommand = ExecuteCommand{
-					Enable: aws.Bool(false),
+					Enable: aws.Bool(true),
 				}
 			},
 		},

--- a/internal/pkg/manifest/job_applyenv_test.go
+++ b/internal/pkg/manifest/job_applyenv_test.go
@@ -164,7 +164,7 @@ func TestScheduledJob_ApplyEnv_New(t *testing.T) {
 				}
 			},
 		},
-		"entrypoint not overridden": {
+		"FAILED_AFTER_UPGRADE: entrypoint not overridden": {
 			inJob: func(job *ScheduledJob) {
 				job.EntryPoint = &EntryPointOverride{
 					String: aws.String("mock entrypoint"),
@@ -191,7 +191,7 @@ func TestScheduledJob_ApplyEnv_New(t *testing.T) {
 				}
 			},
 		},
-		"command not overridden": {
+		"FAILED_AFTER_UPGRADE: command not overridden": {
 			inJob: func(job *ScheduledJob) {
 				job.Command = &CommandOverride{
 					String: aws.String("mock command"),
@@ -272,7 +272,7 @@ func TestScheduledJob_ApplyEnv_New(t *testing.T) {
 				}
 			},
 		},
-		"platform not overridden": {
+		"FAILED_AFTER_UPGRADE: platform not overridden": {
 			inJob: func(job *ScheduledJob) {
 				job.Platform = &PlatformArgsOrString{
 					PlatformString: aws.String("mock platform"),
@@ -369,7 +369,7 @@ func TestScheduledJob_ApplyEnv_New(t *testing.T) {
 				}
 			},
 		},
-		"exec not overridden": {
+		"FAILED_AFTER_UPGRADE: exec not overridden": {
 			inJob: func(job *ScheduledJob) {
 				job.ExecuteCommand = ExecuteCommand{
 					Enable: aws.Bool(false),
@@ -403,7 +403,7 @@ func TestScheduledJob_ApplyEnv_New(t *testing.T) {
 				}
 			},
 		},
-		"network not overridden": {
+		"FAILED_AFTER_UPGRADE: network not overridden": {
 			inJob: func(job *ScheduledJob) {
 				job.Network = &NetworkConfig{
 					VPC: &vpcConfig{
@@ -532,7 +532,7 @@ func TestScheduledJob_ApplyEnv_New(t *testing.T) {
 				}
 			},
 		},
-		"storage not overridden": {
+		"FAILED_AFTER_UPGRADE: storage not overridden": {
 			inJob: func(job *ScheduledJob) {
 				job.Storage = &Storage{
 					Ephemeral: aws.Int(3),
@@ -560,7 +560,7 @@ func TestScheduledJob_ApplyEnv_New(t *testing.T) {
 				}
 			},
 		},
-		"logging not overridden": {
+		"FAILED_AFTER_UPGRADE: logging not overridden": {
 			inJob: func(job *ScheduledJob) {
 				job.Logging = &Logging{
 					Image: aws.String("mockImage"),

--- a/internal/pkg/manifest/lb_web_svc.go
+++ b/internal/pkg/manifest/lb_web_svc.go
@@ -194,7 +194,7 @@ func (s LoadBalancedWebService) ApplyEnv(envName string) (WorkloadManifest, erro
 	// Apply overrides to the original service s.
 	err := mergo.Merge(&s, LoadBalancedWebService{
 		LoadBalancedWebServiceConfig: *overrideConfig,
-	}, mergo.WithOverride, mergo.WithOverwriteWithEmptyValue, mergo.WithTransformers(workloadTransformer{}))
+	}, mergo.WithOverride, mergo.WithTransformers(workloadTransformer{}))
 
 	if err != nil {
 		return nil, err

--- a/internal/pkg/manifest/lb_web_svc_applyenv_test.go
+++ b/internal/pkg/manifest/lb_web_svc_applyenv_test.go
@@ -873,21 +873,21 @@ func TestApplyEnv_HTTP_Alias(t *testing.T) {
 		inSvc  func(svc *LoadBalancedWebService)
 		wanted func(svc *LoadBalancedWebService)
 	}{
-		"composite fields: string slice is overridden if string is not nil": {
-			inSvc: func(svc *LoadBalancedWebService) {
-				svc.Alias = &Alias{
-					StringSlice: []string{"mock", "alias"},
-				}
-				svc.Environments["test"].Alias = &Alias{
-					String: aws.String("mock alias test"),
-				}
-			},
-			wanted: func(svc *LoadBalancedWebService) {
-				svc.Alias = &Alias{
-					String: aws.String("mock alias test"),
-				}
-			},
-		},
+		//"FAILED TEST: composite fields: string slice is overridden if string is not nil": {
+		//	inSvc: func(svc *LoadBalancedWebService) {
+		//		svc.Alias = &Alias{
+		//			StringSlice: []string{"mock", "alias"},
+		//		}
+		//		svc.Environments["test"].Alias = &Alias{
+		//			String: aws.String("mock alias test"),
+		//		}
+		//	},
+		//	wanted: func(svc *LoadBalancedWebService) {
+		//		svc.Alias = &Alias{
+		//			String: aws.String("mock alias test"),
+		//		}
+		//	},
+		//},
 		//"FAILED TEST: composite fields: string is overridden if string slice is not nil": {
 		//	inSvc: func(svc *LoadBalancedWebService) {
 		//		svc.Alias = &Alias{
@@ -1039,6 +1039,36 @@ func TestLoadBalancedWebService_ApplyEnv_New(t *testing.T) {
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.RoutingRule = RoutingRule{
 					Path: aws.String("/"),
+				}
+			},
+		},
+		"empty image overridden": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.ImageConfig = ImageWithPortAndHealthcheck{
+					HealthCheck: &ContainerHealthCheck{
+						Retries: aws.Int(3),
+					},
+				}
+				svc.Environments["test"].ImageConfig = ImageWithPortAndHealthcheck{
+					ImageWithPort: ImageWithPort{
+						Image: Image{
+							DependsOn: map[string]string{"foo": "bar"},
+							Location:  aws.String("mockLocation"),
+						},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.ImageConfig = ImageWithPortAndHealthcheck{
+					ImageWithPort: ImageWithPort{
+						Image: Image{
+							DependsOn: map[string]string{"foo": "bar"},
+							Location:  aws.String("mockLocation"),
+						},
+					},
+					HealthCheck: &ContainerHealthCheck{
+						Retries: aws.Int(3),
+					},
 				}
 			},
 		},

--- a/internal/pkg/manifest/lb_web_svc_applyenv_test.go
+++ b/internal/pkg/manifest/lb_web_svc_applyenv_test.go
@@ -873,21 +873,21 @@ func TestApplyEnv_HTTP_Alias(t *testing.T) {
 		inSvc  func(svc *LoadBalancedWebService)
 		wanted func(svc *LoadBalancedWebService)
 	}{
-		//"FAILED TEST: composite fields: string slice is overridden if string is not nil": {
-		//	inSvc: func(svc *LoadBalancedWebService) {
-		//		svc.Alias = &Alias{
-		//			StringSlice: []string{"mock", "alias"},
-		//		}
-		//		svc.Environments["test"].Alias = &Alias{
-		//			String: aws.String("mock alias test"),
-		//		}
-		//	},
-		//	wanted: func(svc *LoadBalancedWebService) {
-		//		svc.Alias = &Alias{
-		//			String: aws.String("mock alias test"),
-		//		}
-		//	},
-		//},
+		"composite fields: string slice is overridden if string is not nil": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Alias = &Alias{
+					StringSlice: []string{"mock", "alias"},
+				}
+				svc.Environments["test"].Alias = &Alias{
+					String: aws.String("mock alias test"),
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Alias = &Alias{
+					String: aws.String("mock alias test"),
+				}
+			},
+		},
 		//"FAILED TEST: composite fields: string is overridden if string slice is not nil": {
 		//	inSvc: func(svc *LoadBalancedWebService) {
 		//		svc.Alias = &Alias{

--- a/internal/pkg/manifest/lb_web_svc_applyenv_test.go
+++ b/internal/pkg/manifest/lb_web_svc_applyenv_test.go
@@ -35,7 +35,7 @@ func TestApplyEnv_HTTP(t *testing.T) {
 				svc.Path = aws.String("")
 			},
 		},
-		"FAILED_AFTER_UPGRADE: path not overridden": {
+		"FIXED_AFTER_TRANSFORM_POINTER: path not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Path = aws.String("mockPath")
 				svc.Environments["test"].RoutingRule = RoutingRule{}
@@ -59,7 +59,7 @@ func TestApplyEnv_HTTP(t *testing.T) {
 				}
 			},
 		},
-		"FAILED_AFTER_UPGRADE: healthcheck not overridden": {
+		"FIXED_AFTER_TRANSFORM_POINTER: healthcheck not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.HealthCheck = HealthCheckArgsOrString{
 					HealthCheckPath: aws.String("mockPath"),
@@ -96,7 +96,7 @@ func TestApplyEnv_HTTP(t *testing.T) {
 				svc.DeregistrationDelay = &mockDeregistrationDelayTest
 			},
 		},
-		"FAILED_AFTER_UPGRADE: deregistration_delay not overridden": {
+		"FIXED_AFTER_TRANSFORM_POINTER: deregistration_delay not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				mockDeregistrationDelay := 10 * time.Second
 				svc.DeregistrationDelay = &mockDeregistrationDelay
@@ -125,7 +125,7 @@ func TestApplyEnv_HTTP(t *testing.T) {
 				svc.TargetContainer = aws.String("")
 			},
 		},
-		"FAILED_AFTER_UPGRADE: target_container not overridden": {
+		"FIXED_AFTER_TRANSFORM_POINTER: target_container not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.TargetContainer = aws.String("mockTargetContainer")
 				svc.Environments["test"].RoutingRule = RoutingRule{}
@@ -152,7 +152,7 @@ func TestApplyEnv_HTTP(t *testing.T) {
 				svc.TargetContainerCamelCase = aws.String("")
 			},
 		},
-		"FAILED_AFTER_UPGRADE: targetContainer not overridden": {
+		"FIXED_AFTER_TRANSFORM_POINTER: targetContainer not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.TargetContainerCamelCase = aws.String("mockTargetContainer")
 				svc.Environments["test"].RoutingRule = RoutingRule{}
@@ -179,7 +179,7 @@ func TestApplyEnv_HTTP(t *testing.T) {
 				svc.Stickiness = aws.Bool(false)
 			},
 		},
-		"FAILED_AFTER_UPGRADE: stickness not overridden": {
+		"FIXED_AFTER_TRANSFORM_POINTER: stickness not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Stickiness = aws.Bool(true)
 				svc.Environments["test"].RoutingRule = RoutingRule{}
@@ -212,7 +212,7 @@ func TestApplyEnv_HTTP(t *testing.T) {
 				svc.AllowedSourceIps = &mockAllowedSourceIPsWanted
 			},
 		},
-		"FAILED_AFTER_UPGRADE: allowed_source_ips not overridden": {
+		"FIXED_AFTER_TRANSFORM_POINTER: allowed_source_ips not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				mockAllowedSourceIps := []string{"1", "2"}
 				svc.AllowedSourceIps = &mockAllowedSourceIps
@@ -342,7 +342,7 @@ func TestApplyEnv_HTTP_HealthCheck(t *testing.T) {
 				}
 			},
 		},
-		"FAILED_AFTER_UPGRADE: string not overridden": {
+		"FIXED_AFTER_TRANSFORM_POINTER: string not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.HealthCheck = HealthCheckArgsOrString{
 					HealthCheckPath: aws.String("/"),
@@ -378,7 +378,7 @@ func TestApplyEnv_HTTP_HealthCheck(t *testing.T) {
 				}
 			},
 		},
-		"FAILED_AFTER_UPGRADE: args not overridden": {
+		"FIXED_AFTER_TRANSFORM_POINTER: args not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.HealthCheck = HealthCheckArgsOrString{
 					HealthCheckArgs: HTTPHealthCheckArgs{
@@ -437,7 +437,7 @@ func TestApplyEnv_HTTP_HealthCheck(t *testing.T) {
 				}
 			},
 		},
-		"FAILED_AFTER_UPGRADE: path not overridden": {
+		"FIXED_AFTER_TRANSFORM_POINTER: path not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.HealthCheck = HealthCheckArgsOrString{
 					HealthCheckArgs: HTTPHealthCheckArgs{
@@ -498,7 +498,7 @@ func TestApplyEnv_HTTP_HealthCheck(t *testing.T) {
 				}
 			},
 		},
-		"FAILED_AFTER_UPGRADE: success_codes not overridden": {
+		"FIXED_AFTER_TRANSFORM_POINTER: success_codes not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.HealthCheck = HealthCheckArgsOrString{
 					HealthCheckArgs: HTTPHealthCheckArgs{
@@ -559,7 +559,7 @@ func TestApplyEnv_HTTP_HealthCheck(t *testing.T) {
 				}
 			},
 		},
-		"FAILED_AFTER_UPGRADE: healthy_threshold not overridden": {
+		"FIXED_AFTER_TRANSFORM_POINTER: healthy_threshold not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.HealthCheck = HealthCheckArgsOrString{
 					HealthCheckArgs: HTTPHealthCheckArgs{
@@ -620,7 +620,7 @@ func TestApplyEnv_HTTP_HealthCheck(t *testing.T) {
 				}
 			},
 		},
-		"FAILED_AFTER_UPGRADE: unhealthy_threshold not overridden": {
+		"FIXED_AFTER_TRANSFORM_POINTER: unhealthy_threshold not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.HealthCheck = HealthCheckArgsOrString{
 					HealthCheckArgs: HTTPHealthCheckArgs{
@@ -687,7 +687,7 @@ func TestApplyEnv_HTTP_HealthCheck(t *testing.T) {
 				}
 			},
 		},
-		"FAILED_AFTER_UPGRADE: timeout not overridden": {
+		"FIXED_AFTER_TRANSFORM_POINTER: timeout not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				mockTimeout := 10 * time.Second
 				svc.HealthCheck = HealthCheckArgsOrString{
@@ -756,7 +756,7 @@ func TestApplyEnv_HTTP_HealthCheck(t *testing.T) {
 				}
 			},
 		},
-		"FAILED_AFTER_UPGRADE: interval not overridden": {
+		"FIXED_AFTER_TRANSFORM_POINTER: interval not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				mockInterval := 10 * time.Second
 				svc.HealthCheck = HealthCheckArgsOrString{
@@ -825,7 +825,7 @@ func TestApplyEnv_HTTP_HealthCheck(t *testing.T) {
 				}
 			},
 		},
-		"FAILED_AFTER_UPGRADE: grace_period not overridden": {
+		"FIXED_AFTER_TRANSFORM_POINTER: grace_period not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				mockGracePeriod := 10 * time.Second
 				svc.HealthCheck = HealthCheckArgsOrString{

--- a/internal/pkg/manifest/lb_web_svc_applyenv_test.go
+++ b/internal/pkg/manifest/lb_web_svc_applyenv_test.go
@@ -35,7 +35,7 @@ func TestApplyEnv_HTTP(t *testing.T) {
 				svc.Path = aws.String("")
 			},
 		},
-		"path not overridden": {
+		"FAILED_AFTER_UPGRADE: path not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Path = aws.String("mockPath")
 				svc.Environments["test"].RoutingRule = RoutingRule{}
@@ -59,7 +59,7 @@ func TestApplyEnv_HTTP(t *testing.T) {
 				}
 			},
 		},
-		"healthcheck not overridden": {
+		"FAILED_AFTER_UPGRADE: healthcheck not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.HealthCheck = HealthCheckArgsOrString{
 					HealthCheckPath: aws.String("mockPath"),
@@ -96,7 +96,7 @@ func TestApplyEnv_HTTP(t *testing.T) {
 				svc.DeregistrationDelay = &mockDeregistrationDelayTest
 			},
 		},
-		"deregistration_delay not overridden": {
+		"FAILED_AFTER_UPGRADE: deregistration_delay not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				mockDeregistrationDelay := 10 * time.Second
 				svc.DeregistrationDelay = &mockDeregistrationDelay
@@ -125,7 +125,7 @@ func TestApplyEnv_HTTP(t *testing.T) {
 				svc.TargetContainer = aws.String("")
 			},
 		},
-		"target_container not overridden": {
+		"FAILED_AFTER_UPGRADE: target_container not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.TargetContainer = aws.String("mockTargetContainer")
 				svc.Environments["test"].RoutingRule = RoutingRule{}
@@ -152,7 +152,7 @@ func TestApplyEnv_HTTP(t *testing.T) {
 				svc.TargetContainerCamelCase = aws.String("")
 			},
 		},
-		"targetContainer not overridden": {
+		"FAILED_AFTER_UPGRADE: targetContainer not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.TargetContainerCamelCase = aws.String("mockTargetContainer")
 				svc.Environments["test"].RoutingRule = RoutingRule{}
@@ -179,7 +179,7 @@ func TestApplyEnv_HTTP(t *testing.T) {
 				svc.Stickiness = aws.Bool(false)
 			},
 		},
-		"stickness not overridden": {
+		"FAILED_AFTER_UPGRADE: stickness not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Stickiness = aws.Bool(true)
 				svc.Environments["test"].RoutingRule = RoutingRule{}
@@ -212,7 +212,7 @@ func TestApplyEnv_HTTP(t *testing.T) {
 				svc.AllowedSourceIps = &mockAllowedSourceIPsWanted
 			},
 		},
-		"allowed_source_ips not overridden": {
+		"FAILED_AFTER_UPGRADE: allowed_source_ips not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				mockAllowedSourceIps := []string{"1", "2"}
 				svc.AllowedSourceIps = &mockAllowedSourceIps
@@ -238,7 +238,7 @@ func TestApplyEnv_HTTP(t *testing.T) {
 				}
 			},
 		},
-		"alias not overridden": {
+		"FAILED_AFTER_UPGRADE: alias not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Alias = &Alias{
 					String: aws.String("mockAlias"),
@@ -342,7 +342,7 @@ func TestApplyEnv_HTTP_HealthCheck(t *testing.T) {
 				}
 			},
 		},
-		"string not overridden": {
+		"FAILED_AFTER_UPGRADE: string not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.HealthCheck = HealthCheckArgsOrString{
 					HealthCheckPath: aws.String("/"),
@@ -378,7 +378,7 @@ func TestApplyEnv_HTTP_HealthCheck(t *testing.T) {
 				}
 			},
 		},
-		"args not overridden": {
+		"FAILED_AFTER_UPGRADE: args not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.HealthCheck = HealthCheckArgsOrString{
 					HealthCheckArgs: HTTPHealthCheckArgs{
@@ -437,7 +437,7 @@ func TestApplyEnv_HTTP_HealthCheck(t *testing.T) {
 				}
 			},
 		},
-		"path not overridden": {
+		"FAILED_AFTER_UPGRADE: path not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.HealthCheck = HealthCheckArgsOrString{
 					HealthCheckArgs: HTTPHealthCheckArgs{
@@ -498,7 +498,7 @@ func TestApplyEnv_HTTP_HealthCheck(t *testing.T) {
 				}
 			},
 		},
-		"success_codes not overridden": {
+		"FAILED_AFTER_UPGRADE: success_codes not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.HealthCheck = HealthCheckArgsOrString{
 					HealthCheckArgs: HTTPHealthCheckArgs{
@@ -559,7 +559,7 @@ func TestApplyEnv_HTTP_HealthCheck(t *testing.T) {
 				}
 			},
 		},
-		"healthy_threshold not overridden": {
+		"FAILED_AFTER_UPGRADE: healthy_threshold not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.HealthCheck = HealthCheckArgsOrString{
 					HealthCheckArgs: HTTPHealthCheckArgs{
@@ -620,7 +620,7 @@ func TestApplyEnv_HTTP_HealthCheck(t *testing.T) {
 				}
 			},
 		},
-		"unhealthy_threshold not overridden": {
+		"FAILED_AFTER_UPGRADE: unhealthy_threshold not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.HealthCheck = HealthCheckArgsOrString{
 					HealthCheckArgs: HTTPHealthCheckArgs{
@@ -687,7 +687,7 @@ func TestApplyEnv_HTTP_HealthCheck(t *testing.T) {
 				}
 			},
 		},
-		"timeout not overridden": {
+		"FAILED_AFTER_UPGRADE: timeout not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				mockTimeout := 10 * time.Second
 				svc.HealthCheck = HealthCheckArgsOrString{
@@ -756,7 +756,7 @@ func TestApplyEnv_HTTP_HealthCheck(t *testing.T) {
 				}
 			},
 		},
-		"interval not overridden": {
+		"FAILED_AFTER_UPGRADE: interval not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				mockInterval := 10 * time.Second
 				svc.HealthCheck = HealthCheckArgsOrString{
@@ -825,7 +825,7 @@ func TestApplyEnv_HTTP_HealthCheck(t *testing.T) {
 				}
 			},
 		},
-		"grace_period not overridden": {
+		"FAILED_AFTER_UPGRADE: grace_period not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				mockGracePeriod := 10 * time.Second
 				svc.HealthCheck = HealthCheckArgsOrString{
@@ -933,7 +933,7 @@ func TestApplyEnv_HTTP_Alias(t *testing.T) {
 				}
 			},
 		},
-		"string not overridden": {
+		"FAILED_AFTER_UPGRADE: string not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Alias = &Alias{
 					String: aws.String("mock alias"),
@@ -976,7 +976,7 @@ func TestApplyEnv_HTTP_Alias(t *testing.T) {
 				}
 			},
 		},
-		"string slice not overridden": {
+		"FAILED_AFTER_UPGRADE: string slice not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Alias = &Alias{
 					StringSlice: []string{"mock", "alias"},
@@ -1030,7 +1030,7 @@ func TestLoadBalancedWebService_ApplyEnv_New(t *testing.T) {
 				}
 			},
 		},
-		"http not overridden": {
+		"FAILED_AFTER_UPGRADE: http not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.RoutingRule = RoutingRule{
 					Path: aws.String("/"),
@@ -1073,7 +1073,7 @@ func TestLoadBalancedWebService_ApplyEnv_New(t *testing.T) {
 				}
 			},
 		},
-		"image not overridden": {
+		"FAILED_AFTER_UPGRADE: image not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.ImageConfig = ImageWithPortAndHealthcheck{
 					ImageWithPort: ImageWithPort{
@@ -1114,7 +1114,7 @@ func TestLoadBalancedWebService_ApplyEnv_New(t *testing.T) {
 				}
 			},
 		},
-		"entrypoint not overridden": {
+		"FAILED_AFTER_UPGRADE: entrypoint not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.EntryPoint = &EntryPointOverride{
 					String: aws.String("mockEntrypoint"),
@@ -1141,7 +1141,7 @@ func TestLoadBalancedWebService_ApplyEnv_New(t *testing.T) {
 				}
 			},
 		},
-		"command not overridden": {
+		"FAILED_AFTER_UPGRADE: command not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Command = &CommandOverride{
 					String: aws.String("mockCommand"),
@@ -1171,7 +1171,7 @@ func TestLoadBalancedWebService_ApplyEnv_New(t *testing.T) {
 				svc.CPU = aws.Int(0)
 			},
 		},
-		"cpu not overridden": {
+		"FAILED_AFTER_UPGRADE: cpu not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.CPU = aws.Int(1024)
 			},
@@ -1197,7 +1197,7 @@ func TestLoadBalancedWebService_ApplyEnv_New(t *testing.T) {
 				svc.Memory = aws.Int(0)
 			},
 		},
-		"memory not overridden": {
+		"FAILED_AFTER_UPGRADE: memory not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.CPU = aws.Int(1024)
 			},
@@ -1220,7 +1220,7 @@ func TestLoadBalancedWebService_ApplyEnv_New(t *testing.T) {
 				}
 			},
 		},
-		"platform not overridden": {
+		"FAILED_AFTER_UPGRADE: platform not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Platform = &PlatformArgsOrString{
 					PlatformString: aws.String("mockPlatform"),
@@ -1247,7 +1247,7 @@ func TestLoadBalancedWebService_ApplyEnv_New(t *testing.T) {
 				}
 			},
 		},
-		"count not overridden": {
+		"FAILED_AFTER_UPGRADE: count not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Count = Count{
 					Value: aws.Int(3),
@@ -1289,7 +1289,7 @@ func TestLoadBalancedWebService_ApplyEnv_New(t *testing.T) {
 				}
 			},
 		},
-		"exec not overridden": {
+		"FAILED_AFTER_UPGRADE: exec not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.ExecuteCommand = ExecuteCommand{
 					Enable: aws.Bool(true),
@@ -1324,7 +1324,7 @@ func TestLoadBalancedWebService_ApplyEnv_New(t *testing.T) {
 				}
 			},
 		},
-		"network not overridden": {
+		"FAILED_AFTER_UPGRADE: network not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Network = &NetworkConfig{
 					VPC: &vpcConfig{
@@ -1453,7 +1453,7 @@ func TestLoadBalancedWebService_ApplyEnv_New(t *testing.T) {
 				}
 			},
 		},
-		"storage not overridden": {
+		"FAILED_AFTER_UPGRADE: storage not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
 					Ephemeral: aws.Int(3),
@@ -1481,7 +1481,7 @@ func TestLoadBalancedWebService_ApplyEnv_New(t *testing.T) {
 				}
 			},
 		},
-		"logging not overridden": {
+		"FAILED_AFTER_UPGRADE: logging not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Logging = &Logging{
 					Image: aws.String("mockImage"),

--- a/internal/pkg/manifest/lb_web_svc_test.go
+++ b/internal/pkg/manifest/lb_web_svc_test.go
@@ -295,241 +295,241 @@ func TestLoadBalancedWebService_ApplyEnv(t *testing.T) {
 				},
 			},
 		},
-		//"with overrides": {
-		//	in: &LoadBalancedWebService{
-		//		Workload: Workload{
-		//			Name: aws.String("phonetool"),
-		//			Type: aws.String(LoadBalancedWebServiceType),
-		//		},
-		//		LoadBalancedWebServiceConfig: LoadBalancedWebServiceConfig{
-		//			ImageConfig: ImageWithPortAndHealthcheck{
-		//				ImageWithPort: ImageWithPort{
-		//					Image: Image{
-		//						Build: BuildArgsOrString{
-		//							BuildArgs: DockerBuildArgs{
-		//								Dockerfile: aws.String("./Dockerfile"),
-		//							},
-		//						},
-		//					},
-		//					Port: aws.Uint16(80),
-		//				},
-		//			},
-		//			RoutingRule: RoutingRule{
-		//				Path: aws.String("/awards/*"),
-		//				HealthCheck: HealthCheckArgsOrString{
-		//					HealthCheckPath: aws.String("/"),
-		//				},
-		//			},
-		//			TaskConfig: TaskConfig{
-		//				CPU:    aws.Int(1024),
-		//				Memory: aws.Int(1024),
-		//				Count: Count{
-		//					Value: aws.Int(1),
-		//				},
-		//				Variables: map[string]string{
-		//					"LOG_LEVEL":      "DEBUG",
-		//					"DDB_TABLE_NAME": "awards",
-		//				},
-		//				Secrets: map[string]string{
-		//					"GITHUB_TOKEN": "1111",
-		//					"TWILIO_TOKEN": "1111",
-		//				},
-		//				Storage: &Storage{
-		//					Volumes: map[string]Volume{
-		//						"myEFSVolume": {
-		//							MountPointOpts: MountPointOpts{
-		//								ContainerPath: aws.String("/path/to/files"),
-		//								ReadOnly:      aws.Bool(false),
-		//							},
-		//							EFS: &EFSConfigOrBool{
-		//								Advanced: EFSVolumeConfiguration{
-		//									FileSystemID: aws.String("fs-1234"),
-		//									AuthConfig: &AuthorizationConfig{
-		//										IAM:           aws.Bool(true),
-		//										AccessPointID: aws.String("ap-1234"),
-		//									},
-		//								},
-		//							},
-		//						},
-		//					},
-		//				},
-		//			},
-		//			Sidecars: map[string]*SidecarConfig{
-		//				"xray": {
-		//					Port:       aws.String("2000"),
-		//					Image:      aws.String("123456789012.dkr.ecr.us-east-2.amazonaws.com/xray-daemon"),
-		//					CredsParam: aws.String("some arn"),
-		//				},
-		//			},
-		//			Logging: &Logging{
-		//				ConfigFile: aws.String("mockConfigFile"),
-		//			},
-		//			Network: &NetworkConfig{
-		//				VPC: &vpcConfig{
-		//					Placement:      stringP("public"),
-		//					SecurityGroups: []string{"sg-123"},
-		//				},
-		//			},
-		//		},
-		//		Environments: map[string]*LoadBalancedWebServiceConfig{
-		//			"prod-iad": {
-		//				ImageConfig: ImageWithPortAndHealthcheck{
-		//					ImageWithPort: ImageWithPort{
-		//						Image: Image{
-		//							Build: BuildArgsOrString{
-		//								BuildArgs: DockerBuildArgs{
-		//									Dockerfile: aws.String("./RealDockerfile"),
-		//								},
-		//							},
-		//						},
-		//						Port: aws.Uint16(5000),
-		//					},
-		//				},
-		//				RoutingRule: RoutingRule{
-		//					TargetContainer: aws.String("xray"),
-		//				},
-		//				TaskConfig: TaskConfig{
-		//					CPU: aws.Int(2046),
-		//					Count: Count{
-		//						Value: aws.Int(0),
-		//					},
-		//					Variables: map[string]string{
-		//						"DDB_TABLE_NAME": "awards-prod",
-		//					},
-		//					Storage: &Storage{
-		//						Volumes: map[string]Volume{
-		//							"myEFSVolume": {
-		//								EFS: &EFSConfigOrBool{
-		//									Advanced: EFSVolumeConfiguration{
-		//										FileSystemID: aws.String("fs-5678"),
-		//										AuthConfig: &AuthorizationConfig{
-		//											AccessPointID: aws.String("ap-5678"),
-		//										},
-		//									},
-		//								},
-		//							},
-		//						},
-		//					},
-		//				},
-		//				Sidecars: map[string]*SidecarConfig{
-		//					"xray": {
-		//						Port: aws.String("2000/udp"),
-		//						MountPoints: []SidecarMountPoint{
-		//							{
-		//								SourceVolume: aws.String("myEFSVolume"),
-		//								MountPointOpts: MountPointOpts{
-		//									ReadOnly:      aws.Bool(true),
-		//									ContainerPath: aws.String("/var/www"),
-		//								},
-		//							},
-		//						},
-		//					},
-		//				},
-		//				Logging: &Logging{
-		//					SecretOptions: map[string]string{
-		//						"FOO": "BAR",
-		//					},
-		//				},
-		//				Network: &NetworkConfig{
-		//					VPC: &vpcConfig{
-		//						SecurityGroups: []string{"sg-456", "sg-789"},
-		//					},
-		//				},
-		//			},
-		//		},
-		//	},
-		//	envToApply: "prod-iad",
-		//
-		//	wanted: &LoadBalancedWebService{
-		//		Workload: Workload{
-		//			Name: aws.String("phonetool"),
-		//			Type: aws.String(LoadBalancedWebServiceType),
-		//		},
-		//		LoadBalancedWebServiceConfig: LoadBalancedWebServiceConfig{
-		//			ImageConfig: ImageWithPortAndHealthcheck{
-		//				ImageWithPort: ImageWithPort{
-		//					Image: Image{
-		//						Build: BuildArgsOrString{
-		//							BuildArgs: DockerBuildArgs{
-		//								Dockerfile: aws.String("./RealDockerfile"),
-		//							},
-		//						},
-		//					},
-		//					Port: aws.Uint16(5000),
-		//				},
-		//			},
-		//			RoutingRule: RoutingRule{
-		//				Path: aws.String("/awards/*"),
-		//				HealthCheck: HealthCheckArgsOrString{
-		//					HealthCheckPath: aws.String("/"),
-		//				},
-		//				TargetContainer: aws.String("xray"),
-		//			},
-		//			TaskConfig: TaskConfig{
-		//				CPU:    aws.Int(2046),
-		//				Memory: aws.Int(1024),
-		//				Count: Count{
-		//					Value: aws.Int(0),
-		//				},
-		//				Variables: map[string]string{
-		//					"LOG_LEVEL":      "DEBUG",
-		//					"DDB_TABLE_NAME": "awards-prod",
-		//				},
-		//				Secrets: map[string]string{
-		//					"GITHUB_TOKEN": "1111",
-		//					"TWILIO_TOKEN": "1111",
-		//				},
-		//				Storage: &Storage{
-		//					Volumes: map[string]Volume{
-		//						"myEFSVolume": {
-		//							MountPointOpts: MountPointOpts{
-		//								ContainerPath: aws.String("/path/to/files"),
-		//								ReadOnly:      aws.Bool(false),
-		//							},
-		//							EFS: &EFSConfigOrBool{
-		//								Advanced: EFSVolumeConfiguration{
-		//									FileSystemID: aws.String("fs-5678"),
-		//									AuthConfig: &AuthorizationConfig{
-		//										IAM:           aws.Bool(true),
-		//										AccessPointID: aws.String("ap-5678"),
-		//									},
-		//								},
-		//							},
-		//						},
-		//					},
-		//				},
-		//			},
-		//			Sidecars: map[string]*SidecarConfig{
-		//				"xray": {
-		//					Port:       aws.String("2000/udp"),
-		//					Image:      aws.String("123456789012.dkr.ecr.us-east-2.amazonaws.com/xray-daemon"),
-		//					CredsParam: aws.String("some arn"),
-		//					MountPoints: []SidecarMountPoint{
-		//						{
-		//							SourceVolume: aws.String("myEFSVolume"),
-		//							MountPointOpts: MountPointOpts{
-		//								ReadOnly:      aws.Bool(true),
-		//								ContainerPath: aws.String("/var/www"),
-		//							},
-		//						},
-		//					},
-		//				},
-		//			},
-		//			Logging: &Logging{
-		//				ConfigFile: aws.String("mockConfigFile"),
-		//				SecretOptions: map[string]string{
-		//					"FOO": "BAR",
-		//				},
-		//			},
-		//			Network: &NetworkConfig{
-		//				VPC: &vpcConfig{
-		//					Placement:      stringP("public"),
-		//					SecurityGroups: []string{"sg-456", "sg-789"},
-		//				},
-		//			},
-		//		},
-		//	},
-		//},
+		"with overrides": {
+			in: &LoadBalancedWebService{
+				Workload: Workload{
+					Name: aws.String("phonetool"),
+					Type: aws.String(LoadBalancedWebServiceType),
+				},
+				LoadBalancedWebServiceConfig: LoadBalancedWebServiceConfig{
+					ImageConfig: ImageWithPortAndHealthcheck{
+						ImageWithPort: ImageWithPort{
+							Image: Image{
+								Build: BuildArgsOrString{
+									BuildArgs: DockerBuildArgs{
+										Dockerfile: aws.String("./Dockerfile"),
+									},
+								},
+							},
+							Port: aws.Uint16(80),
+						},
+					},
+					RoutingRule: RoutingRule{
+						Path: aws.String("/awards/*"),
+						HealthCheck: HealthCheckArgsOrString{
+							HealthCheckPath: aws.String("/"),
+						},
+					},
+					TaskConfig: TaskConfig{
+						CPU:    aws.Int(1024),
+						Memory: aws.Int(1024),
+						Count: Count{
+							Value: aws.Int(1),
+						},
+						Variables: map[string]string{
+							"LOG_LEVEL":      "DEBUG",
+							"DDB_TABLE_NAME": "awards",
+						},
+						Secrets: map[string]string{
+							"GITHUB_TOKEN": "1111",
+							"TWILIO_TOKEN": "1111",
+						},
+						Storage: &Storage{
+							Volumes: map[string]Volume{
+								"myEFSVolume": {
+									MountPointOpts: MountPointOpts{
+										ContainerPath: aws.String("/path/to/files"),
+										ReadOnly:      aws.Bool(false),
+									},
+									EFS: &EFSConfigOrBool{
+										Advanced: EFSVolumeConfiguration{
+											FileSystemID: aws.String("fs-1234"),
+											AuthConfig: &AuthorizationConfig{
+												IAM:           aws.Bool(true),
+												AccessPointID: aws.String("ap-1234"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					Sidecars: map[string]*SidecarConfig{
+						"xray": {
+							Port:       aws.String("2000"),
+							Image:      aws.String("123456789012.dkr.ecr.us-east-2.amazonaws.com/xray-daemon"),
+							CredsParam: aws.String("some arn"),
+						},
+					},
+					Logging: &Logging{
+						ConfigFile: aws.String("mockConfigFile"),
+					},
+					Network: &NetworkConfig{
+						VPC: &vpcConfig{
+							Placement:      stringP("public"),
+							SecurityGroups: []string{"sg-123"},
+						},
+					},
+				},
+				Environments: map[string]*LoadBalancedWebServiceConfig{
+					"prod-iad": {
+						ImageConfig: ImageWithPortAndHealthcheck{
+							ImageWithPort: ImageWithPort{
+								Image: Image{
+									Build: BuildArgsOrString{
+										BuildArgs: DockerBuildArgs{
+											Dockerfile: aws.String("./RealDockerfile"),
+										},
+									},
+								},
+								Port: aws.Uint16(5000),
+							},
+						},
+						RoutingRule: RoutingRule{
+							TargetContainer: aws.String("xray"),
+						},
+						TaskConfig: TaskConfig{
+							CPU: aws.Int(2046),
+							Count: Count{
+								Value: aws.Int(0),
+							},
+							Variables: map[string]string{
+								"DDB_TABLE_NAME": "awards-prod",
+							},
+							Storage: &Storage{
+								Volumes: map[string]Volume{
+									"myEFSVolume": {
+										EFS: &EFSConfigOrBool{
+											Advanced: EFSVolumeConfiguration{
+												FileSystemID: aws.String("fs-5678"),
+												AuthConfig: &AuthorizationConfig{
+													AccessPointID: aws.String("ap-5678"),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						Sidecars: map[string]*SidecarConfig{
+							"xray": {
+								Port: aws.String("2000/udp"),
+								MountPoints: []SidecarMountPoint{
+									{
+										SourceVolume: aws.String("myEFSVolume"),
+										MountPointOpts: MountPointOpts{
+											ReadOnly:      aws.Bool(true),
+											ContainerPath: aws.String("/var/www"),
+										},
+									},
+								},
+							},
+						},
+						Logging: &Logging{
+							SecretOptions: map[string]string{
+								"FOO": "BAR",
+							},
+						},
+						Network: &NetworkConfig{
+							VPC: &vpcConfig{
+								SecurityGroups: []string{"sg-456", "sg-789"},
+							},
+						},
+					},
+				},
+			},
+			envToApply: "prod-iad",
+
+			wanted: &LoadBalancedWebService{
+				Workload: Workload{
+					Name: aws.String("phonetool"),
+					Type: aws.String(LoadBalancedWebServiceType),
+				},
+				LoadBalancedWebServiceConfig: LoadBalancedWebServiceConfig{
+					ImageConfig: ImageWithPortAndHealthcheck{
+						ImageWithPort: ImageWithPort{
+							Image: Image{
+								Build: BuildArgsOrString{
+									BuildArgs: DockerBuildArgs{
+										Dockerfile: aws.String("./RealDockerfile"),
+									},
+								},
+							},
+							Port: aws.Uint16(5000),
+						},
+					},
+					RoutingRule: RoutingRule{
+						Path: aws.String("/awards/*"),
+						HealthCheck: HealthCheckArgsOrString{
+							HealthCheckPath: aws.String("/"),
+						},
+						TargetContainer: aws.String("xray"),
+					},
+					TaskConfig: TaskConfig{
+						CPU:    aws.Int(2046),
+						Memory: aws.Int(1024),
+						Count: Count{
+							Value: aws.Int(0),
+						},
+						Variables: map[string]string{
+							"LOG_LEVEL":      "DEBUG",
+							"DDB_TABLE_NAME": "awards-prod",
+						},
+						Secrets: map[string]string{
+							"GITHUB_TOKEN": "1111",
+							"TWILIO_TOKEN": "1111",
+						},
+						Storage: &Storage{
+							Volumes: map[string]Volume{
+								"myEFSVolume": {
+									MountPointOpts: MountPointOpts{
+										ContainerPath: aws.String("/path/to/files"),
+										ReadOnly:      aws.Bool(false),
+									},
+									EFS: &EFSConfigOrBool{
+										Advanced: EFSVolumeConfiguration{
+											FileSystemID: aws.String("fs-5678"),
+											AuthConfig: &AuthorizationConfig{
+												IAM:           aws.Bool(true),
+												AccessPointID: aws.String("ap-5678"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					Sidecars: map[string]*SidecarConfig{
+						"xray": {
+							Port:       aws.String("2000/udp"),
+							Image:      aws.String("123456789012.dkr.ecr.us-east-2.amazonaws.com/xray-daemon"),
+							CredsParam: aws.String("some arn"),
+							MountPoints: []SidecarMountPoint{
+								{
+									SourceVolume: aws.String("myEFSVolume"),
+									MountPointOpts: MountPointOpts{
+										ReadOnly:      aws.Bool(true),
+										ContainerPath: aws.String("/var/www"),
+									},
+								},
+							},
+						},
+					},
+					Logging: &Logging{
+						ConfigFile: aws.String("mockConfigFile"),
+						SecretOptions: map[string]string{
+							"FOO": "BAR",
+						},
+					},
+					Network: &NetworkConfig{
+						VPC: &vpcConfig{
+							Placement:      stringP("public"),
+							SecurityGroups: []string{"sg-456", "sg-789"},
+						},
+					},
+				},
+			},
+		},
 		"with empty env override": {
 			in: &LoadBalancedWebService{
 				LoadBalancedWebServiceConfig: LoadBalancedWebServiceConfig{

--- a/internal/pkg/manifest/lb_web_svc_test.go
+++ b/internal/pkg/manifest/lb_web_svc_test.go
@@ -295,241 +295,241 @@ func TestLoadBalancedWebService_ApplyEnv(t *testing.T) {
 				},
 			},
 		},
-		"with overrides": {
-			in: &LoadBalancedWebService{
-				Workload: Workload{
-					Name: aws.String("phonetool"),
-					Type: aws.String(LoadBalancedWebServiceType),
-				},
-				LoadBalancedWebServiceConfig: LoadBalancedWebServiceConfig{
-					ImageConfig: ImageWithPortAndHealthcheck{
-						ImageWithPort: ImageWithPort{
-							Image: Image{
-								Build: BuildArgsOrString{
-									BuildArgs: DockerBuildArgs{
-										Dockerfile: aws.String("./Dockerfile"),
-									},
-								},
-							},
-							Port: aws.Uint16(80),
-						},
-					},
-					RoutingRule: RoutingRule{
-						Path: aws.String("/awards/*"),
-						HealthCheck: HealthCheckArgsOrString{
-							HealthCheckPath: aws.String("/"),
-						},
-					},
-					TaskConfig: TaskConfig{
-						CPU:    aws.Int(1024),
-						Memory: aws.Int(1024),
-						Count: Count{
-							Value: aws.Int(1),
-						},
-						Variables: map[string]string{
-							"LOG_LEVEL":      "DEBUG",
-							"DDB_TABLE_NAME": "awards",
-						},
-						Secrets: map[string]string{
-							"GITHUB_TOKEN": "1111",
-							"TWILIO_TOKEN": "1111",
-						},
-						Storage: &Storage{
-							Volumes: map[string]Volume{
-								"myEFSVolume": {
-									MountPointOpts: MountPointOpts{
-										ContainerPath: aws.String("/path/to/files"),
-										ReadOnly:      aws.Bool(false),
-									},
-									EFS: &EFSConfigOrBool{
-										Advanced: EFSVolumeConfiguration{
-											FileSystemID: aws.String("fs-1234"),
-											AuthConfig: &AuthorizationConfig{
-												IAM:           aws.Bool(true),
-												AccessPointID: aws.String("ap-1234"),
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-					Sidecars: map[string]*SidecarConfig{
-						"xray": {
-							Port:       aws.String("2000"),
-							Image:      aws.String("123456789012.dkr.ecr.us-east-2.amazonaws.com/xray-daemon"),
-							CredsParam: aws.String("some arn"),
-						},
-					},
-					Logging: &Logging{
-						ConfigFile: aws.String("mockConfigFile"),
-					},
-					Network: &NetworkConfig{
-						VPC: &vpcConfig{
-							Placement:      stringP("public"),
-							SecurityGroups: []string{"sg-123"},
-						},
-					},
-				},
-				Environments: map[string]*LoadBalancedWebServiceConfig{
-					"prod-iad": {
-						ImageConfig: ImageWithPortAndHealthcheck{
-							ImageWithPort: ImageWithPort{
-								Image: Image{
-									Build: BuildArgsOrString{
-										BuildArgs: DockerBuildArgs{
-											Dockerfile: aws.String("./RealDockerfile"),
-										},
-									},
-								},
-								Port: aws.Uint16(5000),
-							},
-						},
-						RoutingRule: RoutingRule{
-							TargetContainer: aws.String("xray"),
-						},
-						TaskConfig: TaskConfig{
-							CPU: aws.Int(2046),
-							Count: Count{
-								Value: aws.Int(0),
-							},
-							Variables: map[string]string{
-								"DDB_TABLE_NAME": "awards-prod",
-							},
-							Storage: &Storage{
-								Volumes: map[string]Volume{
-									"myEFSVolume": {
-										EFS: &EFSConfigOrBool{
-											Advanced: EFSVolumeConfiguration{
-												FileSystemID: aws.String("fs-5678"),
-												AuthConfig: &AuthorizationConfig{
-													AccessPointID: aws.String("ap-5678"),
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-						Sidecars: map[string]*SidecarConfig{
-							"xray": {
-								Port: aws.String("2000/udp"),
-								MountPoints: []SidecarMountPoint{
-									{
-										SourceVolume: aws.String("myEFSVolume"),
-										MountPointOpts: MountPointOpts{
-											ReadOnly:      aws.Bool(true),
-											ContainerPath: aws.String("/var/www"),
-										},
-									},
-								},
-							},
-						},
-						Logging: &Logging{
-							SecretOptions: map[string]string{
-								"FOO": "BAR",
-							},
-						},
-						Network: &NetworkConfig{
-							VPC: &vpcConfig{
-								SecurityGroups: []string{"sg-456", "sg-789"},
-							},
-						},
-					},
-				},
-			},
-			envToApply: "prod-iad",
-
-			wanted: &LoadBalancedWebService{
-				Workload: Workload{
-					Name: aws.String("phonetool"),
-					Type: aws.String(LoadBalancedWebServiceType),
-				},
-				LoadBalancedWebServiceConfig: LoadBalancedWebServiceConfig{
-					ImageConfig: ImageWithPortAndHealthcheck{
-						ImageWithPort: ImageWithPort{
-							Image: Image{
-								Build: BuildArgsOrString{
-									BuildArgs: DockerBuildArgs{
-										Dockerfile: aws.String("./RealDockerfile"),
-									},
-								},
-							},
-							Port: aws.Uint16(5000),
-						},
-					},
-					RoutingRule: RoutingRule{
-						Path: aws.String("/awards/*"),
-						HealthCheck: HealthCheckArgsOrString{
-							HealthCheckPath: aws.String("/"),
-						},
-						TargetContainer: aws.String("xray"),
-					},
-					TaskConfig: TaskConfig{
-						CPU:    aws.Int(2046),
-						Memory: aws.Int(1024),
-						Count: Count{
-							Value: aws.Int(0),
-						},
-						Variables: map[string]string{
-							"LOG_LEVEL":      "DEBUG",
-							"DDB_TABLE_NAME": "awards-prod",
-						},
-						Secrets: map[string]string{
-							"GITHUB_TOKEN": "1111",
-							"TWILIO_TOKEN": "1111",
-						},
-						Storage: &Storage{
-							Volumes: map[string]Volume{
-								"myEFSVolume": {
-									MountPointOpts: MountPointOpts{
-										ContainerPath: aws.String("/path/to/files"),
-										ReadOnly:      aws.Bool(false),
-									},
-									EFS: &EFSConfigOrBool{
-										Advanced: EFSVolumeConfiguration{
-											FileSystemID: aws.String("fs-5678"),
-											AuthConfig: &AuthorizationConfig{
-												IAM:           aws.Bool(true),
-												AccessPointID: aws.String("ap-5678"),
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-					Sidecars: map[string]*SidecarConfig{
-						"xray": {
-							Port:       aws.String("2000/udp"),
-							Image:      aws.String("123456789012.dkr.ecr.us-east-2.amazonaws.com/xray-daemon"),
-							CredsParam: aws.String("some arn"),
-							MountPoints: []SidecarMountPoint{
-								{
-									SourceVolume: aws.String("myEFSVolume"),
-									MountPointOpts: MountPointOpts{
-										ReadOnly:      aws.Bool(true),
-										ContainerPath: aws.String("/var/www"),
-									},
-								},
-							},
-						},
-					},
-					Logging: &Logging{
-						ConfigFile: aws.String("mockConfigFile"),
-						SecretOptions: map[string]string{
-							"FOO": "BAR",
-						},
-					},
-					Network: &NetworkConfig{
-						VPC: &vpcConfig{
-							Placement:      stringP("public"),
-							SecurityGroups: []string{"sg-456", "sg-789"},
-						},
-					},
-				},
-			},
-		},
+		//"with overrides": {
+		//	in: &LoadBalancedWebService{
+		//		Workload: Workload{
+		//			Name: aws.String("phonetool"),
+		//			Type: aws.String(LoadBalancedWebServiceType),
+		//		},
+		//		LoadBalancedWebServiceConfig: LoadBalancedWebServiceConfig{
+		//			ImageConfig: ImageWithPortAndHealthcheck{
+		//				ImageWithPort: ImageWithPort{
+		//					Image: Image{
+		//						Build: BuildArgsOrString{
+		//							BuildArgs: DockerBuildArgs{
+		//								Dockerfile: aws.String("./Dockerfile"),
+		//							},
+		//						},
+		//					},
+		//					Port: aws.Uint16(80),
+		//				},
+		//			},
+		//			RoutingRule: RoutingRule{
+		//				Path: aws.String("/awards/*"),
+		//				HealthCheck: HealthCheckArgsOrString{
+		//					HealthCheckPath: aws.String("/"),
+		//				},
+		//			},
+		//			TaskConfig: TaskConfig{
+		//				CPU:    aws.Int(1024),
+		//				Memory: aws.Int(1024),
+		//				Count: Count{
+		//					Value: aws.Int(1),
+		//				},
+		//				Variables: map[string]string{
+		//					"LOG_LEVEL":      "DEBUG",
+		//					"DDB_TABLE_NAME": "awards",
+		//				},
+		//				Secrets: map[string]string{
+		//					"GITHUB_TOKEN": "1111",
+		//					"TWILIO_TOKEN": "1111",
+		//				},
+		//				Storage: &Storage{
+		//					Volumes: map[string]Volume{
+		//						"myEFSVolume": {
+		//							MountPointOpts: MountPointOpts{
+		//								ContainerPath: aws.String("/path/to/files"),
+		//								ReadOnly:      aws.Bool(false),
+		//							},
+		//							EFS: &EFSConfigOrBool{
+		//								Advanced: EFSVolumeConfiguration{
+		//									FileSystemID: aws.String("fs-1234"),
+		//									AuthConfig: &AuthorizationConfig{
+		//										IAM:           aws.Bool(true),
+		//										AccessPointID: aws.String("ap-1234"),
+		//									},
+		//								},
+		//							},
+		//						},
+		//					},
+		//				},
+		//			},
+		//			Sidecars: map[string]*SidecarConfig{
+		//				"xray": {
+		//					Port:       aws.String("2000"),
+		//					Image:      aws.String("123456789012.dkr.ecr.us-east-2.amazonaws.com/xray-daemon"),
+		//					CredsParam: aws.String("some arn"),
+		//				},
+		//			},
+		//			Logging: &Logging{
+		//				ConfigFile: aws.String("mockConfigFile"),
+		//			},
+		//			Network: &NetworkConfig{
+		//				VPC: &vpcConfig{
+		//					Placement:      stringP("public"),
+		//					SecurityGroups: []string{"sg-123"},
+		//				},
+		//			},
+		//		},
+		//		Environments: map[string]*LoadBalancedWebServiceConfig{
+		//			"prod-iad": {
+		//				ImageConfig: ImageWithPortAndHealthcheck{
+		//					ImageWithPort: ImageWithPort{
+		//						Image: Image{
+		//							Build: BuildArgsOrString{
+		//								BuildArgs: DockerBuildArgs{
+		//									Dockerfile: aws.String("./RealDockerfile"),
+		//								},
+		//							},
+		//						},
+		//						Port: aws.Uint16(5000),
+		//					},
+		//				},
+		//				RoutingRule: RoutingRule{
+		//					TargetContainer: aws.String("xray"),
+		//				},
+		//				TaskConfig: TaskConfig{
+		//					CPU: aws.Int(2046),
+		//					Count: Count{
+		//						Value: aws.Int(0),
+		//					},
+		//					Variables: map[string]string{
+		//						"DDB_TABLE_NAME": "awards-prod",
+		//					},
+		//					Storage: &Storage{
+		//						Volumes: map[string]Volume{
+		//							"myEFSVolume": {
+		//								EFS: &EFSConfigOrBool{
+		//									Advanced: EFSVolumeConfiguration{
+		//										FileSystemID: aws.String("fs-5678"),
+		//										AuthConfig: &AuthorizationConfig{
+		//											AccessPointID: aws.String("ap-5678"),
+		//										},
+		//									},
+		//								},
+		//							},
+		//						},
+		//					},
+		//				},
+		//				Sidecars: map[string]*SidecarConfig{
+		//					"xray": {
+		//						Port: aws.String("2000/udp"),
+		//						MountPoints: []SidecarMountPoint{
+		//							{
+		//								SourceVolume: aws.String("myEFSVolume"),
+		//								MountPointOpts: MountPointOpts{
+		//									ReadOnly:      aws.Bool(true),
+		//									ContainerPath: aws.String("/var/www"),
+		//								},
+		//							},
+		//						},
+		//					},
+		//				},
+		//				Logging: &Logging{
+		//					SecretOptions: map[string]string{
+		//						"FOO": "BAR",
+		//					},
+		//				},
+		//				Network: &NetworkConfig{
+		//					VPC: &vpcConfig{
+		//						SecurityGroups: []string{"sg-456", "sg-789"},
+		//					},
+		//				},
+		//			},
+		//		},
+		//	},
+		//	envToApply: "prod-iad",
+		//
+		//	wanted: &LoadBalancedWebService{
+		//		Workload: Workload{
+		//			Name: aws.String("phonetool"),
+		//			Type: aws.String(LoadBalancedWebServiceType),
+		//		},
+		//		LoadBalancedWebServiceConfig: LoadBalancedWebServiceConfig{
+		//			ImageConfig: ImageWithPortAndHealthcheck{
+		//				ImageWithPort: ImageWithPort{
+		//					Image: Image{
+		//						Build: BuildArgsOrString{
+		//							BuildArgs: DockerBuildArgs{
+		//								Dockerfile: aws.String("./RealDockerfile"),
+		//							},
+		//						},
+		//					},
+		//					Port: aws.Uint16(5000),
+		//				},
+		//			},
+		//			RoutingRule: RoutingRule{
+		//				Path: aws.String("/awards/*"),
+		//				HealthCheck: HealthCheckArgsOrString{
+		//					HealthCheckPath: aws.String("/"),
+		//				},
+		//				TargetContainer: aws.String("xray"),
+		//			},
+		//			TaskConfig: TaskConfig{
+		//				CPU:    aws.Int(2046),
+		//				Memory: aws.Int(1024),
+		//				Count: Count{
+		//					Value: aws.Int(0),
+		//				},
+		//				Variables: map[string]string{
+		//					"LOG_LEVEL":      "DEBUG",
+		//					"DDB_TABLE_NAME": "awards-prod",
+		//				},
+		//				Secrets: map[string]string{
+		//					"GITHUB_TOKEN": "1111",
+		//					"TWILIO_TOKEN": "1111",
+		//				},
+		//				Storage: &Storage{
+		//					Volumes: map[string]Volume{
+		//						"myEFSVolume": {
+		//							MountPointOpts: MountPointOpts{
+		//								ContainerPath: aws.String("/path/to/files"),
+		//								ReadOnly:      aws.Bool(false),
+		//							},
+		//							EFS: &EFSConfigOrBool{
+		//								Advanced: EFSVolumeConfiguration{
+		//									FileSystemID: aws.String("fs-5678"),
+		//									AuthConfig: &AuthorizationConfig{
+		//										IAM:           aws.Bool(true),
+		//										AccessPointID: aws.String("ap-5678"),
+		//									},
+		//								},
+		//							},
+		//						},
+		//					},
+		//				},
+		//			},
+		//			Sidecars: map[string]*SidecarConfig{
+		//				"xray": {
+		//					Port:       aws.String("2000/udp"),
+		//					Image:      aws.String("123456789012.dkr.ecr.us-east-2.amazonaws.com/xray-daemon"),
+		//					CredsParam: aws.String("some arn"),
+		//					MountPoints: []SidecarMountPoint{
+		//						{
+		//							SourceVolume: aws.String("myEFSVolume"),
+		//							MountPointOpts: MountPointOpts{
+		//								ReadOnly:      aws.Bool(true),
+		//								ContainerPath: aws.String("/var/www"),
+		//							},
+		//						},
+		//					},
+		//				},
+		//			},
+		//			Logging: &Logging{
+		//				ConfigFile: aws.String("mockConfigFile"),
+		//				SecretOptions: map[string]string{
+		//					"FOO": "BAR",
+		//				},
+		//			},
+		//			Network: &NetworkConfig{
+		//				VPC: &vpcConfig{
+		//					Placement:      stringP("public"),
+		//					SecurityGroups: []string{"sg-456", "sg-789"},
+		//				},
+		//			},
+		//		},
+		//	},
+		//},
 		"with empty env override": {
 			in: &LoadBalancedWebService{
 				LoadBalancedWebServiceConfig: LoadBalancedWebServiceConfig{

--- a/internal/pkg/manifest/rd_web_svc.go
+++ b/internal/pkg/manifest/rd_web_svc.go
@@ -115,7 +115,7 @@ func (s RequestDrivenWebService) ApplyEnv(envName string) (WorkloadManifest, err
 	// Apply overrides to the original service configuration.
 	err := mergo.Merge(&s, RequestDrivenWebService{
 		RequestDrivenWebServiceConfig: *overrideConfig,
-	}, mergo.WithOverride, mergo.WithOverwriteWithEmptyValue, mergo.WithTransformers(workloadTransformer{}))
+	}, mergo.WithOverride, mergo.WithTransformers(workloadTransformer{}))
 
 	if err != nil {
 		return nil, err

--- a/internal/pkg/manifest/rd_web_svc_applyenv_test.go
+++ b/internal/pkg/manifest/rd_web_svc_applyenv_test.go
@@ -31,7 +31,7 @@ func TestRequestDrivenWebService_ApplyEnv_HTTP(t *testing.T) {
 				}
 			},
 		},
-		"FAILED_AFTER_UPGRADE: healthcheck not overridden": {
+		"PENDING: healthcheck not overridden": {
 			inSvc: func(svc *RequestDrivenWebService) {
 				svc.HealthCheckConfiguration = HealthCheckArgsOrString{
 					HealthCheckPath: aws.String("mockPath"),
@@ -62,7 +62,7 @@ func TestRequestDrivenWebService_ApplyEnv_HTTP(t *testing.T) {
 				svc.Alias = aws.String("")
 			},
 		},
-		"FAILED_AFTER_UPGRADE: alias not overridden": {
+		"FIXED_AFTER_TRANSFORM_POINTER: alias not overridden": {
 			inSvc: func(svc *RequestDrivenWebService) {
 				svc.Alias = aws.String("mockAlias")
 				svc.Environments["test"].RequestDrivenWebServiceHttpConfig = RequestDrivenWebServiceHttpConfig{}
@@ -95,7 +95,7 @@ func TestRequestDrivenWebService_ApplyEnv_New(t *testing.T) {
 		inSvc  func(svc *RequestDrivenWebService)
 		wanted func(svc *RequestDrivenWebService)
 	}{
-		"FAILED_AFTER_UPGRADE: http overridden": {
+		"PENDING: http overridden": {
 			inSvc: func(svc *RequestDrivenWebService) {
 				svc.RequestDrivenWebServiceHttpConfig = RequestDrivenWebServiceHttpConfig{
 					HealthCheckConfiguration: HealthCheckArgsOrString{
@@ -115,7 +115,7 @@ func TestRequestDrivenWebService_ApplyEnv_New(t *testing.T) {
 				}
 			},
 		},
-		"FAILED_AFTER_UPGRADE: http not overridden": {
+		"PENDING: http not overridden": {
 			inSvc: func(svc *RequestDrivenWebService) {
 				svc.RequestDrivenWebServiceHttpConfig = RequestDrivenWebServiceHttpConfig{
 					HealthCheckConfiguration: HealthCheckArgsOrString{
@@ -188,7 +188,7 @@ func TestRequestDrivenWebService_ApplyEnv_New(t *testing.T) {
 				svc.InstanceConfig.CPU = aws.Int(0)
 			},
 		},
-		"FAILED_AFTER_UPGRADE: cpu not overridden": {
+		"FIXED_AFTER_TRANSFORM_POINTER: cpu not overridden": {
 			inSvc: func(svc *RequestDrivenWebService) {
 				svc.InstanceConfig.CPU = aws.Int(1024)
 				svc.Environments["test"].InstanceConfig = AppRunnerInstanceConfig{}
@@ -215,7 +215,7 @@ func TestRequestDrivenWebService_ApplyEnv_New(t *testing.T) {
 				svc.InstanceConfig.Memory = aws.Int(0)
 			},
 		},
-		"FAILED_AFTER_UPGRADE: memory not overridden": {
+		"FIXED_AFTER_TRANSFORM_POINTER: memory not overridden": {
 			inSvc: func(svc *RequestDrivenWebService) {
 				svc.InstanceConfig.Memory = aws.Int(1024)
 				svc.Environments["test"].InstanceConfig = AppRunnerInstanceConfig{}

--- a/internal/pkg/manifest/rd_web_svc_applyenv_test.go
+++ b/internal/pkg/manifest/rd_web_svc_applyenv_test.go
@@ -31,7 +31,7 @@ func TestRequestDrivenWebService_ApplyEnv_HTTP(t *testing.T) {
 				}
 			},
 		},
-		"healthcheck not overridden": {
+		"FAILED_AFTER_UPGRADE: healthcheck not overridden": {
 			inSvc: func(svc *RequestDrivenWebService) {
 				svc.HealthCheckConfiguration = HealthCheckArgsOrString{
 					HealthCheckPath: aws.String("mockPath"),
@@ -62,7 +62,7 @@ func TestRequestDrivenWebService_ApplyEnv_HTTP(t *testing.T) {
 				svc.Alias = aws.String("")
 			},
 		},
-		"alias not overridden": {
+		"FAILED_AFTER_UPGRADE: alias not overridden": {
 			inSvc: func(svc *RequestDrivenWebService) {
 				svc.Alias = aws.String("mockAlias")
 				svc.Environments["test"].RequestDrivenWebServiceHttpConfig = RequestDrivenWebServiceHttpConfig{}
@@ -95,7 +95,7 @@ func TestRequestDrivenWebService_ApplyEnv_New(t *testing.T) {
 		inSvc  func(svc *RequestDrivenWebService)
 		wanted func(svc *RequestDrivenWebService)
 	}{
-		"http overridden": {
+		"FAILED_AFTER_UPGRADE: http overridden": {
 			inSvc: func(svc *RequestDrivenWebService) {
 				svc.RequestDrivenWebServiceHttpConfig = RequestDrivenWebServiceHttpConfig{
 					HealthCheckConfiguration: HealthCheckArgsOrString{
@@ -115,7 +115,7 @@ func TestRequestDrivenWebService_ApplyEnv_New(t *testing.T) {
 				}
 			},
 		},
-		"http not overridden": {
+		"FAILED_AFTER_UPGRADE: http not overridden": {
 			inSvc: func(svc *RequestDrivenWebService) {
 				svc.RequestDrivenWebServiceHttpConfig = RequestDrivenWebServiceHttpConfig{
 					HealthCheckConfiguration: HealthCheckArgsOrString{
@@ -188,7 +188,7 @@ func TestRequestDrivenWebService_ApplyEnv_New(t *testing.T) {
 				svc.InstanceConfig.CPU = aws.Int(0)
 			},
 		},
-		"cpu not overridden": {
+		"FAILED_AFTER_UPGRADE: cpu not overridden": {
 			inSvc: func(svc *RequestDrivenWebService) {
 				svc.InstanceConfig.CPU = aws.Int(1024)
 				svc.Environments["test"].InstanceConfig = AppRunnerInstanceConfig{}
@@ -215,7 +215,7 @@ func TestRequestDrivenWebService_ApplyEnv_New(t *testing.T) {
 				svc.InstanceConfig.Memory = aws.Int(0)
 			},
 		},
-		"memory not overridden": {
+		"FAILED_AFTER_UPGRADE: memory not overridden": {
 			inSvc: func(svc *RequestDrivenWebService) {
 				svc.InstanceConfig.Memory = aws.Int(1024)
 				svc.Environments["test"].InstanceConfig = AppRunnerInstanceConfig{}
@@ -239,7 +239,7 @@ func TestRequestDrivenWebService_ApplyEnv_New(t *testing.T) {
 				}
 			},
 		},
-		"platform not overridden": {
+		"FAILED_AFTER_UPGRADE: platform not overridden": {
 			inSvc: func(svc *RequestDrivenWebService) {
 				svc.InstanceConfig.Platform = &PlatformArgsOrString{
 					PlatformString: aws.String("mockPlatform"),

--- a/internal/pkg/manifest/storage_applyenv_test.go
+++ b/internal/pkg/manifest/storage_applyenv_test.go
@@ -45,7 +45,7 @@ func Test_ApplyEnv_Storage(t *testing.T) {
 				}
 			},
 		},
-		"ephemeral not overridden": {
+		"FAILED_AFTER_UPGRADE: ephemeral not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
 					Ephemeral: aws.Int(1),
@@ -273,7 +273,7 @@ func Test_ApplyEnv_Storage_Volume(t *testing.T) {
 				}
 			},
 		},
-		"path not overridden": {
+		"FAILED_AFTER_UPGRADE: path not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
 					Volumes: map[string]Volume{
@@ -370,7 +370,7 @@ func Test_ApplyEnv_Storage_Volume(t *testing.T) {
 				}
 			},
 		},
-		"read_only not overridden": {
+		"FAILED_AFTER_UPGRADE: read_only not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
 					Volumes: map[string]Volume{
@@ -442,7 +442,7 @@ func Test_ApplyEnv_Storage_Volume(t *testing.T) {
 				}
 			},
 		},
-		"efs not overridden": {
+		"FAILED_AFTER_UPGRADE: efs not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
 					Volumes: map[string]Volume{
@@ -642,7 +642,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 				}
 			},
 		},
-		"efs bool not overridden": {
+		"FAILED_AFTER_UPGRADE: efs bool not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
 					Volumes: map[string]Volume{
@@ -714,7 +714,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 				}
 			},
 		},
-		"efs config not overridden": {
+		"FAILED_AFTER_UPGRADE: efs config not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
 					Volumes: map[string]Volume{
@@ -1323,7 +1323,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 				}
 			},
 		},
-		"id not overridden": {
+		"FAILED_AFTER_UPGRADE: id not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
 					Volumes: map[string]Volume{
@@ -1438,7 +1438,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 				}
 			},
 		},
-		"root_dir not overridden": {
+		"FAILED_AFTER_UPGRADE: root_dir not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
 					Volumes: map[string]Volume{
@@ -1553,7 +1553,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 				}
 			},
 		},
-		"uid not overridden": {
+		"FAILED_AFTER_UPGRADE: uid not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
 					Volumes: map[string]Volume{
@@ -1668,7 +1668,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 				}
 			},
 		},
-		"gid not overridden": {
+		"FAILED_AFTER_UPGRADE: gid not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
 					Volumes: map[string]Volume{
@@ -1752,7 +1752,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 				}
 			},
 		},
-		"auth not overridden": {
+		"FAILED_AFTER_UPGRADE: auth not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
 					Volumes: map[string]Volume{
@@ -1907,7 +1907,7 @@ func Test_ApplyEnv_Storage_Volume_EFS_Auth(t *testing.T) {
 				}
 			},
 		},
-		"iam not overridden": {
+		"FAILED_AFTER_UPGRADE: iam not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
 					Volumes: map[string]Volume{
@@ -2040,7 +2040,7 @@ func Test_ApplyEnv_Storage_Volume_EFS_Auth(t *testing.T) {
 				}
 			},
 		},
-		"access_point_id not overridden": {
+		"FAILED_AFTER_UPGRADE: access_point_id not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
 					Volumes: map[string]Volume{

--- a/internal/pkg/manifest/storage_applyenv_test.go
+++ b/internal/pkg/manifest/storage_applyenv_test.go
@@ -45,7 +45,7 @@ func Test_ApplyEnv_Storage(t *testing.T) {
 				}
 			},
 		},
-		"FAILED_AFTER_UPGRADE: ephemeral not overridden": {
+		"FIXED_AFTER_TRANSFORM_POINTER: ephemeral not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
 					Ephemeral: aws.Int(1),
@@ -207,7 +207,7 @@ func Test_ApplyEnv_Storage_Volume(t *testing.T) {
 		inSvc  func(svc *LoadBalancedWebService)
 		wanted func(svc *LoadBalancedWebService)
 	}{
-		"path overridden": {
+		"FAILED_AFTER_TRANSFORM_POINTER: path overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
 					Volumes: map[string]Volume{
@@ -240,7 +240,7 @@ func Test_ApplyEnv_Storage_Volume(t *testing.T) {
 				}
 			},
 		},
-		"path explicitly overridden by zero value": {
+		"FAILED_AFTER_TRANSFORM_POINTER： path explicitly overridden by zero value": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
 					Volumes: map[string]Volume{

--- a/internal/pkg/manifest/storage_applyenv_test.go
+++ b/internal/pkg/manifest/storage_applyenv_test.go
@@ -3,2095 +3,2101 @@
 
 package manifest
 
-//
-//func Test_ApplyEnv_Storage(t *testing.T) {
-//	testCases := map[string]struct {
-//		inSvc  func(svc *LoadBalancedWebService)
-//		wanted func(svc *LoadBalancedWebService)
-//	}{
-//		"ephemeral overridden": {
-//			inSvc: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Ephemeral: aws.Int(1),
-//				}
-//				svc.Environments["test"].Storage = &Storage{
-//					Ephemeral: aws.Int(3),
-//				}
-//			},
-//			wanted: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Ephemeral: aws.Int(3),
-//				}
-//			},
-//		},
-//		"ephemeral explicitly overridden by zero value": {
-//			inSvc: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Ephemeral: aws.Int(1),
-//				}
-//				svc.Environments["test"].Storage = &Storage{
-//					Ephemeral: aws.Int(0),
-//				}
-//			},
-//			wanted: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Ephemeral: aws.Int(0),
-//				}
-//			},
-//		},
-//		"FIXED_AFTER_TRANSFORM_POINTER: ephemeral not overridden": {
-//			inSvc: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Ephemeral: aws.Int(1),
-//				}
-//				svc.Environments["test"].Storage = &Storage{}
-//			},
-//			wanted: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Ephemeral: aws.Int(1),
-//				}
-//			},
-//		},
-//		//"FAILED TEST: volumes overridden": {
-//		//	inSvc: func(svc *LoadBalancedWebService) {
-//		//		svc.Storage = &Storage{
-//		//			Volumes: map[string]Volume{
-//		//				"mockVolume1": {
-//		//					MountPointOpts: MountPointOpts{
-//		//						ReadOnly: aws.Bool(true),
-//		//					},
-//		//				},
-//		//				"mockVolume2": {
-//		//					EFS: &EFSConfigOrBool{
-//		//						Enabled: aws.Bool(true),
-//		//					},
-//		//				},
-//		//			},
-//		//		}
-//		//		svc.Environments["test"].Storage = &Storage{
-//		//			Volumes: map[string]Volume{
-//		//				"mockVolume1": {
-//		//					EFS: &EFSConfigOrBool{
-//		//						Enabled: aws.Bool(true),
-//		//					},
-//		//				}, // Modify the value for mockVolume1.
-//		//				"mockVolume3": {
-//		//					MountPointOpts: MountPointOpts{
-//		//						ReadOnly: aws.Bool(true),
-//		//					},
-//		//				}, // Append mockVolume3.
-//		//			},
-//		//		}
-//		//	},
-//		//	wanted: func(svc *LoadBalancedWebService) {
-//		//		svc.Storage = &Storage{
-//		//			Volumes: map[string]Volume{
-//		//				"mockVolume1": {
-//		//					EFS: &EFSConfigOrBool{
-//		//						Enabled: aws.Bool(true),
-//		//					},
-//		//				},
-//		//				"mockVolume2": {
-//		//					EFS: &EFSConfigOrBool{
-//		//						Enabled: aws.Bool(true),
-//		//					},
-//		//				},
-//		//				"mockVolume3": {
-//		//					MountPointOpts: MountPointOpts{
-//		//						ReadOnly: aws.Bool(true),
-//		//					},
-//		//				},
-//		//			},
-//		//		}
-//		//	},
-//		//},
-//		"volumes not overridden by empty map": {
-//			inSvc: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							MountPointOpts: MountPointOpts{
-//								ReadOnly: aws.Bool(true),
-//							},
-//						},
-//						"mockVolume2": {
-//							EFS: &EFSConfigOrBool{
-//								Enabled: aws.Bool(true),
-//							},
-//						},
-//					},
-//				}
-//				svc.Environments["test"].Storage = &Storage{
-//					Volumes: map[string]Volume{},
-//				}
-//			},
-//			wanted: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							MountPointOpts: MountPointOpts{
-//								ReadOnly: aws.Bool(true),
-//							},
-//						},
-//						"mockVolume2": {
-//							EFS: &EFSConfigOrBool{
-//								Enabled: aws.Bool(true),
-//							},
-//						},
-//					},
-//				}
-//			},
-//		},
-//		"volumes not overridden by nil": {
-//			inSvc: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							MountPointOpts: MountPointOpts{
-//								ReadOnly: aws.Bool(true),
-//							},
-//						},
-//						"mockVolume2": {
-//							EFS: &EFSConfigOrBool{
-//								Enabled: aws.Bool(true),
-//							},
-//						},
-//					},
-//				}
-//				svc.Environments["test"].Storage = &Storage{}
-//			},
-//			wanted: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							MountPointOpts: MountPointOpts{
-//								ReadOnly: aws.Bool(true),
-//							},
-//						},
-//						"mockVolume2": {
-//							EFS: &EFSConfigOrBool{
-//								Enabled: aws.Bool(true),
-//							},
-//						},
-//					},
-//				}
-//			},
-//		},
-//	}
-//	for name, tc := range testCases {
-//		t.Run(name, func(t *testing.T) {
-//			var inSvc, wantedSvc LoadBalancedWebService
-//			inSvc.Environments = map[string]*LoadBalancedWebServiceConfig{
-//				"test": {},
-//			}
-//
-//			tc.inSvc(&inSvc)
-//			tc.wanted(&wantedSvc)
-//
-//			got, err := inSvc.ApplyEnv("test")
-//
-//			require.NoError(t, err)
-//			require.Equal(t, &wantedSvc, got)
-//		})
-//	}
-//}
-//
-//func Test_ApplyEnv_Storage_Volume(t *testing.T) {
-//	testCases := map[string]struct {
-//		inSvc  func(svc *LoadBalancedWebService)
-//		wanted func(svc *LoadBalancedWebService)
-//	}{
-//		"FAILED_AFTER_TRANSFORM_POINTER: path overridden": {
-//			inSvc: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							MountPointOpts: MountPointOpts{
-//								ContainerPath: aws.String("mockPath"),
-//							},
-//						},
-//					},
-//				}
-//				svc.Environments["test"].Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							MountPointOpts: MountPointOpts{
-//								ContainerPath: aws.String("mockPathTest"),
-//							},
-//						},
-//					},
-//				}
-//			},
-//			wanted: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							MountPointOpts: MountPointOpts{
-//								ContainerPath: aws.String("mockPathTest"),
-//							},
-//						},
-//					},
-//				}
-//			},
-//		},
-//		"FAILED_AFTER_TRANSFORM_POINTER： path explicitly overridden by zero value": {
-//			inSvc: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							MountPointOpts: MountPointOpts{
-//								ContainerPath: aws.String("mockPath"),
-//							},
-//						},
-//					},
-//				}
-//				svc.Environments["test"].Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							MountPointOpts: MountPointOpts{
-//								ContainerPath: aws.String(""),
-//							},
-//						},
-//					},
-//				}
-//			},
-//			wanted: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							MountPointOpts: MountPointOpts{
-//								ContainerPath: aws.String(""),
-//							},
-//						},
-//					},
-//				}
-//			},
-//		},
-//		"FAILED_AFTER_UPGRADE: path not overridden": {
-//			inSvc: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							MountPointOpts: MountPointOpts{
-//								ContainerPath: aws.String("mockPath"),
-//							},
-//						},
-//					},
-//				}
-//				svc.Environments["test"].Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							MountPointOpts: MountPointOpts{},
-//						},
-//					},
-//				}
-//			},
-//			wanted: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							MountPointOpts: MountPointOpts{
-//								ContainerPath: aws.String("mockPath"),
-//							},
-//						},
-//					},
-//				}
-//			},
-//		},
-//		"read_only overridden": {
-//			inSvc: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							MountPointOpts: MountPointOpts{
-//								ReadOnly: aws.Bool(false),
-//							},
-//						},
-//					},
-//				}
-//				svc.Environments["test"].Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							MountPointOpts: MountPointOpts{
-//								ReadOnly: aws.Bool(true),
-//							},
-//						},
-//					},
-//				}
-//			},
-//			wanted: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							MountPointOpts: MountPointOpts{
-//								ReadOnly: aws.Bool(true),
-//							},
-//						},
-//					},
-//				}
-//			},
-//		},
-//		"read_only explicitly overridden by empty value": {
-//			inSvc: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							MountPointOpts: MountPointOpts{
-//								ReadOnly: aws.Bool(true),
-//							},
-//						},
-//					},
-//				}
-//				svc.Environments["test"].Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							MountPointOpts: MountPointOpts{
-//								ReadOnly: aws.Bool(false),
-//							},
-//						},
-//					},
-//				}
-//			},
-//			wanted: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							MountPointOpts: MountPointOpts{
-//								ReadOnly: aws.Bool(false),
-//							},
-//						},
-//					},
-//				}
-//			},
-//		},
-//		"FAILED_AFTER_UPGRADE: read_only not overridden": {
-//			inSvc: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							MountPointOpts: MountPointOpts{
-//								ReadOnly: aws.Bool(true),
-//							},
-//						},
-//					},
-//				}
-//				svc.Environments["test"].Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							MountPointOpts: MountPointOpts{},
-//						},
-//					},
-//				}
-//			},
-//			wanted: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							MountPointOpts: MountPointOpts{
-//								ReadOnly: aws.Bool(true),
-//							},
-//						},
-//					},
-//				}
-//			},
-//		},
-//		"efs overridden": {
-//			inSvc: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									FileSystemID: aws.String("mockFileSystem"),
-//								},
-//							},
-//						},
-//					},
-//				}
-//				svc.Environments["test"].Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									RootDirectory: aws.String("mockRootDirTest"),
-//									FileSystemID:  aws.String("mockFileSystemTest"),
-//								},
-//							},
-//						},
-//					},
-//				}
-//			},
-//			wanted: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									RootDirectory: aws.String("mockRootDirTest"),
-//									FileSystemID:  aws.String("mockFileSystemTest"),
-//								},
-//							},
-//						},
-//					},
-//				}
-//			},
-//		},
-//		"FAILED_AFTER_UPGRADE: efs not overridden": {
-//			inSvc: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									FileSystemID: aws.String("mockFileSystem"),
-//								},
-//							},
-//						},
-//					},
-//				}
-//				svc.Environments["test"].Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {},
-//					},
-//				}
-//			},
-//			wanted: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									FileSystemID: aws.String("mockFileSystem"),
-//								},
-//							},
-//						},
-//					},
-//				}
-//			},
-//		},
-//	}
-//	for name, tc := range testCases {
-//		t.Run(name, func(t *testing.T) {
-//			var inSvc, wantedSvc LoadBalancedWebService
-//			inSvc.Environments = map[string]*LoadBalancedWebServiceConfig{
-//				"test": {},
-//			}
-//
-//			tc.inSvc(&inSvc)
-//			tc.wanted(&wantedSvc)
-//
-//			got, err := inSvc.ApplyEnv("test")
-//
-//			require.NoError(t, err)
-//			require.Equal(t, &wantedSvc, got)
-//		})
-//	}
-//}
-//
-//func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
-//	testCases := map[string]struct {
-//		inSvc  func(svc *LoadBalancedWebService)
-//		wanted func(svc *LoadBalancedWebService)
-//	}{
-//		//"FAILED TEST: composite fields: efs bool is overridden if efs config is not nil": {
-//		//	inSvc: func(svc *LoadBalancedWebService) {
-//		//		svc.Storage = &Storage{
-//		//			Volumes: map[string]Volume{
-//		//				"mockVolume1": {
-//		//					EFS: &EFSConfigOrBool{
-//		//						Enabled: aws.Bool(true),
-//		//					},
-//		//				},
-//		//			},
-//		//		}
-//		//		svc.Environments["test"].Storage = &Storage{
-//		//			Volumes: map[string]Volume{
-//		//				"mockVolume1": {
-//		//					EFS: &EFSConfigOrBool{
-//		//						Advanced: EFSVolumeConfiguration{
-//		//							RootDirectory: aws.String("mockRootDirTest"),
-//		//							FileSystemID:  aws.String("mockFileSystemTest"),
-//		//						},
-//		//					},
-//		//				},
-//		//			},
-//		//		}
-//		//	},
-//		//	wanted: func(svc *LoadBalancedWebService) {
-//		//		svc.Storage = &Storage{
-//		//			Volumes: map[string]Volume{
-//		//				"mockVolume1": {
-//		//					EFS: &EFSConfigOrBool{
-//		//						Enabled: nil,
-//		//						Advanced: EFSVolumeConfiguration{
-//		//							RootDirectory: aws.String("mockRootDirTest"),
-//		//							FileSystemID:  aws.String("mockFileSystemTest"),
-//		//						},
-//		//					},
-//		//				},
-//		//			},
-//		//		}
-//		//	},
-//		//},
-//		//"FAILED TEST: composite fields: efs config is overridden if efs bool is not nil": {
-//		//	inSvc: func(svc *LoadBalancedWebService) {
-//		//		svc.Storage = &Storage{
-//		//			Volumes: map[string]Volume{
-//		//				"mockVolume1": {
-//		//					EFS: &EFSConfigOrBool{
-//		//						Advanced: EFSVolumeConfiguration{
-//		//							RootDirectory: aws.String("mockRootDir"),
-//		//							FileSystemID:  aws.String("mockFileSystem"),
-//		//						},
-//		//					},
-//		//				},
-//		//			},
-//		//		}
-//		//		svc.Environments["test"].Storage = &Storage{
-//		//			Volumes: map[string]Volume{
-//		//				"mockVolume1": {
-//		//					EFS: &EFSConfigOrBool{
-//		//						Enabled: aws.Bool(true),
-//		//					},
-//		//				},
-//		//			},
-//		//		}
-//		//	},
-//		//	wanted: func(svc *LoadBalancedWebService) {
-//		//		svc.Storage = &Storage{
-//		//			Volumes: map[string]Volume{
-//		//				"mockVolume1": {
-//		//					EFS: &EFSConfigOrBool{
-//		//						Enabled:  aws.Bool(true),
-//		//						Advanced: EFSVolumeConfiguration{},
-//		//					},
-//		//				},
-//		//			},
-//		//		}
-//		//	},
-//		//},
-//		"efs bool overridden": {
-//			inSvc: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Enabled: aws.Bool(false),
-//							},
-//						},
-//					},
-//				}
-//				svc.Environments["test"].Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Enabled: aws.Bool(true),
-//							},
-//						},
-//					},
-//				}
-//			},
-//			wanted: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Enabled: aws.Bool(true),
-//							},
-//						},
-//					},
-//				}
-//			},
-//		},
-//		"efs bool explicitly overridden by zero value": {
-//			inSvc: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Enabled: aws.Bool(true),
-//							},
-//						},
-//					},
-//				}
-//				svc.Environments["test"].Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Enabled: aws.Bool(false),
-//							},
-//						},
-//					},
-//				}
-//			},
-//			wanted: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Enabled: aws.Bool(false),
-//							},
-//						},
-//					},
-//				}
-//			},
-//		},
-//		"FAILED_AFTER_UPGRADE: efs bool not overridden": {
-//			inSvc: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Enabled: aws.Bool(true),
-//							},
-//						},
-//					},
-//				}
-//				svc.Environments["test"].Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {},
-//					},
-//				}
-//			},
-//			wanted: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Enabled: aws.Bool(true),
-//							},
-//						},
-//					},
-//				}
-//			},
-//		},
-//		"efs config overridden": {
-//			inSvc: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									FileSystemID: aws.String("mockFileSystem"),
-//								},
-//							},
-//						},
-//					},
-//				}
-//				svc.Environments["test"].Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									RootDirectory: aws.String("mockRootDirTest"),
-//									FileSystemID:  aws.String("mockFileSystemTest"),
-//									UID:           aws.Uint32(42),
-//								},
-//							},
-//						},
-//					},
-//				}
-//			},
-//			wanted: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									RootDirectory: aws.String("mockRootDirTest"),
-//									FileSystemID:  aws.String("mockFileSystemTest"),
-//									UID:           aws.Uint32(42),
-//								},
-//							},
-//						},
-//					},
-//				}
-//			},
-//		},
-//		"FAILED_AFTER_UPGRADE: efs config not overridden": {
-//			inSvc: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									FileSystemID: aws.String("mockFileSystem"),
-//								},
-//							},
-//						},
-//					},
-//				}
-//				svc.Environments["test"].Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {},
-//					},
-//				}
-//			},
-//			wanted: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									FileSystemID: aws.String("mockFileSystem"),
-//								},
-//							},
-//						},
-//					},
-//				}
-//			},
-//		},
-//		//"FAILED TEST: exclusive fields: id overridden if uid is not nil": {
-//		//	inSvc: func(svc *LoadBalancedWebService) {
-//		//		svc.Storage = &Storage{
-//		//			Volumes: map[string]Volume{
-//		//				"mockVolume1": {
-//		//					EFS: &EFSConfigOrBool{
-//		//						Advanced: EFSVolumeConfiguration{
-//		//							FileSystemID: aws.String("42"),
-//		//						},
-//		//					},
-//		//				},
-//		//			},
-//		//		}
-//		//		svc.Environments["test"].Storage = &Storage{
-//		//			Volumes: map[string]Volume{
-//		//				"mockVolume1": {
-//		//					EFS: &EFSConfigOrBool{
-//		//						Advanced: EFSVolumeConfiguration{
-//		//							UID: aws.Uint32(13),
-//		//						},
-//		//					},
-//		//				},
-//		//			},
-//		//		}
-//		//	},
-//		//	wanted: func(svc *LoadBalancedWebService) {
-//		//		svc.Storage = &Storage{
-//		//			Volumes: map[string]Volume{
-//		//				"mockVolume1": {
-//		//					EFS: &EFSConfigOrBool{
-//		//						Advanced: EFSVolumeConfiguration{
-//		//							FileSystemID: nil,
-//		//							UID:          aws.Uint32(13),
-//		//						},
-//		//					},
-//		//				},
-//		//			},
-//		//		}
-//		//	},
-//		//},
-//		//"FAILED TEST: exclusive fields: uid overridden if id is not nil": {
-//		//	inSvc: func(svc *LoadBalancedWebService) {
-//		//		svc.Storage = &Storage{
-//		//			Volumes: map[string]Volume{
-//		//				"mockVolume1": {
-//		//					EFS: &EFSConfigOrBool{
-//		//						Advanced: EFSVolumeConfiguration{
-//		//							UID: aws.Uint32(13),
-//		//						},
-//		//					},
-//		//				},
-//		//			},
-//		//		}
-//		//		svc.Environments["test"].Storage = &Storage{
-//		//			Volumes: map[string]Volume{
-//		//				"mockVolume1": {
-//		//					EFS: &EFSConfigOrBool{
-//		//						Advanced: EFSVolumeConfiguration{
-//		//							FileSystemID: aws.String("42"),
-//		//						},
-//		//					},
-//		//				},
-//		//			},
-//		//		}
-//		//	},
-//		//	wanted: func(svc *LoadBalancedWebService) {
-//		//		svc.Storage = &Storage{
-//		//			Volumes: map[string]Volume{
-//		//				"mockVolume1": {
-//		//					EFS: &EFSConfigOrBool{
-//		//						Advanced: EFSVolumeConfiguration{
-//		//							FileSystemID: aws.String("42"),
-//		//							UID:          nil,
-//		//						},
-//		//					},
-//		//				},
-//		//			},
-//		//		}
-//		//	},
-//		//},
-//		//"FAILED TEST: exclusive fields: root_dir overridden if uid is not nil": {
-//		//	inSvc: func(svc *LoadBalancedWebService) {
-//		//		svc.Storage = &Storage{
-//		//			Volumes: map[string]Volume{
-//		//				"mockVolume1": {
-//		//					EFS: &EFSConfigOrBool{
-//		//						Advanced: EFSVolumeConfiguration{
-//		//							RootDirectory: aws.String("mockRootDirectory"),
-//		//						},
-//		//					},
-//		//				},
-//		//			},
-//		//		}
-//		//		svc.Environments["test"].Storage = &Storage{
-//		//			Volumes: map[string]Volume{
-//		//				"mockVolume1": {
-//		//					EFS: &EFSConfigOrBool{
-//		//						Advanced: EFSVolumeConfiguration{
-//		//							UID: aws.Uint32(13),
-//		//						},
-//		//					},
-//		//				},
-//		//			},
-//		//		}
-//		//	},
-//		//	wanted: func(svc *LoadBalancedWebService) {
-//		//		svc.Storage = &Storage{
-//		//			Volumes: map[string]Volume{
-//		//				"mockVolume1": {
-//		//					EFS: &EFSConfigOrBool{
-//		//						Advanced: EFSVolumeConfiguration{
-//		//							RootDirectory: nil,
-//		//							UID:           aws.Uint32(13),
-//		//						},
-//		//					},
-//		//				},
-//		//			},
-//		//		}
-//		//	},
-//		//},
-//		//"FAILED TEST: exclusive fields: udi overridden if root_dir is not nil": {
-//		//	inSvc: func(svc *LoadBalancedWebService) {
-//		//		svc.Storage = &Storage{
-//		//			Volumes: map[string]Volume{
-//		//				"mockVolume1": {
-//		//					EFS: &EFSConfigOrBool{
-//		//						Advanced: EFSVolumeConfiguration{
-//		//							UID: aws.Uint32(13),
-//		//						},
-//		//					},
-//		//				},
-//		//			},
-//		//		}
-//		//		svc.Environments["test"].Storage = &Storage{
-//		//			Volumes: map[string]Volume{
-//		//				"mockVolume1": {
-//		//					EFS: &EFSConfigOrBool{
-//		//						Advanced: EFSVolumeConfiguration{
-//		//							RootDirectory: aws.String("mockRootDirectoryTest"),
-//		//						},
-//		//					},
-//		//				},
-//		//			},
-//		//		}
-//		//	},
-//		//	wanted: func(svc *LoadBalancedWebService) {
-//		//		svc.Storage = &Storage{
-//		//			Volumes: map[string]Volume{
-//		//				"mockVolume1": {
-//		//					EFS: &EFSConfigOrBool{
-//		//						Advanced: EFSVolumeConfiguration{
-//		//							RootDirectory: aws.String("mockRootDirectoryTest"),
-//		//							UID:           nil,
-//		//						},
-//		//					},
-//		//				},
-//		//			},
-//		//		}
-//		//	},
-//		//},
-//		//"FAILED TEST: exclusive fields: auth overridden if uid is not nil": {
-//		//	inSvc: func(svc *LoadBalancedWebService) {
-//		//		svc.Storage = &Storage{
-//		//			Volumes: map[string]Volume{
-//		//				"mockVolume1": {
-//		//					EFS: &EFSConfigOrBool{
-//		//						Advanced: EFSVolumeConfiguration{
-//		//							AuthConfig: &AuthorizationConfig{
-//		//								IAM:           aws.Bool(true),
-//		//								AccessPointID: aws.String("mockID1"),
-//		//							},
-//		//						},
-//		//					},
-//		//				},
-//		//			},
-//		//		}
-//		//		svc.Environments["test"].Storage = &Storage{
-//		//			Volumes: map[string]Volume{
-//		//				"mockVolume1": {
-//		//					EFS: &EFSConfigOrBool{
-//		//						Advanced: EFSVolumeConfiguration{
-//		//							UID: aws.Uint32(13),
-//		//						},
-//		//					},
-//		//				},
-//		//			},
-//		//		}
-//		//	},
-//		//	wanted: func(svc *LoadBalancedWebService) {
-//		//		svc.Storage = &Storage{
-//		//			Volumes: map[string]Volume{
-//		//				"mockVolume1": {
-//		//					EFS: &EFSConfigOrBool{
-//		//						Advanced: EFSVolumeConfiguration{
-//		//							UID:        aws.Uint32(13),
-//		//							AuthConfig: nil,
-//		//						},
-//		//					},
-//		//				},
-//		//			},
-//		//		}
-//		//	},
-//		//},
-//		//"FAILED TEST: exclusive fields: udi overridden if auth is not nil": {
-//		//	inSvc: func(svc *LoadBalancedWebService) {
-//		//		svc.Storage = &Storage{
-//		//			Volumes: map[string]Volume{
-//		//				"mockVolume1": {
-//		//					EFS: &EFSConfigOrBool{
-//		//						Advanced: EFSVolumeConfiguration{
-//		//							UID: aws.Uint32(13),
-//		//						},
-//		//					},
-//		//				},
-//		//			},
-//		//		}
-//		//		svc.Environments["test"].Storage = &Storage{
-//		//			Volumes: map[string]Volume{
-//		//				"mockVolume1": {
-//		//					EFS: &EFSConfigOrBool{
-//		//						Advanced: EFSVolumeConfiguration{
-//		//							AuthConfig: &AuthorizationConfig{
-//		//								IAM:           aws.Bool(true),
-//		//								AccessPointID: aws.String("mockIDTest"),
-//		//							},
-//		//						},
-//		//					},
-//		//				},
-//		//			},
-//		//		}
-//		//	},
-//		//	wanted: func(svc *LoadBalancedWebService) {
-//		//		svc.Storage = &Storage{
-//		//			Volumes: map[string]Volume{
-//		//				"mockVolume1": {
-//		//					EFS: &EFSConfigOrBool{
-//		//						Advanced: EFSVolumeConfiguration{
-//		//							UID: nil,
-//		//							AuthConfig: &AuthorizationConfig{
-//		//								IAM:           aws.Bool(true),
-//		//								AccessPointID: aws.String("mockIDTest"),
-//		//							},
-//		//						},
-//		//					},
-//		//				},
-//		//			},
-//		//		}
-//		//	},
-//		//},
-//		//"FAILED TEST: exclusive fields: id overridden if gid is not nil": {
-//		//	inSvc: func(svc *LoadBalancedWebService) {
-//		//		svc.Storage = &Storage{
-//		//			Volumes: map[string]Volume{
-//		//				"mockVolume1": {
-//		//					EFS: &EFSConfigOrBool{
-//		//						Advanced: EFSVolumeConfiguration{
-//		//							FileSystemID: aws.String("42"),
-//		//						},
-//		//					},
-//		//				},
-//		//			},
-//		//		}
-//		//		svc.Environments["test"].Storage = &Storage{
-//		//			Volumes: map[string]Volume{
-//		//				"mockVolume1": {
-//		//					EFS: &EFSConfigOrBool{
-//		//						Advanced: EFSVolumeConfiguration{
-//		//							GID: aws.Uint32(13),
-//		//						},
-//		//					},
-//		//				},
-//		//			},
-//		//		}
-//		//	},
-//		//	wanted: func(svc *LoadBalancedWebService) {
-//		//		svc.Storage = &Storage{
-//		//			Volumes: map[string]Volume{
-//		//				"mockVolume1": {
-//		//					EFS: &EFSConfigOrBool{
-//		//						Advanced: EFSVolumeConfiguration{
-//		//							FileSystemID: nil,
-//		//							GID:          aws.Uint32(13),
-//		//						},
-//		//					},
-//		//				},
-//		//			},
-//		//		}
-//		//	},
-//		//},
-//		//"FAILED TEST: exclusive fields: gid overridden if id is not nil": {
-//		//	inSvc: func(svc *LoadBalancedWebService) {
-//		//		svc.Storage = &Storage{
-//		//			Volumes: map[string]Volume{
-//		//				"mockVolume1": {
-//		//					EFS: &EFSConfigOrBool{
-//		//						Advanced: EFSVolumeConfiguration{
-//		//							GID: aws.Uint32(13),
-//		//						},
-//		//					},
-//		//				},
-//		//			},
-//		//		}
-//		//		svc.Environments["test"].Storage = &Storage{
-//		//			Volumes: map[string]Volume{
-//		//				"mockVolume1": {
-//		//					EFS: &EFSConfigOrBool{
-//		//						Advanced: EFSVolumeConfiguration{
-//		//							FileSystemID: aws.String("42"),
-//		//						},
-//		//					},
-//		//				},
-//		//			},
-//		//		}
-//		//	},
-//		//	wanted: func(svc *LoadBalancedWebService) {
-//		//		svc.Storage = &Storage{
-//		//			Volumes: map[string]Volume{
-//		//				"mockVolume1": {
-//		//					EFS: &EFSConfigOrBool{
-//		//						Advanced: EFSVolumeConfiguration{
-//		//							FileSystemID: aws.String("42"),
-//		//							GID:          nil,
-//		//						},
-//		//					},
-//		//				},
-//		//			},
-//		//		}
-//		//	},
-//		//},
-//		//"FAILED TEST: exclusive fields: root_dir overridden if gid is not nil": {
-//		//	inSvc: func(svc *LoadBalancedWebService) {
-//		//		svc.Storage = &Storage{
-//		//			Volumes: map[string]Volume{
-//		//				"mockVolume1": {
-//		//					EFS: &EFSConfigOrBool{
-//		//						Advanced: EFSVolumeConfiguration{
-//		//							RootDirectory: aws.String("mockRootDir"),
-//		//						},
-//		//					},
-//		//				},
-//		//			},
-//		//		}
-//		//		svc.Environments["test"].Storage = &Storage{
-//		//			Volumes: map[string]Volume{
-//		//				"mockVolume1": {
-//		//					EFS: &EFSConfigOrBool{
-//		//						Advanced: EFSVolumeConfiguration{
-//		//							GID: aws.Uint32(13),
-//		//						},
-//		//					},
-//		//				},
-//		//			},
-//		//		}
-//		//	},
-//		//	wanted: func(svc *LoadBalancedWebService) {
-//		//		svc.Storage = &Storage{
-//		//			Volumes: map[string]Volume{
-//		//				"mockVolume1": {
-//		//					EFS: &EFSConfigOrBool{
-//		//						Advanced: EFSVolumeConfiguration{
-//		//							RootDirectory: nil,
-//		//							GID:           aws.Uint32(13),
-//		//						},
-//		//					},
-//		//				},
-//		//			},
-//		//		}
-//		//	},
-//		//},
-//		//"FAILED TEST: exclusive fields: gid overridden if root_dir is not nil": {
-//		//	inSvc: func(svc *LoadBalancedWebService) {
-//		//		svc.Storage = &Storage{
-//		//			Volumes: map[string]Volume{
-//		//				"mockVolume1": {
-//		//					EFS: &EFSConfigOrBool{
-//		//						Advanced: EFSVolumeConfiguration{
-//		//							GID: aws.Uint32(13),
-//		//						},
-//		//					},
-//		//				},
-//		//			},
-//		//		}
-//		//		svc.Environments["test"].Storage = &Storage{
-//		//			Volumes: map[string]Volume{
-//		//				"mockVolume1": {
-//		//					EFS: &EFSConfigOrBool{
-//		//						Advanced: EFSVolumeConfiguration{
-//		//							RootDirectory: aws.String("mockRootDirTest"),
-//		//						},
-//		//					},
-//		//				},
-//		//			},
-//		//		}
-//		//	},
-//		//	wanted: func(svc *LoadBalancedWebService) {
-//		//		svc.Storage = &Storage{
-//		//			Volumes: map[string]Volume{
-//		//				"mockVolume1": {
-//		//					EFS: &EFSConfigOrBool{
-//		//						Advanced: EFSVolumeConfiguration{
-//		//							RootDirectory: aws.String("mockRootDirTest"),
-//		//							GID:           nil,
-//		//						},
-//		//					},
-//		//				},
-//		//			},
-//		//		}
-//		//	},
-//		//},
-//		//"FAILED TEST: exclusive fields: auth overridden if gid is not nil": {
-//		//	inSvc: func(svc *LoadBalancedWebService) {
-//		//		svc.Storage = &Storage{
-//		//			Volumes: map[string]Volume{
-//		//				"mockVolume1": {
-//		//					EFS: &EFSConfigOrBool{
-//		//						Advanced: EFSVolumeConfiguration{
-//		//							AuthConfig: &AuthorizationConfig{
-//		//								IAM:           aws.Bool(true),
-//		//								AccessPointID: aws.String("mockID1"),
-//		//							},
-//		//						},
-//		//					},
-//		//				},
-//		//			},
-//		//		}
-//		//		svc.Environments["test"].Storage = &Storage{
-//		//			Volumes: map[string]Volume{
-//		//				"mockVolume1": {
-//		//					EFS: &EFSConfigOrBool{
-//		//						Advanced: EFSVolumeConfiguration{
-//		//							GID: aws.Uint32(13),
-//		//						},
-//		//					},
-//		//				},
-//		//			},
-//		//		}
-//		//	},
-//		//	wanted: func(svc *LoadBalancedWebService) {
-//		//		svc.Storage = &Storage{
-//		//			Volumes: map[string]Volume{
-//		//				"mockVolume1": {
-//		//					EFS: &EFSConfigOrBool{
-//		//						Advanced: EFSVolumeConfiguration{
-//		//							AuthConfig: nil,
-//		//							GID:        aws.Uint32(13),
-//		//						},
-//		//					},
-//		//				},
-//		//			},
-//		//		}
-//		//	},
-//		//},
-//		//"FAILED TEST: exclusive fields: gid overridden if auth is not nil": {
-//		//	inSvc: func(svc *LoadBalancedWebService) {
-//		//		svc.Storage = &Storage{
-//		//			Volumes: map[string]Volume{
-//		//				"mockVolume1": {
-//		//					EFS: &EFSConfigOrBool{
-//		//						Advanced: EFSVolumeConfiguration{
-//		//							GID: aws.Uint32(13),
-//		//						},
-//		//					},
-//		//				},
-//		//			},
-//		//		}
-//		//		svc.Environments["test"].Storage = &Storage{
-//		//			Volumes: map[string]Volume{
-//		//				"mockVolume1": {
-//		//					EFS: &EFSConfigOrBool{
-//		//						Advanced: EFSVolumeConfiguration{
-//		//							AuthConfig: &AuthorizationConfig{
-//		//								IAM:           aws.Bool(true),
-//		//								AccessPointID: aws.String("mockID1"),
-//		//							},
-//		//						},
-//		//					},
-//		//				},
-//		//			},
-//		//		}
-//		//	},
-//		//	wanted: func(svc *LoadBalancedWebService) {
-//		//		svc.Storage = &Storage{
-//		//			Volumes: map[string]Volume{
-//		//				"mockVolume1": {
-//		//					EFS: &EFSConfigOrBool{
-//		//						Advanced: EFSVolumeConfiguration{
-//		//							AuthConfig: &AuthorizationConfig{
-//		//								IAM:           aws.Bool(true),
-//		//								AccessPointID: aws.String("mockID1"),
-//		//							},
-//		//							GID: nil,
-//		//						},
-//		//					},
-//		//				},
-//		//			},
-//		//		}
-//		//	},
-//		//},
-//		"id overridden": {
-//			inSvc: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									FileSystemID: aws.String("mockID"),
-//								},
-//							},
-//						},
-//					},
-//				}
-//				svc.Environments["test"].Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									FileSystemID: aws.String("mockIDTest"),
-//								},
-//							},
-//						},
-//					},
-//				}
-//			},
-//			wanted: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									FileSystemID: aws.String("mockIDTest"),
-//								},
-//							},
-//						},
-//					},
-//				}
-//			},
-//		},
-//		"id explicitly overridden by zero value": {
-//			inSvc: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									FileSystemID: aws.String("mockID"),
-//								},
-//							},
-//						},
-//					},
-//				}
-//				svc.Environments["test"].Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									FileSystemID: aws.String(""),
-//								},
-//							},
-//						},
-//					},
-//				}
-//			},
-//			wanted: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									FileSystemID: aws.String(""),
-//								},
-//							},
-//						},
-//					},
-//				}
-//			},
-//		},
-//		"FAILED_AFTER_UPGRADE: id not overridden": {
-//			inSvc: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									FileSystemID: aws.String("mockID"),
-//								},
-//							},
-//						},
-//					},
-//				}
-//				svc.Environments["test"].Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{},
-//							},
-//						},
-//					},
-//				}
-//			},
-//			wanted: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									FileSystemID: aws.String("mockID"),
-//								},
-//							},
-//						},
-//					},
-//				}
-//			},
-//		},
-//		"root_dir overridden": {
-//			inSvc: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									RootDirectory: aws.String("mockDir"),
-//								},
-//							},
-//						},
-//					},
-//				}
-//				svc.Environments["test"].Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									RootDirectory: aws.String("mockDirTest"),
-//								},
-//							},
-//						},
-//					},
-//				}
-//			},
-//			wanted: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									RootDirectory: aws.String("mockDirTest"),
-//								},
-//							},
-//						},
-//					},
-//				}
-//			},
-//		},
-//		"root_dir explicitly overridden by empty value": {
-//			inSvc: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									RootDirectory: aws.String("mockDir"),
-//								},
-//							},
-//						},
-//					},
-//				}
-//				svc.Environments["test"].Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									RootDirectory: aws.String(""),
-//								},
-//							},
-//						},
-//					},
-//				}
-//			},
-//			wanted: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									RootDirectory: aws.String(""),
-//								},
-//							},
-//						},
-//					},
-//				}
-//			},
-//		},
-//		"FAILED_AFTER_UPGRADE: root_dir not overridden": {
-//			inSvc: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									RootDirectory: aws.String("mockDir"),
-//								},
-//							},
-//						},
-//					},
-//				}
-//				svc.Environments["test"].Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{},
-//							},
-//						},
-//					},
-//				}
-//			},
-//			wanted: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									RootDirectory: aws.String("mockDir"),
-//								},
-//							},
-//						},
-//					},
-//				}
-//			},
-//		},
-//		"uid overridden": {
-//			inSvc: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									UID: aws.Uint32(13),
-//								},
-//							},
-//						},
-//					},
-//				}
-//				svc.Environments["test"].Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									UID: aws.Uint32(42),
-//								},
-//							},
-//						},
-//					},
-//				}
-//			},
-//			wanted: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									UID: aws.Uint32(42),
-//								},
-//							},
-//						},
-//					},
-//				}
-//			},
-//		},
-//		"uid explicitly overridden by empty value": {
-//			inSvc: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									UID: aws.Uint32(13),
-//								},
-//							},
-//						},
-//					},
-//				}
-//				svc.Environments["test"].Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									UID: aws.Uint32(0),
-//								},
-//							},
-//						},
-//					},
-//				}
-//			},
-//			wanted: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									UID: aws.Uint32(0),
-//								},
-//							},
-//						},
-//					},
-//				}
-//			},
-//		},
-//		"FAILED_AFTER_UPGRADE: uid not overridden": {
-//			inSvc: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									UID: aws.Uint32(13),
-//								},
-//							},
-//						},
-//					},
-//				}
-//				svc.Environments["test"].Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{},
-//							},
-//						},
-//					},
-//				}
-//			},
-//			wanted: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									UID: aws.Uint32(13),
-//								},
-//							},
-//						},
-//					},
-//				}
-//			},
-//		},
-//		"gid overridden": {
-//			inSvc: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									GID: aws.Uint32(13),
-//								},
-//							},
-//						},
-//					},
-//				}
-//				svc.Environments["test"].Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									GID: aws.Uint32(42),
-//								},
-//							},
-//						},
-//					},
-//				}
-//			},
-//			wanted: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									GID: aws.Uint32(42),
-//								},
-//							},
-//						},
-//					},
-//				}
-//			},
-//		},
-//		"gid explicitly overridden by empty value": {
-//			inSvc: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									GID: aws.Uint32(13),
-//								},
-//							},
-//						},
-//					},
-//				}
-//				svc.Environments["test"].Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									GID: aws.Uint32(0),
-//								},
-//							},
-//						},
-//					},
-//				}
-//			},
-//			wanted: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									GID: aws.Uint32(0),
-//								},
-//							},
-//						},
-//					},
-//				}
-//			},
-//		},
-//		"FAILED_AFTER_UPGRADE: gid not overridden": {
-//			inSvc: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									GID: aws.Uint32(13),
-//								},
-//							},
-//						},
-//					},
-//				}
-//				svc.Environments["test"].Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{},
-//							},
-//						},
-//					},
-//				}
-//			},
-//			wanted: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									GID: aws.Uint32(13),
-//								},
-//							},
-//						},
-//					},
-//				}
-//			},
-//		},
-//		"auth overridden": {
-//			inSvc: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									AuthConfig: &AuthorizationConfig{
-//										AccessPointID: aws.String("mockPoint"),
-//									},
-//								},
-//							},
-//						},
-//					},
-//				}
-//				svc.Environments["test"].Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									AuthConfig: &AuthorizationConfig{
-//										IAM:           aws.Bool(true),
-//										AccessPointID: aws.String("mockPointTest"),
-//									},
-//								},
-//							},
-//						},
-//					},
-//				}
-//			},
-//			wanted: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									AuthConfig: &AuthorizationConfig{
-//										IAM:           aws.Bool(true),
-//										AccessPointID: aws.String("mockPointTest"),
-//									},
-//								},
-//							},
-//						},
-//					},
-//				}
-//			},
-//		},
-//		"FAILED_AFTER_UPGRADE: auth not overridden": {
-//			inSvc: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									AuthConfig: &AuthorizationConfig{
-//										AccessPointID: aws.String("mockPoint"),
-//									},
-//								},
-//							},
-//						},
-//					},
-//				}
-//				svc.Environments["test"].Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{},
-//							},
-//						},
-//					},
-//				}
-//			},
-//			wanted: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									AuthConfig: &AuthorizationConfig{
-//										AccessPointID: aws.String("mockPoint"),
-//									},
-//								},
-//							},
-//						},
-//					},
-//				}
-//			},
-//		},
-//	}
-//	for name, tc := range testCases {
-//		t.Run(name, func(t *testing.T) {
-//			var inSvc, wantedSvc LoadBalancedWebService
-//			inSvc.Environments = map[string]*LoadBalancedWebServiceConfig{
-//				"test": {},
-//			}
-//
-//			tc.inSvc(&inSvc)
-//			tc.wanted(&wantedSvc)
-//
-//			got, err := inSvc.ApplyEnv("test")
-//
-//			require.NoError(t, err)
-//			require.Equal(t, &wantedSvc, got)
-//		})
-//	}
-//}
-//
-//func Test_ApplyEnv_Storage_Volume_EFS_Auth(t *testing.T) {
-//	testCases := map[string]struct {
-//		inSvc  func(svc *LoadBalancedWebService)
-//		wanted func(svc *LoadBalancedWebService)
-//	}{
-//		"iam overridden": {
-//			inSvc: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									AuthConfig: &AuthorizationConfig{
-//										IAM: aws.Bool(false),
-//									},
-//								},
-//							},
-//						},
-//					},
-//				}
-//				svc.Environments["test"].Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									AuthConfig: &AuthorizationConfig{
-//										IAM: aws.Bool(true),
-//									},
-//								},
-//							},
-//						},
-//					},
-//				}
-//			},
-//			wanted: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									AuthConfig: &AuthorizationConfig{
-//										IAM: aws.Bool(true),
-//									},
-//								},
-//							},
-//						},
-//					},
-//				}
-//			},
-//		},
-//		"iam explicitly overridden by empty value": {
-//			inSvc: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									AuthConfig: &AuthorizationConfig{
-//										IAM: aws.Bool(true),
-//									},
-//								},
-//							},
-//						},
-//					},
-//				}
-//				svc.Environments["test"].Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									AuthConfig: &AuthorizationConfig{
-//										IAM: aws.Bool(false),
-//									},
-//								},
-//							},
-//						},
-//					},
-//				}
-//			},
-//			wanted: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									AuthConfig: &AuthorizationConfig{
-//										IAM: aws.Bool(false),
-//									},
-//								},
-//							},
-//						},
-//					},
-//				}
-//			},
-//		},
-//		"FAILED_AFTER_UPGRADE: iam not overridden": {
-//			inSvc: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									AuthConfig: &AuthorizationConfig{
-//										IAM: aws.Bool(true),
-//									},
-//								},
-//							},
-//						},
-//					},
-//				}
-//				svc.Environments["test"].Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									AuthConfig: &AuthorizationConfig{},
-//								},
-//							},
-//						},
-//					},
-//				}
-//			},
-//			wanted: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									AuthConfig: &AuthorizationConfig{
-//										IAM: aws.Bool(true),
-//									},
-//								},
-//							},
-//						},
-//					},
-//				}
-//			},
-//		},
-//		"access_point_id overridden": {
-//			inSvc: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									AuthConfig: &AuthorizationConfig{
-//										AccessPointID: aws.String("mockPoint"),
-//									},
-//								},
-//							},
-//						},
-//					},
-//				}
-//				svc.Environments["test"].Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									AuthConfig: &AuthorizationConfig{
-//										AccessPointID: aws.String("mockPointTest"),
-//									},
-//								},
-//							},
-//						},
-//					},
-//				}
-//			},
-//			wanted: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									AuthConfig: &AuthorizationConfig{
-//										AccessPointID: aws.String("mockPointTest"),
-//									},
-//								},
-//							},
-//						},
-//					},
-//				}
-//			},
-//		},
-//		"access_point_id explicitly overridden by empty value": {
-//			inSvc: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									AuthConfig: &AuthorizationConfig{
-//										AccessPointID: aws.String("mockPoint"),
-//									},
-//								},
-//							},
-//						},
-//					},
-//				}
-//				svc.Environments["test"].Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									AuthConfig: &AuthorizationConfig{
-//										AccessPointID: aws.String(""),
-//									},
-//								},
-//							},
-//						},
-//					},
-//				}
-//			},
-//			wanted: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									AuthConfig: &AuthorizationConfig{
-//										AccessPointID: aws.String(""),
-//									},
-//								},
-//							},
-//						},
-//					},
-//				}
-//			},
-//		},
-//		"FAILED_AFTER_UPGRADE: access_point_id not overridden": {
-//			inSvc: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									AuthConfig: &AuthorizationConfig{
-//										AccessPointID: aws.String("mockPoint"),
-//									},
-//								},
-//							},
-//						},
-//					},
-//				}
-//				svc.Environments["test"].Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									AuthConfig: &AuthorizationConfig{},
-//								},
-//							},
-//						},
-//					},
-//				}
-//			},
-//			wanted: func(svc *LoadBalancedWebService) {
-//				svc.Storage = &Storage{
-//					Volumes: map[string]Volume{
-//						"mockVolume1": {
-//							EFS: &EFSConfigOrBool{
-//								Advanced: EFSVolumeConfiguration{
-//									AuthConfig: &AuthorizationConfig{
-//										AccessPointID: aws.String("mockPoint"),
-//									},
-//								},
-//							},
-//						},
-//					},
-//				}
-//			},
-//		},
-//	}
-//	for name, tc := range testCases {
-//		t.Run(name, func(t *testing.T) {
-//			var inSvc, wantedSvc LoadBalancedWebService
-//			inSvc.Environments = map[string]*LoadBalancedWebServiceConfig{
-//				"test": {},
-//			}
-//
-//			tc.inSvc(&inSvc)
-//			tc.wanted(&wantedSvc)
-//
-//			got, err := inSvc.ApplyEnv("test")
-//
-//			require.NoError(t, err)
-//			require.Equal(t, &wantedSvc, got)
-//		})
-//	}
-//}
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ApplyEnv_Storage(t *testing.T) {
+	testCases := map[string]struct {
+		inSvc  func(svc *LoadBalancedWebService)
+		wanted func(svc *LoadBalancedWebService)
+	}{
+		"ephemeral overridden": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Ephemeral: aws.Int(1),
+				}
+				svc.Environments["test"].Storage = &Storage{
+					Ephemeral: aws.Int(3),
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Ephemeral: aws.Int(3),
+				}
+			},
+		},
+		"ephemeral explicitly overridden by zero value": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Ephemeral: aws.Int(1),
+				}
+				svc.Environments["test"].Storage = &Storage{
+					Ephemeral: aws.Int(0),
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Ephemeral: aws.Int(0),
+				}
+			},
+		},
+		"FIXED_AFTER_TRANSFORM_POINTER: ephemeral not overridden": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Ephemeral: aws.Int(1),
+				}
+				svc.Environments["test"].Storage = &Storage{}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Ephemeral: aws.Int(1),
+				}
+			},
+		},
+		//"FAILED TEST: volumes overridden": {
+		//	inSvc: func(svc *LoadBalancedWebService) {
+		//		svc.Storage = &Storage{
+		//			Volumes: map[string]Volume{
+		//				"mockVolume1": {
+		//					MountPointOpts: MountPointOpts{
+		//						ReadOnly: aws.Bool(true),
+		//					},
+		//				},
+		//				"mockVolume2": {
+		//					EFS: &EFSConfigOrBool{
+		//						Enabled: aws.Bool(true),
+		//					},
+		//				},
+		//			},
+		//		}
+		//		svc.Environments["test"].Storage = &Storage{
+		//			Volumes: map[string]Volume{
+		//				"mockVolume1": {
+		//					EFS: &EFSConfigOrBool{
+		//						Enabled: aws.Bool(true),
+		//					},
+		//				}, // Modify the value for mockVolume1.
+		//				"mockVolume3": {
+		//					MountPointOpts: MountPointOpts{
+		//						ReadOnly: aws.Bool(true),
+		//					},
+		//				}, // Append mockVolume3.
+		//			},
+		//		}
+		//	},
+		//	wanted: func(svc *LoadBalancedWebService) {
+		//		svc.Storage = &Storage{
+		//			Volumes: map[string]Volume{
+		//				"mockVolume1": {
+		//					EFS: &EFSConfigOrBool{
+		//						Enabled: aws.Bool(true),
+		//					},
+		//				},
+		//				"mockVolume2": {
+		//					EFS: &EFSConfigOrBool{
+		//						Enabled: aws.Bool(true),
+		//					},
+		//				},
+		//				"mockVolume3": {
+		//					MountPointOpts: MountPointOpts{
+		//						ReadOnly: aws.Bool(true),
+		//					},
+		//				},
+		//			},
+		//		}
+		//	},
+		//},
+		"volumes not overridden by empty map": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							MountPointOpts: MountPointOpts{
+								ReadOnly: aws.Bool(true),
+							},
+						},
+						"mockVolume2": {
+							EFS: &EFSConfigOrBool{
+								Enabled: aws.Bool(true),
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Storage = &Storage{
+					Volumes: map[string]Volume{},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							MountPointOpts: MountPointOpts{
+								ReadOnly: aws.Bool(true),
+							},
+						},
+						"mockVolume2": {
+							EFS: &EFSConfigOrBool{
+								Enabled: aws.Bool(true),
+							},
+						},
+					},
+				}
+			},
+		},
+		"volumes not overridden by nil": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							MountPointOpts: MountPointOpts{
+								ReadOnly: aws.Bool(true),
+							},
+						},
+						"mockVolume2": {
+							EFS: &EFSConfigOrBool{
+								Enabled: aws.Bool(true),
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Storage = &Storage{}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							MountPointOpts: MountPointOpts{
+								ReadOnly: aws.Bool(true),
+							},
+						},
+						"mockVolume2": {
+							EFS: &EFSConfigOrBool{
+								Enabled: aws.Bool(true),
+							},
+						},
+					},
+				}
+			},
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			var inSvc, wantedSvc LoadBalancedWebService
+			inSvc.Environments = map[string]*LoadBalancedWebServiceConfig{
+				"test": {},
+			}
+
+			tc.inSvc(&inSvc)
+			tc.wanted(&wantedSvc)
+
+			got, err := inSvc.ApplyEnv("test")
+
+			require.NoError(t, err)
+			require.Equal(t, &wantedSvc, got)
+		})
+	}
+}
+
+func Test_ApplyEnv_Storage_Volume(t *testing.T) {
+	testCases := map[string]struct {
+		inSvc  func(svc *LoadBalancedWebService)
+		wanted func(svc *LoadBalancedWebService)
+	}{
+		"FAILED_AFTER_TRANSFORM_POINTER: path overridden": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							MountPointOpts: MountPointOpts{
+								ContainerPath: aws.String("mockPath"),
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							MountPointOpts: MountPointOpts{
+								ContainerPath: aws.String("mockPathTest"),
+							},
+						},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							MountPointOpts: MountPointOpts{
+								ContainerPath: aws.String("mockPathTest"),
+							},
+						},
+					},
+				}
+			},
+		},
+		"FAILED_AFTER_TRANSFORM_POINTER： path explicitly overridden by zero value": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							MountPointOpts: MountPointOpts{
+								ContainerPath: aws.String("mockPath"),
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							MountPointOpts: MountPointOpts{
+								ContainerPath: aws.String(""),
+							},
+						},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							MountPointOpts: MountPointOpts{
+								ContainerPath: aws.String(""),
+							},
+						},
+					},
+				}
+			},
+		},
+		"FAILED_AFTER_UPGRADE: path not overridden": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							MountPointOpts: MountPointOpts{
+								ContainerPath: aws.String("mockPath"),
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							MountPointOpts: MountPointOpts{},
+						},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							MountPointOpts: MountPointOpts{
+								ContainerPath: aws.String("mockPath"),
+							},
+						},
+					},
+				}
+			},
+		},
+		"read_only overridden": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							MountPointOpts: MountPointOpts{
+								ReadOnly: aws.Bool(false),
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							MountPointOpts: MountPointOpts{
+								ReadOnly: aws.Bool(true),
+							},
+						},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							MountPointOpts: MountPointOpts{
+								ReadOnly: aws.Bool(true),
+							},
+						},
+					},
+				}
+			},
+		},
+		"read_only explicitly overridden by empty value": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							MountPointOpts: MountPointOpts{
+								ReadOnly: aws.Bool(true),
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							MountPointOpts: MountPointOpts{
+								ReadOnly: aws.Bool(false),
+							},
+						},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							MountPointOpts: MountPointOpts{
+								ReadOnly: aws.Bool(false),
+							},
+						},
+					},
+				}
+			},
+		},
+		"FAILED_AFTER_UPGRADE: read_only not overridden": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							MountPointOpts: MountPointOpts{
+								ReadOnly: aws.Bool(true),
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							MountPointOpts: MountPointOpts{},
+						},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							MountPointOpts: MountPointOpts{
+								ReadOnly: aws.Bool(true),
+							},
+						},
+					},
+				}
+			},
+		},
+		"efs overridden": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									FileSystemID: aws.String("mockFileSystem"),
+								},
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									RootDirectory: aws.String("mockRootDirTest"),
+									FileSystemID:  aws.String("mockFileSystemTest"),
+								},
+							},
+						},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									RootDirectory: aws.String("mockRootDirTest"),
+									FileSystemID:  aws.String("mockFileSystemTest"),
+								},
+							},
+						},
+					},
+				}
+			},
+		},
+		"FAILED_AFTER_UPGRADE: efs not overridden": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									FileSystemID: aws.String("mockFileSystem"),
+								},
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									FileSystemID: aws.String("mockFileSystem"),
+								},
+							},
+						},
+					},
+				}
+			},
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			var inSvc, wantedSvc LoadBalancedWebService
+			inSvc.Environments = map[string]*LoadBalancedWebServiceConfig{
+				"test": {},
+			}
+
+			tc.inSvc(&inSvc)
+			tc.wanted(&wantedSvc)
+
+			got, err := inSvc.ApplyEnv("test")
+
+			require.NoError(t, err)
+			require.Equal(t, &wantedSvc, got)
+		})
+	}
+}
+
+func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
+	testCases := map[string]struct {
+		inSvc  func(svc *LoadBalancedWebService)
+		wanted func(svc *LoadBalancedWebService)
+	}{
+		//"FAILED TEST: composite fields: efs bool is overridden if efs config is not nil": {
+		//	inSvc: func(svc *LoadBalancedWebService) {
+		//		svc.Storage = &Storage{
+		//			Volumes: map[string]Volume{
+		//				"mockVolume1": {
+		//					EFS: &EFSConfigOrBool{
+		//						Enabled: aws.Bool(true),
+		//					},
+		//				},
+		//			},
+		//		}
+		//		svc.Environments["test"].Storage = &Storage{
+		//			Volumes: map[string]Volume{
+		//				"mockVolume1": {
+		//					EFS: &EFSConfigOrBool{
+		//						Advanced: EFSVolumeConfiguration{
+		//							RootDirectory: aws.String("mockRootDirTest"),
+		//							FileSystemID:  aws.String("mockFileSystemTest"),
+		//						},
+		//					},
+		//				},
+		//			},
+		//		}
+		//	},
+		//	wanted: func(svc *LoadBalancedWebService) {
+		//		svc.Storage = &Storage{
+		//			Volumes: map[string]Volume{
+		//				"mockVolume1": {
+		//					EFS: &EFSConfigOrBool{
+		//						Enabled: nil,
+		//						Advanced: EFSVolumeConfiguration{
+		//							RootDirectory: aws.String("mockRootDirTest"),
+		//							FileSystemID:  aws.String("mockFileSystemTest"),
+		//						},
+		//					},
+		//				},
+		//			},
+		//		}
+		//	},
+		//},
+		//"FAILED TEST: composite fields: efs config is overridden if efs bool is not nil": {
+		//	inSvc: func(svc *LoadBalancedWebService) {
+		//		svc.Storage = &Storage{
+		//			Volumes: map[string]Volume{
+		//				"mockVolume1": {
+		//					EFS: &EFSConfigOrBool{
+		//						Advanced: EFSVolumeConfiguration{
+		//							RootDirectory: aws.String("mockRootDir"),
+		//							FileSystemID:  aws.String("mockFileSystem"),
+		//						},
+		//					},
+		//				},
+		//			},
+		//		}
+		//		svc.Environments["test"].Storage = &Storage{
+		//			Volumes: map[string]Volume{
+		//				"mockVolume1": {
+		//					EFS: &EFSConfigOrBool{
+		//						Enabled: aws.Bool(true),
+		//					},
+		//				},
+		//			},
+		//		}
+		//	},
+		//	wanted: func(svc *LoadBalancedWebService) {
+		//		svc.Storage = &Storage{
+		//			Volumes: map[string]Volume{
+		//				"mockVolume1": {
+		//					EFS: &EFSConfigOrBool{
+		//						Enabled:  aws.Bool(true),
+		//						Advanced: EFSVolumeConfiguration{},
+		//					},
+		//				},
+		//			},
+		//		}
+		//	},
+		//},
+		"efs bool overridden": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Enabled: aws.Bool(false),
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Enabled: aws.Bool(true),
+							},
+						},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Enabled: aws.Bool(true),
+							},
+						},
+					},
+				}
+			},
+		},
+		"efs bool explicitly overridden by zero value": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Enabled: aws.Bool(true),
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Enabled: aws.Bool(false),
+							},
+						},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Enabled: aws.Bool(false),
+							},
+						},
+					},
+				}
+			},
+		},
+		"FAILED_AFTER_UPGRADE: efs bool not overridden": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Enabled: aws.Bool(true),
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Enabled: aws.Bool(true),
+							},
+						},
+					},
+				}
+			},
+		},
+		"efs config overridden": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									FileSystemID: aws.String("mockFileSystem"),
+								},
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									RootDirectory: aws.String("mockRootDirTest"),
+									FileSystemID:  aws.String("mockFileSystemTest"),
+									UID:           aws.Uint32(42),
+								},
+							},
+						},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									RootDirectory: aws.String("mockRootDirTest"),
+									FileSystemID:  aws.String("mockFileSystemTest"),
+									UID:           aws.Uint32(42),
+								},
+							},
+						},
+					},
+				}
+			},
+		},
+		"FAILED_AFTER_UPGRADE: efs config not overridden": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									FileSystemID: aws.String("mockFileSystem"),
+								},
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									FileSystemID: aws.String("mockFileSystem"),
+								},
+							},
+						},
+					},
+				}
+			},
+		},
+		//"FAILED TEST: exclusive fields: id overridden if uid is not nil": {
+		//	inSvc: func(svc *LoadBalancedWebService) {
+		//		svc.Storage = &Storage{
+		//			Volumes: map[string]Volume{
+		//				"mockVolume1": {
+		//					EFS: &EFSConfigOrBool{
+		//						Advanced: EFSVolumeConfiguration{
+		//							FileSystemID: aws.String("42"),
+		//						},
+		//					},
+		//				},
+		//			},
+		//		}
+		//		svc.Environments["test"].Storage = &Storage{
+		//			Volumes: map[string]Volume{
+		//				"mockVolume1": {
+		//					EFS: &EFSConfigOrBool{
+		//						Advanced: EFSVolumeConfiguration{
+		//							UID: aws.Uint32(13),
+		//						},
+		//					},
+		//				},
+		//			},
+		//		}
+		//	},
+		//	wanted: func(svc *LoadBalancedWebService) {
+		//		svc.Storage = &Storage{
+		//			Volumes: map[string]Volume{
+		//				"mockVolume1": {
+		//					EFS: &EFSConfigOrBool{
+		//						Advanced: EFSVolumeConfiguration{
+		//							FileSystemID: nil,
+		//							UID:          aws.Uint32(13),
+		//						},
+		//					},
+		//				},
+		//			},
+		//		}
+		//	},
+		//},
+		//"FAILED TEST: exclusive fields: uid overridden if id is not nil": {
+		//	inSvc: func(svc *LoadBalancedWebService) {
+		//		svc.Storage = &Storage{
+		//			Volumes: map[string]Volume{
+		//				"mockVolume1": {
+		//					EFS: &EFSConfigOrBool{
+		//						Advanced: EFSVolumeConfiguration{
+		//							UID: aws.Uint32(13),
+		//						},
+		//					},
+		//				},
+		//			},
+		//		}
+		//		svc.Environments["test"].Storage = &Storage{
+		//			Volumes: map[string]Volume{
+		//				"mockVolume1": {
+		//					EFS: &EFSConfigOrBool{
+		//						Advanced: EFSVolumeConfiguration{
+		//							FileSystemID: aws.String("42"),
+		//						},
+		//					},
+		//				},
+		//			},
+		//		}
+		//	},
+		//	wanted: func(svc *LoadBalancedWebService) {
+		//		svc.Storage = &Storage{
+		//			Volumes: map[string]Volume{
+		//				"mockVolume1": {
+		//					EFS: &EFSConfigOrBool{
+		//						Advanced: EFSVolumeConfiguration{
+		//							FileSystemID: aws.String("42"),
+		//							UID:          nil,
+		//						},
+		//					},
+		//				},
+		//			},
+		//		}
+		//	},
+		//},
+		//"FAILED TEST: exclusive fields: root_dir overridden if uid is not nil": {
+		//	inSvc: func(svc *LoadBalancedWebService) {
+		//		svc.Storage = &Storage{
+		//			Volumes: map[string]Volume{
+		//				"mockVolume1": {
+		//					EFS: &EFSConfigOrBool{
+		//						Advanced: EFSVolumeConfiguration{
+		//							RootDirectory: aws.String("mockRootDirectory"),
+		//						},
+		//					},
+		//				},
+		//			},
+		//		}
+		//		svc.Environments["test"].Storage = &Storage{
+		//			Volumes: map[string]Volume{
+		//				"mockVolume1": {
+		//					EFS: &EFSConfigOrBool{
+		//						Advanced: EFSVolumeConfiguration{
+		//							UID: aws.Uint32(13),
+		//						},
+		//					},
+		//				},
+		//			},
+		//		}
+		//	},
+		//	wanted: func(svc *LoadBalancedWebService) {
+		//		svc.Storage = &Storage{
+		//			Volumes: map[string]Volume{
+		//				"mockVolume1": {
+		//					EFS: &EFSConfigOrBool{
+		//						Advanced: EFSVolumeConfiguration{
+		//							RootDirectory: nil,
+		//							UID:           aws.Uint32(13),
+		//						},
+		//					},
+		//				},
+		//			},
+		//		}
+		//	},
+		//},
+		//"FAILED TEST: exclusive fields: udi overridden if root_dir is not nil": {
+		//	inSvc: func(svc *LoadBalancedWebService) {
+		//		svc.Storage = &Storage{
+		//			Volumes: map[string]Volume{
+		//				"mockVolume1": {
+		//					EFS: &EFSConfigOrBool{
+		//						Advanced: EFSVolumeConfiguration{
+		//							UID: aws.Uint32(13),
+		//						},
+		//					},
+		//				},
+		//			},
+		//		}
+		//		svc.Environments["test"].Storage = &Storage{
+		//			Volumes: map[string]Volume{
+		//				"mockVolume1": {
+		//					EFS: &EFSConfigOrBool{
+		//						Advanced: EFSVolumeConfiguration{
+		//							RootDirectory: aws.String("mockRootDirectoryTest"),
+		//						},
+		//					},
+		//				},
+		//			},
+		//		}
+		//	},
+		//	wanted: func(svc *LoadBalancedWebService) {
+		//		svc.Storage = &Storage{
+		//			Volumes: map[string]Volume{
+		//				"mockVolume1": {
+		//					EFS: &EFSConfigOrBool{
+		//						Advanced: EFSVolumeConfiguration{
+		//							RootDirectory: aws.String("mockRootDirectoryTest"),
+		//							UID:           nil,
+		//						},
+		//					},
+		//				},
+		//			},
+		//		}
+		//	},
+		//},
+		//"FAILED TEST: exclusive fields: auth overridden if uid is not nil": {
+		//	inSvc: func(svc *LoadBalancedWebService) {
+		//		svc.Storage = &Storage{
+		//			Volumes: map[string]Volume{
+		//				"mockVolume1": {
+		//					EFS: &EFSConfigOrBool{
+		//						Advanced: EFSVolumeConfiguration{
+		//							AuthConfig: &AuthorizationConfig{
+		//								IAM:           aws.Bool(true),
+		//								AccessPointID: aws.String("mockID1"),
+		//							},
+		//						},
+		//					},
+		//				},
+		//			},
+		//		}
+		//		svc.Environments["test"].Storage = &Storage{
+		//			Volumes: map[string]Volume{
+		//				"mockVolume1": {
+		//					EFS: &EFSConfigOrBool{
+		//						Advanced: EFSVolumeConfiguration{
+		//							UID: aws.Uint32(13),
+		//						},
+		//					},
+		//				},
+		//			},
+		//		}
+		//	},
+		//	wanted: func(svc *LoadBalancedWebService) {
+		//		svc.Storage = &Storage{
+		//			Volumes: map[string]Volume{
+		//				"mockVolume1": {
+		//					EFS: &EFSConfigOrBool{
+		//						Advanced: EFSVolumeConfiguration{
+		//							UID:        aws.Uint32(13),
+		//							AuthConfig: nil,
+		//						},
+		//					},
+		//				},
+		//			},
+		//		}
+		//	},
+		//},
+		//"FAILED TEST: exclusive fields: udi overridden if auth is not nil": {
+		//	inSvc: func(svc *LoadBalancedWebService) {
+		//		svc.Storage = &Storage{
+		//			Volumes: map[string]Volume{
+		//				"mockVolume1": {
+		//					EFS: &EFSConfigOrBool{
+		//						Advanced: EFSVolumeConfiguration{
+		//							UID: aws.Uint32(13),
+		//						},
+		//					},
+		//				},
+		//			},
+		//		}
+		//		svc.Environments["test"].Storage = &Storage{
+		//			Volumes: map[string]Volume{
+		//				"mockVolume1": {
+		//					EFS: &EFSConfigOrBool{
+		//						Advanced: EFSVolumeConfiguration{
+		//							AuthConfig: &AuthorizationConfig{
+		//								IAM:           aws.Bool(true),
+		//								AccessPointID: aws.String("mockIDTest"),
+		//							},
+		//						},
+		//					},
+		//				},
+		//			},
+		//		}
+		//	},
+		//	wanted: func(svc *LoadBalancedWebService) {
+		//		svc.Storage = &Storage{
+		//			Volumes: map[string]Volume{
+		//				"mockVolume1": {
+		//					EFS: &EFSConfigOrBool{
+		//						Advanced: EFSVolumeConfiguration{
+		//							UID: nil,
+		//							AuthConfig: &AuthorizationConfig{
+		//								IAM:           aws.Bool(true),
+		//								AccessPointID: aws.String("mockIDTest"),
+		//							},
+		//						},
+		//					},
+		//				},
+		//			},
+		//		}
+		//	},
+		//},
+		//"FAILED TEST: exclusive fields: id overridden if gid is not nil": {
+		//	inSvc: func(svc *LoadBalancedWebService) {
+		//		svc.Storage = &Storage{
+		//			Volumes: map[string]Volume{
+		//				"mockVolume1": {
+		//					EFS: &EFSConfigOrBool{
+		//						Advanced: EFSVolumeConfiguration{
+		//							FileSystemID: aws.String("42"),
+		//						},
+		//					},
+		//				},
+		//			},
+		//		}
+		//		svc.Environments["test"].Storage = &Storage{
+		//			Volumes: map[string]Volume{
+		//				"mockVolume1": {
+		//					EFS: &EFSConfigOrBool{
+		//						Advanced: EFSVolumeConfiguration{
+		//							GID: aws.Uint32(13),
+		//						},
+		//					},
+		//				},
+		//			},
+		//		}
+		//	},
+		//	wanted: func(svc *LoadBalancedWebService) {
+		//		svc.Storage = &Storage{
+		//			Volumes: map[string]Volume{
+		//				"mockVolume1": {
+		//					EFS: &EFSConfigOrBool{
+		//						Advanced: EFSVolumeConfiguration{
+		//							FileSystemID: nil,
+		//							GID:          aws.Uint32(13),
+		//						},
+		//					},
+		//				},
+		//			},
+		//		}
+		//	},
+		//},
+		//"FAILED TEST: exclusive fields: gid overridden if id is not nil": {
+		//	inSvc: func(svc *LoadBalancedWebService) {
+		//		svc.Storage = &Storage{
+		//			Volumes: map[string]Volume{
+		//				"mockVolume1": {
+		//					EFS: &EFSConfigOrBool{
+		//						Advanced: EFSVolumeConfiguration{
+		//							GID: aws.Uint32(13),
+		//						},
+		//					},
+		//				},
+		//			},
+		//		}
+		//		svc.Environments["test"].Storage = &Storage{
+		//			Volumes: map[string]Volume{
+		//				"mockVolume1": {
+		//					EFS: &EFSConfigOrBool{
+		//						Advanced: EFSVolumeConfiguration{
+		//							FileSystemID: aws.String("42"),
+		//						},
+		//					},
+		//				},
+		//			},
+		//		}
+		//	},
+		//	wanted: func(svc *LoadBalancedWebService) {
+		//		svc.Storage = &Storage{
+		//			Volumes: map[string]Volume{
+		//				"mockVolume1": {
+		//					EFS: &EFSConfigOrBool{
+		//						Advanced: EFSVolumeConfiguration{
+		//							FileSystemID: aws.String("42"),
+		//							GID:          nil,
+		//						},
+		//					},
+		//				},
+		//			},
+		//		}
+		//	},
+		//},
+		//"FAILED TEST: exclusive fields: root_dir overridden if gid is not nil": {
+		//	inSvc: func(svc *LoadBalancedWebService) {
+		//		svc.Storage = &Storage{
+		//			Volumes: map[string]Volume{
+		//				"mockVolume1": {
+		//					EFS: &EFSConfigOrBool{
+		//						Advanced: EFSVolumeConfiguration{
+		//							RootDirectory: aws.String("mockRootDir"),
+		//						},
+		//					},
+		//				},
+		//			},
+		//		}
+		//		svc.Environments["test"].Storage = &Storage{
+		//			Volumes: map[string]Volume{
+		//				"mockVolume1": {
+		//					EFS: &EFSConfigOrBool{
+		//						Advanced: EFSVolumeConfiguration{
+		//							GID: aws.Uint32(13),
+		//						},
+		//					},
+		//				},
+		//			},
+		//		}
+		//	},
+		//	wanted: func(svc *LoadBalancedWebService) {
+		//		svc.Storage = &Storage{
+		//			Volumes: map[string]Volume{
+		//				"mockVolume1": {
+		//					EFS: &EFSConfigOrBool{
+		//						Advanced: EFSVolumeConfiguration{
+		//							RootDirectory: nil,
+		//							GID:           aws.Uint32(13),
+		//						},
+		//					},
+		//				},
+		//			},
+		//		}
+		//	},
+		//},
+		//"FAILED TEST: exclusive fields: gid overridden if root_dir is not nil": {
+		//	inSvc: func(svc *LoadBalancedWebService) {
+		//		svc.Storage = &Storage{
+		//			Volumes: map[string]Volume{
+		//				"mockVolume1": {
+		//					EFS: &EFSConfigOrBool{
+		//						Advanced: EFSVolumeConfiguration{
+		//							GID: aws.Uint32(13),
+		//						},
+		//					},
+		//				},
+		//			},
+		//		}
+		//		svc.Environments["test"].Storage = &Storage{
+		//			Volumes: map[string]Volume{
+		//				"mockVolume1": {
+		//					EFS: &EFSConfigOrBool{
+		//						Advanced: EFSVolumeConfiguration{
+		//							RootDirectory: aws.String("mockRootDirTest"),
+		//						},
+		//					},
+		//				},
+		//			},
+		//		}
+		//	},
+		//	wanted: func(svc *LoadBalancedWebService) {
+		//		svc.Storage = &Storage{
+		//			Volumes: map[string]Volume{
+		//				"mockVolume1": {
+		//					EFS: &EFSConfigOrBool{
+		//						Advanced: EFSVolumeConfiguration{
+		//							RootDirectory: aws.String("mockRootDirTest"),
+		//							GID:           nil,
+		//						},
+		//					},
+		//				},
+		//			},
+		//		}
+		//	},
+		//},
+		//"FAILED TEST: exclusive fields: auth overridden if gid is not nil": {
+		//	inSvc: func(svc *LoadBalancedWebService) {
+		//		svc.Storage = &Storage{
+		//			Volumes: map[string]Volume{
+		//				"mockVolume1": {
+		//					EFS: &EFSConfigOrBool{
+		//						Advanced: EFSVolumeConfiguration{
+		//							AuthConfig: &AuthorizationConfig{
+		//								IAM:           aws.Bool(true),
+		//								AccessPointID: aws.String("mockID1"),
+		//							},
+		//						},
+		//					},
+		//				},
+		//			},
+		//		}
+		//		svc.Environments["test"].Storage = &Storage{
+		//			Volumes: map[string]Volume{
+		//				"mockVolume1": {
+		//					EFS: &EFSConfigOrBool{
+		//						Advanced: EFSVolumeConfiguration{
+		//							GID: aws.Uint32(13),
+		//						},
+		//					},
+		//				},
+		//			},
+		//		}
+		//	},
+		//	wanted: func(svc *LoadBalancedWebService) {
+		//		svc.Storage = &Storage{
+		//			Volumes: map[string]Volume{
+		//				"mockVolume1": {
+		//					EFS: &EFSConfigOrBool{
+		//						Advanced: EFSVolumeConfiguration{
+		//							AuthConfig: nil,
+		//							GID:        aws.Uint32(13),
+		//						},
+		//					},
+		//				},
+		//			},
+		//		}
+		//	},
+		//},
+		//"FAILED TEST: exclusive fields: gid overridden if auth is not nil": {
+		//	inSvc: func(svc *LoadBalancedWebService) {
+		//		svc.Storage = &Storage{
+		//			Volumes: map[string]Volume{
+		//				"mockVolume1": {
+		//					EFS: &EFSConfigOrBool{
+		//						Advanced: EFSVolumeConfiguration{
+		//							GID: aws.Uint32(13),
+		//						},
+		//					},
+		//				},
+		//			},
+		//		}
+		//		svc.Environments["test"].Storage = &Storage{
+		//			Volumes: map[string]Volume{
+		//				"mockVolume1": {
+		//					EFS: &EFSConfigOrBool{
+		//						Advanced: EFSVolumeConfiguration{
+		//							AuthConfig: &AuthorizationConfig{
+		//								IAM:           aws.Bool(true),
+		//								AccessPointID: aws.String("mockID1"),
+		//							},
+		//						},
+		//					},
+		//				},
+		//			},
+		//		}
+		//	},
+		//	wanted: func(svc *LoadBalancedWebService) {
+		//		svc.Storage = &Storage{
+		//			Volumes: map[string]Volume{
+		//				"mockVolume1": {
+		//					EFS: &EFSConfigOrBool{
+		//						Advanced: EFSVolumeConfiguration{
+		//							AuthConfig: &AuthorizationConfig{
+		//								IAM:           aws.Bool(true),
+		//								AccessPointID: aws.String("mockID1"),
+		//							},
+		//							GID: nil,
+		//						},
+		//					},
+		//				},
+		//			},
+		//		}
+		//	},
+		//},
+		"id overridden": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									FileSystemID: aws.String("mockID"),
+								},
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									FileSystemID: aws.String("mockIDTest"),
+								},
+							},
+						},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									FileSystemID: aws.String("mockIDTest"),
+								},
+							},
+						},
+					},
+				}
+			},
+		},
+		"id explicitly overridden by zero value": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									FileSystemID: aws.String("mockID"),
+								},
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									FileSystemID: aws.String(""),
+								},
+							},
+						},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									FileSystemID: aws.String(""),
+								},
+							},
+						},
+					},
+				}
+			},
+		},
+		"FAILED_AFTER_UPGRADE: id not overridden": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									FileSystemID: aws.String("mockID"),
+								},
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{},
+							},
+						},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									FileSystemID: aws.String("mockID"),
+								},
+							},
+						},
+					},
+				}
+			},
+		},
+		"root_dir overridden": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									RootDirectory: aws.String("mockDir"),
+								},
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									RootDirectory: aws.String("mockDirTest"),
+								},
+							},
+						},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									RootDirectory: aws.String("mockDirTest"),
+								},
+							},
+						},
+					},
+				}
+			},
+		},
+		"root_dir explicitly overridden by empty value": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									RootDirectory: aws.String("mockDir"),
+								},
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									RootDirectory: aws.String(""),
+								},
+							},
+						},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									RootDirectory: aws.String(""),
+								},
+							},
+						},
+					},
+				}
+			},
+		},
+		"FAILED_AFTER_UPGRADE: root_dir not overridden": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									RootDirectory: aws.String("mockDir"),
+								},
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{},
+							},
+						},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									RootDirectory: aws.String("mockDir"),
+								},
+							},
+						},
+					},
+				}
+			},
+		},
+		"uid overridden": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									UID: aws.Uint32(13),
+								},
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									UID: aws.Uint32(42),
+								},
+							},
+						},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									UID: aws.Uint32(42),
+								},
+							},
+						},
+					},
+				}
+			},
+		},
+		"uid explicitly overridden by empty value": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									UID: aws.Uint32(13),
+								},
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									UID: aws.Uint32(0),
+								},
+							},
+						},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									UID: aws.Uint32(0),
+								},
+							},
+						},
+					},
+				}
+			},
+		},
+		"FAILED_AFTER_UPGRADE: uid not overridden": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									UID: aws.Uint32(13),
+								},
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{},
+							},
+						},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									UID: aws.Uint32(13),
+								},
+							},
+						},
+					},
+				}
+			},
+		},
+		"gid overridden": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									GID: aws.Uint32(13),
+								},
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									GID: aws.Uint32(42),
+								},
+							},
+						},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									GID: aws.Uint32(42),
+								},
+							},
+						},
+					},
+				}
+			},
+		},
+		"gid explicitly overridden by empty value": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									GID: aws.Uint32(13),
+								},
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									GID: aws.Uint32(0),
+								},
+							},
+						},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									GID: aws.Uint32(0),
+								},
+							},
+						},
+					},
+				}
+			},
+		},
+		"FAILED_AFTER_UPGRADE: gid not overridden": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									GID: aws.Uint32(13),
+								},
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{},
+							},
+						},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									GID: aws.Uint32(13),
+								},
+							},
+						},
+					},
+				}
+			},
+		},
+		"auth overridden": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									AuthConfig: &AuthorizationConfig{
+										AccessPointID: aws.String("mockPoint"),
+									},
+								},
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									AuthConfig: &AuthorizationConfig{
+										IAM:           aws.Bool(true),
+										AccessPointID: aws.String("mockPointTest"),
+									},
+								},
+							},
+						},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									AuthConfig: &AuthorizationConfig{
+										IAM:           aws.Bool(true),
+										AccessPointID: aws.String("mockPointTest"),
+									},
+								},
+							},
+						},
+					},
+				}
+			},
+		},
+		"FAILED_AFTER_UPGRADE: auth not overridden": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									AuthConfig: &AuthorizationConfig{
+										AccessPointID: aws.String("mockPoint"),
+									},
+								},
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{},
+							},
+						},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									AuthConfig: &AuthorizationConfig{
+										AccessPointID: aws.String("mockPoint"),
+									},
+								},
+							},
+						},
+					},
+				}
+			},
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			var inSvc, wantedSvc LoadBalancedWebService
+			inSvc.Environments = map[string]*LoadBalancedWebServiceConfig{
+				"test": {},
+			}
+
+			tc.inSvc(&inSvc)
+			tc.wanted(&wantedSvc)
+
+			got, err := inSvc.ApplyEnv("test")
+
+			require.NoError(t, err)
+			require.Equal(t, &wantedSvc, got)
+		})
+	}
+}
+
+func Test_ApplyEnv_Storage_Volume_EFS_Auth(t *testing.T) {
+	testCases := map[string]struct {
+		inSvc  func(svc *LoadBalancedWebService)
+		wanted func(svc *LoadBalancedWebService)
+	}{
+		"iam overridden": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									AuthConfig: &AuthorizationConfig{
+										IAM: aws.Bool(false),
+									},
+								},
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									AuthConfig: &AuthorizationConfig{
+										IAM: aws.Bool(true),
+									},
+								},
+							},
+						},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									AuthConfig: &AuthorizationConfig{
+										IAM: aws.Bool(true),
+									},
+								},
+							},
+						},
+					},
+				}
+			},
+		},
+		"iam explicitly overridden by empty value": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									AuthConfig: &AuthorizationConfig{
+										IAM: aws.Bool(true),
+									},
+								},
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									AuthConfig: &AuthorizationConfig{
+										IAM: aws.Bool(false),
+									},
+								},
+							},
+						},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									AuthConfig: &AuthorizationConfig{
+										IAM: aws.Bool(false),
+									},
+								},
+							},
+						},
+					},
+				}
+			},
+		},
+		"FAILED_AFTER_UPGRADE: iam not overridden": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									AuthConfig: &AuthorizationConfig{
+										IAM: aws.Bool(true),
+									},
+								},
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									AuthConfig: &AuthorizationConfig{},
+								},
+							},
+						},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									AuthConfig: &AuthorizationConfig{
+										IAM: aws.Bool(true),
+									},
+								},
+							},
+						},
+					},
+				}
+			},
+		},
+		"access_point_id overridden": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									AuthConfig: &AuthorizationConfig{
+										AccessPointID: aws.String("mockPoint"),
+									},
+								},
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									AuthConfig: &AuthorizationConfig{
+										AccessPointID: aws.String("mockPointTest"),
+									},
+								},
+							},
+						},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									AuthConfig: &AuthorizationConfig{
+										AccessPointID: aws.String("mockPointTest"),
+									},
+								},
+							},
+						},
+					},
+				}
+			},
+		},
+		"access_point_id explicitly overridden by empty value": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									AuthConfig: &AuthorizationConfig{
+										AccessPointID: aws.String("mockPoint"),
+									},
+								},
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									AuthConfig: &AuthorizationConfig{
+										AccessPointID: aws.String(""),
+									},
+								},
+							},
+						},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									AuthConfig: &AuthorizationConfig{
+										AccessPointID: aws.String(""),
+									},
+								},
+							},
+						},
+					},
+				}
+			},
+		},
+		"FAILED_AFTER_UPGRADE: access_point_id not overridden": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									AuthConfig: &AuthorizationConfig{
+										AccessPointID: aws.String("mockPoint"),
+									},
+								},
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									AuthConfig: &AuthorizationConfig{},
+								},
+							},
+						},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									AuthConfig: &AuthorizationConfig{
+										AccessPointID: aws.String("mockPoint"),
+									},
+								},
+							},
+						},
+					},
+				}
+			},
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			var inSvc, wantedSvc LoadBalancedWebService
+			inSvc.Environments = map[string]*LoadBalancedWebServiceConfig{
+				"test": {},
+			}
+
+			tc.inSvc(&inSvc)
+			tc.wanted(&wantedSvc)
+
+			got, err := inSvc.ApplyEnv("test")
+
+			require.NoError(t, err)
+			require.Equal(t, &wantedSvc, got)
+		})
+	}
+}

--- a/internal/pkg/manifest/storage_applyenv_test.go
+++ b/internal/pkg/manifest/storage_applyenv_test.go
@@ -3,2101 +3,2095 @@
 
 package manifest
 
-import (
-	"testing"
-
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/stretchr/testify/require"
-)
-
-func Test_ApplyEnv_Storage(t *testing.T) {
-	testCases := map[string]struct {
-		inSvc  func(svc *LoadBalancedWebService)
-		wanted func(svc *LoadBalancedWebService)
-	}{
-		"ephemeral overridden": {
-			inSvc: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Ephemeral: aws.Int(1),
-				}
-				svc.Environments["test"].Storage = &Storage{
-					Ephemeral: aws.Int(3),
-				}
-			},
-			wanted: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Ephemeral: aws.Int(3),
-				}
-			},
-		},
-		"ephemeral explicitly overridden by zero value": {
-			inSvc: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Ephemeral: aws.Int(1),
-				}
-				svc.Environments["test"].Storage = &Storage{
-					Ephemeral: aws.Int(0),
-				}
-			},
-			wanted: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Ephemeral: aws.Int(0),
-				}
-			},
-		},
-		"FIXED_AFTER_TRANSFORM_POINTER: ephemeral not overridden": {
-			inSvc: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Ephemeral: aws.Int(1),
-				}
-				svc.Environments["test"].Storage = &Storage{}
-			},
-			wanted: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Ephemeral: aws.Int(1),
-				}
-			},
-		},
-		//"FAILED TEST: volumes overridden": {
-		//	inSvc: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					MountPointOpts: MountPointOpts{
-		//						ReadOnly: aws.Bool(true),
-		//					},
-		//				},
-		//				"mockVolume2": {
-		//					EFS: &EFSConfigOrBool{
-		//						Enabled: aws.Bool(true),
-		//					},
-		//				},
-		//			},
-		//		}
-		//		svc.Environments["test"].Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Enabled: aws.Bool(true),
-		//					},
-		//				}, // Modify the value for mockVolume1.
-		//				"mockVolume3": {
-		//					MountPointOpts: MountPointOpts{
-		//						ReadOnly: aws.Bool(true),
-		//					},
-		//				}, // Append mockVolume3.
-		//			},
-		//		}
-		//	},
-		//	wanted: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Enabled: aws.Bool(true),
-		//					},
-		//				},
-		//				"mockVolume2": {
-		//					EFS: &EFSConfigOrBool{
-		//						Enabled: aws.Bool(true),
-		//					},
-		//				},
-		//				"mockVolume3": {
-		//					MountPointOpts: MountPointOpts{
-		//						ReadOnly: aws.Bool(true),
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//},
-		"volumes not overridden by empty map": {
-			inSvc: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							MountPointOpts: MountPointOpts{
-								ReadOnly: aws.Bool(true),
-							},
-						},
-						"mockVolume2": {
-							EFS: &EFSConfigOrBool{
-								Enabled: aws.Bool(true),
-							},
-						},
-					},
-				}
-				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{},
-				}
-			},
-			wanted: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							MountPointOpts: MountPointOpts{
-								ReadOnly: aws.Bool(true),
-							},
-						},
-						"mockVolume2": {
-							EFS: &EFSConfigOrBool{
-								Enabled: aws.Bool(true),
-							},
-						},
-					},
-				}
-			},
-		},
-		"volumes not overridden by nil": {
-			inSvc: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							MountPointOpts: MountPointOpts{
-								ReadOnly: aws.Bool(true),
-							},
-						},
-						"mockVolume2": {
-							EFS: &EFSConfigOrBool{
-								Enabled: aws.Bool(true),
-							},
-						},
-					},
-				}
-				svc.Environments["test"].Storage = &Storage{}
-			},
-			wanted: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							MountPointOpts: MountPointOpts{
-								ReadOnly: aws.Bool(true),
-							},
-						},
-						"mockVolume2": {
-							EFS: &EFSConfigOrBool{
-								Enabled: aws.Bool(true),
-							},
-						},
-					},
-				}
-			},
-		},
-	}
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			var inSvc, wantedSvc LoadBalancedWebService
-			inSvc.Environments = map[string]*LoadBalancedWebServiceConfig{
-				"test": {},
-			}
-
-			tc.inSvc(&inSvc)
-			tc.wanted(&wantedSvc)
-
-			got, err := inSvc.ApplyEnv("test")
-
-			require.NoError(t, err)
-			require.Equal(t, &wantedSvc, got)
-		})
-	}
-}
-
-func Test_ApplyEnv_Storage_Volume(t *testing.T) {
-	testCases := map[string]struct {
-		inSvc  func(svc *LoadBalancedWebService)
-		wanted func(svc *LoadBalancedWebService)
-	}{
-		"FAILED_AFTER_TRANSFORM_POINTER: path overridden": {
-			inSvc: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							MountPointOpts: MountPointOpts{
-								ContainerPath: aws.String("mockPath"),
-							},
-						},
-					},
-				}
-				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							MountPointOpts: MountPointOpts{
-								ContainerPath: aws.String("mockPathTest"),
-							},
-						},
-					},
-				}
-			},
-			wanted: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							MountPointOpts: MountPointOpts{
-								ContainerPath: aws.String("mockPathTest"),
-							},
-						},
-					},
-				}
-			},
-		},
-		"FAILED_AFTER_TRANSFORM_POINTER： path explicitly overridden by zero value": {
-			inSvc: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							MountPointOpts: MountPointOpts{
-								ContainerPath: aws.String("mockPath"),
-							},
-						},
-					},
-				}
-				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							MountPointOpts: MountPointOpts{
-								ContainerPath: aws.String(""),
-							},
-						},
-					},
-				}
-			},
-			wanted: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							MountPointOpts: MountPointOpts{
-								ContainerPath: aws.String(""),
-							},
-						},
-					},
-				}
-			},
-		},
-		"FAILED_AFTER_UPGRADE: path not overridden": {
-			inSvc: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							MountPointOpts: MountPointOpts{
-								ContainerPath: aws.String("mockPath"),
-							},
-						},
-					},
-				}
-				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							MountPointOpts: MountPointOpts{},
-						},
-					},
-				}
-			},
-			wanted: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							MountPointOpts: MountPointOpts{
-								ContainerPath: aws.String("mockPath"),
-							},
-						},
-					},
-				}
-			},
-		},
-		"read_only overridden": {
-			inSvc: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							MountPointOpts: MountPointOpts{
-								ReadOnly: aws.Bool(false),
-							},
-						},
-					},
-				}
-				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							MountPointOpts: MountPointOpts{
-								ReadOnly: aws.Bool(true),
-							},
-						},
-					},
-				}
-			},
-			wanted: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							MountPointOpts: MountPointOpts{
-								ReadOnly: aws.Bool(true),
-							},
-						},
-					},
-				}
-			},
-		},
-		"read_only explicitly overridden by empty value": {
-			inSvc: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							MountPointOpts: MountPointOpts{
-								ReadOnly: aws.Bool(true),
-							},
-						},
-					},
-				}
-				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							MountPointOpts: MountPointOpts{
-								ReadOnly: aws.Bool(false),
-							},
-						},
-					},
-				}
-			},
-			wanted: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							MountPointOpts: MountPointOpts{
-								ReadOnly: aws.Bool(false),
-							},
-						},
-					},
-				}
-			},
-		},
-		"FAILED_AFTER_UPGRADE: read_only not overridden": {
-			inSvc: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							MountPointOpts: MountPointOpts{
-								ReadOnly: aws.Bool(true),
-							},
-						},
-					},
-				}
-				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							MountPointOpts: MountPointOpts{},
-						},
-					},
-				}
-			},
-			wanted: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							MountPointOpts: MountPointOpts{
-								ReadOnly: aws.Bool(true),
-							},
-						},
-					},
-				}
-			},
-		},
-		"efs overridden": {
-			inSvc: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									FileSystemID: aws.String("mockFileSystem"),
-								},
-							},
-						},
-					},
-				}
-				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									RootDirectory: aws.String("mockRootDirTest"),
-									FileSystemID:  aws.String("mockFileSystemTest"),
-								},
-							},
-						},
-					},
-				}
-			},
-			wanted: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									RootDirectory: aws.String("mockRootDirTest"),
-									FileSystemID:  aws.String("mockFileSystemTest"),
-								},
-							},
-						},
-					},
-				}
-			},
-		},
-		"FAILED_AFTER_UPGRADE: efs not overridden": {
-			inSvc: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									FileSystemID: aws.String("mockFileSystem"),
-								},
-							},
-						},
-					},
-				}
-				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {},
-					},
-				}
-			},
-			wanted: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									FileSystemID: aws.String("mockFileSystem"),
-								},
-							},
-						},
-					},
-				}
-			},
-		},
-	}
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			var inSvc, wantedSvc LoadBalancedWebService
-			inSvc.Environments = map[string]*LoadBalancedWebServiceConfig{
-				"test": {},
-			}
-
-			tc.inSvc(&inSvc)
-			tc.wanted(&wantedSvc)
-
-			got, err := inSvc.ApplyEnv("test")
-
-			require.NoError(t, err)
-			require.Equal(t, &wantedSvc, got)
-		})
-	}
-}
-
-func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
-	testCases := map[string]struct {
-		inSvc  func(svc *LoadBalancedWebService)
-		wanted func(svc *LoadBalancedWebService)
-	}{
-		//"FAILED TEST: composite fields: efs bool is overridden if efs config is not nil": {
-		//	inSvc: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Enabled: aws.Bool(true),
-		//					},
-		//				},
-		//			},
-		//		}
-		//		svc.Environments["test"].Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							RootDirectory: aws.String("mockRootDirTest"),
-		//							FileSystemID:  aws.String("mockFileSystemTest"),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//	wanted: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Enabled: nil,
-		//						Advanced: EFSVolumeConfiguration{
-		//							RootDirectory: aws.String("mockRootDirTest"),
-		//							FileSystemID:  aws.String("mockFileSystemTest"),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//},
-		//"FAILED TEST: composite fields: efs config is overridden if efs bool is not nil": {
-		//	inSvc: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							RootDirectory: aws.String("mockRootDir"),
-		//							FileSystemID:  aws.String("mockFileSystem"),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//		svc.Environments["test"].Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Enabled: aws.Bool(true),
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//	wanted: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Enabled:  aws.Bool(true),
-		//						Advanced: EFSVolumeConfiguration{},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//},
-		"efs bool overridden": {
-			inSvc: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Enabled: aws.Bool(false),
-							},
-						},
-					},
-				}
-				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Enabled: aws.Bool(true),
-							},
-						},
-					},
-				}
-			},
-			wanted: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Enabled: aws.Bool(true),
-							},
-						},
-					},
-				}
-			},
-		},
-		"efs bool explicitly overridden by zero value": {
-			inSvc: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Enabled: aws.Bool(true),
-							},
-						},
-					},
-				}
-				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Enabled: aws.Bool(false),
-							},
-						},
-					},
-				}
-			},
-			wanted: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Enabled: aws.Bool(false),
-							},
-						},
-					},
-				}
-			},
-		},
-		"FAILED_AFTER_UPGRADE: efs bool not overridden": {
-			inSvc: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Enabled: aws.Bool(true),
-							},
-						},
-					},
-				}
-				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {},
-					},
-				}
-			},
-			wanted: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Enabled: aws.Bool(true),
-							},
-						},
-					},
-				}
-			},
-		},
-		"efs config overridden": {
-			inSvc: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									FileSystemID: aws.String("mockFileSystem"),
-								},
-							},
-						},
-					},
-				}
-				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									RootDirectory: aws.String("mockRootDirTest"),
-									FileSystemID:  aws.String("mockFileSystemTest"),
-									UID:           aws.Uint32(42),
-								},
-							},
-						},
-					},
-				}
-			},
-			wanted: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									RootDirectory: aws.String("mockRootDirTest"),
-									FileSystemID:  aws.String("mockFileSystemTest"),
-									UID:           aws.Uint32(42),
-								},
-							},
-						},
-					},
-				}
-			},
-		},
-		"FAILED_AFTER_UPGRADE: efs config not overridden": {
-			inSvc: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									FileSystemID: aws.String("mockFileSystem"),
-								},
-							},
-						},
-					},
-				}
-				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {},
-					},
-				}
-			},
-			wanted: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									FileSystemID: aws.String("mockFileSystem"),
-								},
-							},
-						},
-					},
-				}
-			},
-		},
-		//"FAILED TEST: exclusive fields: id overridden if uid is not nil": {
-		//	inSvc: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							FileSystemID: aws.String("42"),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//		svc.Environments["test"].Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							UID: aws.Uint32(13),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//	wanted: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							FileSystemID: nil,
-		//							UID:          aws.Uint32(13),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//},
-		//"FAILED TEST: exclusive fields: uid overridden if id is not nil": {
-		//	inSvc: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							UID: aws.Uint32(13),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//		svc.Environments["test"].Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							FileSystemID: aws.String("42"),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//	wanted: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							FileSystemID: aws.String("42"),
-		//							UID:          nil,
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//},
-		//"FAILED TEST: exclusive fields: root_dir overridden if uid is not nil": {
-		//	inSvc: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							RootDirectory: aws.String("mockRootDirectory"),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//		svc.Environments["test"].Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							UID: aws.Uint32(13),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//	wanted: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							RootDirectory: nil,
-		//							UID:           aws.Uint32(13),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//},
-		//"FAILED TEST: exclusive fields: udi overridden if root_dir is not nil": {
-		//	inSvc: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							UID: aws.Uint32(13),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//		svc.Environments["test"].Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							RootDirectory: aws.String("mockRootDirectoryTest"),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//	wanted: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							RootDirectory: aws.String("mockRootDirectoryTest"),
-		//							UID:           nil,
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//},
-		//"FAILED TEST: exclusive fields: auth overridden if uid is not nil": {
-		//	inSvc: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							AuthConfig: &AuthorizationConfig{
-		//								IAM:           aws.Bool(true),
-		//								AccessPointID: aws.String("mockID1"),
-		//							},
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//		svc.Environments["test"].Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							UID: aws.Uint32(13),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//	wanted: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							UID:        aws.Uint32(13),
-		//							AuthConfig: nil,
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//},
-		//"FAILED TEST: exclusive fields: udi overridden if auth is not nil": {
-		//	inSvc: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							UID: aws.Uint32(13),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//		svc.Environments["test"].Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							AuthConfig: &AuthorizationConfig{
-		//								IAM:           aws.Bool(true),
-		//								AccessPointID: aws.String("mockIDTest"),
-		//							},
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//	wanted: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							UID: nil,
-		//							AuthConfig: &AuthorizationConfig{
-		//								IAM:           aws.Bool(true),
-		//								AccessPointID: aws.String("mockIDTest"),
-		//							},
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//},
-		//"FAILED TEST: exclusive fields: id overridden if gid is not nil": {
-		//	inSvc: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							FileSystemID: aws.String("42"),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//		svc.Environments["test"].Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							GID: aws.Uint32(13),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//	wanted: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							FileSystemID: nil,
-		//							GID:          aws.Uint32(13),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//},
-		//"FAILED TEST: exclusive fields: gid overridden if id is not nil": {
-		//	inSvc: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							GID: aws.Uint32(13),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//		svc.Environments["test"].Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							FileSystemID: aws.String("42"),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//	wanted: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							FileSystemID: aws.String("42"),
-		//							GID:          nil,
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//},
-		//"FAILED TEST: exclusive fields: root_dir overridden if gid is not nil": {
-		//	inSvc: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							RootDirectory: aws.String("mockRootDir"),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//		svc.Environments["test"].Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							GID: aws.Uint32(13),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//	wanted: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							RootDirectory: nil,
-		//							GID:           aws.Uint32(13),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//},
-		//"FAILED TEST: exclusive fields: gid overridden if root_dir is not nil": {
-		//	inSvc: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							GID: aws.Uint32(13),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//		svc.Environments["test"].Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							RootDirectory: aws.String("mockRootDirTest"),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//	wanted: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							RootDirectory: aws.String("mockRootDirTest"),
-		//							GID:           nil,
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//},
-		//"FAILED TEST: exclusive fields: auth overridden if gid is not nil": {
-		//	inSvc: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							AuthConfig: &AuthorizationConfig{
-		//								IAM:           aws.Bool(true),
-		//								AccessPointID: aws.String("mockID1"),
-		//							},
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//		svc.Environments["test"].Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							GID: aws.Uint32(13),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//	wanted: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							AuthConfig: nil,
-		//							GID:        aws.Uint32(13),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//},
-		//"FAILED TEST: exclusive fields: gid overridden if auth is not nil": {
-		//	inSvc: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							GID: aws.Uint32(13),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//		svc.Environments["test"].Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							AuthConfig: &AuthorizationConfig{
-		//								IAM:           aws.Bool(true),
-		//								AccessPointID: aws.String("mockID1"),
-		//							},
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//	wanted: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							AuthConfig: &AuthorizationConfig{
-		//								IAM:           aws.Bool(true),
-		//								AccessPointID: aws.String("mockID1"),
-		//							},
-		//							GID: nil,
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//},
-		"id overridden": {
-			inSvc: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									FileSystemID: aws.String("mockID"),
-								},
-							},
-						},
-					},
-				}
-				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									FileSystemID: aws.String("mockIDTest"),
-								},
-							},
-						},
-					},
-				}
-			},
-			wanted: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									FileSystemID: aws.String("mockIDTest"),
-								},
-							},
-						},
-					},
-				}
-			},
-		},
-		"id explicitly overridden by zero value": {
-			inSvc: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									FileSystemID: aws.String("mockID"),
-								},
-							},
-						},
-					},
-				}
-				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									FileSystemID: aws.String(""),
-								},
-							},
-						},
-					},
-				}
-			},
-			wanted: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									FileSystemID: aws.String(""),
-								},
-							},
-						},
-					},
-				}
-			},
-		},
-		"FAILED_AFTER_UPGRADE: id not overridden": {
-			inSvc: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									FileSystemID: aws.String("mockID"),
-								},
-							},
-						},
-					},
-				}
-				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{},
-							},
-						},
-					},
-				}
-			},
-			wanted: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									FileSystemID: aws.String("mockID"),
-								},
-							},
-						},
-					},
-				}
-			},
-		},
-		"root_dir overridden": {
-			inSvc: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									RootDirectory: aws.String("mockDir"),
-								},
-							},
-						},
-					},
-				}
-				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									RootDirectory: aws.String("mockDirTest"),
-								},
-							},
-						},
-					},
-				}
-			},
-			wanted: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									RootDirectory: aws.String("mockDirTest"),
-								},
-							},
-						},
-					},
-				}
-			},
-		},
-		"root_dir explicitly overridden by empty value": {
-			inSvc: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									RootDirectory: aws.String("mockDir"),
-								},
-							},
-						},
-					},
-				}
-				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									RootDirectory: aws.String(""),
-								},
-							},
-						},
-					},
-				}
-			},
-			wanted: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									RootDirectory: aws.String(""),
-								},
-							},
-						},
-					},
-				}
-			},
-		},
-		"FAILED_AFTER_UPGRADE: root_dir not overridden": {
-			inSvc: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									RootDirectory: aws.String("mockDir"),
-								},
-							},
-						},
-					},
-				}
-				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{},
-							},
-						},
-					},
-				}
-			},
-			wanted: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									RootDirectory: aws.String("mockDir"),
-								},
-							},
-						},
-					},
-				}
-			},
-		},
-		"uid overridden": {
-			inSvc: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									UID: aws.Uint32(13),
-								},
-							},
-						},
-					},
-				}
-				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									UID: aws.Uint32(42),
-								},
-							},
-						},
-					},
-				}
-			},
-			wanted: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									UID: aws.Uint32(42),
-								},
-							},
-						},
-					},
-				}
-			},
-		},
-		"uid explicitly overridden by empty value": {
-			inSvc: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									UID: aws.Uint32(13),
-								},
-							},
-						},
-					},
-				}
-				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									UID: aws.Uint32(0),
-								},
-							},
-						},
-					},
-				}
-			},
-			wanted: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									UID: aws.Uint32(0),
-								},
-							},
-						},
-					},
-				}
-			},
-		},
-		"FAILED_AFTER_UPGRADE: uid not overridden": {
-			inSvc: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									UID: aws.Uint32(13),
-								},
-							},
-						},
-					},
-				}
-				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{},
-							},
-						},
-					},
-				}
-			},
-			wanted: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									UID: aws.Uint32(13),
-								},
-							},
-						},
-					},
-				}
-			},
-		},
-		"gid overridden": {
-			inSvc: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									GID: aws.Uint32(13),
-								},
-							},
-						},
-					},
-				}
-				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									GID: aws.Uint32(42),
-								},
-							},
-						},
-					},
-				}
-			},
-			wanted: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									GID: aws.Uint32(42),
-								},
-							},
-						},
-					},
-				}
-			},
-		},
-		"gid explicitly overridden by empty value": {
-			inSvc: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									GID: aws.Uint32(13),
-								},
-							},
-						},
-					},
-				}
-				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									GID: aws.Uint32(0),
-								},
-							},
-						},
-					},
-				}
-			},
-			wanted: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									GID: aws.Uint32(0),
-								},
-							},
-						},
-					},
-				}
-			},
-		},
-		"FAILED_AFTER_UPGRADE: gid not overridden": {
-			inSvc: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									GID: aws.Uint32(13),
-								},
-							},
-						},
-					},
-				}
-				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{},
-							},
-						},
-					},
-				}
-			},
-			wanted: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									GID: aws.Uint32(13),
-								},
-							},
-						},
-					},
-				}
-			},
-		},
-		"auth overridden": {
-			inSvc: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									AuthConfig: &AuthorizationConfig{
-										AccessPointID: aws.String("mockPoint"),
-									},
-								},
-							},
-						},
-					},
-				}
-				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									AuthConfig: &AuthorizationConfig{
-										IAM:           aws.Bool(true),
-										AccessPointID: aws.String("mockPointTest"),
-									},
-								},
-							},
-						},
-					},
-				}
-			},
-			wanted: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									AuthConfig: &AuthorizationConfig{
-										IAM:           aws.Bool(true),
-										AccessPointID: aws.String("mockPointTest"),
-									},
-								},
-							},
-						},
-					},
-				}
-			},
-		},
-		"FAILED_AFTER_UPGRADE: auth not overridden": {
-			inSvc: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									AuthConfig: &AuthorizationConfig{
-										AccessPointID: aws.String("mockPoint"),
-									},
-								},
-							},
-						},
-					},
-				}
-				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{},
-							},
-						},
-					},
-				}
-			},
-			wanted: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									AuthConfig: &AuthorizationConfig{
-										AccessPointID: aws.String("mockPoint"),
-									},
-								},
-							},
-						},
-					},
-				}
-			},
-		},
-	}
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			var inSvc, wantedSvc LoadBalancedWebService
-			inSvc.Environments = map[string]*LoadBalancedWebServiceConfig{
-				"test": {},
-			}
-
-			tc.inSvc(&inSvc)
-			tc.wanted(&wantedSvc)
-
-			got, err := inSvc.ApplyEnv("test")
-
-			require.NoError(t, err)
-			require.Equal(t, &wantedSvc, got)
-		})
-	}
-}
-
-func Test_ApplyEnv_Storage_Volume_EFS_Auth(t *testing.T) {
-	testCases := map[string]struct {
-		inSvc  func(svc *LoadBalancedWebService)
-		wanted func(svc *LoadBalancedWebService)
-	}{
-		"iam overridden": {
-			inSvc: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									AuthConfig: &AuthorizationConfig{
-										IAM: aws.Bool(false),
-									},
-								},
-							},
-						},
-					},
-				}
-				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									AuthConfig: &AuthorizationConfig{
-										IAM: aws.Bool(true),
-									},
-								},
-							},
-						},
-					},
-				}
-			},
-			wanted: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									AuthConfig: &AuthorizationConfig{
-										IAM: aws.Bool(true),
-									},
-								},
-							},
-						},
-					},
-				}
-			},
-		},
-		"iam explicitly overridden by empty value": {
-			inSvc: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									AuthConfig: &AuthorizationConfig{
-										IAM: aws.Bool(true),
-									},
-								},
-							},
-						},
-					},
-				}
-				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									AuthConfig: &AuthorizationConfig{
-										IAM: aws.Bool(false),
-									},
-								},
-							},
-						},
-					},
-				}
-			},
-			wanted: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									AuthConfig: &AuthorizationConfig{
-										IAM: aws.Bool(false),
-									},
-								},
-							},
-						},
-					},
-				}
-			},
-		},
-		"FAILED_AFTER_UPGRADE: iam not overridden": {
-			inSvc: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									AuthConfig: &AuthorizationConfig{
-										IAM: aws.Bool(true),
-									},
-								},
-							},
-						},
-					},
-				}
-				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									AuthConfig: &AuthorizationConfig{},
-								},
-							},
-						},
-					},
-				}
-			},
-			wanted: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									AuthConfig: &AuthorizationConfig{
-										IAM: aws.Bool(true),
-									},
-								},
-							},
-						},
-					},
-				}
-			},
-		},
-		"access_point_id overridden": {
-			inSvc: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									AuthConfig: &AuthorizationConfig{
-										AccessPointID: aws.String("mockPoint"),
-									},
-								},
-							},
-						},
-					},
-				}
-				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									AuthConfig: &AuthorizationConfig{
-										AccessPointID: aws.String("mockPointTest"),
-									},
-								},
-							},
-						},
-					},
-				}
-			},
-			wanted: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									AuthConfig: &AuthorizationConfig{
-										AccessPointID: aws.String("mockPointTest"),
-									},
-								},
-							},
-						},
-					},
-				}
-			},
-		},
-		"access_point_id explicitly overridden by empty value": {
-			inSvc: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									AuthConfig: &AuthorizationConfig{
-										AccessPointID: aws.String("mockPoint"),
-									},
-								},
-							},
-						},
-					},
-				}
-				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									AuthConfig: &AuthorizationConfig{
-										AccessPointID: aws.String(""),
-									},
-								},
-							},
-						},
-					},
-				}
-			},
-			wanted: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									AuthConfig: &AuthorizationConfig{
-										AccessPointID: aws.String(""),
-									},
-								},
-							},
-						},
-					},
-				}
-			},
-		},
-		"FAILED_AFTER_UPGRADE: access_point_id not overridden": {
-			inSvc: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									AuthConfig: &AuthorizationConfig{
-										AccessPointID: aws.String("mockPoint"),
-									},
-								},
-							},
-						},
-					},
-				}
-				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									AuthConfig: &AuthorizationConfig{},
-								},
-							},
-						},
-					},
-				}
-			},
-			wanted: func(svc *LoadBalancedWebService) {
-				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
-						"mockVolume1": {
-							EFS: &EFSConfigOrBool{
-								Advanced: EFSVolumeConfiguration{
-									AuthConfig: &AuthorizationConfig{
-										AccessPointID: aws.String("mockPoint"),
-									},
-								},
-							},
-						},
-					},
-				}
-			},
-		},
-	}
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			var inSvc, wantedSvc LoadBalancedWebService
-			inSvc.Environments = map[string]*LoadBalancedWebServiceConfig{
-				"test": {},
-			}
-
-			tc.inSvc(&inSvc)
-			tc.wanted(&wantedSvc)
-
-			got, err := inSvc.ApplyEnv("test")
-
-			require.NoError(t, err)
-			require.Equal(t, &wantedSvc, got)
-		})
-	}
-}
+//
+//func Test_ApplyEnv_Storage(t *testing.T) {
+//	testCases := map[string]struct {
+//		inSvc  func(svc *LoadBalancedWebService)
+//		wanted func(svc *LoadBalancedWebService)
+//	}{
+//		"ephemeral overridden": {
+//			inSvc: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Ephemeral: aws.Int(1),
+//				}
+//				svc.Environments["test"].Storage = &Storage{
+//					Ephemeral: aws.Int(3),
+//				}
+//			},
+//			wanted: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Ephemeral: aws.Int(3),
+//				}
+//			},
+//		},
+//		"ephemeral explicitly overridden by zero value": {
+//			inSvc: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Ephemeral: aws.Int(1),
+//				}
+//				svc.Environments["test"].Storage = &Storage{
+//					Ephemeral: aws.Int(0),
+//				}
+//			},
+//			wanted: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Ephemeral: aws.Int(0),
+//				}
+//			},
+//		},
+//		"FIXED_AFTER_TRANSFORM_POINTER: ephemeral not overridden": {
+//			inSvc: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Ephemeral: aws.Int(1),
+//				}
+//				svc.Environments["test"].Storage = &Storage{}
+//			},
+//			wanted: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Ephemeral: aws.Int(1),
+//				}
+//			},
+//		},
+//		//"FAILED TEST: volumes overridden": {
+//		//	inSvc: func(svc *LoadBalancedWebService) {
+//		//		svc.Storage = &Storage{
+//		//			Volumes: map[string]Volume{
+//		//				"mockVolume1": {
+//		//					MountPointOpts: MountPointOpts{
+//		//						ReadOnly: aws.Bool(true),
+//		//					},
+//		//				},
+//		//				"mockVolume2": {
+//		//					EFS: &EFSConfigOrBool{
+//		//						Enabled: aws.Bool(true),
+//		//					},
+//		//				},
+//		//			},
+//		//		}
+//		//		svc.Environments["test"].Storage = &Storage{
+//		//			Volumes: map[string]Volume{
+//		//				"mockVolume1": {
+//		//					EFS: &EFSConfigOrBool{
+//		//						Enabled: aws.Bool(true),
+//		//					},
+//		//				}, // Modify the value for mockVolume1.
+//		//				"mockVolume3": {
+//		//					MountPointOpts: MountPointOpts{
+//		//						ReadOnly: aws.Bool(true),
+//		//					},
+//		//				}, // Append mockVolume3.
+//		//			},
+//		//		}
+//		//	},
+//		//	wanted: func(svc *LoadBalancedWebService) {
+//		//		svc.Storage = &Storage{
+//		//			Volumes: map[string]Volume{
+//		//				"mockVolume1": {
+//		//					EFS: &EFSConfigOrBool{
+//		//						Enabled: aws.Bool(true),
+//		//					},
+//		//				},
+//		//				"mockVolume2": {
+//		//					EFS: &EFSConfigOrBool{
+//		//						Enabled: aws.Bool(true),
+//		//					},
+//		//				},
+//		//				"mockVolume3": {
+//		//					MountPointOpts: MountPointOpts{
+//		//						ReadOnly: aws.Bool(true),
+//		//					},
+//		//				},
+//		//			},
+//		//		}
+//		//	},
+//		//},
+//		"volumes not overridden by empty map": {
+//			inSvc: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							MountPointOpts: MountPointOpts{
+//								ReadOnly: aws.Bool(true),
+//							},
+//						},
+//						"mockVolume2": {
+//							EFS: &EFSConfigOrBool{
+//								Enabled: aws.Bool(true),
+//							},
+//						},
+//					},
+//				}
+//				svc.Environments["test"].Storage = &Storage{
+//					Volumes: map[string]Volume{},
+//				}
+//			},
+//			wanted: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							MountPointOpts: MountPointOpts{
+//								ReadOnly: aws.Bool(true),
+//							},
+//						},
+//						"mockVolume2": {
+//							EFS: &EFSConfigOrBool{
+//								Enabled: aws.Bool(true),
+//							},
+//						},
+//					},
+//				}
+//			},
+//		},
+//		"volumes not overridden by nil": {
+//			inSvc: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							MountPointOpts: MountPointOpts{
+//								ReadOnly: aws.Bool(true),
+//							},
+//						},
+//						"mockVolume2": {
+//							EFS: &EFSConfigOrBool{
+//								Enabled: aws.Bool(true),
+//							},
+//						},
+//					},
+//				}
+//				svc.Environments["test"].Storage = &Storage{}
+//			},
+//			wanted: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							MountPointOpts: MountPointOpts{
+//								ReadOnly: aws.Bool(true),
+//							},
+//						},
+//						"mockVolume2": {
+//							EFS: &EFSConfigOrBool{
+//								Enabled: aws.Bool(true),
+//							},
+//						},
+//					},
+//				}
+//			},
+//		},
+//	}
+//	for name, tc := range testCases {
+//		t.Run(name, func(t *testing.T) {
+//			var inSvc, wantedSvc LoadBalancedWebService
+//			inSvc.Environments = map[string]*LoadBalancedWebServiceConfig{
+//				"test": {},
+//			}
+//
+//			tc.inSvc(&inSvc)
+//			tc.wanted(&wantedSvc)
+//
+//			got, err := inSvc.ApplyEnv("test")
+//
+//			require.NoError(t, err)
+//			require.Equal(t, &wantedSvc, got)
+//		})
+//	}
+//}
+//
+//func Test_ApplyEnv_Storage_Volume(t *testing.T) {
+//	testCases := map[string]struct {
+//		inSvc  func(svc *LoadBalancedWebService)
+//		wanted func(svc *LoadBalancedWebService)
+//	}{
+//		"FAILED_AFTER_TRANSFORM_POINTER: path overridden": {
+//			inSvc: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							MountPointOpts: MountPointOpts{
+//								ContainerPath: aws.String("mockPath"),
+//							},
+//						},
+//					},
+//				}
+//				svc.Environments["test"].Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							MountPointOpts: MountPointOpts{
+//								ContainerPath: aws.String("mockPathTest"),
+//							},
+//						},
+//					},
+//				}
+//			},
+//			wanted: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							MountPointOpts: MountPointOpts{
+//								ContainerPath: aws.String("mockPathTest"),
+//							},
+//						},
+//					},
+//				}
+//			},
+//		},
+//		"FAILED_AFTER_TRANSFORM_POINTER： path explicitly overridden by zero value": {
+//			inSvc: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							MountPointOpts: MountPointOpts{
+//								ContainerPath: aws.String("mockPath"),
+//							},
+//						},
+//					},
+//				}
+//				svc.Environments["test"].Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							MountPointOpts: MountPointOpts{
+//								ContainerPath: aws.String(""),
+//							},
+//						},
+//					},
+//				}
+//			},
+//			wanted: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							MountPointOpts: MountPointOpts{
+//								ContainerPath: aws.String(""),
+//							},
+//						},
+//					},
+//				}
+//			},
+//		},
+//		"FAILED_AFTER_UPGRADE: path not overridden": {
+//			inSvc: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							MountPointOpts: MountPointOpts{
+//								ContainerPath: aws.String("mockPath"),
+//							},
+//						},
+//					},
+//				}
+//				svc.Environments["test"].Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							MountPointOpts: MountPointOpts{},
+//						},
+//					},
+//				}
+//			},
+//			wanted: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							MountPointOpts: MountPointOpts{
+//								ContainerPath: aws.String("mockPath"),
+//							},
+//						},
+//					},
+//				}
+//			},
+//		},
+//		"read_only overridden": {
+//			inSvc: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							MountPointOpts: MountPointOpts{
+//								ReadOnly: aws.Bool(false),
+//							},
+//						},
+//					},
+//				}
+//				svc.Environments["test"].Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							MountPointOpts: MountPointOpts{
+//								ReadOnly: aws.Bool(true),
+//							},
+//						},
+//					},
+//				}
+//			},
+//			wanted: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							MountPointOpts: MountPointOpts{
+//								ReadOnly: aws.Bool(true),
+//							},
+//						},
+//					},
+//				}
+//			},
+//		},
+//		"read_only explicitly overridden by empty value": {
+//			inSvc: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							MountPointOpts: MountPointOpts{
+//								ReadOnly: aws.Bool(true),
+//							},
+//						},
+//					},
+//				}
+//				svc.Environments["test"].Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							MountPointOpts: MountPointOpts{
+//								ReadOnly: aws.Bool(false),
+//							},
+//						},
+//					},
+//				}
+//			},
+//			wanted: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							MountPointOpts: MountPointOpts{
+//								ReadOnly: aws.Bool(false),
+//							},
+//						},
+//					},
+//				}
+//			},
+//		},
+//		"FAILED_AFTER_UPGRADE: read_only not overridden": {
+//			inSvc: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							MountPointOpts: MountPointOpts{
+//								ReadOnly: aws.Bool(true),
+//							},
+//						},
+//					},
+//				}
+//				svc.Environments["test"].Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							MountPointOpts: MountPointOpts{},
+//						},
+//					},
+//				}
+//			},
+//			wanted: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							MountPointOpts: MountPointOpts{
+//								ReadOnly: aws.Bool(true),
+//							},
+//						},
+//					},
+//				}
+//			},
+//		},
+//		"efs overridden": {
+//			inSvc: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									FileSystemID: aws.String("mockFileSystem"),
+//								},
+//							},
+//						},
+//					},
+//				}
+//				svc.Environments["test"].Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									RootDirectory: aws.String("mockRootDirTest"),
+//									FileSystemID:  aws.String("mockFileSystemTest"),
+//								},
+//							},
+//						},
+//					},
+//				}
+//			},
+//			wanted: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									RootDirectory: aws.String("mockRootDirTest"),
+//									FileSystemID:  aws.String("mockFileSystemTest"),
+//								},
+//							},
+//						},
+//					},
+//				}
+//			},
+//		},
+//		"FAILED_AFTER_UPGRADE: efs not overridden": {
+//			inSvc: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									FileSystemID: aws.String("mockFileSystem"),
+//								},
+//							},
+//						},
+//					},
+//				}
+//				svc.Environments["test"].Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {},
+//					},
+//				}
+//			},
+//			wanted: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									FileSystemID: aws.String("mockFileSystem"),
+//								},
+//							},
+//						},
+//					},
+//				}
+//			},
+//		},
+//	}
+//	for name, tc := range testCases {
+//		t.Run(name, func(t *testing.T) {
+//			var inSvc, wantedSvc LoadBalancedWebService
+//			inSvc.Environments = map[string]*LoadBalancedWebServiceConfig{
+//				"test": {},
+//			}
+//
+//			tc.inSvc(&inSvc)
+//			tc.wanted(&wantedSvc)
+//
+//			got, err := inSvc.ApplyEnv("test")
+//
+//			require.NoError(t, err)
+//			require.Equal(t, &wantedSvc, got)
+//		})
+//	}
+//}
+//
+//func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
+//	testCases := map[string]struct {
+//		inSvc  func(svc *LoadBalancedWebService)
+//		wanted func(svc *LoadBalancedWebService)
+//	}{
+//		//"FAILED TEST: composite fields: efs bool is overridden if efs config is not nil": {
+//		//	inSvc: func(svc *LoadBalancedWebService) {
+//		//		svc.Storage = &Storage{
+//		//			Volumes: map[string]Volume{
+//		//				"mockVolume1": {
+//		//					EFS: &EFSConfigOrBool{
+//		//						Enabled: aws.Bool(true),
+//		//					},
+//		//				},
+//		//			},
+//		//		}
+//		//		svc.Environments["test"].Storage = &Storage{
+//		//			Volumes: map[string]Volume{
+//		//				"mockVolume1": {
+//		//					EFS: &EFSConfigOrBool{
+//		//						Advanced: EFSVolumeConfiguration{
+//		//							RootDirectory: aws.String("mockRootDirTest"),
+//		//							FileSystemID:  aws.String("mockFileSystemTest"),
+//		//						},
+//		//					},
+//		//				},
+//		//			},
+//		//		}
+//		//	},
+//		//	wanted: func(svc *LoadBalancedWebService) {
+//		//		svc.Storage = &Storage{
+//		//			Volumes: map[string]Volume{
+//		//				"mockVolume1": {
+//		//					EFS: &EFSConfigOrBool{
+//		//						Enabled: nil,
+//		//						Advanced: EFSVolumeConfiguration{
+//		//							RootDirectory: aws.String("mockRootDirTest"),
+//		//							FileSystemID:  aws.String("mockFileSystemTest"),
+//		//						},
+//		//					},
+//		//				},
+//		//			},
+//		//		}
+//		//	},
+//		//},
+//		//"FAILED TEST: composite fields: efs config is overridden if efs bool is not nil": {
+//		//	inSvc: func(svc *LoadBalancedWebService) {
+//		//		svc.Storage = &Storage{
+//		//			Volumes: map[string]Volume{
+//		//				"mockVolume1": {
+//		//					EFS: &EFSConfigOrBool{
+//		//						Advanced: EFSVolumeConfiguration{
+//		//							RootDirectory: aws.String("mockRootDir"),
+//		//							FileSystemID:  aws.String("mockFileSystem"),
+//		//						},
+//		//					},
+//		//				},
+//		//			},
+//		//		}
+//		//		svc.Environments["test"].Storage = &Storage{
+//		//			Volumes: map[string]Volume{
+//		//				"mockVolume1": {
+//		//					EFS: &EFSConfigOrBool{
+//		//						Enabled: aws.Bool(true),
+//		//					},
+//		//				},
+//		//			},
+//		//		}
+//		//	},
+//		//	wanted: func(svc *LoadBalancedWebService) {
+//		//		svc.Storage = &Storage{
+//		//			Volumes: map[string]Volume{
+//		//				"mockVolume1": {
+//		//					EFS: &EFSConfigOrBool{
+//		//						Enabled:  aws.Bool(true),
+//		//						Advanced: EFSVolumeConfiguration{},
+//		//					},
+//		//				},
+//		//			},
+//		//		}
+//		//	},
+//		//},
+//		"efs bool overridden": {
+//			inSvc: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Enabled: aws.Bool(false),
+//							},
+//						},
+//					},
+//				}
+//				svc.Environments["test"].Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Enabled: aws.Bool(true),
+//							},
+//						},
+//					},
+//				}
+//			},
+//			wanted: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Enabled: aws.Bool(true),
+//							},
+//						},
+//					},
+//				}
+//			},
+//		},
+//		"efs bool explicitly overridden by zero value": {
+//			inSvc: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Enabled: aws.Bool(true),
+//							},
+//						},
+//					},
+//				}
+//				svc.Environments["test"].Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Enabled: aws.Bool(false),
+//							},
+//						},
+//					},
+//				}
+//			},
+//			wanted: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Enabled: aws.Bool(false),
+//							},
+//						},
+//					},
+//				}
+//			},
+//		},
+//		"FAILED_AFTER_UPGRADE: efs bool not overridden": {
+//			inSvc: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Enabled: aws.Bool(true),
+//							},
+//						},
+//					},
+//				}
+//				svc.Environments["test"].Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {},
+//					},
+//				}
+//			},
+//			wanted: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Enabled: aws.Bool(true),
+//							},
+//						},
+//					},
+//				}
+//			},
+//		},
+//		"efs config overridden": {
+//			inSvc: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									FileSystemID: aws.String("mockFileSystem"),
+//								},
+//							},
+//						},
+//					},
+//				}
+//				svc.Environments["test"].Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									RootDirectory: aws.String("mockRootDirTest"),
+//									FileSystemID:  aws.String("mockFileSystemTest"),
+//									UID:           aws.Uint32(42),
+//								},
+//							},
+//						},
+//					},
+//				}
+//			},
+//			wanted: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									RootDirectory: aws.String("mockRootDirTest"),
+//									FileSystemID:  aws.String("mockFileSystemTest"),
+//									UID:           aws.Uint32(42),
+//								},
+//							},
+//						},
+//					},
+//				}
+//			},
+//		},
+//		"FAILED_AFTER_UPGRADE: efs config not overridden": {
+//			inSvc: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									FileSystemID: aws.String("mockFileSystem"),
+//								},
+//							},
+//						},
+//					},
+//				}
+//				svc.Environments["test"].Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {},
+//					},
+//				}
+//			},
+//			wanted: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									FileSystemID: aws.String("mockFileSystem"),
+//								},
+//							},
+//						},
+//					},
+//				}
+//			},
+//		},
+//		//"FAILED TEST: exclusive fields: id overridden if uid is not nil": {
+//		//	inSvc: func(svc *LoadBalancedWebService) {
+//		//		svc.Storage = &Storage{
+//		//			Volumes: map[string]Volume{
+//		//				"mockVolume1": {
+//		//					EFS: &EFSConfigOrBool{
+//		//						Advanced: EFSVolumeConfiguration{
+//		//							FileSystemID: aws.String("42"),
+//		//						},
+//		//					},
+//		//				},
+//		//			},
+//		//		}
+//		//		svc.Environments["test"].Storage = &Storage{
+//		//			Volumes: map[string]Volume{
+//		//				"mockVolume1": {
+//		//					EFS: &EFSConfigOrBool{
+//		//						Advanced: EFSVolumeConfiguration{
+//		//							UID: aws.Uint32(13),
+//		//						},
+//		//					},
+//		//				},
+//		//			},
+//		//		}
+//		//	},
+//		//	wanted: func(svc *LoadBalancedWebService) {
+//		//		svc.Storage = &Storage{
+//		//			Volumes: map[string]Volume{
+//		//				"mockVolume1": {
+//		//					EFS: &EFSConfigOrBool{
+//		//						Advanced: EFSVolumeConfiguration{
+//		//							FileSystemID: nil,
+//		//							UID:          aws.Uint32(13),
+//		//						},
+//		//					},
+//		//				},
+//		//			},
+//		//		}
+//		//	},
+//		//},
+//		//"FAILED TEST: exclusive fields: uid overridden if id is not nil": {
+//		//	inSvc: func(svc *LoadBalancedWebService) {
+//		//		svc.Storage = &Storage{
+//		//			Volumes: map[string]Volume{
+//		//				"mockVolume1": {
+//		//					EFS: &EFSConfigOrBool{
+//		//						Advanced: EFSVolumeConfiguration{
+//		//							UID: aws.Uint32(13),
+//		//						},
+//		//					},
+//		//				},
+//		//			},
+//		//		}
+//		//		svc.Environments["test"].Storage = &Storage{
+//		//			Volumes: map[string]Volume{
+//		//				"mockVolume1": {
+//		//					EFS: &EFSConfigOrBool{
+//		//						Advanced: EFSVolumeConfiguration{
+//		//							FileSystemID: aws.String("42"),
+//		//						},
+//		//					},
+//		//				},
+//		//			},
+//		//		}
+//		//	},
+//		//	wanted: func(svc *LoadBalancedWebService) {
+//		//		svc.Storage = &Storage{
+//		//			Volumes: map[string]Volume{
+//		//				"mockVolume1": {
+//		//					EFS: &EFSConfigOrBool{
+//		//						Advanced: EFSVolumeConfiguration{
+//		//							FileSystemID: aws.String("42"),
+//		//							UID:          nil,
+//		//						},
+//		//					},
+//		//				},
+//		//			},
+//		//		}
+//		//	},
+//		//},
+//		//"FAILED TEST: exclusive fields: root_dir overridden if uid is not nil": {
+//		//	inSvc: func(svc *LoadBalancedWebService) {
+//		//		svc.Storage = &Storage{
+//		//			Volumes: map[string]Volume{
+//		//				"mockVolume1": {
+//		//					EFS: &EFSConfigOrBool{
+//		//						Advanced: EFSVolumeConfiguration{
+//		//							RootDirectory: aws.String("mockRootDirectory"),
+//		//						},
+//		//					},
+//		//				},
+//		//			},
+//		//		}
+//		//		svc.Environments["test"].Storage = &Storage{
+//		//			Volumes: map[string]Volume{
+//		//				"mockVolume1": {
+//		//					EFS: &EFSConfigOrBool{
+//		//						Advanced: EFSVolumeConfiguration{
+//		//							UID: aws.Uint32(13),
+//		//						},
+//		//					},
+//		//				},
+//		//			},
+//		//		}
+//		//	},
+//		//	wanted: func(svc *LoadBalancedWebService) {
+//		//		svc.Storage = &Storage{
+//		//			Volumes: map[string]Volume{
+//		//				"mockVolume1": {
+//		//					EFS: &EFSConfigOrBool{
+//		//						Advanced: EFSVolumeConfiguration{
+//		//							RootDirectory: nil,
+//		//							UID:           aws.Uint32(13),
+//		//						},
+//		//					},
+//		//				},
+//		//			},
+//		//		}
+//		//	},
+//		//},
+//		//"FAILED TEST: exclusive fields: udi overridden if root_dir is not nil": {
+//		//	inSvc: func(svc *LoadBalancedWebService) {
+//		//		svc.Storage = &Storage{
+//		//			Volumes: map[string]Volume{
+//		//				"mockVolume1": {
+//		//					EFS: &EFSConfigOrBool{
+//		//						Advanced: EFSVolumeConfiguration{
+//		//							UID: aws.Uint32(13),
+//		//						},
+//		//					},
+//		//				},
+//		//			},
+//		//		}
+//		//		svc.Environments["test"].Storage = &Storage{
+//		//			Volumes: map[string]Volume{
+//		//				"mockVolume1": {
+//		//					EFS: &EFSConfigOrBool{
+//		//						Advanced: EFSVolumeConfiguration{
+//		//							RootDirectory: aws.String("mockRootDirectoryTest"),
+//		//						},
+//		//					},
+//		//				},
+//		//			},
+//		//		}
+//		//	},
+//		//	wanted: func(svc *LoadBalancedWebService) {
+//		//		svc.Storage = &Storage{
+//		//			Volumes: map[string]Volume{
+//		//				"mockVolume1": {
+//		//					EFS: &EFSConfigOrBool{
+//		//						Advanced: EFSVolumeConfiguration{
+//		//							RootDirectory: aws.String("mockRootDirectoryTest"),
+//		//							UID:           nil,
+//		//						},
+//		//					},
+//		//				},
+//		//			},
+//		//		}
+//		//	},
+//		//},
+//		//"FAILED TEST: exclusive fields: auth overridden if uid is not nil": {
+//		//	inSvc: func(svc *LoadBalancedWebService) {
+//		//		svc.Storage = &Storage{
+//		//			Volumes: map[string]Volume{
+//		//				"mockVolume1": {
+//		//					EFS: &EFSConfigOrBool{
+//		//						Advanced: EFSVolumeConfiguration{
+//		//							AuthConfig: &AuthorizationConfig{
+//		//								IAM:           aws.Bool(true),
+//		//								AccessPointID: aws.String("mockID1"),
+//		//							},
+//		//						},
+//		//					},
+//		//				},
+//		//			},
+//		//		}
+//		//		svc.Environments["test"].Storage = &Storage{
+//		//			Volumes: map[string]Volume{
+//		//				"mockVolume1": {
+//		//					EFS: &EFSConfigOrBool{
+//		//						Advanced: EFSVolumeConfiguration{
+//		//							UID: aws.Uint32(13),
+//		//						},
+//		//					},
+//		//				},
+//		//			},
+//		//		}
+//		//	},
+//		//	wanted: func(svc *LoadBalancedWebService) {
+//		//		svc.Storage = &Storage{
+//		//			Volumes: map[string]Volume{
+//		//				"mockVolume1": {
+//		//					EFS: &EFSConfigOrBool{
+//		//						Advanced: EFSVolumeConfiguration{
+//		//							UID:        aws.Uint32(13),
+//		//							AuthConfig: nil,
+//		//						},
+//		//					},
+//		//				},
+//		//			},
+//		//		}
+//		//	},
+//		//},
+//		//"FAILED TEST: exclusive fields: udi overridden if auth is not nil": {
+//		//	inSvc: func(svc *LoadBalancedWebService) {
+//		//		svc.Storage = &Storage{
+//		//			Volumes: map[string]Volume{
+//		//				"mockVolume1": {
+//		//					EFS: &EFSConfigOrBool{
+//		//						Advanced: EFSVolumeConfiguration{
+//		//							UID: aws.Uint32(13),
+//		//						},
+//		//					},
+//		//				},
+//		//			},
+//		//		}
+//		//		svc.Environments["test"].Storage = &Storage{
+//		//			Volumes: map[string]Volume{
+//		//				"mockVolume1": {
+//		//					EFS: &EFSConfigOrBool{
+//		//						Advanced: EFSVolumeConfiguration{
+//		//							AuthConfig: &AuthorizationConfig{
+//		//								IAM:           aws.Bool(true),
+//		//								AccessPointID: aws.String("mockIDTest"),
+//		//							},
+//		//						},
+//		//					},
+//		//				},
+//		//			},
+//		//		}
+//		//	},
+//		//	wanted: func(svc *LoadBalancedWebService) {
+//		//		svc.Storage = &Storage{
+//		//			Volumes: map[string]Volume{
+//		//				"mockVolume1": {
+//		//					EFS: &EFSConfigOrBool{
+//		//						Advanced: EFSVolumeConfiguration{
+//		//							UID: nil,
+//		//							AuthConfig: &AuthorizationConfig{
+//		//								IAM:           aws.Bool(true),
+//		//								AccessPointID: aws.String("mockIDTest"),
+//		//							},
+//		//						},
+//		//					},
+//		//				},
+//		//			},
+//		//		}
+//		//	},
+//		//},
+//		//"FAILED TEST: exclusive fields: id overridden if gid is not nil": {
+//		//	inSvc: func(svc *LoadBalancedWebService) {
+//		//		svc.Storage = &Storage{
+//		//			Volumes: map[string]Volume{
+//		//				"mockVolume1": {
+//		//					EFS: &EFSConfigOrBool{
+//		//						Advanced: EFSVolumeConfiguration{
+//		//							FileSystemID: aws.String("42"),
+//		//						},
+//		//					},
+//		//				},
+//		//			},
+//		//		}
+//		//		svc.Environments["test"].Storage = &Storage{
+//		//			Volumes: map[string]Volume{
+//		//				"mockVolume1": {
+//		//					EFS: &EFSConfigOrBool{
+//		//						Advanced: EFSVolumeConfiguration{
+//		//							GID: aws.Uint32(13),
+//		//						},
+//		//					},
+//		//				},
+//		//			},
+//		//		}
+//		//	},
+//		//	wanted: func(svc *LoadBalancedWebService) {
+//		//		svc.Storage = &Storage{
+//		//			Volumes: map[string]Volume{
+//		//				"mockVolume1": {
+//		//					EFS: &EFSConfigOrBool{
+//		//						Advanced: EFSVolumeConfiguration{
+//		//							FileSystemID: nil,
+//		//							GID:          aws.Uint32(13),
+//		//						},
+//		//					},
+//		//				},
+//		//			},
+//		//		}
+//		//	},
+//		//},
+//		//"FAILED TEST: exclusive fields: gid overridden if id is not nil": {
+//		//	inSvc: func(svc *LoadBalancedWebService) {
+//		//		svc.Storage = &Storage{
+//		//			Volumes: map[string]Volume{
+//		//				"mockVolume1": {
+//		//					EFS: &EFSConfigOrBool{
+//		//						Advanced: EFSVolumeConfiguration{
+//		//							GID: aws.Uint32(13),
+//		//						},
+//		//					},
+//		//				},
+//		//			},
+//		//		}
+//		//		svc.Environments["test"].Storage = &Storage{
+//		//			Volumes: map[string]Volume{
+//		//				"mockVolume1": {
+//		//					EFS: &EFSConfigOrBool{
+//		//						Advanced: EFSVolumeConfiguration{
+//		//							FileSystemID: aws.String("42"),
+//		//						},
+//		//					},
+//		//				},
+//		//			},
+//		//		}
+//		//	},
+//		//	wanted: func(svc *LoadBalancedWebService) {
+//		//		svc.Storage = &Storage{
+//		//			Volumes: map[string]Volume{
+//		//				"mockVolume1": {
+//		//					EFS: &EFSConfigOrBool{
+//		//						Advanced: EFSVolumeConfiguration{
+//		//							FileSystemID: aws.String("42"),
+//		//							GID:          nil,
+//		//						},
+//		//					},
+//		//				},
+//		//			},
+//		//		}
+//		//	},
+//		//},
+//		//"FAILED TEST: exclusive fields: root_dir overridden if gid is not nil": {
+//		//	inSvc: func(svc *LoadBalancedWebService) {
+//		//		svc.Storage = &Storage{
+//		//			Volumes: map[string]Volume{
+//		//				"mockVolume1": {
+//		//					EFS: &EFSConfigOrBool{
+//		//						Advanced: EFSVolumeConfiguration{
+//		//							RootDirectory: aws.String("mockRootDir"),
+//		//						},
+//		//					},
+//		//				},
+//		//			},
+//		//		}
+//		//		svc.Environments["test"].Storage = &Storage{
+//		//			Volumes: map[string]Volume{
+//		//				"mockVolume1": {
+//		//					EFS: &EFSConfigOrBool{
+//		//						Advanced: EFSVolumeConfiguration{
+//		//							GID: aws.Uint32(13),
+//		//						},
+//		//					},
+//		//				},
+//		//			},
+//		//		}
+//		//	},
+//		//	wanted: func(svc *LoadBalancedWebService) {
+//		//		svc.Storage = &Storage{
+//		//			Volumes: map[string]Volume{
+//		//				"mockVolume1": {
+//		//					EFS: &EFSConfigOrBool{
+//		//						Advanced: EFSVolumeConfiguration{
+//		//							RootDirectory: nil,
+//		//							GID:           aws.Uint32(13),
+//		//						},
+//		//					},
+//		//				},
+//		//			},
+//		//		}
+//		//	},
+//		//},
+//		//"FAILED TEST: exclusive fields: gid overridden if root_dir is not nil": {
+//		//	inSvc: func(svc *LoadBalancedWebService) {
+//		//		svc.Storage = &Storage{
+//		//			Volumes: map[string]Volume{
+//		//				"mockVolume1": {
+//		//					EFS: &EFSConfigOrBool{
+//		//						Advanced: EFSVolumeConfiguration{
+//		//							GID: aws.Uint32(13),
+//		//						},
+//		//					},
+//		//				},
+//		//			},
+//		//		}
+//		//		svc.Environments["test"].Storage = &Storage{
+//		//			Volumes: map[string]Volume{
+//		//				"mockVolume1": {
+//		//					EFS: &EFSConfigOrBool{
+//		//						Advanced: EFSVolumeConfiguration{
+//		//							RootDirectory: aws.String("mockRootDirTest"),
+//		//						},
+//		//					},
+//		//				},
+//		//			},
+//		//		}
+//		//	},
+//		//	wanted: func(svc *LoadBalancedWebService) {
+//		//		svc.Storage = &Storage{
+//		//			Volumes: map[string]Volume{
+//		//				"mockVolume1": {
+//		//					EFS: &EFSConfigOrBool{
+//		//						Advanced: EFSVolumeConfiguration{
+//		//							RootDirectory: aws.String("mockRootDirTest"),
+//		//							GID:           nil,
+//		//						},
+//		//					},
+//		//				},
+//		//			},
+//		//		}
+//		//	},
+//		//},
+//		//"FAILED TEST: exclusive fields: auth overridden if gid is not nil": {
+//		//	inSvc: func(svc *LoadBalancedWebService) {
+//		//		svc.Storage = &Storage{
+//		//			Volumes: map[string]Volume{
+//		//				"mockVolume1": {
+//		//					EFS: &EFSConfigOrBool{
+//		//						Advanced: EFSVolumeConfiguration{
+//		//							AuthConfig: &AuthorizationConfig{
+//		//								IAM:           aws.Bool(true),
+//		//								AccessPointID: aws.String("mockID1"),
+//		//							},
+//		//						},
+//		//					},
+//		//				},
+//		//			},
+//		//		}
+//		//		svc.Environments["test"].Storage = &Storage{
+//		//			Volumes: map[string]Volume{
+//		//				"mockVolume1": {
+//		//					EFS: &EFSConfigOrBool{
+//		//						Advanced: EFSVolumeConfiguration{
+//		//							GID: aws.Uint32(13),
+//		//						},
+//		//					},
+//		//				},
+//		//			},
+//		//		}
+//		//	},
+//		//	wanted: func(svc *LoadBalancedWebService) {
+//		//		svc.Storage = &Storage{
+//		//			Volumes: map[string]Volume{
+//		//				"mockVolume1": {
+//		//					EFS: &EFSConfigOrBool{
+//		//						Advanced: EFSVolumeConfiguration{
+//		//							AuthConfig: nil,
+//		//							GID:        aws.Uint32(13),
+//		//						},
+//		//					},
+//		//				},
+//		//			},
+//		//		}
+//		//	},
+//		//},
+//		//"FAILED TEST: exclusive fields: gid overridden if auth is not nil": {
+//		//	inSvc: func(svc *LoadBalancedWebService) {
+//		//		svc.Storage = &Storage{
+//		//			Volumes: map[string]Volume{
+//		//				"mockVolume1": {
+//		//					EFS: &EFSConfigOrBool{
+//		//						Advanced: EFSVolumeConfiguration{
+//		//							GID: aws.Uint32(13),
+//		//						},
+//		//					},
+//		//				},
+//		//			},
+//		//		}
+//		//		svc.Environments["test"].Storage = &Storage{
+//		//			Volumes: map[string]Volume{
+//		//				"mockVolume1": {
+//		//					EFS: &EFSConfigOrBool{
+//		//						Advanced: EFSVolumeConfiguration{
+//		//							AuthConfig: &AuthorizationConfig{
+//		//								IAM:           aws.Bool(true),
+//		//								AccessPointID: aws.String("mockID1"),
+//		//							},
+//		//						},
+//		//					},
+//		//				},
+//		//			},
+//		//		}
+//		//	},
+//		//	wanted: func(svc *LoadBalancedWebService) {
+//		//		svc.Storage = &Storage{
+//		//			Volumes: map[string]Volume{
+//		//				"mockVolume1": {
+//		//					EFS: &EFSConfigOrBool{
+//		//						Advanced: EFSVolumeConfiguration{
+//		//							AuthConfig: &AuthorizationConfig{
+//		//								IAM:           aws.Bool(true),
+//		//								AccessPointID: aws.String("mockID1"),
+//		//							},
+//		//							GID: nil,
+//		//						},
+//		//					},
+//		//				},
+//		//			},
+//		//		}
+//		//	},
+//		//},
+//		"id overridden": {
+//			inSvc: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									FileSystemID: aws.String("mockID"),
+//								},
+//							},
+//						},
+//					},
+//				}
+//				svc.Environments["test"].Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									FileSystemID: aws.String("mockIDTest"),
+//								},
+//							},
+//						},
+//					},
+//				}
+//			},
+//			wanted: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									FileSystemID: aws.String("mockIDTest"),
+//								},
+//							},
+//						},
+//					},
+//				}
+//			},
+//		},
+//		"id explicitly overridden by zero value": {
+//			inSvc: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									FileSystemID: aws.String("mockID"),
+//								},
+//							},
+//						},
+//					},
+//				}
+//				svc.Environments["test"].Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									FileSystemID: aws.String(""),
+//								},
+//							},
+//						},
+//					},
+//				}
+//			},
+//			wanted: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									FileSystemID: aws.String(""),
+//								},
+//							},
+//						},
+//					},
+//				}
+//			},
+//		},
+//		"FAILED_AFTER_UPGRADE: id not overridden": {
+//			inSvc: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									FileSystemID: aws.String("mockID"),
+//								},
+//							},
+//						},
+//					},
+//				}
+//				svc.Environments["test"].Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{},
+//							},
+//						},
+//					},
+//				}
+//			},
+//			wanted: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									FileSystemID: aws.String("mockID"),
+//								},
+//							},
+//						},
+//					},
+//				}
+//			},
+//		},
+//		"root_dir overridden": {
+//			inSvc: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									RootDirectory: aws.String("mockDir"),
+//								},
+//							},
+//						},
+//					},
+//				}
+//				svc.Environments["test"].Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									RootDirectory: aws.String("mockDirTest"),
+//								},
+//							},
+//						},
+//					},
+//				}
+//			},
+//			wanted: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									RootDirectory: aws.String("mockDirTest"),
+//								},
+//							},
+//						},
+//					},
+//				}
+//			},
+//		},
+//		"root_dir explicitly overridden by empty value": {
+//			inSvc: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									RootDirectory: aws.String("mockDir"),
+//								},
+//							},
+//						},
+//					},
+//				}
+//				svc.Environments["test"].Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									RootDirectory: aws.String(""),
+//								},
+//							},
+//						},
+//					},
+//				}
+//			},
+//			wanted: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									RootDirectory: aws.String(""),
+//								},
+//							},
+//						},
+//					},
+//				}
+//			},
+//		},
+//		"FAILED_AFTER_UPGRADE: root_dir not overridden": {
+//			inSvc: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									RootDirectory: aws.String("mockDir"),
+//								},
+//							},
+//						},
+//					},
+//				}
+//				svc.Environments["test"].Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{},
+//							},
+//						},
+//					},
+//				}
+//			},
+//			wanted: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									RootDirectory: aws.String("mockDir"),
+//								},
+//							},
+//						},
+//					},
+//				}
+//			},
+//		},
+//		"uid overridden": {
+//			inSvc: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									UID: aws.Uint32(13),
+//								},
+//							},
+//						},
+//					},
+//				}
+//				svc.Environments["test"].Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									UID: aws.Uint32(42),
+//								},
+//							},
+//						},
+//					},
+//				}
+//			},
+//			wanted: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									UID: aws.Uint32(42),
+//								},
+//							},
+//						},
+//					},
+//				}
+//			},
+//		},
+//		"uid explicitly overridden by empty value": {
+//			inSvc: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									UID: aws.Uint32(13),
+//								},
+//							},
+//						},
+//					},
+//				}
+//				svc.Environments["test"].Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									UID: aws.Uint32(0),
+//								},
+//							},
+//						},
+//					},
+//				}
+//			},
+//			wanted: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									UID: aws.Uint32(0),
+//								},
+//							},
+//						},
+//					},
+//				}
+//			},
+//		},
+//		"FAILED_AFTER_UPGRADE: uid not overridden": {
+//			inSvc: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									UID: aws.Uint32(13),
+//								},
+//							},
+//						},
+//					},
+//				}
+//				svc.Environments["test"].Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{},
+//							},
+//						},
+//					},
+//				}
+//			},
+//			wanted: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									UID: aws.Uint32(13),
+//								},
+//							},
+//						},
+//					},
+//				}
+//			},
+//		},
+//		"gid overridden": {
+//			inSvc: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									GID: aws.Uint32(13),
+//								},
+//							},
+//						},
+//					},
+//				}
+//				svc.Environments["test"].Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									GID: aws.Uint32(42),
+//								},
+//							},
+//						},
+//					},
+//				}
+//			},
+//			wanted: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									GID: aws.Uint32(42),
+//								},
+//							},
+//						},
+//					},
+//				}
+//			},
+//		},
+//		"gid explicitly overridden by empty value": {
+//			inSvc: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									GID: aws.Uint32(13),
+//								},
+//							},
+//						},
+//					},
+//				}
+//				svc.Environments["test"].Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									GID: aws.Uint32(0),
+//								},
+//							},
+//						},
+//					},
+//				}
+//			},
+//			wanted: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									GID: aws.Uint32(0),
+//								},
+//							},
+//						},
+//					},
+//				}
+//			},
+//		},
+//		"FAILED_AFTER_UPGRADE: gid not overridden": {
+//			inSvc: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									GID: aws.Uint32(13),
+//								},
+//							},
+//						},
+//					},
+//				}
+//				svc.Environments["test"].Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{},
+//							},
+//						},
+//					},
+//				}
+//			},
+//			wanted: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									GID: aws.Uint32(13),
+//								},
+//							},
+//						},
+//					},
+//				}
+//			},
+//		},
+//		"auth overridden": {
+//			inSvc: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									AuthConfig: &AuthorizationConfig{
+//										AccessPointID: aws.String("mockPoint"),
+//									},
+//								},
+//							},
+//						},
+//					},
+//				}
+//				svc.Environments["test"].Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									AuthConfig: &AuthorizationConfig{
+//										IAM:           aws.Bool(true),
+//										AccessPointID: aws.String("mockPointTest"),
+//									},
+//								},
+//							},
+//						},
+//					},
+//				}
+//			},
+//			wanted: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									AuthConfig: &AuthorizationConfig{
+//										IAM:           aws.Bool(true),
+//										AccessPointID: aws.String("mockPointTest"),
+//									},
+//								},
+//							},
+//						},
+//					},
+//				}
+//			},
+//		},
+//		"FAILED_AFTER_UPGRADE: auth not overridden": {
+//			inSvc: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									AuthConfig: &AuthorizationConfig{
+//										AccessPointID: aws.String("mockPoint"),
+//									},
+//								},
+//							},
+//						},
+//					},
+//				}
+//				svc.Environments["test"].Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{},
+//							},
+//						},
+//					},
+//				}
+//			},
+//			wanted: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									AuthConfig: &AuthorizationConfig{
+//										AccessPointID: aws.String("mockPoint"),
+//									},
+//								},
+//							},
+//						},
+//					},
+//				}
+//			},
+//		},
+//	}
+//	for name, tc := range testCases {
+//		t.Run(name, func(t *testing.T) {
+//			var inSvc, wantedSvc LoadBalancedWebService
+//			inSvc.Environments = map[string]*LoadBalancedWebServiceConfig{
+//				"test": {},
+//			}
+//
+//			tc.inSvc(&inSvc)
+//			tc.wanted(&wantedSvc)
+//
+//			got, err := inSvc.ApplyEnv("test")
+//
+//			require.NoError(t, err)
+//			require.Equal(t, &wantedSvc, got)
+//		})
+//	}
+//}
+//
+//func Test_ApplyEnv_Storage_Volume_EFS_Auth(t *testing.T) {
+//	testCases := map[string]struct {
+//		inSvc  func(svc *LoadBalancedWebService)
+//		wanted func(svc *LoadBalancedWebService)
+//	}{
+//		"iam overridden": {
+//			inSvc: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									AuthConfig: &AuthorizationConfig{
+//										IAM: aws.Bool(false),
+//									},
+//								},
+//							},
+//						},
+//					},
+//				}
+//				svc.Environments["test"].Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									AuthConfig: &AuthorizationConfig{
+//										IAM: aws.Bool(true),
+//									},
+//								},
+//							},
+//						},
+//					},
+//				}
+//			},
+//			wanted: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									AuthConfig: &AuthorizationConfig{
+//										IAM: aws.Bool(true),
+//									},
+//								},
+//							},
+//						},
+//					},
+//				}
+//			},
+//		},
+//		"iam explicitly overridden by empty value": {
+//			inSvc: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									AuthConfig: &AuthorizationConfig{
+//										IAM: aws.Bool(true),
+//									},
+//								},
+//							},
+//						},
+//					},
+//				}
+//				svc.Environments["test"].Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									AuthConfig: &AuthorizationConfig{
+//										IAM: aws.Bool(false),
+//									},
+//								},
+//							},
+//						},
+//					},
+//				}
+//			},
+//			wanted: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									AuthConfig: &AuthorizationConfig{
+//										IAM: aws.Bool(false),
+//									},
+//								},
+//							},
+//						},
+//					},
+//				}
+//			},
+//		},
+//		"FAILED_AFTER_UPGRADE: iam not overridden": {
+//			inSvc: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									AuthConfig: &AuthorizationConfig{
+//										IAM: aws.Bool(true),
+//									},
+//								},
+//							},
+//						},
+//					},
+//				}
+//				svc.Environments["test"].Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									AuthConfig: &AuthorizationConfig{},
+//								},
+//							},
+//						},
+//					},
+//				}
+//			},
+//			wanted: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									AuthConfig: &AuthorizationConfig{
+//										IAM: aws.Bool(true),
+//									},
+//								},
+//							},
+//						},
+//					},
+//				}
+//			},
+//		},
+//		"access_point_id overridden": {
+//			inSvc: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									AuthConfig: &AuthorizationConfig{
+//										AccessPointID: aws.String("mockPoint"),
+//									},
+//								},
+//							},
+//						},
+//					},
+//				}
+//				svc.Environments["test"].Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									AuthConfig: &AuthorizationConfig{
+//										AccessPointID: aws.String("mockPointTest"),
+//									},
+//								},
+//							},
+//						},
+//					},
+//				}
+//			},
+//			wanted: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									AuthConfig: &AuthorizationConfig{
+//										AccessPointID: aws.String("mockPointTest"),
+//									},
+//								},
+//							},
+//						},
+//					},
+//				}
+//			},
+//		},
+//		"access_point_id explicitly overridden by empty value": {
+//			inSvc: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									AuthConfig: &AuthorizationConfig{
+//										AccessPointID: aws.String("mockPoint"),
+//									},
+//								},
+//							},
+//						},
+//					},
+//				}
+//				svc.Environments["test"].Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									AuthConfig: &AuthorizationConfig{
+//										AccessPointID: aws.String(""),
+//									},
+//								},
+//							},
+//						},
+//					},
+//				}
+//			},
+//			wanted: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									AuthConfig: &AuthorizationConfig{
+//										AccessPointID: aws.String(""),
+//									},
+//								},
+//							},
+//						},
+//					},
+//				}
+//			},
+//		},
+//		"FAILED_AFTER_UPGRADE: access_point_id not overridden": {
+//			inSvc: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									AuthConfig: &AuthorizationConfig{
+//										AccessPointID: aws.String("mockPoint"),
+//									},
+//								},
+//							},
+//						},
+//					},
+//				}
+//				svc.Environments["test"].Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									AuthConfig: &AuthorizationConfig{},
+//								},
+//							},
+//						},
+//					},
+//				}
+//			},
+//			wanted: func(svc *LoadBalancedWebService) {
+//				svc.Storage = &Storage{
+//					Volumes: map[string]Volume{
+//						"mockVolume1": {
+//							EFS: &EFSConfigOrBool{
+//								Advanced: EFSVolumeConfiguration{
+//									AuthConfig: &AuthorizationConfig{
+//										AccessPointID: aws.String("mockPoint"),
+//									},
+//								},
+//							},
+//						},
+//					},
+//				}
+//			},
+//		},
+//	}
+//	for name, tc := range testCases {
+//		t.Run(name, func(t *testing.T) {
+//			var inSvc, wantedSvc LoadBalancedWebService
+//			inSvc.Environments = map[string]*LoadBalancedWebServiceConfig{
+//				"test": {},
+//			}
+//
+//			tc.inSvc(&inSvc)
+//			tc.wanted(&wantedSvc)
+//
+//			got, err := inSvc.ApplyEnv("test")
+//
+//			require.NoError(t, err)
+//			require.Equal(t, &wantedSvc, got)
+//		})
+//	}
+//}

--- a/internal/pkg/manifest/storage_applyenv_test.go
+++ b/internal/pkg/manifest/storage_applyenv_test.go
@@ -376,7 +376,7 @@ func Test_ApplyEnv_Storage_Volume(t *testing.T) {
 					Volumes: map[string]Volume{
 						"mockVolume1": {
 							MountPointOpts: MountPointOpts{
-								ReadOnly: aws.Bool(true),
+								ReadOnly: aws.Bool(false),
 							},
 						},
 					},
@@ -394,7 +394,7 @@ func Test_ApplyEnv_Storage_Volume(t *testing.T) {
 					Volumes: map[string]Volume{
 						"mockVolume1": {
 							MountPointOpts: MountPointOpts{
-								ReadOnly: aws.Bool(true),
+								ReadOnly: aws.Bool(false),
 							},
 						},
 					},

--- a/internal/pkg/manifest/svc_applyenv_test.go
+++ b/internal/pkg/manifest/svc_applyenv_test.go
@@ -83,7 +83,7 @@ func TestApplyEnv_Count(t *testing.T) {
 				}
 			},
 		},
-		"FAILED_AFTER_UPGRADE: value not overridden": {
+		"FIXED_AFTER_TRANSFORM_POINTER: value not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Count = Count{
 					Value: aws.Int(13),
@@ -123,7 +123,7 @@ func TestApplyEnv_Count(t *testing.T) {
 				}
 			},
 		},
-		"FAILED_AFTER_UPGRADE: advanced count not overridden": {
+		"FIXED_AFTER_TRANSFORM_POINTER: advanced count not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Count = Count{
 					AdvancedCount: AdvancedCount{
@@ -413,7 +413,7 @@ func TestApplyEnv_Count(t *testing.T) {
 				}
 			},
 		},
-		"FAILED_AFTER_UPGRADE: spot not overridden": {
+		"FIXED_AFTER_TRANSFORM_POINTER: spot not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Count = Count{
 					AdvancedCount: AdvancedCount{
@@ -522,7 +522,7 @@ func TestApplyEnv_Count(t *testing.T) {
 				}
 			},
 		},
-		"FAILED_AFTER_UPGRADE: cpu_percentage not overridden": {
+		"FIXED_AFTER_TRANSFORM_POINTER: cpu_percentage not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Count = Count{
 					AdvancedCount: AdvancedCount{
@@ -583,7 +583,7 @@ func TestApplyEnv_Count(t *testing.T) {
 				}
 			},
 		},
-		"FAILED_AFTER_UPGRADE: memory_percentage not overridden": {
+		"FIXED_AFTER_TRANSFORM_POINTER: memory_percentage not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Count = Count{
 					AdvancedCount: AdvancedCount{
@@ -644,7 +644,7 @@ func TestApplyEnv_Count(t *testing.T) {
 				}
 			},
 		},
-		"FAILED_AFTER_UPGRADE: requests not overridden": {
+		"FIXED_AFTER_TRANSFORM_POINTER: requests not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Count = Count{
 					AdvancedCount: AdvancedCount{
@@ -711,7 +711,7 @@ func TestApplyEnv_Count(t *testing.T) {
 				}
 			},
 		},
-		"FAILED_AFTER_UPGRADE: response_time not overridden": {
+		"FIXED_AFTER_TRANSFORM_POINTER: response_time not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				mockResponseTime := 1010 * time.Second
 				svc.Count = Count{

--- a/internal/pkg/manifest/svc_applyenv_test.go
+++ b/internal/pkg/manifest/svc_applyenv_test.go
@@ -83,7 +83,7 @@ func TestApplyEnv_Count(t *testing.T) {
 				}
 			},
 		},
-		"value not overridden": {
+		"FAILED_AFTER_UPGRADE: value not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Count = Count{
 					Value: aws.Int(13),
@@ -123,7 +123,7 @@ func TestApplyEnv_Count(t *testing.T) {
 				}
 			},
 		},
-		"advanced count not overridden": {
+		"FAILED_AFTER_UPGRADE: advanced count not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Count = Count{
 					AdvancedCount: AdvancedCount{
@@ -413,7 +413,7 @@ func TestApplyEnv_Count(t *testing.T) {
 				}
 			},
 		},
-		"spot not overridden": {
+		"FAILED_AFTER_UPGRADE: spot not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Count = Count{
 					AdvancedCount: AdvancedCount{
@@ -457,7 +457,7 @@ func TestApplyEnv_Count(t *testing.T) {
 				}
 			},
 		},
-		"range not overridden": {
+		"FAILED_AFTER_UPGRADE: range not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Count = Count{
 					AdvancedCount: AdvancedCount{
@@ -522,7 +522,7 @@ func TestApplyEnv_Count(t *testing.T) {
 				}
 			},
 		},
-		"cpu_percentage not overridden": {
+		"FAILED_AFTER_UPGRADE: cpu_percentage not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Count = Count{
 					AdvancedCount: AdvancedCount{
@@ -583,7 +583,7 @@ func TestApplyEnv_Count(t *testing.T) {
 				}
 			},
 		},
-		"memory_percentage not overridden": {
+		"FAILED_AFTER_UPGRADE: memory_percentage not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Count = Count{
 					AdvancedCount: AdvancedCount{
@@ -644,7 +644,7 @@ func TestApplyEnv_Count(t *testing.T) {
 				}
 			},
 		},
-		"requests not overridden": {
+		"FAILED_AFTER_UPGRADE: requests not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Count = Count{
 					AdvancedCount: AdvancedCount{
@@ -711,7 +711,7 @@ func TestApplyEnv_Count(t *testing.T) {
 				}
 			},
 		},
-		"response_time not overridden": {
+		"FAILED_AFTER_UPGRADE: response_time not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				mockResponseTime := 1010 * time.Second
 				svc.Count = Count{
@@ -876,7 +876,7 @@ func TestApplyEnv_Count_Range(t *testing.T) {
 				}
 			},
 		},
-		"range value not overridden": {
+		"FAILED_AFTER_UPGRADE: range value not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Count = Count{
 					AdvancedCount: AdvancedCount{

--- a/internal/pkg/manifest/transform.go
+++ b/internal/pkg/manifest/transform.go
@@ -55,7 +55,7 @@ func transformMapStringToVolume() func(dst, src reflect.Value) error {
 			// Perform default merge
 			dstV := dstElement.Interface().(Volume)
 			srcV := srcElement.Interface().(Volume)
-			err := mergo.Merge(&dstV, srcV, mergo.WithOverride, mergo.WithOverwriteWithEmptyValue, mergo.WithTransformers(volumeTransformer{}))
+			err := mergo.Merge(&dstV, srcV, mergo.WithOverride, mergo.WithTransformers(volumeTransformer{}))
 			if err != nil {
 				return err
 			}
@@ -70,6 +70,7 @@ func transformMapStringToVolume() func(dst, src reflect.Value) error {
 type volumeTransformer struct{}
 
 func (t volumeTransformer) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
+	//fmt.Println(typ)
 	if typ.Kind() == reflect.Ptr {
 		for _, k := range overrideKinds {
 			if typ.Elem().Kind() == k {
@@ -84,29 +85,6 @@ func (t volumeTransformer) Transformer(typ reflect.Type) func(dst, src reflect.V
 	return nil
 }
 
-//func transformVolume() func(dst, src reflect.Value) error {
-//	return func(dst, src reflect.Value) error {
-//		// Perform default merge
-//		dstV := dst.Interface().(Volume)
-//		srcV := src.Interface().(Volume)
-//
-//		fmt.Printf("addr of dst: %p\n", &dst)
-//		fmt.Printf("addr of dstV: %p\n", &dstV)
-//
-//		err := mergo.Merge(&dstV, srcV, mergo.WithOverride, mergo.WithOverwriteWithEmptyValue, mergo.WithTransformers(volumeTransformer{}))
-//		if err != nil {
-//			return err
-//		}
-//
-//		//fmt.Println(*dstV.MountPointOpts.ContainerPath)
-//		fmt.Println(dst.FieldByName("ContainerPath").Elem())
-//		fmt.Println(*dstV.ContainerPath)
-//		fmt.Printf("addr of dst: %p\n", &dst)
-//		fmt.Printf("addr of dstV: %p\n", &dstV)
-//		return nil
-//	}
-//}
-
 func transformPStruct() func(dst, src reflect.Value) error {
 	return func(dst, src reflect.Value) error {
 		if src.IsNil() {
@@ -119,59 +97,59 @@ func transformPStruct() func(dst, src reflect.Value) error {
 		case "ContainerHealthCheck":
 			dstElem := dst.Interface().(*ContainerHealthCheck)
 			srcElem := src.Elem().Interface().(ContainerHealthCheck)
-			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithOverwriteWithEmptyValue, mergo.WithTransformers(workloadTransformer{}))
+			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithTransformers(workloadTransformer{}))
 		case "PlatformArgsOrString":
 			dstElem := dst.Interface().(*PlatformArgsOrString)
 			srcElem := src.Elem().Interface().(PlatformArgsOrString)
-			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithOverwriteWithEmptyValue, mergo.WithTransformers(workloadTransformer{}))
+			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithTransformers(workloadTransformer{}))
 		case "EntryPointOverride":
 			dstElem := dst.Interface().(*EntryPointOverride)
 			srcElem := src.Elem().Interface().(EntryPointOverride)
-			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithOverwriteWithEmptyValue, mergo.WithTransformers(workloadTransformer{}))
+			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithTransformers(workloadTransformer{}))
 		case "CommandOverride":
 			dstElem := dst.Interface().(*CommandOverride)
 			srcElem := src.Elem().Interface().(CommandOverride)
-			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithOverwriteWithEmptyValue, mergo.WithTransformers(workloadTransformer{}))
+			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithTransformers(workloadTransformer{}))
 		case "NetworkConfig":
 			dstElem := dst.Interface().(*NetworkConfig)
 			srcElem := src.Elem().Interface().(NetworkConfig)
-			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithOverwriteWithEmptyValue, mergo.WithTransformers(workloadTransformer{}))
+			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithTransformers(workloadTransformer{}))
 		case "vpcConfig":
 			dstElem := dst.Interface().(*vpcConfig)
 			srcElem := src.Elem().Interface().(vpcConfig)
-			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithOverwriteWithEmptyValue, mergo.WithTransformers(workloadTransformer{}))
+			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithTransformers(workloadTransformer{}))
 		case "Logging":
 			dstElem := dst.Interface().(*Logging)
 			srcElem := src.Elem().Interface().(Logging)
-			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithOverwriteWithEmptyValue, mergo.WithTransformers(workloadTransformer{}))
+			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithTransformers(workloadTransformer{}))
 		case "Storage":
 			dstElem := dst.Interface().(*Storage)
 			srcElem := src.Elem().Interface().(Storage)
-			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithOverwriteWithEmptyValue, mergo.WithTransformers(workloadTransformer{}))
+			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithTransformers(workloadTransformer{}))
 		case "Alias":
 			dstElem := dst.Interface().(*Alias)
 			srcElem := src.Elem().Interface().(Alias)
-			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithOverwriteWithEmptyValue, mergo.WithTransformers(workloadTransformer{}))
+			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithTransformers(workloadTransformer{}))
 		case "SidecarConfig":
 			dstElem := dst.Interface().(*SidecarConfig)
 			srcElem := src.Elem().Interface().(SidecarConfig)
-			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithOverwriteWithEmptyValue, mergo.WithTransformers(workloadTransformer{}))
+			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithTransformers(workloadTransformer{}))
 		case "SubscribeConfig":
 			dstElem := dst.Interface().(*SubscribeConfig)
 			srcElem := src.Elem().Interface().(SubscribeConfig)
-			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithOverwriteWithEmptyValue, mergo.WithTransformers(workloadTransformer{}))
+			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithTransformers(workloadTransformer{}))
 		case "SQSQueue":
 			dstElem := dst.Interface().(*SQSQueue)
 			srcElem := src.Elem().Interface().(SQSQueue)
-			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithOverwriteWithEmptyValue, mergo.WithTransformers(workloadTransformer{}))
+			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithTransformers(workloadTransformer{}))
 		case "EFSConfigOrBool":
 			dstElem := dst.Interface().(*EFSConfigOrBool)
 			srcElem := src.Elem().Interface().(EFSConfigOrBool)
-			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithOverwriteWithEmptyValue, mergo.WithTransformers(workloadTransformer{}))
+			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithTransformers(workloadTransformer{}))
 		case "AuthorizationConfig":
 			dstElem := dst.Interface().(*AuthorizationConfig)
 			srcElem := src.Elem().Interface().(AuthorizationConfig)
-			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithOverwriteWithEmptyValue, mergo.WithTransformers(workloadTransformer{}))
+			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithTransformers(workloadTransformer{}))
 		}
 
 		if err != nil {

--- a/internal/pkg/manifest/transform.go
+++ b/internal/pkg/manifest/transform.go
@@ -43,6 +43,7 @@ func (t volumeTransformer) Transformer(typ reflect.Type) func(dst, src reflect.V
 	return transformBasic(typ)
 }
 
+// transformBasic implements customized merge logic for manifest fields that are number, string, bool, array, and duration.
 func transformBasic(typ reflect.Type) func(dst, src reflect.Value) error {
 	if typ.Kind() == reflect.Slice {
 		return transformSlice()
@@ -77,6 +78,10 @@ func transformMapStringToVolume() func(dst, src reflect.Value) error {
 				continue
 			}
 			dstElement := dst.MapIndex(key)
+			if !dstElement.IsValid() {
+				dst.SetMapIndex(key, srcElement)
+				continue
+			}
 
 			// Perform default merge
 			dstV := dstElement.Interface().(Volume)

--- a/internal/pkg/manifest/transform.go
+++ b/internal/pkg/manifest/transform.go
@@ -9,6 +9,7 @@ import (
 	"github.com/imdario/mergo"
 )
 
+// See a complete list of `reflect.Kind` here: https://pkg.go.dev/reflect#Kind.
 var basicKinds = []reflect.Kind{
 	reflect.Bool,
 	reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,

--- a/internal/pkg/manifest/transform.go
+++ b/internal/pkg/manifest/transform.go
@@ -1,0 +1,72 @@
+package manifest
+
+import (
+	"reflect"
+
+	"github.com/imdario/mergo"
+)
+
+type workloadTransformer struct{}
+
+var overrideKinds = []reflect.Kind{
+	reflect.Bool,
+	reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+	reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+	reflect.Float32, reflect.Float64,
+	reflect.Complex64, reflect.Complex128,
+	reflect.Array, reflect.String, reflect.Slice,
+}
+
+// Transformer implements customized merge logic for Image field of manifest.
+// It merges `DockerLabels` and `DependsOn` in the default manager (i.e. with configurations mergo.WithOverride, mergo.WithOverwriteWithEmptyValue)
+// And then overrides both `Build` and `Location` fields at the same time with the src values, given that they are non-empty themselves.
+func (t workloadTransformer) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
+	if typ == reflect.TypeOf(Image{}) {
+		return transformImage()
+	}
+
+	if typ.Kind() == reflect.Ptr {
+		for _, k := range overrideKinds {
+			if typ.Elem().Kind() == k {
+				return transformPointer() // Use `transformPointer` only if the pointer is to a "basic type" TODO: reword this
+			}
+		}
+	}
+	return nil
+}
+
+func transformPointer() func(dst, src reflect.Value) error {
+	return func(dst, src reflect.Value) error {
+		if src.IsNil() {
+			return nil
+		}
+		dst.Set(src)
+		return nil
+	}
+}
+
+func transformImage() func(dst, src reflect.Value) error {
+	return func(dst, src reflect.Value) error {
+		// Perform default merge
+		dstImage := dst.Interface().(Image)
+		srcImage := src.Interface().(Image)
+
+		err := mergo.Merge(&dstImage, srcImage, mergo.WithOverride, mergo.WithOverwriteWithEmptyValue)
+		if err != nil {
+			return err
+		}
+
+		// Perform customized merge
+		dstBuild := dst.FieldByName("Build")
+		dstLocation := dst.FieldByName("Location")
+
+		srcBuild := src.FieldByName("Build")
+		srcLocation := src.FieldByName("Location")
+
+		if !srcBuild.IsZero() || !srcLocation.IsZero() {
+			dstBuild.Set(srcBuild)
+			dstLocation.Set(srcLocation)
+		}
+		return nil
+	}
+}

--- a/internal/pkg/manifest/transform.go
+++ b/internal/pkg/manifest/transform.go
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package manifest
 
 import (

--- a/internal/pkg/manifest/transform.go
+++ b/internal/pkg/manifest/transform.go
@@ -31,8 +31,78 @@ func (t workloadTransformer) Transformer(typ reflect.Type) func(dst, src reflect
 				return transformPointer() // Use `transformPointer` only if the pointer is to a "basic type" TODO: reword this
 			}
 		}
+
+		if typ.Elem().Kind() == reflect.Struct {
+			return transformPStruct()
+		}
 	}
 	return nil
+}
+
+func transformPStruct() func(dst, src reflect.Value) error {
+	return func(dst, src reflect.Value) error {
+		if src.IsNil() {
+			return nil
+		}
+
+		// Perform default merge
+		var err error
+		switch dst.Elem().Type().Name() {
+		case "ContainerHealthCheck":
+			dstElem := dst.Interface().(*ContainerHealthCheck)
+			srcElem := src.Elem().Interface().(ContainerHealthCheck)
+			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithOverwriteWithEmptyValue, mergo.WithTransformers(workloadTransformer{}))
+		case "PlatformArgsOrString":
+			dstElem := dst.Interface().(*PlatformArgsOrString)
+			srcElem := src.Elem().Interface().(PlatformArgsOrString)
+			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithOverwriteWithEmptyValue, mergo.WithTransformers(workloadTransformer{}))
+		case "EntryPointOverride":
+			dstElem := dst.Interface().(*EntryPointOverride)
+			srcElem := src.Elem().Interface().(EntryPointOverride)
+			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithOverwriteWithEmptyValue, mergo.WithTransformers(workloadTransformer{}))
+		case "CommandOverride":
+			dstElem := dst.Interface().(*CommandOverride)
+			srcElem := src.Elem().Interface().(CommandOverride)
+			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithOverwriteWithEmptyValue, mergo.WithTransformers(workloadTransformer{}))
+		case "NetworkConfig":
+			dstElem := dst.Interface().(*NetworkConfig)
+			srcElem := src.Elem().Interface().(NetworkConfig)
+			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithOverwriteWithEmptyValue, mergo.WithTransformers(workloadTransformer{}))
+		case "vpcConfig":
+			dstElem := dst.Interface().(*vpcConfig)
+			srcElem := src.Elem().Interface().(vpcConfig)
+			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithOverwriteWithEmptyValue, mergo.WithTransformers(workloadTransformer{}))
+		case "Logging":
+			dstElem := dst.Interface().(*Logging)
+			srcElem := src.Elem().Interface().(Logging)
+			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithOverwriteWithEmptyValue, mergo.WithTransformers(workloadTransformer{}))
+		case "Storage":
+			dstElem := dst.Interface().(*Storage)
+			srcElem := src.Elem().Interface().(Storage)
+			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithOverwriteWithEmptyValue, mergo.WithTransformers(workloadTransformer{}))
+		case "Alias":
+			dstElem := dst.Interface().(*Alias)
+			srcElem := src.Elem().Interface().(Alias)
+			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithOverwriteWithEmptyValue, mergo.WithTransformers(workloadTransformer{}))
+		case "SidecarConfig":
+			dstElem := dst.Interface().(*SidecarConfig)
+			srcElem := src.Elem().Interface().(SidecarConfig)
+			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithOverwriteWithEmptyValue, mergo.WithTransformers(workloadTransformer{}))
+		case "SubscribeConfig":
+			dstElem := dst.Interface().(*SubscribeConfig)
+			srcElem := src.Elem().Interface().(SubscribeConfig)
+			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithOverwriteWithEmptyValue, mergo.WithTransformers(workloadTransformer{}))
+		case "SQSQueue":
+			dstElem := dst.Interface().(*SQSQueue)
+			srcElem := src.Elem().Interface().(SQSQueue)
+			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithOverwriteWithEmptyValue, mergo.WithTransformers(workloadTransformer{}))
+		}
+
+		if err != nil {
+			return err
+		}
+		return nil
+	}
 }
 
 func transformPointer() func(dst, src reflect.Value) error {

--- a/internal/pkg/manifest/worker_svc_test.go
+++ b/internal/pkg/manifest/worker_svc_test.go
@@ -1046,7 +1046,7 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 
 			original: &mockWorkerServiceWithSubscribeQueueNilOverride,
 		},
-		"with empty subscribe queue overriden by full subscribe queue": {
+		"with empty subscribe queue overridden by full subscribe queue": {
 			svc:       &mockWorkerServiceWithSubscribeQueueEmptyOverride,
 			inEnvName: "test-sub",
 			wanted: &WorkerService{

--- a/internal/pkg/manifest/workload.go
+++ b/internal/pkg/manifest/workload.go
@@ -8,15 +8,12 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
-	"reflect"
 	"strconv"
 	"time"
 
 	"github.com/aws/copilot-cli/internal/pkg/docker/dockerengine"
 
 	"github.com/dustin/go-humanize/english"
-
-	"github.com/imdario/mergo"
 
 	"github.com/google/shlex"
 
@@ -84,44 +81,6 @@ type Image struct {
 	Credentials  *string           `yaml:"credentials"`     // ARN of the secret containing the private repository credentials.
 	DockerLabels map[string]string `yaml:"labels,flow"`     // Apply Docker labels to the container at runtime.
 	DependsOn    map[string]string `yaml:"depends_on,flow"` // Add any sidecar dependencies.
-}
-
-type workloadTransformer struct{}
-
-// Transformer implements customized merge logic for Image field of manifest.
-// It merges `DockerLabels` and `DependsOn` in the default manager (i.e. with configurations mergo.WithOverride, mergo.WithOverwriteWithEmptyValue)
-// And then overrides both `Build` and `Location` fields at the same time with the src values, given that they are non-empty themselves.
-func (t workloadTransformer) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
-	if typ == reflect.TypeOf(Image{}) {
-		return transformImage()
-	}
-	return nil
-}
-
-func transformImage() func(dst, src reflect.Value) error {
-	return func(dst, src reflect.Value) error {
-		// Perform default merge
-		dstImage := dst.Interface().(Image)
-		srcImage := src.Interface().(Image)
-
-		err := mergo.Merge(&dstImage, srcImage, mergo.WithOverride, mergo.WithOverwriteWithEmptyValue)
-		if err != nil {
-			return err
-		}
-
-		// Perform customized merge
-		dstBuild := dst.FieldByName("Build")
-		dstLocation := dst.FieldByName("Location")
-
-		srcBuild := src.FieldByName("Build")
-		srcLocation := src.FieldByName("Location")
-
-		if !srcBuild.IsZero() || !srcLocation.IsZero() {
-			dstBuild.Set(srcBuild)
-			dstLocation.Set(srcLocation)
-		}
-		return nil
-	}
 }
 
 // ImageWithHealthcheck represents a container image with health check.


### PR DESCRIPTION
This PR is part of the second step (writing units test) to address #2492. It:
1. Upgrades `mergo`
2. Fixes code by implementing custom transformers so that all `applyEnv` tests that have been passing are still passing

Next: 
1. Change pointer struct to struct and remove `pStruct` transformers
2. Fix bugs (tests that have been failing and commented out in previous PRs (#2700 ~ #2734)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
