### PR TITLE
fix(manifest): fix previously found `ApplyEnv` bugs

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/lb_web_service_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/lb_web_service_integration_test.go
@@ -55,10 +55,9 @@ func TestLoadBalancedWebService_Template(t *testing.T) {
 	path := filepath.Join("testdata", "workloads", svcManifestPath)
 	manifestBytes, err := ioutil.ReadFile(path)
 	require.NoError(t, err)
-	mft, err := manifest.UnmarshalWorkload(manifestBytes)
-	require.NoError(t, err)
-
 	for name, tc := range testCases {
+		mft, err := manifest.UnmarshalWorkload(manifestBytes)
+		require.NoError(t, err)
 		envMft, err := mft.ApplyEnv(tc.envName)
 		require.NoError(t, err)
 		v, ok := envMft.(*manifest.LoadBalancedWebService)

--- a/internal/pkg/deploy/cloudformation/stack/transformers.go
+++ b/internal/pkg/deploy/cloudformation/stack/transformers.go
@@ -667,7 +667,7 @@ func convertSubscribe(s *manifest.SubscribeConfig, validTopicARNs []string, acco
 	}
 
 	var subscriptions template.SubscribeOpts
-	for _, sb := range *s.Topics {
+	for _, sb := range s.Topics {
 		ts, err := convertTopicSubscription(sb, validTopicARNs, sqsEndpoint.URL, accountID, app, env, svc)
 		if err != nil {
 			return nil, err

--- a/internal/pkg/deploy/cloudformation/stack/transformers_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/transformers_test.go
@@ -1585,7 +1585,7 @@ func Test_convertSubscribe(t *testing.T) {
 		},
 		"subscription with empty topic subscriptions": {
 			inSubscribe: &manifest.SubscribeConfig{
-				Topics: &[]manifest.TopicSubscription{
+				Topics: []manifest.TopicSubscription{
 					{},
 				},
 			},
@@ -1593,7 +1593,7 @@ func Test_convertSubscribe(t *testing.T) {
 		},
 		"valid subscribe": {
 			inSubscribe: &manifest.SubscribeConfig{
-				Topics: &[]manifest.TopicSubscription{
+				Topics: []manifest.TopicSubscription{
 					{
 						Name:    "name",
 						Service: "svc",
@@ -1636,7 +1636,7 @@ func Test_convertSubscribe(t *testing.T) {
 		},
 		"valid subscribe with minimal queue": {
 			inSubscribe: &manifest.SubscribeConfig{
-				Topics: &[]manifest.TopicSubscription{
+				Topics: []manifest.TopicSubscription{
 					{
 						Name:    "name",
 						Service: "svc",
@@ -1656,7 +1656,7 @@ func Test_convertSubscribe(t *testing.T) {
 		},
 		"invalid topic name": {
 			inSubscribe: &manifest.SubscribeConfig{
-				Topics: &[]manifest.TopicSubscription{
+				Topics: []manifest.TopicSubscription{
 					{
 						Name:    "t@p!c1~",
 						Service: "service1",
@@ -1667,7 +1667,7 @@ func Test_convertSubscribe(t *testing.T) {
 		},
 		"invalid service name": {
 			inSubscribe: &manifest.SubscribeConfig{
-				Topics: &[]manifest.TopicSubscription{
+				Topics: []manifest.TopicSubscription{
 					{
 						Name:    "topic1",
 						Service: "s#rv!ce1~",
@@ -1678,7 +1678,7 @@ func Test_convertSubscribe(t *testing.T) {
 		},
 		"topic not allowed": {
 			inSubscribe: &manifest.SubscribeConfig{
-				Topics: &[]manifest.TopicSubscription{
+				Topics: []manifest.TopicSubscription{
 					{
 						Name:    "topic1",
 						Service: "svc",
@@ -1689,7 +1689,7 @@ func Test_convertSubscribe(t *testing.T) {
 		},
 		"sneaky topic not allowed": {
 			inSubscribe: &manifest.SubscribeConfig{
-				Topics: &[]manifest.TopicSubscription{
+				Topics: []manifest.TopicSubscription{
 					{
 						Name:    "sneakytopic",
 						Service: "svc-name",
@@ -1700,7 +1700,7 @@ func Test_convertSubscribe(t *testing.T) {
 		},
 		"subscribe queue delay invalid": {
 			inSubscribe: &manifest.SubscribeConfig{
-				Topics: &[]manifest.TopicSubscription{
+				Topics: []manifest.TopicSubscription{
 					{
 						Name:    "name",
 						Service: "svc",

--- a/internal/pkg/deploy/cloudformation/stack/worker_svc_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/worker_svc_test.go
@@ -94,7 +94,7 @@ Outputs:
 			setUpManifest: func(svc *WorkerService) {
 				testWorkerSvcManifestWithBadSubscribe := manifest.NewWorkerService(baseProps)
 				testWorkerSvcManifestWithBadSubscribe.Subscribe = &manifest.SubscribeConfig{
-					Topics: &[]manifest.TopicSubscription{
+					Topics: []manifest.TopicSubscription{
 						{
 							Name:    "name",
 							Service: "un@cept#ble",
@@ -124,7 +124,7 @@ Outputs:
 			setUpManifest: func(svc *WorkerService) {
 				testWorkerSvcManifestWithBadSubscribe := manifest.NewWorkerService(baseProps)
 				testWorkerSvcManifestWithBadSubscribe.Subscribe = &manifest.SubscribeConfig{
-					Topics: &[]manifest.TopicSubscription{
+					Topics: []manifest.TopicSubscription{
 						{
 							Name:    "badname",
 							Service: "frontend",

--- a/internal/pkg/initialize/workload.go
+++ b/internal/pkg/initialize/workload.go
@@ -354,7 +354,7 @@ func newWorkerServiceManifest(i *ServiceProps) (*manifest.WorkerService, error) 
 			Image:      i.Image,
 		},
 		HealthCheck: i.HealthCheck,
-		Topics:      &i.Topics,
+		Topics:      i.Topics,
 	}), nil
 }
 

--- a/internal/pkg/manifest/applyenv_test.go
+++ b/internal/pkg/manifest/applyenv_test.go
@@ -1108,45 +1108,45 @@ func TestApplyEnv_Platform(t *testing.T) {
 		inSvc  func(svc *LoadBalancedWebService)
 		wanted func(svc *LoadBalancedWebService)
 	}{
-		//"FIXED_BUG: composite fields: platform string is overridden if platform args is not nil": {
-		//	inSvc: func(svc *LoadBalancedWebService) {
-		//		svc.Platform = &PlatformArgsOrString{
-		//			PlatformString: aws.String("mockPlatform"),
-		//		}
-		//		svc.Environments["test"].Platform = &PlatformArgsOrString{
-		//			PlatformArgs: PlatformArgs{
-		//				OSFamily: aws.String("mock"),
-		//				Arch:     aws.String("platformTest"),
-		//			},
-		//		}
-		//	},
-		//	wanted: func(svc *LoadBalancedWebService) {
-		//		svc.Platform = &PlatformArgsOrString{
-		//			PlatformArgs: PlatformArgs{
-		//				OSFamily: aws.String("mock"),
-		//				Arch:     aws.String("platformTest"),
-		//			},
-		//		}
-		//	},
-		//},
-		//"FIXED_BUG: composite fields: platform args is overridden if platform string is not nil": {
-		//	inSvc: func(svc *LoadBalancedWebService) {
-		//		svc.Platform = &PlatformArgsOrString{
-		//			PlatformArgs: PlatformArgs{
-		//				OSFamily: aws.String("mock"),
-		//				Arch:     aws.String("platformTest"),
-		//			},
-		//		}
-		//		svc.Environments["test"].Platform = &PlatformArgsOrString{
-		//			PlatformString: aws.String("mockPlatform"),
-		//		}
-		//	},
-		//	wanted: func(svc *LoadBalancedWebService) {
-		//		svc.Platform = &PlatformArgsOrString{
-		//			PlatformString: aws.String("mockPlatform"),
-		//		}
-		//	},
-		//},
+		"FIXED_BUG: composite fields: platform string is overridden if platform args is not nil": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Platform = &PlatformArgsOrString{
+					PlatformString: aws.String("mockPlatform"),
+				}
+				svc.Environments["test"].Platform = &PlatformArgsOrString{
+					PlatformArgs: PlatformArgs{
+						OSFamily: aws.String("mock"),
+						Arch:     aws.String("platformTest"),
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Platform = &PlatformArgsOrString{
+					PlatformArgs: PlatformArgs{
+						OSFamily: aws.String("mock"),
+						Arch:     aws.String("platformTest"),
+					},
+				}
+			},
+		},
+		"FIXED_BUG: composite fields: platform args is overridden if platform string is not nil": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Platform = &PlatformArgsOrString{
+					PlatformArgs: PlatformArgs{
+						OSFamily: aws.String("mock"),
+						Arch:     aws.String("platformTest"),
+					},
+				}
+				svc.Environments["test"].Platform = &PlatformArgsOrString{
+					PlatformString: aws.String("mockPlatform"),
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Platform = &PlatformArgsOrString{
+					PlatformString: aws.String("mockPlatform"),
+				}
+			},
+		},
 		"platform string overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Platform = &PlatformArgsOrString{

--- a/internal/pkg/manifest/applyenv_test.go
+++ b/internal/pkg/manifest/applyenv_test.go
@@ -322,6 +322,23 @@ func TestApplyEnv_Image(t *testing.T) {
 				}
 			},
 		},
+		"empty healthcheck overridden": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.ImageConfig.Image = Image{}
+				svc.Environments["test"].ImageConfig.HealthCheck = &ContainerHealthCheck{
+					Retries: aws.Int(3),
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.ImageConfig.HealthCheck = &ContainerHealthCheck{
+					Command:     nil,
+					Interval:    nil,
+					Retries:     aws.Int(3),
+					Timeout:     nil,
+					StartPeriod: nil,
+				}
+			},
+		},
 	}
 
 	for name, tc := range testCases {

--- a/internal/pkg/manifest/applyenv_test.go
+++ b/internal/pkg/manifest/applyenv_test.go
@@ -605,66 +605,66 @@ func TestApplyEnv_Image_Build(t *testing.T) {
 				}
 			},
 		},
-		//"FAILED TEST: args overridden": {
-		//	inSvc: func(svc *LoadBalancedWebService) {
-		//		svc.ImageConfig.Build = BuildArgsOrString{
-		//			BuildArgs: DockerBuildArgs{
-		//				Args: map[string]string{
-		//					"mockArg1": "1",
-		//					"mockArg2": "2",
-		//				},
-		//			},
-		//		}
-		//		svc.Environments["test"].ImageConfig.Build = BuildArgsOrString{
-		//			BuildArgs: DockerBuildArgs{
-		//				Args: map[string]string{
-		//					"mockArg1": "3", // Override value for mockArg1
-		//					"mockArg3": "3", // Append an arg mockArg3
-		//				},
-		//			},
-		//		}
-		//	},
-		//	wanted: func(svc *LoadBalancedWebService) {
-		//		svc.ImageConfig.Build = BuildArgsOrString{
-		//			BuildString: nil,
-		//			BuildArgs: DockerBuildArgs{
-		//				Args: map[string]string{
-		//					"mockArg1": "3",
-		//					"mockArg2": "2",
-		//					"mockArg3": "3",
-		//				},
-		//			},
-		//		}
-		//	},
-		//},
-		//"FAILED TEST: args not overridden by empty map": {
-		//	inSvc: func(svc *LoadBalancedWebService) {
-		//		svc.ImageConfig.Build = BuildArgsOrString{
-		//			BuildArgs: DockerBuildArgs{
-		//				Args: map[string]string{
-		//					"mockArg1": "1",
-		//					"mockArg2": "2",
-		//				},
-		//			},
-		//		}
-		//		svc.Environments["test"].ImageConfig.Build = BuildArgsOrString{
-		//			BuildArgs: DockerBuildArgs{
-		//				Args: map[string]string{},
-		//			},
-		//		}
-		//	},
-		//	wanted: func(svc *LoadBalancedWebService) {
-		//		svc.ImageConfig.Build = BuildArgsOrString{
-		//			BuildString: nil,
-		//			BuildArgs: DockerBuildArgs{
-		//				Args: map[string]string{
-		//					"mockArg1": "1",
-		//					"mockArg2": "2",
-		//				},
-		//			},
-		//		}
-		//	},
-		//},
+		"FIXED_BUG: args overridden": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.ImageConfig.Build = BuildArgsOrString{
+					BuildArgs: DockerBuildArgs{
+						Args: map[string]string{
+							"mockArg1": "1",
+							"mockArg2": "2",
+						},
+					},
+				}
+				svc.Environments["test"].ImageConfig.Build = BuildArgsOrString{
+					BuildArgs: DockerBuildArgs{
+						Args: map[string]string{
+							"mockArg1": "3", // Override value for mockArg1
+							"mockArg3": "3", // Append an arg mockArg3
+						},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.ImageConfig.Build = BuildArgsOrString{
+					BuildString: nil,
+					BuildArgs: DockerBuildArgs{
+						Args: map[string]string{
+							"mockArg1": "3",
+							"mockArg2": "2",
+							"mockArg3": "3",
+						},
+					},
+				}
+			},
+		},
+		"FIXED_BUG: args not overridden by empty map": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.ImageConfig.Build = BuildArgsOrString{
+					BuildArgs: DockerBuildArgs{
+						Args: map[string]string{
+							"mockArg1": "1",
+							"mockArg2": "2",
+						},
+					},
+				}
+				svc.Environments["test"].ImageConfig.Build = BuildArgsOrString{
+					BuildArgs: DockerBuildArgs{
+						Args: map[string]string{},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.ImageConfig.Build = BuildArgsOrString{
+					BuildString: nil,
+					BuildArgs: DockerBuildArgs{
+						Args: map[string]string{
+							"mockArg1": "1",
+							"mockArg2": "2",
+						},
+					},
+				}
+			},
+		},
 		"args not overridden by nil": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.ImageConfig.Build = BuildArgsOrString{
@@ -874,19 +874,19 @@ func TestApplyEnv_Image_HealthCheck(t *testing.T) {
 				}
 			},
 		},
-		//"FAILED TEST: command not overridden": {
-		//	inSvc: func(svc *LoadBalancedWebService) {
-		//		svc.ImageConfig.HealthCheck = &ContainerHealthCheck{
-		//			Command: []string{"mock", "command"},
-		//		}
-		//		svc.Environments["test"].ImageConfig.HealthCheck = &ContainerHealthCheck{}
-		//	},
-		//	wanted: func(svc *LoadBalancedWebService) {
-		//		svc.ImageConfig.HealthCheck = &ContainerHealthCheck{
-		//			Command: []string{"mock", "command"},
-		//		}
-		//	},
-		//},
+		"FIXED BUG: command not overridden": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.ImageConfig.HealthCheck = &ContainerHealthCheck{
+					Command: []string{"mock", "command"},
+				}
+				svc.Environments["test"].ImageConfig.HealthCheck = &ContainerHealthCheck{}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.ImageConfig.HealthCheck = &ContainerHealthCheck{
+					Command: []string{"mock", "command"},
+				}
+			},
+		},
 		"interval overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				mockInterval := 600 * time.Second
@@ -1108,7 +1108,7 @@ func TestApplyEnv_Platform(t *testing.T) {
 		inSvc  func(svc *LoadBalancedWebService)
 		wanted func(svc *LoadBalancedWebService)
 	}{
-		//"FAILED_TEST: composite fields: platform string is overridden if platform args is not nil": {
+		//"FIXED_BUG: composite fields: platform string is overridden if platform args is not nil": {
 		//	inSvc: func(svc *LoadBalancedWebService) {
 		//		svc.Platform = &PlatformArgsOrString{
 		//			PlatformString: aws.String("mockPlatform"),
@@ -1129,7 +1129,7 @@ func TestApplyEnv_Platform(t *testing.T) {
 		//		}
 		//	},
 		//},
-		//"FAILED_TEST: composite fields: platform args is overridden if platform string is not nil": {
+		//"FIXED_BUG: composite fields: platform args is overridden if platform string is not nil": {
 		//	inSvc: func(svc *LoadBalancedWebService) {
 		//		svc.Platform = &PlatformArgsOrString{
 		//			PlatformArgs: PlatformArgs{
@@ -1393,21 +1393,21 @@ func TestApplyEnv_Entrypoint(t *testing.T) {
 				}
 			},
 		},
-		//"FAILED TEST: composite fields: string is overridden if string slice is not nil": {
-		//	inSvc: func(svc *LoadBalancedWebService) {
-		//		svc.EntryPoint = &EntryPointOverride{
-		//			String: aws.String("mock entrypoint"),
-		//		}
-		//		svc.Environments["test"].EntryPoint = &EntryPointOverride{
-		//			StringSlice: []string{"mock", "entrypoint_test", "test"},
-		//		}
-		//	},
-		//	wanted: func(svc *LoadBalancedWebService) {
-		//		svc.EntryPoint = &EntryPointOverride{
-		//			StringSlice: []string{"mock", "entrypoint_test", "test"},
-		//		}
-		//	},
-		//},
+		"FIXED_BUG: composite fields: string is overridden if string slice is not nil": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.EntryPoint = &EntryPointOverride{
+					String: aws.String("mock entrypoint"),
+				}
+				svc.Environments["test"].EntryPoint = &EntryPointOverride{
+					StringSlice: []string{"mock", "entrypoint_test", "test"},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.EntryPoint = &EntryPointOverride{
+					StringSlice: []string{"mock", "entrypoint_test", "test"},
+				}
+			},
+		},
 		"string overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.EntryPoint = &EntryPointOverride{
@@ -1533,21 +1533,21 @@ func TestApplyEnv_Command(t *testing.T) {
 				}
 			},
 		},
-		//"FAILED TEST: composite fields: string is overridden if string slice is not nil": {
-		//	inSvc: func(svc *LoadBalancedWebService) {
-		//		svc.Command = &CommandOverride{
-		//			String: aws.String("mock command"),
-		//		}
-		//		svc.Environments["test"].Command = &CommandOverride{
-		//			StringSlice: []string{"mock", "command_test", "test"},
-		//		}
-		//	},
-		//	wanted: func(svc *LoadBalancedWebService) {
-		//		svc.Command = &CommandOverride{
-		//			StringSlice: []string{"mock", "command_test", "test"},
-		//		}
-		//	},
-		//},
+		"FIXED_BUG: composite fields: string is overridden if string slice is not nil": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Command = &CommandOverride{
+					String: aws.String("mock command"),
+				}
+				svc.Environments["test"].Command = &CommandOverride{
+					StringSlice: []string{"mock", "command_test", "test"},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Command = &CommandOverride{
+					StringSlice: []string{"mock", "command_test", "test"},
+				}
+			},
+		},
 		"string overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Command = &CommandOverride{
@@ -2108,25 +2108,25 @@ func TestApplyEnv_Network_VPC(t *testing.T) {
 				}
 			},
 		},
-		//"FAILED TEST: security_groups not overridden": {
-		//	inSvc: func(svc *LoadBalancedWebService) {
-		//		svc.Network = &NetworkConfig{
-		//			VPC: &vpcConfig{
-		//				SecurityGroups: []string{"mock", "security_group"},
-		//			},
-		//		}
-		//		svc.Environments["test"].Network = &NetworkConfig{
-		//			VPC: &vpcConfig{},
-		//		}
-		//	},
-		//	wanted: func(svc *LoadBalancedWebService) {
-		//		svc.Network = &NetworkConfig{
-		//			VPC: &vpcConfig{
-		//				SecurityGroups: []string{"mock", "security_group"},
-		//			},
-		//		}
-		//	},
-		//},
+		"FIXED_BUG: security_groups not overridden": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Network = &NetworkConfig{
+					VPC: &vpcConfig{
+						SecurityGroups: []string{"mock", "security_group"},
+					},
+				}
+				svc.Environments["test"].Network = &NetworkConfig{
+					VPC: &vpcConfig{},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Network = &NetworkConfig{
+					VPC: &vpcConfig{
+						SecurityGroups: []string{"mock", "security_group"},
+					},
+				}
+			},
+		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {

--- a/internal/pkg/manifest/applyenv_test.go
+++ b/internal/pkg/manifest/applyenv_test.go
@@ -39,6 +39,16 @@ Expected Behaviors:
 	- Map: override value of existing keys, append non-existing keys.
 */
 
+func TestEnsureTransformersOrder(t *testing.T) {
+	t.Run("ensure we transform volumes first", func(t *testing.T) {
+		_, ok := defaultTransformers[0].(mapToVolumeTransformer)
+		require.True(t, ok, "mapToVolumeTransformer need has to be the first transformer. Otherwise `mergo` will overwrite the `dst` map completely and we will lose `dst`'s values.")
+
+		_, ok = defaultTransformers[1].(basicTransformer)
+		require.True(t, ok, "basicTransformer needs to used before the rest of the custom transformers, because the other transformers do not merge anything - they just unset the fields that do not get specified in source manifest.")
+	})
+}
+
 func TestApplyEnv_Image(t *testing.T) {
 	testCases := map[string]struct {
 		inSvc  func(svc *LoadBalancedWebService)

--- a/internal/pkg/manifest/backend_svc.go
+++ b/internal/pkg/manifest/backend_svc.go
@@ -91,12 +91,13 @@ func (s BackendService) ApplyEnv(envName string) (WorkloadManifest, error) {
 	}
 
 	// Apply overrides to the original service s.
-	err := mergo.Merge(&s, BackendService{
-		BackendServiceConfig: *overrideConfig,
-	}, mergo.WithOverride, mergo.WithTransformers(workloadTransformer{}))
-
-	if err != nil {
-		return nil, err
+	for _, t := range TT {
+		err := mergo.Merge(&s, BackendService{
+			BackendServiceConfig: *overrideConfig,
+		}, mergo.WithOverride, mergo.WithTransformers(t))
+		if err != nil {
+			return nil, err
+		}
 	}
 	s.Environments = nil
 	return &s, nil

--- a/internal/pkg/manifest/backend_svc.go
+++ b/internal/pkg/manifest/backend_svc.go
@@ -90,11 +90,6 @@ func (s BackendService) ApplyEnv(envName string) (WorkloadManifest, error) {
 		return &s, nil
 	}
 
-	envCount := overrideConfig.TaskConfig.Count
-	if !envCount.IsEmpty() {
-		s.TaskConfig.Count = envCount
-	}
-
 	// Apply overrides to the original service s.
 	err := mergo.Merge(&s, BackendService{
 		BackendServiceConfig: *overrideConfig,

--- a/internal/pkg/manifest/backend_svc.go
+++ b/internal/pkg/manifest/backend_svc.go
@@ -91,7 +91,7 @@ func (s BackendService) ApplyEnv(envName string) (WorkloadManifest, error) {
 	}
 
 	// Apply overrides to the original service s.
-	for _, t := range TT {
+	for _, t := range defaultTransformers {
 		err := mergo.Merge(&s, BackendService{
 			BackendServiceConfig: *overrideConfig,
 		}, mergo.WithOverride, mergo.WithTransformers(t))

--- a/internal/pkg/manifest/job.go
+++ b/internal/pkg/manifest/job.go
@@ -126,7 +126,7 @@ func (j ScheduledJob) ApplyEnv(envName string) (WorkloadManifest, error) {
 	}
 
 	// Apply overrides to the original job
-	for _, t := range TT {
+	for _, t := range defaultTransformers {
 		err := mergo.Merge(&j, ScheduledJob{
 			ScheduledJobConfig: *overrideConfig,
 		}, mergo.WithOverride, mergo.WithTransformers(t))

--- a/internal/pkg/manifest/job.go
+++ b/internal/pkg/manifest/job.go
@@ -124,13 +124,15 @@ func (j ScheduledJob) ApplyEnv(envName string) (WorkloadManifest, error) {
 	if !ok {
 		return &j, nil
 	}
-	// Apply overrides to the original job
-	err := mergo.Merge(&j, ScheduledJob{
-		ScheduledJobConfig: *overrideConfig,
-	}, mergo.WithOverride, mergo.WithTransformers(workloadTransformer{}))
 
-	if err != nil {
-		return nil, err
+	// Apply overrides to the original job
+	for _, t := range TT {
+		err := mergo.Merge(&j, ScheduledJob{
+			ScheduledJobConfig: *overrideConfig,
+		}, mergo.WithOverride, mergo.WithTransformers(t))
+		if err != nil {
+			return nil, err
+		}
 	}
 	j.Environments = nil
 	return &j, nil

--- a/internal/pkg/manifest/lb_web_svc.go
+++ b/internal/pkg/manifest/lb_web_svc.go
@@ -186,14 +186,49 @@ func (s LoadBalancedWebService) ApplyEnv(envName string) (WorkloadManifest, erro
 		return &s, nil
 	}
 
-	// Apply overrides to the original service s.
-	err := mergo.Merge(&s, LoadBalancedWebService{
-		LoadBalancedWebServiceConfig: *overrideConfig,
-	}, mergo.WithOverride, mergo.WithTransformers(workloadTransformer{}))
+	transformers := []mergo.Transformers{
+		mapToVolumeTransformer{},
 
-	if err != nil {
-		return nil, err
+		basicTransformer{},
+
+		imageTransformer{},
+		buildArgsOrStringTransformer{},
+		stringSliceOrStringTransformer{},
+		platformArgsOrStringTransformer{},
+		healthCheckArgsOrStringTransformer{},
+		countTransformer{},
+		advancedCountTransformer{},
+		rangeTransformer{},
 	}
+
+	for _, t := range transformers {
+		// Apply overrides to the original service s.
+		err := mergo.Merge(&s, LoadBalancedWebService{
+			LoadBalancedWebServiceConfig: *overrideConfig,
+		}, mergo.WithOverride, mergo.WithTransformers(t))
+
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	s.Environments = nil
 	return &s, nil
+}
+
+var TT = []mergo.Transformers{
+	//workloadTransformer{},
+
+	mapToVolumeTransformer{},
+
+	basicTransformer{},
+
+	imageTransformer{},
+	buildArgsOrStringTransformer{},
+	stringSliceOrStringTransformer{},
+	platformArgsOrStringTransformer{},
+	healthCheckArgsOrStringTransformer{},
+	countTransformer{},
+	advancedCountTransformer{},
+	rangeTransformer{},
 }

--- a/internal/pkg/manifest/lb_web_svc.go
+++ b/internal/pkg/manifest/lb_web_svc.go
@@ -186,11 +186,6 @@ func (s LoadBalancedWebService) ApplyEnv(envName string) (WorkloadManifest, erro
 		return &s, nil
 	}
 
-	envCount := overrideConfig.TaskConfig.Count
-	if !envCount.IsEmpty() {
-		s.TaskConfig.Count = envCount
-	}
-
 	// Apply overrides to the original service s.
 	err := mergo.Merge(&s, LoadBalancedWebService{
 		LoadBalancedWebServiceConfig: *overrideConfig,

--- a/internal/pkg/manifest/lb_web_svc.go
+++ b/internal/pkg/manifest/lb_web_svc.go
@@ -186,22 +186,7 @@ func (s LoadBalancedWebService) ApplyEnv(envName string) (WorkloadManifest, erro
 		return &s, nil
 	}
 
-	transformers := []mergo.Transformers{
-		mapToVolumeTransformer{},
-
-		basicTransformer{},
-
-		imageTransformer{},
-		buildArgsOrStringTransformer{},
-		stringSliceOrStringTransformer{},
-		platformArgsOrStringTransformer{},
-		healthCheckArgsOrStringTransformer{},
-		countTransformer{},
-		advancedCountTransformer{},
-		rangeTransformer{},
-	}
-
-	for _, t := range transformers {
+	for _, t := range defaultTransformers {
 		// Apply overrides to the original service s.
 		err := mergo.Merge(&s, LoadBalancedWebService{
 			LoadBalancedWebServiceConfig: *overrideConfig,
@@ -214,21 +199,4 @@ func (s LoadBalancedWebService) ApplyEnv(envName string) (WorkloadManifest, erro
 
 	s.Environments = nil
 	return &s, nil
-}
-
-var TT = []mergo.Transformers{
-	//workloadTransformer{},
-
-	mapToVolumeTransformer{},
-
-	basicTransformer{},
-
-	imageTransformer{},
-	buildArgsOrStringTransformer{},
-	stringSliceOrStringTransformer{},
-	platformArgsOrStringTransformer{},
-	healthCheckArgsOrStringTransformer{},
-	countTransformer{},
-	advancedCountTransformer{},
-	rangeTransformer{},
 }

--- a/internal/pkg/manifest/lb_web_svc_applyenv_test.go
+++ b/internal/pkg/manifest/lb_web_svc_applyenv_test.go
@@ -888,21 +888,21 @@ func TestApplyEnv_HTTP_Alias(t *testing.T) {
 				}
 			},
 		},
-		//"FAILED TEST: composite fields: string is overridden if string slice is not nil": {
-		//	inSvc: func(svc *LoadBalancedWebService) {
-		//		svc.Alias = &Alias{
-		//			String: aws.String("mock alias"),
-		//		}
-		//		svc.Environments["test"].Alias = &Alias{
-		//			StringSlice: []string{"mock", "alias_test", "test"},
-		//		}
-		//	},
-		//	wanted: func(svc *LoadBalancedWebService) {
-		//		svc.Alias = &Alias{
-		//			StringSlice: []string{"mock", "alias_test", "test"},
-		//		}
-		//	},
-		//},
+		"FIXED_BUG: composite fields: string is overridden if string slice is not nil": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Alias = &Alias{
+					String: aws.String("mock alias"),
+				}
+				svc.Environments["test"].Alias = &Alias{
+					StringSlice: []string{"mock", "alias_test", "test"},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Alias = &Alias{
+					StringSlice: []string{"mock", "alias_test", "test"},
+				}
+			},
+		},
 		"string overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Alias = &Alias{

--- a/internal/pkg/manifest/lb_web_svc_applyenv_test.go
+++ b/internal/pkg/manifest/lb_web_svc_applyenv_test.go
@@ -276,42 +276,42 @@ func TestApplyEnv_HTTP_HealthCheck(t *testing.T) {
 		inSvc  func(svc *LoadBalancedWebService)
 		wanted func(svc *LoadBalancedWebService)
 	}{
-		//"FAILED_TEST: composite fields: string is overridden if args is not nil": {
-		//	inSvc: func(svc *LoadBalancedWebService) {
-		//		svc.HealthCheck = HealthCheckArgsOrString{
-		//			HealthCheckPath: aws.String("/"),
-		//		}
-		//		svc.Environments["test"].HealthCheck = HealthCheckArgsOrString{
-		//			HealthCheckArgs: HTTPHealthCheckArgs{
-		//				Path: aws.String("/test"),
-		//			},
-		//		}
-		//	},
-		//	wanted: func(svc *LoadBalancedWebService) {
-		//		svc.HealthCheck = HealthCheckArgsOrString{
-		//			HealthCheckArgs: HTTPHealthCheckArgs{
-		//				Path: aws.String("/test"),
-		//			},
-		//		}
-		//	},
-		//},
-		//"FAILED_TEST: composite fields: args is overridden if string is not nil": {
-		//	inSvc: func(svc *LoadBalancedWebService) {
-		//		svc.HealthCheck = HealthCheckArgsOrString{
-		//			HealthCheckArgs: HTTPHealthCheckArgs{
-		//				Path: aws.String("/test"),
-		//			},
-		//		}
-		//		svc.Environments["test"].HealthCheck = HealthCheckArgsOrString{
-		//			HealthCheckPath: aws.String("/"),
-		//		}
-		//	},
-		//	wanted: func(svc *LoadBalancedWebService) {
-		//		svc.HealthCheck = HealthCheckArgsOrString{
-		//			HealthCheckPath: aws.String("/"),
-		//		}
-		//	},
-		//},
+		"FIXED_BUG: composite fields: string is overridden if args is not nil": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.HealthCheck = HealthCheckArgsOrString{
+					HealthCheckPath: aws.String("/"),
+				}
+				svc.Environments["test"].HealthCheck = HealthCheckArgsOrString{
+					HealthCheckArgs: HTTPHealthCheckArgs{
+						Path: aws.String("/test"),
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.HealthCheck = HealthCheckArgsOrString{
+					HealthCheckArgs: HTTPHealthCheckArgs{
+						Path: aws.String("/test"),
+					},
+				}
+			},
+		},
+		"FIXED_BUG: composite fields: args is overridden if string is not nil": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.HealthCheck = HealthCheckArgsOrString{
+					HealthCheckArgs: HTTPHealthCheckArgs{
+						Path: aws.String("/test"),
+					},
+				}
+				svc.Environments["test"].HealthCheck = HealthCheckArgsOrString{
+					HealthCheckPath: aws.String("/"),
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.HealthCheck = HealthCheckArgsOrString{
+					HealthCheckPath: aws.String("/"),
+				}
+			},
+		},
 		"string overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.HealthCheck = HealthCheckArgsOrString{

--- a/internal/pkg/manifest/rd_web_svc.go
+++ b/internal/pkg/manifest/rd_web_svc.go
@@ -113,7 +113,7 @@ func (s RequestDrivenWebService) ApplyEnv(envName string) (WorkloadManifest, err
 		return &s, nil
 	}
 	// Apply overrides to the original service configuration.
-	for _, t := range TT {
+	for _, t := range defaultTransformers {
 		err := mergo.Merge(&s, RequestDrivenWebService{
 			RequestDrivenWebServiceConfig: *overrideConfig,
 		}, mergo.WithOverride, mergo.WithTransformers(t))

--- a/internal/pkg/manifest/rd_web_svc.go
+++ b/internal/pkg/manifest/rd_web_svc.go
@@ -113,13 +113,15 @@ func (s RequestDrivenWebService) ApplyEnv(envName string) (WorkloadManifest, err
 		return &s, nil
 	}
 	// Apply overrides to the original service configuration.
-	err := mergo.Merge(&s, RequestDrivenWebService{
-		RequestDrivenWebServiceConfig: *overrideConfig,
-	}, mergo.WithOverride, mergo.WithTransformers(workloadTransformer{}))
-
-	if err != nil {
-		return nil, err
+	for _, t := range TT {
+		err := mergo.Merge(&s, RequestDrivenWebService{
+			RequestDrivenWebServiceConfig: *overrideConfig,
+		}, mergo.WithOverride, mergo.WithTransformers(t))
+		if err != nil {
+			return nil, err
+		}
 	}
+
 	s.Environments = nil
 	return &s, nil
 }

--- a/internal/pkg/manifest/storage_applyenv_test.go
+++ b/internal/pkg/manifest/storage_applyenv_test.go
@@ -58,59 +58,62 @@ func Test_ApplyEnv_Storage(t *testing.T) {
 				}
 			},
 		},
-		//"FAILED TEST: volumes overridden": {
-		//	inSvc: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					MountPointOpts: MountPointOpts{
-		//						ReadOnly: aws.Bool(true),
-		//					},
-		//				},
-		//				"mockVolume2": {
-		//					EFS: &EFSConfigOrBool{
-		//						Enabled: aws.Bool(true),
-		//					},
-		//				},
-		//			},
-		//		}
-		//		svc.Environments["test"].Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Enabled: aws.Bool(true),
-		//					},
-		//				}, // Modify the value for mockVolume1.
-		//				"mockVolume3": {
-		//					MountPointOpts: MountPointOpts{
-		//						ReadOnly: aws.Bool(true),
-		//					},
-		//				}, // Append mockVolume3.
-		//			},
-		//		}
-		//	},
-		//	wanted: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Enabled: aws.Bool(true),
-		//					},
-		//				},
-		//				"mockVolume2": {
-		//					EFS: &EFSConfigOrBool{
-		//						Enabled: aws.Bool(true),
-		//					},
-		//				},
-		//				"mockVolume3": {
-		//					MountPointOpts: MountPointOpts{
-		//						ReadOnly: aws.Bool(true),
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//},
+		"FAILED TEST: volumes overridden": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							MountPointOpts: MountPointOpts{
+								ReadOnly: aws.Bool(true),
+							},
+						},
+						"mockVolume2": {
+							EFS: &EFSConfigOrBool{
+								Enabled: aws.Bool(true),
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Enabled: aws.Bool(true),
+							},
+						}, // Modify the value for mockVolume1.
+						"mockVolume3": {
+							MountPointOpts: MountPointOpts{
+								ReadOnly: aws.Bool(true),
+							},
+						}, // Append mockVolume3.
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Enabled: aws.Bool(true),
+							},
+							MountPointOpts: MountPointOpts{
+								ReadOnly: aws.Bool(true),
+							},
+						},
+						"mockVolume2": {
+							EFS: &EFSConfigOrBool{
+								Enabled: aws.Bool(true),
+							},
+						},
+						"mockVolume3": {
+							MountPointOpts: MountPointOpts{
+								ReadOnly: aws.Bool(true),
+							},
+						},
+					},
+				}
+			},
+		},
 		"volumes not overridden by empty map": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
@@ -499,83 +502,83 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 		inSvc  func(svc *LoadBalancedWebService)
 		wanted func(svc *LoadBalancedWebService)
 	}{
-		//"FAILED TEST: composite fields: efs bool is overridden if efs config is not nil": {
-		//	inSvc: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Enabled: aws.Bool(true),
-		//					},
-		//				},
-		//			},
-		//		}
-		//		svc.Environments["test"].Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							RootDirectory: aws.String("mockRootDirTest"),
-		//							FileSystemID:  aws.String("mockFileSystemTest"),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//	wanted: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Enabled: nil,
-		//						Advanced: EFSVolumeConfiguration{
-		//							RootDirectory: aws.String("mockRootDirTest"),
-		//							FileSystemID:  aws.String("mockFileSystemTest"),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//},
-		//"FAILED TEST: composite fields: efs config is overridden if efs bool is not nil": {
-		//	inSvc: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							RootDirectory: aws.String("mockRootDir"),
-		//							FileSystemID:  aws.String("mockFileSystem"),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//		svc.Environments["test"].Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Enabled: aws.Bool(true),
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//	wanted: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Enabled:  aws.Bool(true),
-		//						Advanced: EFSVolumeConfiguration{},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//},
+		"FIXED_BUG: composite fields: efs bool is overridden if efs config is not nil": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Enabled: aws.Bool(true),
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									RootDirectory: aws.String("mockRootDirTest"),
+									FileSystemID:  aws.String("mockFileSystemTest"),
+								},
+							},
+						},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Enabled: nil,
+								Advanced: EFSVolumeConfiguration{
+									RootDirectory: aws.String("mockRootDirTest"),
+									FileSystemID:  aws.String("mockFileSystemTest"),
+								},
+							},
+						},
+					},
+				}
+			},
+		},
+		"FIXED_BUG: composite fields: efs config is overridden if efs bool is not nil": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									RootDirectory: aws.String("mockRootDir"),
+									FileSystemID:  aws.String("mockFileSystem"),
+								},
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Enabled: aws.Bool(true),
+							},
+						},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Enabled:  aws.Bool(true),
+								Advanced: EFSVolumeConfiguration{},
+							},
+						},
+					},
+				}
+			},
+		},
 		"efs bool overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{

--- a/internal/pkg/manifest/storage_applyenv_test.go
+++ b/internal/pkg/manifest/storage_applyenv_test.go
@@ -694,7 +694,6 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 								Advanced: EFSVolumeConfiguration{
 									RootDirectory: aws.String("mockRootDirTest"),
 									FileSystemID:  aws.String("mockFileSystemTest"),
-									UID:           aws.Uint32(42),
 								},
 							},
 						},
@@ -709,7 +708,6 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 								Advanced: EFSVolumeConfiguration{
 									RootDirectory: aws.String("mockRootDirTest"),
 									FileSystemID:  aws.String("mockFileSystemTest"),
-									UID:           aws.Uint32(42),
 								},
 							},
 						},

--- a/internal/pkg/manifest/storage_applyenv_test.go
+++ b/internal/pkg/manifest/storage_applyenv_test.go
@@ -58,7 +58,7 @@ func Test_ApplyEnv_Storage(t *testing.T) {
 				}
 			},
 		},
-		"FAILED TEST: volumes overridden": {
+		"FIXED_BUG: volumes overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
 					Volumes: map[string]Volume{
@@ -750,504 +750,504 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 				}
 			},
 		},
-		//"FAILED TEST: exclusive fields: id overridden if uid is not nil": {
-		//	inSvc: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							FileSystemID: aws.String("42"),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//		svc.Environments["test"].Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							UID: aws.Uint32(13),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//	wanted: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							FileSystemID: nil,
-		//							UID:          aws.Uint32(13),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//},
-		//"FAILED TEST: exclusive fields: uid overridden if id is not nil": {
-		//	inSvc: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							UID: aws.Uint32(13),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//		svc.Environments["test"].Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							FileSystemID: aws.String("42"),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//	wanted: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							FileSystemID: aws.String("42"),
-		//							UID:          nil,
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//},
-		//"FAILED TEST: exclusive fields: root_dir overridden if uid is not nil": {
-		//	inSvc: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							RootDirectory: aws.String("mockRootDirectory"),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//		svc.Environments["test"].Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							UID: aws.Uint32(13),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//	wanted: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							RootDirectory: nil,
-		//							UID:           aws.Uint32(13),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//},
-		//"FAILED TEST: exclusive fields: udi overridden if root_dir is not nil": {
-		//	inSvc: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							UID: aws.Uint32(13),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//		svc.Environments["test"].Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							RootDirectory: aws.String("mockRootDirectoryTest"),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//	wanted: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							RootDirectory: aws.String("mockRootDirectoryTest"),
-		//							UID:           nil,
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//},
-		//"FAILED TEST: exclusive fields: auth overridden if uid is not nil": {
-		//	inSvc: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							AuthConfig: &AuthorizationConfig{
-		//								IAM:           aws.Bool(true),
-		//								AccessPointID: aws.String("mockID1"),
-		//							},
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//		svc.Environments["test"].Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							UID: aws.Uint32(13),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//	wanted: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							UID:        aws.Uint32(13),
-		//							AuthConfig: nil,
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//},
-		//"FAILED TEST: exclusive fields: udi overridden if auth is not nil": {
-		//	inSvc: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							UID: aws.Uint32(13),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//		svc.Environments["test"].Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							AuthConfig: &AuthorizationConfig{
-		//								IAM:           aws.Bool(true),
-		//								AccessPointID: aws.String("mockIDTest"),
-		//							},
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//	wanted: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							UID: nil,
-		//							AuthConfig: &AuthorizationConfig{
-		//								IAM:           aws.Bool(true),
-		//								AccessPointID: aws.String("mockIDTest"),
-		//							},
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//},
-		//"FAILED TEST: exclusive fields: id overridden if gid is not nil": {
-		//	inSvc: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							FileSystemID: aws.String("42"),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//		svc.Environments["test"].Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							GID: aws.Uint32(13),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//	wanted: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							FileSystemID: nil,
-		//							GID:          aws.Uint32(13),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//},
-		//"FAILED TEST: exclusive fields: gid overridden if id is not nil": {
-		//	inSvc: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							GID: aws.Uint32(13),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//		svc.Environments["test"].Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							FileSystemID: aws.String("42"),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//	wanted: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							FileSystemID: aws.String("42"),
-		//							GID:          nil,
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//},
-		//"FAILED TEST: exclusive fields: root_dir overridden if gid is not nil": {
-		//	inSvc: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							RootDirectory: aws.String("mockRootDir"),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//		svc.Environments["test"].Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							GID: aws.Uint32(13),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//	wanted: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							RootDirectory: nil,
-		//							GID:           aws.Uint32(13),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//},
-		//"FAILED TEST: exclusive fields: gid overridden if root_dir is not nil": {
-		//	inSvc: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							GID: aws.Uint32(13),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//		svc.Environments["test"].Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							RootDirectory: aws.String("mockRootDirTest"),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//	wanted: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							RootDirectory: aws.String("mockRootDirTest"),
-		//							GID:           nil,
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//},
-		//"FAILED TEST: exclusive fields: auth overridden if gid is not nil": {
-		//	inSvc: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							AuthConfig: &AuthorizationConfig{
-		//								IAM:           aws.Bool(true),
-		//								AccessPointID: aws.String("mockID1"),
-		//							},
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//		svc.Environments["test"].Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							GID: aws.Uint32(13),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//	wanted: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							AuthConfig: nil,
-		//							GID:        aws.Uint32(13),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//},
-		//"FAILED TEST: exclusive fields: gid overridden if auth is not nil": {
-		//	inSvc: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							GID: aws.Uint32(13),
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//		svc.Environments["test"].Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							AuthConfig: &AuthorizationConfig{
-		//								IAM:           aws.Bool(true),
-		//								AccessPointID: aws.String("mockID1"),
-		//							},
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//	wanted: func(svc *LoadBalancedWebService) {
-		//		svc.Storage = &Storage{
-		//			Volumes: map[string]Volume{
-		//				"mockVolume1": {
-		//					EFS: &EFSConfigOrBool{
-		//						Advanced: EFSVolumeConfiguration{
-		//							AuthConfig: &AuthorizationConfig{
-		//								IAM:           aws.Bool(true),
-		//								AccessPointID: aws.String("mockID1"),
-		//							},
-		//							GID: nil,
-		//						},
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//},
+		"FIXED_BUG: exclusive fields: id overridden if uid is not nil": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									FileSystemID: aws.String("42"),
+								},
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									UID: aws.Uint32(13),
+								},
+							},
+						},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									FileSystemID: nil,
+									UID:          aws.Uint32(13),
+								},
+							},
+						},
+					},
+				}
+			},
+		},
+		"FIXED_BUG: exclusive fields: uid overridden if id is not nil": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									UID: aws.Uint32(13),
+								},
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									FileSystemID: aws.String("42"),
+								},
+							},
+						},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									FileSystemID: aws.String("42"),
+									UID:          nil,
+								},
+							},
+						},
+					},
+				}
+			},
+		},
+		"FIXED_BUG: exclusive fields: root_dir overridden if uid is not nil": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									RootDirectory: aws.String("mockRootDirectory"),
+								},
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									UID: aws.Uint32(13),
+								},
+							},
+						},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									RootDirectory: nil,
+									UID:           aws.Uint32(13),
+								},
+							},
+						},
+					},
+				}
+			},
+		},
+		"FIXED_BUG: exclusive fields: udi overridden if root_dir is not nil": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									UID: aws.Uint32(13),
+								},
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									RootDirectory: aws.String("mockRootDirectoryTest"),
+								},
+							},
+						},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									RootDirectory: aws.String("mockRootDirectoryTest"),
+									UID:           nil,
+								},
+							},
+						},
+					},
+				}
+			},
+		},
+		"FIXED_BUG: exclusive fields: auth overridden if uid is not nil": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									AuthConfig: &AuthorizationConfig{
+										IAM:           aws.Bool(true),
+										AccessPointID: aws.String("mockID1"),
+									},
+								},
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									UID: aws.Uint32(13),
+								},
+							},
+						},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									UID:        aws.Uint32(13),
+									AuthConfig: nil,
+								},
+							},
+						},
+					},
+				}
+			},
+		},
+		"FIXED_BUG: exclusive fields: udi overridden if auth is not nil": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									UID: aws.Uint32(13),
+								},
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									AuthConfig: &AuthorizationConfig{
+										IAM:           aws.Bool(true),
+										AccessPointID: aws.String("mockIDTest"),
+									},
+								},
+							},
+						},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									UID: nil,
+									AuthConfig: &AuthorizationConfig{
+										IAM:           aws.Bool(true),
+										AccessPointID: aws.String("mockIDTest"),
+									},
+								},
+							},
+						},
+					},
+				}
+			},
+		},
+		"FIXED_BUG: exclusive fields: id overridden if gid is not nil": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									FileSystemID: aws.String("42"),
+								},
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									GID: aws.Uint32(13),
+								},
+							},
+						},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									FileSystemID: nil,
+									GID:          aws.Uint32(13),
+								},
+							},
+						},
+					},
+				}
+			},
+		},
+		"FIXED_BUG: exclusive fields: gid overridden if id is not nil": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									GID: aws.Uint32(13),
+								},
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									FileSystemID: aws.String("42"),
+								},
+							},
+						},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									FileSystemID: aws.String("42"),
+									GID:          nil,
+								},
+							},
+						},
+					},
+				}
+			},
+		},
+		"FIXED_BUG exclusive fields: root_dir overridden if gid is not nil": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									RootDirectory: aws.String("mockRootDir"),
+								},
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									GID: aws.Uint32(13),
+								},
+							},
+						},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									RootDirectory: nil,
+									GID:           aws.Uint32(13),
+								},
+							},
+						},
+					},
+				}
+			},
+		},
+		"FIXED_BUG: exclusive fields: gid overridden if root_dir is not nil": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									GID: aws.Uint32(13),
+								},
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									RootDirectory: aws.String("mockRootDirTest"),
+								},
+							},
+						},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									RootDirectory: aws.String("mockRootDirTest"),
+									GID:           nil,
+								},
+							},
+						},
+					},
+				}
+			},
+		},
+		"FIXED_BUG: exclusive fields: auth overridden if gid is not nil": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									AuthConfig: &AuthorizationConfig{
+										IAM:           aws.Bool(true),
+										AccessPointID: aws.String("mockID1"),
+									},
+								},
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									GID: aws.Uint32(13),
+								},
+							},
+						},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									AuthConfig: nil,
+									GID:        aws.Uint32(13),
+								},
+							},
+						},
+					},
+				}
+			},
+		},
+		"FIXED_BUG: exclusive fields: gid overridden if auth is not nil": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									GID: aws.Uint32(13),
+								},
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									AuthConfig: &AuthorizationConfig{
+										IAM:           aws.Bool(true),
+										AccessPointID: aws.String("mockID1"),
+									},
+								},
+							},
+						},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Storage = &Storage{
+					Volumes: map[string]Volume{
+						"mockVolume1": {
+							EFS: &EFSConfigOrBool{
+								Advanced: EFSVolumeConfiguration{
+									AuthConfig: &AuthorizationConfig{
+										IAM:           aws.Bool(true),
+										AccessPointID: aws.String("mockID1"),
+									},
+									GID: nil,
+								},
+							},
+						},
+					},
+				}
+			},
+		},
 		"id overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{

--- a/internal/pkg/manifest/storage_test.go
+++ b/internal/pkg/manifest/storage_test.go
@@ -77,6 +77,14 @@ efs:
 				},
 			},
 		},
+		"invalid": {
+			manifest: []byte(`
+efs: 
+  uid: 1000
+  gid: 10000
+  id: 1`),
+			wantErr: `must specify one, not both, of "uid/gid" and "id/root_dir/auth"`,
+		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {

--- a/internal/pkg/manifest/svc.go
+++ b/internal/pkg/manifest/svc.go
@@ -211,6 +211,14 @@ func (a *AdvancedCount) IsValid() error {
 	return nil
 }
 
+func (a *AdvancedCount) unsetAutoscaling() {
+	a.Range = nil
+	a.CPU = nil
+	a.Memory = nil
+	a.Requests = nil
+	a.ResponseTime = nil
+}
+
 // ServiceDockerfileBuildRequired returns if the service container image should be built from local Dockerfile.
 func ServiceDockerfileBuildRequired(svc interface{}) (bool, error) {
 	return dockerfileBuildRequired("service", svc)

--- a/internal/pkg/manifest/svc_applyenv_test.go
+++ b/internal/pkg/manifest/svc_applyenv_test.go
@@ -632,14 +632,14 @@ func TestApplyEnv_Count(t *testing.T) {
 				}
 				svc.Environments["test"].Count = Count{
 					AdvancedCount: AdvancedCount{
-						Memory: aws.Int(0),
+						Requests: aws.Int(0),
 					},
 				}
 			},
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.Count = Count{
 					AdvancedCount: AdvancedCount{
-						Memory: aws.Int(0),
+						Requests: aws.Int(0),
 					},
 				}
 			},
@@ -965,37 +965,37 @@ func TestApplyEnv_Count_Range(t *testing.T) {
 				}
 			},
 		},
-		//"FAILED TEST: min not overridden": {
-		//	inSvc: func(svc *LoadBalancedWebService) {
-		//		svc.Count = Count{
-		//			AdvancedCount: AdvancedCount{
-		//				Range: &Range{
-		//					RangeConfig: RangeConfig{
-		//						Min: aws.Int(5),
-		//					},
-		//				},
-		//			},
-		//		}
-		//		svc.Environments["test"].Count = Count{
-		//			AdvancedCount: AdvancedCount{
-		//				Range: &Range{
-		//					RangeConfig: RangeConfig{},
-		//				},
-		//			},
-		//		}
-		//	},
-		//	wanted: func(svc *LoadBalancedWebService) {
-		//		svc.Count = Count{
-		//			AdvancedCount: AdvancedCount{
-		//				Range: &Range{
-		//					RangeConfig: RangeConfig{
-		//						Min: aws.Int(5),
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//},
+		"FIXED_BUG: min not overridden": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Count = Count{
+					AdvancedCount: AdvancedCount{
+						Range: &Range{
+							RangeConfig: RangeConfig{
+								Min: aws.Int(5),
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Count = Count{
+					AdvancedCount: AdvancedCount{
+						Range: &Range{
+							RangeConfig: RangeConfig{},
+						},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Count = Count{
+					AdvancedCount: AdvancedCount{
+						Range: &Range{
+							RangeConfig: RangeConfig{
+								Min: aws.Int(5),
+							},
+						},
+					},
+				}
+			},
+		},
 		"max overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Count = Count{
@@ -1062,37 +1062,37 @@ func TestApplyEnv_Count_Range(t *testing.T) {
 				}
 			},
 		},
-		//"FAILED TEST: max not overridden": {
-		//	inSvc: func(svc *LoadBalancedWebService) {
-		//		svc.Count = Count{
-		//			AdvancedCount: AdvancedCount{
-		//				Range: &Range{
-		//					RangeConfig: RangeConfig{
-		//						Max: aws.Int(13),
-		//					},
-		//				},
-		//			},
-		//		}
-		//		svc.Environments["test"].Count = Count{
-		//			AdvancedCount: AdvancedCount{
-		//				Range: &Range{
-		//					RangeConfig: RangeConfig{},
-		//				},
-		//			},
-		//		}
-		//	},
-		//	wanted: func(svc *LoadBalancedWebService) {
-		//		svc.Count = Count{
-		//			AdvancedCount: AdvancedCount{
-		//				Range: &Range{
-		//					RangeConfig: RangeConfig{
-		//						Max: aws.Int(13),
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//},
+		"FIXED_BUG: max not overridden": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Count = Count{
+					AdvancedCount: AdvancedCount{
+						Range: &Range{
+							RangeConfig: RangeConfig{
+								Max: aws.Int(13),
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Count = Count{
+					AdvancedCount: AdvancedCount{
+						Range: &Range{
+							RangeConfig: RangeConfig{},
+						},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Count = Count{
+					AdvancedCount: AdvancedCount{
+						Range: &Range{
+							RangeConfig: RangeConfig{
+								Max: aws.Int(13),
+							},
+						},
+					},
+				}
+			},
+		},
 		"spot_from overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Count = Count{
@@ -1159,37 +1159,37 @@ func TestApplyEnv_Count_Range(t *testing.T) {
 				}
 			},
 		},
-		//"FAILED TEST: spot_from not overridden": {
-		//	inSvc: func(svc *LoadBalancedWebService) {
-		//		svc.Count = Count{
-		//			AdvancedCount: AdvancedCount{
-		//				Range: &Range{
-		//					RangeConfig: RangeConfig{
-		//						SpotFrom: aws.Int(10),
-		//					},
-		//				},
-		//			},
-		//		}
-		//		svc.Environments["test"].Count = Count{
-		//			AdvancedCount: AdvancedCount{
-		//				Range: &Range{
-		//					RangeConfig: RangeConfig{},
-		//				},
-		//			},
-		//		}
-		//	},
-		//	wanted: func(svc *LoadBalancedWebService) {
-		//		svc.Count = Count{
-		//			AdvancedCount: AdvancedCount{
-		//				Range: &Range{
-		//					RangeConfig: RangeConfig{
-		//						SpotFrom: aws.Int(10),
-		//					},
-		//				},
-		//			},
-		//		}
-		//	},
-		//},
+		"FIXED_BUG: spot_from not overridden": {
+			inSvc: func(svc *LoadBalancedWebService) {
+				svc.Count = Count{
+					AdvancedCount: AdvancedCount{
+						Range: &Range{
+							RangeConfig: RangeConfig{
+								SpotFrom: aws.Int(10),
+							},
+						},
+					},
+				}
+				svc.Environments["test"].Count = Count{
+					AdvancedCount: AdvancedCount{
+						Range: &Range{
+							RangeConfig: RangeConfig{},
+						},
+					},
+				}
+			},
+			wanted: func(svc *LoadBalancedWebService) {
+				svc.Count = Count{
+					AdvancedCount: AdvancedCount{
+						Range: &Range{
+							RangeConfig: RangeConfig{
+								SpotFrom: aws.Int(10),
+							},
+						},
+					},
+				}
+			},
+		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {

--- a/internal/pkg/manifest/svc_test.go
+++ b/internal/pkg/manifest/svc_test.go
@@ -323,7 +323,7 @@ subscribe:
 							},
 						},
 						Subscribe: &SubscribeConfig{
-							Topics: &[]TopicSubscription{
+							Topics: []TopicSubscription{
 								{
 									Name:    "publisher1",
 									Service: "testpubsvc",

--- a/internal/pkg/manifest/transform.go
+++ b/internal/pkg/manifest/transform.go
@@ -13,11 +13,11 @@ import (
 var fmtExclusiveFieldsSpecifiedTogether = "invalid manifest: %s %s mutually exclusive with %s and shouldn't be specified at the same time"
 
 var defaultTransformers = []mergo.Transformers{
-	// NOTE: mapToVolumeTransformer need has to be the first transformer. Otherwise `mergo` will overwrite the `dst` map
+	// NOTE: mapToVolumeTransformer needs to be the first transformer. Otherwise `mergo` will overwrite the `dst` map
 	// completely and we will lose `dst`'s values.
 	mapToVolumeTransformer{},
 
-	// NOTE: basicTransformer needs to used before the rest of the custom transformers, because the other transformers
+	// NOTE: basicTransformer needs to be used before the rest of the custom transformers, because the other transformers
 	// do not merge anything - they just unset the fields that do not get specified in source manifest.
 	basicTransformer{},
 	imageTransformer{},

--- a/internal/pkg/manifest/transform.go
+++ b/internal/pkg/manifest/transform.go
@@ -38,6 +38,10 @@ func (t workloadTransformer) Transformer(typ reflect.Type) func(dst, src reflect
 	if typ == reflect.TypeOf(Alias{}) {
 		return transformStringSliceOrString(reflect.TypeOf(Alias{}))
 	}
+	//
+	//if typ == reflect.TypeOf(PlatformArgsOrString{}) {
+	//	return transformPlatformArgsOrString()
+	//}
 
 	if typ.String() == "map[string]manifest.Volume" {
 		return transformMapStringToVolume()
@@ -219,6 +223,22 @@ func transformBuildArgsOrString() func(dst, src reflect.Value) error {
 
 		// Perform customized merge
 		resetComposite(dst, src, "BuildString", "BuildArgs")
+		return nil
+	}
+}
+
+func transformPlatformArgsOrString() func(dst, src reflect.Value) error {
+	return func(dst, src reflect.Value) error {
+		// Perform default merge
+		dstPlatformArgsOrString := dst.Interface().(PlatformArgsOrString)
+		srcPlatformArgsOrString := src.Interface().(PlatformArgsOrString)
+		if err := mergo.Merge(&dstPlatformArgsOrString, srcPlatformArgsOrString, opts(basicTransformer{})...); err != nil {
+			return err
+		}
+		dst.Set(reflect.ValueOf(dstPlatformArgsOrString))
+
+		// Perform customized merge
+		resetComposite(dst, src, "PlatformString", "PlatformArgs")
 		return nil
 	}
 }

--- a/internal/pkg/manifest/transform.go
+++ b/internal/pkg/manifest/transform.go
@@ -38,10 +38,10 @@ func (t workloadTransformer) Transformer(typ reflect.Type) func(dst, src reflect
 	if typ == reflect.TypeOf(Alias{}) {
 		return transformStringSliceOrString(reflect.TypeOf(Alias{}))
 	}
-	//
-	//if typ == reflect.TypeOf(PlatformArgsOrString{}) {
-	//	return transformPlatformArgsOrString()
-	//}
+
+	if typ == reflect.TypeOf(PlatformArgsOrString{}) {
+		return transformPlatformArgsOrString()
+	}
 
 	if typ.String() == "map[string]manifest.Volume" {
 		return transformMapStringToVolume()

--- a/internal/pkg/manifest/transform.go
+++ b/internal/pkg/manifest/transform.go
@@ -12,6 +12,8 @@ import (
 	"github.com/imdario/mergo"
 )
 
+var fmtExclusiveFieldsSpecifiedTogether = "invalid manifest: %s %s mutually exclusive with %s and shouldn't be specified at the same time"
+
 // See a complete list of `reflect.Kind` here: https://pkg.go.dev/reflect#Kind.
 var basicKinds = []reflect.Kind{
 	reflect.Bool,
@@ -21,271 +23,420 @@ var basicKinds = []reflect.Kind{
 	reflect.Complex64, reflect.Complex128,
 	reflect.Array, reflect.String, reflect.Slice,
 }
-var fmtExclusiveFieldsSpecifiedTogether = "invalid manifest: %s %s mutually exclusive with %s and shouldn't be specified at the same time"
-
-type workloadTransformer struct{}
-
-// Transformer returns custom merge logic for workload's fields.
-func (t workloadTransformer) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
-	if transform := t.transformExclusiveTypes(typ); transform != nil {
-		return transform
-	}
-
-	if transform := t.transformCompositeTypes(typ); transform != nil {
-		return transform
-	}
-
-	if typ.String() == "map[string]manifest.Volume" {
-		return transformMapStringToVolume
-	}
-
-	if transform := transformBasic(typ); transform != nil {
-		return transform
-	}
-
-	return nil
-}
-
-func (t workloadTransformer) transformCompositeTypes(typ reflect.Type) func(dst, src reflect.Value) error {
-	var et exclusiveTransformer
-	switch typ {
-	case reflect.TypeOf(EntryPointOverride{}), reflect.TypeOf(CommandOverride{}), reflect.TypeOf(Alias{}):
-		et.merge = func(dst, src reflect.Value) error {
-			dstStruct := dst.Convert(reflect.TypeOf(stringSliceOrString{})).Interface().(stringSliceOrString)
-			srcStruct := src.Convert(reflect.TypeOf(stringSliceOrString{})).Interface().(stringSliceOrString)
-			if err := mergo.Merge(&dstStruct, srcStruct, opts(basicTransformer{})...); err != nil {
-				return err
-			}
-			dst.Set(reflect.ValueOf(dstStruct).Convert(typ))
-			return nil
-		}
-		et.resetExclusiveFields = func(dst, src reflect.Value) error {
-			return resetExclusiveFields(dst, src, []string{"String"}, []string{"StringSlice"})
-		}
-	case reflect.TypeOf(PlatformArgsOrString{}):
-		et.merge = func(dst, src reflect.Value) error {
-			dstPlatformArgsOrString := dst.Interface().(PlatformArgsOrString)
-			srcPlatformArgsOrString := src.Interface().(PlatformArgsOrString)
-			if err := mergo.Merge(&dstPlatformArgsOrString, srcPlatformArgsOrString, opts(basicTransformer{})...); err != nil {
-				return err
-			}
-			dst.Set(reflect.ValueOf(dstPlatformArgsOrString))
-			return nil
-		}
-		et.resetExclusiveFields = func(dst, src reflect.Value) error {
-			return resetExclusiveFields(dst, src, []string{"PlatformString"}, []string{"PlatformArgs"})
-		}
-	case reflect.TypeOf(HealthCheckArgsOrString{}):
-		et.merge = func(dst, src reflect.Value) error {
-			dstHC := dst.Interface().(HealthCheckArgsOrString)
-			srcHC := src.Interface().(HealthCheckArgsOrString)
-			if err := mergo.Merge(&dstHC, srcHC, opts(basicTransformer{})...); err != nil {
-				return err
-			}
-			dst.Set(reflect.ValueOf(dstHC))
-			return nil
-		}
-		et.resetExclusiveFields = func(dst, src reflect.Value) error {
-			return resetExclusiveFields(dst, src, []string{"HealthCheckPath"}, []string{"HealthCheckArgs"})
-		}
-	case reflect.TypeOf(Count{}):
-		et.merge = func(dst, src reflect.Value) error {
-			dstC := dst.Interface().(Count)
-			srcC := src.Interface().(Count)
-			if err := mergo.Merge(&dstC, srcC, opts(countTransformer{})...); err != nil {
-				return err
-			}
-			dst.Set(reflect.ValueOf(dstC))
-			return nil
-		}
-		et.resetExclusiveFields = func(dst, src reflect.Value) error {
-			return resetExclusiveFields(dst, src, []string{"Value"}, []string{"AdvancedCount"})
-		}
-	default:
-		return nil // Return `nil` if this is not a composite type.
-	}
-	return et.transform
-}
-
-func (t workloadTransformer) transformExclusiveTypes(originalType reflect.Type) func(dst, src reflect.Value) error {
-	var et exclusiveTransformer
-	switch originalType {
-	case reflect.TypeOf(Image{}):
-		et.merge = func(dst, src reflect.Value) error {
-			dstImage := dst.Interface().(Image)
-			srcImage := src.Interface().(Image)
-			if err := mergo.Merge(&dstImage, srcImage, opts(imageTransformer{})...); err != nil {
-				return err
-			}
-			dst.Set(reflect.ValueOf(dstImage))
-			return nil
-		}
-		et.resetExclusiveFields = func(dst, src reflect.Value) error {
-			return resetExclusiveFields(dst, src, []string{"Build"}, []string{"Location"})
-		}
-	default:
-		return nil
-	}
-	return et.transform
-}
 
 type imageTransformer struct{}
 
-// Transformer returns custom merge logic for volume's fields.
+// Transformer provides custom logic to transform an Image.
 func (t imageTransformer) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
-	if transform := t.transformCompositeTypes(typ); transform != nil {
-		return transform
+	if typ != reflect.TypeOf(Image{}) {
+		return nil
 	}
-	return transformBasic(typ)
+
+	return func(dst, src reflect.Value) error {
+		// NOTE: Since `dst` comes from an exported field (all manifest fields are exported), `Interface{}` won't panic.
+		dstStruct, srcStruct := dst.Interface().(Image), src.Interface().(Image)
+
+		if !srcStruct.Build.isEmpty() && srcStruct.Location != nil {
+			return fmt.Errorf(fmtExclusiveFieldsSpecifiedTogether, "image.build", "is", "image.location")
+		}
+
+		if !srcStruct.Build.isEmpty() {
+			dstStruct.Location = nil
+		}
+
+		if srcStruct.Location != nil {
+			dstStruct.Build = BuildArgsOrString{}
+		}
+
+		if dst.CanSet() { // For extra safety to prevent panicking.
+			dst.Set(reflect.ValueOf(dstStruct))
+		}
+		return nil
+	}
 }
 
-func (t imageTransformer) transformCompositeTypes(typ reflect.Type) func(dst, src reflect.Value) error {
+type buildArgsOrStringTransformer struct{}
+
+// Transformer returns custom merge logic for BuildArgsOrString's fields.
+func (t buildArgsOrStringTransformer) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
 	if typ != reflect.TypeOf(BuildArgsOrString{}) {
 		return nil
 	}
 
-	var et exclusiveTransformer
-	et.merge = func(dst, src reflect.Value) error {
-		dstBuildArgsOrString := dst.Interface().(BuildArgsOrString)
-		srcBuildArgsOrString := src.Interface().(BuildArgsOrString)
-		if err := mergo.Merge(&dstBuildArgsOrString, srcBuildArgsOrString, opts(basicTransformer{})...); err != nil {
-			return err
+	return func(dst, src reflect.Value) error {
+		dstStruct, srcStruct := dst.Interface().(BuildArgsOrString), src.Interface().(BuildArgsOrString)
+
+		if !srcStruct.BuildArgs.isEmpty() {
+			dstStruct.BuildString = nil
 		}
-		dst.Set(reflect.ValueOf(dstBuildArgsOrString))
-		return nil
-	}
-	et.resetExclusiveFields = func(dst, src reflect.Value) error {
-		return resetExclusiveFields(dst, src, []string{"BuildString"}, []string{"BuildArgs"})
-	}
-	return et.transform
-}
 
-type volumeTransformer struct{}
-
-// Transformer returns custom merge logic for volume's fields.
-func (t volumeTransformer) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
-	if transform := t.transformCompositeTypes(typ); transform != nil {
-		return transform
-	}
-	return transformBasic(typ)
-}
-
-func (t volumeTransformer) transformCompositeTypes(typ reflect.Type) func(dst, src reflect.Value) error {
-	if typ != reflect.TypeOf(EFSConfigOrBool{}) {
-		return nil
-	}
-	var et exclusiveTransformer
-	et.merge = func(dst, src reflect.Value) error {
-		dstEFSConfigOrBool := dst.Interface().(EFSConfigOrBool)
-		srcEFSConfigOrBool := src.Interface().(EFSConfigOrBool)
-		if err := mergo.Merge(&dstEFSConfigOrBool, srcEFSConfigOrBool, opts(efsConfigOrBoolTransformer{})...); err != nil {
-			return err
+		if srcStruct.BuildString != nil {
+			dstStruct.BuildArgs = DockerBuildArgs{}
 		}
-		dst.Set(reflect.ValueOf(dstEFSConfigOrBool))
-		return nil
-	}
-	et.resetExclusiveFields = func(dst, src reflect.Value) error {
-		return resetExclusiveFields(dst, src, []string{"Enabled"}, []string{"Advanced"})
-	}
-	return et.transform
-}
 
-type efsConfigOrBoolTransformer struct{}
-
-// Transformer returns custom merge logic for volume's fields.
-func (t efsConfigOrBoolTransformer) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
-	if transform := t.transformExclusiveTypes(typ); transform != nil {
-		return transform
-	}
-	return transformBasic(typ)
-}
-
-func (t efsConfigOrBoolTransformer) transformExclusiveTypes(typ reflect.Type) func(dst, src reflect.Value) error {
-	if typ != reflect.TypeOf(EFSVolumeConfiguration{}) {
-		return nil
-	}
-
-	var et exclusiveTransformer
-	et.merge = func(dst, src reflect.Value) error {
-		dstV := dst.Interface().(EFSVolumeConfiguration)
-		srcV := src.Interface().(EFSVolumeConfiguration)
-		if err := mergo.Merge(&dstV, srcV, opts(volumeTransformer{})...); err != nil {
-			return err
+		if dst.CanSet() { // For extra safety to prevent panicking.
+			dst.Set(reflect.ValueOf(dstStruct))
 		}
-		dst.Set(reflect.ValueOf(dstV))
 		return nil
 	}
-	et.resetExclusiveFields = func(dst, src reflect.Value) error {
-		return resetExclusiveFields(dst, src, []string{"UID", "GID"}, []string{"FileSystemID", "RootDirectory", "AuthConfig"})
+}
+
+type stringSliceOrStringTransformer struct{}
+
+// Transformer returns custom merge logic for stringSliceOrStringTransformer's fields.
+func (t stringSliceOrStringTransformer) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
+	if !typ.ConvertibleTo(reflect.TypeOf(stringSliceOrString{})) {
+		return nil
 	}
-	return et.transform
+
+	return func(dst, src reflect.Value) error {
+		dstStruct := dst.Convert(reflect.TypeOf(stringSliceOrString{})).Interface().(stringSliceOrString)
+		srcStruct := src.Convert(reflect.TypeOf(stringSliceOrString{})).Interface().(stringSliceOrString)
+
+		if srcStruct.String != nil {
+			dstStruct.StringSlice = nil
+		}
+
+		if srcStruct.StringSlice != nil {
+			dstStruct.String = nil
+		}
+
+		if dst.CanSet() { // For extra safety to prevent panicking.
+			dst.Set(reflect.ValueOf(dstStruct).Convert(typ))
+		}
+		return nil
+	}
+}
+
+type platformArgsOrStringTransformer struct{}
+
+// Transformer returns custom merge logic for PlatformArgsOrString's fields.
+func (t platformArgsOrStringTransformer) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
+	if typ != reflect.TypeOf(PlatformArgsOrString{}) {
+		return nil
+	}
+
+	return func(dst, src reflect.Value) error {
+		dstStruct, srcStruct := dst.Interface().(PlatformArgsOrString), src.Interface().(PlatformArgsOrString)
+
+		if srcStruct.PlatformString != nil {
+			dstStruct.PlatformArgs = PlatformArgs{}
+		}
+
+		if !srcStruct.PlatformArgs.isEmpty() {
+			dstStruct.PlatformString = nil
+		}
+
+		if dst.CanSet() { // For extra safety to prevent panicking.
+			dst.Set(reflect.ValueOf(dstStruct))
+		}
+		return nil
+	}
+}
+
+type healthCheckArgsOrStringTransformer struct{}
+
+// Transformer returns custom merge logic for HealthCheckArgsOrString's fields.
+func (t healthCheckArgsOrStringTransformer) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
+	if typ != reflect.TypeOf(HealthCheckArgsOrString{}) {
+		return nil
+	}
+
+	return func(dst, src reflect.Value) error {
+		dstStruct, srcStruct := dst.Interface().(HealthCheckArgsOrString), src.Interface().(HealthCheckArgsOrString)
+
+		if srcStruct.HealthCheckPath != nil {
+			dstStruct.HealthCheckArgs = HTTPHealthCheckArgs{}
+		}
+
+		if !srcStruct.HealthCheckArgs.isEmpty() {
+			dstStruct.HealthCheckPath = nil
+		}
+
+		if dst.CanSet() { // For extra safety to prevent panicking.
+			dst.Set(reflect.ValueOf(dstStruct))
+		}
+		return nil
+	}
 }
 
 type countTransformer struct{}
 
-// Transformer returns custom merge logic for volume's fields.
+// Transformer returns custom merge logic for Count's fields.
 func (t countTransformer) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
-	if transform := t.transformExclusiveTypes(typ); transform != nil {
-		return transform
+	if typ != reflect.TypeOf(Count{}) {
+		return nil
 	}
-	return transformBasic(typ)
-}
 
-func (t countTransformer) transformExclusiveTypes(typ reflect.Type) func(dst, src reflect.Value) error {
-	if typ != reflect.TypeOf(AdvancedCount{}) {
-		return nil
-	}
-	var et exclusiveTransformer
-	et.merge = func(dst, src reflect.Value) error {
-		dstC := dst.Interface().(AdvancedCount)
-		srcC := src.Interface().(AdvancedCount)
-		if err := mergo.Merge(&dstC, srcC, opts(advancedCountTransformer{})...); err != nil {
-			return err
+	return func(dst, src reflect.Value) error {
+		dstStruct, srcStruct := dst.Interface().(Count), src.Interface().(Count)
+
+		if !srcStruct.AdvancedCount.IsEmpty() {
+			dstStruct.Value = nil
 		}
-		dst.Set(reflect.ValueOf(dstC))
+
+		if srcStruct.Value != nil {
+			dstStruct.AdvancedCount = AdvancedCount{}
+		}
+
+		if dst.CanSet() { // For extra safety to prevent panicking.
+			dst.Set(reflect.ValueOf(dstStruct))
+		}
 		return nil
 	}
-	et.resetExclusiveFields = func(dst, src reflect.Value) error {
-		return resetExclusiveFields(dst, src, []string{"Spot"}, []string{"Range", "CPU", "Memory", "Requests", "ResponseTime"})
-	}
-	return et.transform
 }
 
 type advancedCountTransformer struct{}
 
-// Transformer returns custom merge logic for volume's fields.
+// Transformer returns custom merge logic for AdvancedCount's fields.
 func (t advancedCountTransformer) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
-	if transform := t.transformCompositeTypes(typ); transform != nil {
-		return transform
+	if typ != reflect.TypeOf(AdvancedCount{}) {
+		return nil
 	}
-	return transformBasic(typ)
+
+	return func(dst, src reflect.Value) error {
+		dstStruct, srcStruct := dst.Interface().(AdvancedCount), src.Interface().(AdvancedCount)
+
+		spotSpecified := srcStruct.Spot != nil
+		elseSpecified := srcStruct.Range != nil ||
+			srcStruct.CPU != nil ||
+			srcStruct.Memory != nil ||
+			srcStruct.Requests != nil ||
+			srcStruct.ResponseTime != nil
+		if spotSpecified && elseSpecified {
+			return fmt.Errorf(fmtExclusiveFieldsSpecifiedTogether, "spot", "is",
+				english.WordSeries([]string{"range", "cpu", "memory", "requests", "response_time"}, "and"))
+		}
+
+		if spotSpecified {
+			dstStruct.Range = nil
+			dstStruct.CPU = nil
+			dstStruct.Memory = nil
+			dstStruct.Requests = nil
+			dstStruct.ResponseTime = nil
+		}
+
+		if elseSpecified {
+			dstStruct.Spot = nil
+		}
+
+		if dst.CanSet() { // For extra safety to prevent panicking.
+			dst.Set(reflect.ValueOf(dstStruct))
+		}
+		return nil
+	}
 }
 
-func (t advancedCountTransformer) transformCompositeTypes(typ reflect.Type) func(dst, src reflect.Value) error {
+type rangeTransformer struct{}
+
+// Transformer returns custom merge logic for Range's fields.
+func (t rangeTransformer) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
 	if typ != reflect.TypeOf(Range{}) {
 		return nil
 	}
 
-	var et exclusiveTransformer
-	et.merge = func(dst, src reflect.Value) error {
-		dstHC := dst.Interface().(Range)
-		srcHC := src.Interface().(Range)
-		if err := mergo.Merge(&dstHC, srcHC, opts(basicTransformer{})...); err != nil {
-			return err
+	return func(dst, src reflect.Value) error {
+		dstStruct, srcStruct := dst.Interface().(Range), src.Interface().(Range)
+
+		if !srcStruct.RangeConfig.IsEmpty() {
+			dstStruct.Value = nil
 		}
-		dst.Set(reflect.ValueOf(dstHC))
+
+		if srcStruct.Value != nil {
+			dstStruct.RangeConfig = RangeConfig{}
+		}
+
+		if dst.CanSet() { // For extra safety to prevent panicking.
+			dst.Set(reflect.ValueOf(dstStruct))
+		}
 		return nil
 	}
-	et.resetExclusiveFields = func(dst, src reflect.Value) error {
-		return resetExclusiveFields(dst, src, []string{"Value"}, []string{"RangeConfig"})
-	}
-	return et.transform
 }
 
-// transformBasic implements customized merge logic for manifest fields that are number, string, bool, array, and duration.
-func transformBasic(typ reflect.Type) func(dst, src reflect.Value) error {
+type mapToVolumeTransformer struct{}
+
+// Transformer returns custom merge logic for map[string]Volume.
+func (t mapToVolumeTransformer) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
+	/**
+	There are two things to notice:
+	1. Custom logic for `map[string]Volume` is needed because when `withOverride` flag is specified, `mergo` set
+	dst map's value directly by src map's value, instead of continuing deep merging `Volume`.
+	For example, given that
+			dst = map[string]Volume{
+				"volume1": {
+					prop1: 1,
+					prop2: 2,
+				},
+			}
+	and 	src = map[string]Volume{
+				"volume1": {
+					prop1: 3,
+				},
+			}
+	Without this transformer, the result would be
+			res = map[string]Volume{
+				"volume1": {
+					prop1: 3,
+				}
+			}
+	The merge stops at `map`, while we expect `Volume` to be merged instead of overwritten.
+	2. Note that at the end the transformer sets src map's value as well by `src.SetMapIndex(key, reflect.ValueOf(dstV))`.
+	This is because when `withOverride` flag is specified, `mergo` stops merging at map instead of `Volume`. The merged
+	value will get overwritten by any other transformers.
+	*/
+	if typ.Kind() != reflect.Map {
+		return nil
+	}
+
+	if typ.Key().Kind() != reflect.String || typ.Elem() != reflect.TypeOf(Volume{}) {
+		return nil
+	}
+
+	return func(dst, src reflect.Value) error {
+		for _, key := range src.MapKeys() {
+			srcElement := src.MapIndex(key)
+			if !srcElement.IsValid() {
+				continue
+			}
+
+			dstElement := dst.MapIndex(key)
+			if !dstElement.IsValid() {
+				dst.SetMapIndex(key, srcElement)
+				continue
+			}
+
+			// Perform default merge
+			dstV := dstElement.Interface().(Volume)
+			srcV := srcElement.Interface().(Volume)
+
+			transformers := []mergo.Transformers{
+				efsConfigOrBoolTransformer{},
+				efsVolumeConfigurationTransformer{},
+				basicTransformer{},
+			}
+
+			for _, t := range transformers {
+				if err := mergo.Merge(&dstV, srcV, mergo.WithOverride, mergo.WithTransformers(t)); err != nil {
+					return err
+				}
+			}
+
+			// Set merged value for the key
+			dst.SetMapIndex(key, reflect.ValueOf(dstV))
+
+			// NOTE: if we don't set the merged value for `src`, `dst`'s value for this key will be completely overwritten
+			// (instead of merging) by other transformers.
+			src.SetMapIndex(key, reflect.ValueOf(dstV))
+		}
+		return nil
+	}
+}
+
+type efsConfigOrBoolTransformer struct{}
+
+// Transformer returns custom merge logic for EFSConfigOrBool's fields.
+func (t efsConfigOrBoolTransformer) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
+	if typ != reflect.TypeOf(EFSConfigOrBool{}) {
+		return nil
+	}
+	return func(dst, src reflect.Value) error {
+		dstStruct, srcStruct := dst.Interface().(EFSConfigOrBool), src.Interface().(EFSConfigOrBool)
+
+		if !srcStruct.Advanced.IsEmpty() {
+			dstStruct.Enabled = nil
+		}
+
+		if srcStruct.Enabled != nil {
+			dstStruct.Advanced = EFSVolumeConfiguration{}
+		}
+
+		if dst.CanSet() { // For extra safety to prevent panicking.
+			dst.Set(reflect.ValueOf(dstStruct))
+		}
+		return nil
+	}
+}
+
+type efsVolumeConfigurationTransformer struct{}
+
+// Transformer returns custom merge logic for EFSVolumeConfiguration's fields.
+func (t efsVolumeConfigurationTransformer) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
+	if typ != reflect.TypeOf(EFSVolumeConfiguration{}) {
+		return nil
+	}
+	return func(dst, src reflect.Value) error {
+		dstStruct, srcStruct := dst.Interface().(EFSVolumeConfiguration), src.Interface().(EFSVolumeConfiguration)
+
+		uidOrGIDSet := srcStruct.UID != nil || srcStruct.GID != nil
+		elseSet := srcStruct.FileSystemID != nil ||
+			srcStruct.RootDirectory != nil ||
+			srcStruct.AuthConfig != nil
+
+		if uidOrGIDSet && elseSet {
+			return fmt.Errorf(fmtExclusiveFieldsSpecifiedTogether,
+				english.WordSeries([]string{"uid", "gid"}, "and"),
+				english.PluralWord(len([]string{"uid", "gid"}), "is", "and"),
+				english.WordSeries([]string{"id", "root_dir", "auth"}, "and"))
+		}
+
+		if uidOrGIDSet {
+			dstStruct.FileSystemID = nil
+			dstStruct.RootDirectory = nil
+			dstStruct.AuthConfig = nil
+		}
+
+		if elseSet {
+			dstStruct.UID = nil
+			dstStruct.GID = nil
+		}
+
+		if dst.CanSet() { // For extra safety to prevent panicking.
+			dst.Set(reflect.ValueOf(dstStruct))
+		}
+		return nil
+	}
+}
+
+func transformPBasic() func(dst, src reflect.Value) error {
+	// NOTE: `dst` must be of kind reflect.Ptr.
+	return func(dst, src reflect.Value) error {
+		// This condition shouldn't ever be true. It's merely here for extra safety so that `src.IsNil` won't panic.
+		if src.Kind() != reflect.Ptr {
+			return nil
+		}
+
+		if src.IsNil() {
+			return nil
+		}
+
+		if dst.CanSet() {
+			dst.Set(src)
+		}
+		return nil
+	}
+}
+
+type basicTransformer struct{}
+
+// Transformer returns custom merge logic for volume's fields.
+func (t basicTransformer) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
 	if typ.Kind() == reflect.Slice {
-		return transformSlice
+		return func(dst, src reflect.Value) error {
+			// This condition shouldn't ever be true. It's merely here for extra safety so that `src.IsNil` won't panic.
+			if src.Kind() != reflect.Slice {
+				return nil
+			}
+
+			if src.IsNil() {
+				return nil
+			}
+
+			if dst.CanSet() {
+				dst.Set(src)
+			}
+
+			return nil
+		}
 	}
 
 	if typ.Kind() == reflect.Ptr {
@@ -294,201 +445,6 @@ func transformBasic(typ reflect.Type) func(dst, src reflect.Value) error {
 				return transformPBasic()
 			}
 		}
-
-		if typ.Elem().Kind() == reflect.Struct {
-			return transformPStruct()
-		}
 	}
-	return nil
-}
-
-func transformSlice(dst, src reflect.Value) error {
-	if !src.IsNil() {
-		dst.Set(src)
-	}
-	return nil
-}
-
-func transformMapStringToVolume(dst, src reflect.Value) error {
-	for _, key := range src.MapKeys() {
-		srcElement := src.MapIndex(key)
-		if !srcElement.IsValid() {
-			continue
-		}
-		dstElement := dst.MapIndex(key)
-		if !dstElement.IsValid() {
-			dst.SetMapIndex(key, srcElement)
-			continue
-		}
-
-		// Perform default merge
-		dstV := dstElement.Interface().(Volume)
-		srcV := srcElement.Interface().(Volume)
-		if err := mergo.Merge(&dstV, srcV, opts(volumeTransformer{})...); err != nil {
-			return err
-		}
-
-		// Set merged value for the key
-		dst.SetMapIndex(key, reflect.ValueOf(dstV))
-	}
-	return nil
-}
-
-func transformPStruct() func(dst, src reflect.Value) error {
-	return func(dst, src reflect.Value) error {
-		if src.IsNil() {
-			return nil
-		}
-
-		// TODO: these can be removed if we change all pointers struct to struct
-		// Perform default merge
-		var err error
-		switch dst.Elem().Type().Name() {
-		case "ContainerHealthCheck":
-			dstElem := dst.Interface().(*ContainerHealthCheck)
-			srcElem := src.Elem().Interface().(ContainerHealthCheck)
-			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithTransformers(workloadTransformer{}))
-		case "PlatformArgsOrString":
-			dstElem := dst.Interface().(*PlatformArgsOrString)
-			srcElem := src.Elem().Interface().(PlatformArgsOrString)
-			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithTransformers(workloadTransformer{}))
-		case "EntryPointOverride":
-			dstElem := dst.Interface().(*EntryPointOverride)
-			srcElem := src.Elem().Interface().(EntryPointOverride)
-			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithTransformers(workloadTransformer{}))
-		case "CommandOverride":
-			dstElem := dst.Interface().(*CommandOverride)
-			srcElem := src.Elem().Interface().(CommandOverride)
-			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithTransformers(workloadTransformer{}))
-		case "NetworkConfig":
-			dstElem := dst.Interface().(*NetworkConfig)
-			srcElem := src.Elem().Interface().(NetworkConfig)
-			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithTransformers(workloadTransformer{}))
-		case "vpcConfig":
-			dstElem := dst.Interface().(*vpcConfig)
-			srcElem := src.Elem().Interface().(vpcConfig)
-			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithTransformers(workloadTransformer{}))
-		case "Logging":
-			dstElem := dst.Interface().(*Logging)
-			srcElem := src.Elem().Interface().(Logging)
-			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithTransformers(workloadTransformer{}))
-		case "Storage":
-			dstElem := dst.Interface().(*Storage)
-			srcElem := src.Elem().Interface().(Storage)
-			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithTransformers(workloadTransformer{}))
-		case "Alias":
-			dstElem := dst.Interface().(*Alias)
-			srcElem := src.Elem().Interface().(Alias)
-			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithTransformers(workloadTransformer{}))
-		case "Range":
-			dstElem := dst.Interface().(*Range)
-			srcElem := src.Elem().Interface().(Range)
-			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithTransformers(advancedCountTransformer{}))
-		case "SidecarConfig":
-			dstElem := dst.Interface().(*SidecarConfig)
-			srcElem := src.Elem().Interface().(SidecarConfig)
-			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithTransformers(workloadTransformer{}))
-		case "SubscribeConfig":
-			dstElem := dst.Interface().(*SubscribeConfig)
-			srcElem := src.Elem().Interface().(SubscribeConfig)
-			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithTransformers(workloadTransformer{}))
-		case "SQSQueue":
-			dstElem := dst.Interface().(*SQSQueue)
-			srcElem := src.Elem().Interface().(SQSQueue)
-			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithTransformers(workloadTransformer{}))
-		case "EFSConfigOrBool":
-			dstElem := dst.Interface().(*EFSConfigOrBool)
-			srcElem := src.Elem().Interface().(EFSConfigOrBool)
-			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithTransformers(volumeTransformer{}))
-		case "AuthorizationConfig":
-			dstElem := dst.Interface().(*AuthorizationConfig)
-			srcElem := src.Elem().Interface().(AuthorizationConfig)
-			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithTransformers(workloadTransformer{}))
-		}
-
-		if err != nil {
-			return err
-		}
-		return nil
-	}
-}
-
-func transformPBasic() func(dst, src reflect.Value) error {
-	return func(dst, src reflect.Value) error {
-		if src.IsNil() {
-			return nil
-		}
-		dst.Set(src)
-		return nil
-	}
-}
-
-type exclusiveTransformer struct {
-	merge                func(dst, src reflect.Value) error
-	resetExclusiveFields func(dst, src reflect.Value) error
-}
-
-func (t exclusiveTransformer) transform(dst, src reflect.Value) error {
-	// Perform default merge
-	if err := t.merge(dst, src); err != nil {
-		return err
-	}
-	// Set or unset exclusive fields
-	if err := t.resetExclusiveFields(dst, src); err != nil {
-		return err
-	}
-	return nil
-}
-
-type basicTransformer struct{}
-
-// Transformer returns custom merge logic for volume's fields.
-func (t basicTransformer) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
-	return transformBasic(typ)
-}
-
-func opts(transformers mergo.Transformers) []func(*mergo.Config) {
-	return []func(*mergo.Config){
-		mergo.WithOverride,
-		mergo.WithTransformers(transformers),
-	}
-}
-
-func resetExclusiveFields(dst, src reflect.Value, fieldsA, fieldsB []string) error {
-	var fieldsASpecifiedInSrc, fieldsBSpecifiedInSrc bool
-	for _, a := range fieldsA {
-		if !src.FieldByName(a).IsZero() {
-			fieldsASpecifiedInSrc = true
-			break
-		}
-	}
-
-	for _, b := range fieldsB {
-		if !src.FieldByName(b).IsZero() {
-			fieldsBSpecifiedInSrc = true
-			break
-		}
-	}
-
-	// TODO: we should validate that they are not specified at the same time at an earlier stage, possibly in `manifest.validate`.
-	if fieldsASpecifiedInSrc && fieldsBSpecifiedInSrc {
-		return fmt.Errorf(fmtExclusiveFieldsSpecifiedTogether,
-			english.WordSeries(fieldsA, "and"),
-			english.Plural(len(fieldsA), "is", "are"),
-			english.WordSeries(fieldsB, "and"))
-	}
-
-	if fieldsASpecifiedInSrc {
-		for _, b := range fieldsB {
-			dst.FieldByName(b).Set(reflect.Zero(dst.FieldByName(b).Type()))
-		}
-	}
-
-	if fieldsBSpecifiedInSrc {
-		for _, a := range fieldsA {
-			dst.FieldByName(a).Set(reflect.Zero(dst.FieldByName(a).Type()))
-		}
-	}
-
 	return nil
 }

--- a/internal/pkg/manifest/transform.go
+++ b/internal/pkg/manifest/transform.go
@@ -14,6 +14,24 @@ import (
 
 var fmtExclusiveFieldsSpecifiedTogether = "invalid manifest: %s %s mutually exclusive with %s and shouldn't be specified at the same time"
 
+var defaultTransformers = []mergo.Transformers{
+	// NOTE: mapToVolumeTransformer need has to be the first transformer. Otherwise `mergo` will overwrite the `dst` map
+	// completely and we will lose `dst`'s values.
+	mapToVolumeTransformer{},
+
+	// NOTE: basicTransformer needs to used before the rest of the custom transformers, because the other transformers
+	// do not merge anything - they just unset the fields that do not get specified in source manifest.
+	basicTransformer{},
+	imageTransformer{},
+	buildArgsOrStringTransformer{},
+	stringSliceOrStringTransformer{},
+	platformArgsOrStringTransformer{},
+	healthCheckArgsOrStringTransformer{},
+	countTransformer{},
+	advancedCountTransformer{},
+	rangeTransformer{},
+}
+
 // See a complete list of `reflect.Kind` here: https://pkg.go.dev/reflect#Kind.
 var basicKinds = []reflect.Kind{
 	reflect.Bool,

--- a/internal/pkg/manifest/transform.go
+++ b/internal/pkg/manifest/transform.go
@@ -4,7 +4,10 @@
 package manifest
 
 import (
+	"fmt"
 	"reflect"
+
+	"github.com/dustin/go-humanize/english"
 
 	"github.com/imdario/mergo"
 )
@@ -18,21 +21,22 @@ var basicKinds = []reflect.Kind{
 	reflect.Complex64, reflect.Complex128,
 	reflect.Array, reflect.String, reflect.Slice,
 }
+var fmtExclusiveFieldsSpecifiedTogether = "invalid manifest: %s %s mutually exclusive with %s and shouldn't be specified at the same time"
 
 type workloadTransformer struct{}
 
 // Transformer returns custom merge logic for workload's fields.
 func (t workloadTransformer) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
-	if transform := transformExclusiveType(typ); transform != nil {
+	if transform := t.transformExclusiveTypes(typ); transform != nil {
 		return transform
 	}
 
-	if transform := transformCompositeType(typ); transform != nil {
+	if transform := t.transformCompositeTypes(typ); transform != nil {
 		return transform
 	}
 
 	if typ.String() == "map[string]manifest.Volume" {
-		return transformMapStringToVolume()
+		return transformMapStringToVolume
 	}
 
 	if transform := transformBasic(typ); transform != nil {
@@ -42,57 +46,259 @@ func (t workloadTransformer) Transformer(typ reflect.Type) func(dst, src reflect
 	return nil
 }
 
-type basicTransformer struct{}
+func (t workloadTransformer) transformCompositeTypes(typ reflect.Type) func(dst, src reflect.Value) error {
+	var et exclusiveTransformer
+	switch typ {
+	case reflect.TypeOf(EntryPointOverride{}), reflect.TypeOf(CommandOverride{}), reflect.TypeOf(Alias{}):
+		et.merge = func(dst, src reflect.Value) error {
+			dstStruct := dst.Convert(reflect.TypeOf(stringSliceOrString{})).Interface().(stringSliceOrString)
+			srcStruct := src.Convert(reflect.TypeOf(stringSliceOrString{})).Interface().(stringSliceOrString)
+			if err := mergo.Merge(&dstStruct, srcStruct, opts(basicTransformer{})...); err != nil {
+				return err
+			}
+			dst.Set(reflect.ValueOf(dstStruct).Convert(typ))
+			return nil
+		}
+		et.resetExclusiveFields = func(dst, src reflect.Value) error {
+			return resetExclusiveFields(dst, src, []string{"String"}, []string{"StringSlice"})
+		}
+	case reflect.TypeOf(PlatformArgsOrString{}):
+		et.merge = func(dst, src reflect.Value) error {
+			dstPlatformArgsOrString := dst.Interface().(PlatformArgsOrString)
+			srcPlatformArgsOrString := src.Interface().(PlatformArgsOrString)
+			if err := mergo.Merge(&dstPlatformArgsOrString, srcPlatformArgsOrString, opts(basicTransformer{})...); err != nil {
+				return err
+			}
+			dst.Set(reflect.ValueOf(dstPlatformArgsOrString))
+			return nil
+		}
+		et.resetExclusiveFields = func(dst, src reflect.Value) error {
+			return resetExclusiveFields(dst, src, []string{"PlatformString"}, []string{"PlatformArgs"})
+		}
+	case reflect.TypeOf(HealthCheckArgsOrString{}):
+		et.merge = func(dst, src reflect.Value) error {
+			dstHC := dst.Interface().(HealthCheckArgsOrString)
+			srcHC := src.Interface().(HealthCheckArgsOrString)
+			if err := mergo.Merge(&dstHC, srcHC, opts(basicTransformer{})...); err != nil {
+				return err
+			}
+			dst.Set(reflect.ValueOf(dstHC))
+			return nil
+		}
+		et.resetExclusiveFields = func(dst, src reflect.Value) error {
+			return resetExclusiveFields(dst, src, []string{"HealthCheckPath"}, []string{"HealthCheckArgs"})
+		}
+	case reflect.TypeOf(Count{}):
+		et.merge = func(dst, src reflect.Value) error {
+			dstC := dst.Interface().(Count)
+			srcC := src.Interface().(Count)
+			if err := mergo.Merge(&dstC, srcC, opts(countTransformer{})...); err != nil {
+				return err
+			}
+			dst.Set(reflect.ValueOf(dstC))
+			return nil
+		}
+		et.resetExclusiveFields = func(dst, src reflect.Value) error {
+			return resetExclusiveFields(dst, src, []string{"Value"}, []string{"AdvancedCount"})
+		}
+	default:
+		return nil // Return `nil` if this is not a composite type.
+	}
+	return et.transform
+}
 
-// Transformer returns custom merge logic for volume's fields.
-func (t basicTransformer) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
-	return transformBasic(typ)
+func (t workloadTransformer) transformExclusiveTypes(originalType reflect.Type) func(dst, src reflect.Value) error {
+	var et exclusiveTransformer
+	switch originalType {
+	case reflect.TypeOf(Image{}):
+		et.merge = func(dst, src reflect.Value) error {
+			dstImage := dst.Interface().(Image)
+			srcImage := src.Interface().(Image)
+			if err := mergo.Merge(&dstImage, srcImage, opts(imageTransformer{})...); err != nil {
+				return err
+			}
+			dst.Set(reflect.ValueOf(dstImage))
+			return nil
+		}
+		et.resetExclusiveFields = func(dst, src reflect.Value) error {
+			return resetExclusiveFields(dst, src, []string{"Build"}, []string{"Location"})
+		}
+	//case reflect.TypeOf(AdvancedCount{}):
+	//	et.merge = func(dst, src reflect.Value) error {
+	//		dstC := dst.Interface().(AdvancedCount)
+	//		srcC := src.Interface().(AdvancedCount)
+	//		if err := mergo.Merge(&dstC, srcC, opts(basicTransformer{})...); err != nil {
+	//			return err
+	//		}
+	//		dst.Set(reflect.ValueOf(dstC))
+	//		return nil
+	//	}
+	//	et.resetExclusiveFields = func(dst, src reflect.Value) error {
+	//		return resetExclusiveFields(dst, src, []string{"Spot"}, []string{"Range", "CPU", "Memory", "Requests", "ResponseTime"})
+	//	}
+	default:
+		return nil
+	}
+	return et.transform
 }
 
 type imageTransformer struct{}
 
 // Transformer returns custom merge logic for volume's fields.
 func (t imageTransformer) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
-	if typ == reflect.TypeOf(BuildArgsOrString{}) {
-		return transformCompositeType(typ)
+	if transform := t.transformCompositeTypes(typ); transform != nil {
+		return transform
 	}
 	return transformBasic(typ)
+}
+
+func (t imageTransformer) transformCompositeTypes(typ reflect.Type) func(dst, src reflect.Value) error {
+	if typ != reflect.TypeOf(BuildArgsOrString{}) {
+		return nil
+	}
+
+	var et exclusiveTransformer
+	et.merge = func(dst, src reflect.Value) error {
+		dstBuildArgsOrString := dst.Interface().(BuildArgsOrString)
+		srcBuildArgsOrString := src.Interface().(BuildArgsOrString)
+		if err := mergo.Merge(&dstBuildArgsOrString, srcBuildArgsOrString, opts(basicTransformer{})...); err != nil {
+			return err
+		}
+		dst.Set(reflect.ValueOf(dstBuildArgsOrString))
+		return nil
+	}
+	et.resetExclusiveFields = func(dst, src reflect.Value) error {
+		return resetExclusiveFields(dst, src, []string{"BuildString"}, []string{"BuildArgs"})
+	}
+	return et.transform
 }
 
 type volumeTransformer struct{}
 
 // Transformer returns custom merge logic for volume's fields.
 func (t volumeTransformer) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
-	if typ == reflect.TypeOf(EFSConfigOrBool{}) {
-		return transformCompositeType(typ)
+	if transform := t.transformCompositeTypes(typ); transform != nil {
+		return transform
 	}
 	return transformBasic(typ)
+}
+
+func (t volumeTransformer) transformCompositeTypes(typ reflect.Type) func(dst, src reflect.Value) error {
+	if typ != reflect.TypeOf(EFSConfigOrBool{}) {
+		return nil
+	}
+	var et exclusiveTransformer
+	et.merge = func(dst, src reflect.Value) error {
+		dstEFSConfigOrBool := dst.Interface().(EFSConfigOrBool)
+		srcEFSConfigOrBool := src.Interface().(EFSConfigOrBool)
+		if err := mergo.Merge(&dstEFSConfigOrBool, srcEFSConfigOrBool, opts(efsConfigOrBoolTransformer{})...); err != nil {
+			return err
+		}
+		dst.Set(reflect.ValueOf(dstEFSConfigOrBool))
+		return nil
+	}
+	et.resetExclusiveFields = func(dst, src reflect.Value) error {
+		return resetExclusiveFields(dst, src, []string{"Enabled"}, []string{"Advanced"})
+	}
+	return et.transform
 }
 
 type efsConfigOrBoolTransformer struct{}
 
 // Transformer returns custom merge logic for volume's fields.
 func (t efsConfigOrBoolTransformer) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
-	if transform := transformExclusiveType(typ); transform != nil {
+	if transform := t.transformExclusiveTypes(typ); transform != nil {
 		return transform
 	}
 	return transformBasic(typ)
+}
+
+func (t efsConfigOrBoolTransformer) transformExclusiveTypes(typ reflect.Type) func(dst, src reflect.Value) error {
+	if typ != reflect.TypeOf(EFSVolumeConfiguration{}) {
+		return nil
+	}
+
+	var et exclusiveTransformer
+	et.merge = func(dst, src reflect.Value) error {
+		dstV := dst.Interface().(EFSVolumeConfiguration)
+		srcV := src.Interface().(EFSVolumeConfiguration)
+		if err := mergo.Merge(&dstV, srcV, opts(volumeTransformer{})...); err != nil {
+			return err
+		}
+		dst.Set(reflect.ValueOf(dstV))
+		return nil
+	}
+	et.resetExclusiveFields = func(dst, src reflect.Value) error {
+		return resetExclusiveFields(dst, src, []string{"UID", "GID"}, []string{"FileSystemID", "RootDirectory", "AuthConfig"})
+	}
+	return et.transform
 }
 
 type countTransformer struct{}
 
 // Transformer returns custom merge logic for volume's fields.
 func (t countTransformer) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
-	if transform := transformExclusiveType(typ); transform != nil {
+	if transform := t.transformExclusiveTypes(typ); transform != nil {
 		return transform
 	}
 	return transformBasic(typ)
 }
 
+func (t countTransformer) transformExclusiveTypes(typ reflect.Type) func(dst, src reflect.Value) error {
+	if typ != reflect.TypeOf(AdvancedCount{}) {
+		return nil
+	}
+	var et exclusiveTransformer
+	et.merge = func(dst, src reflect.Value) error {
+		dstC := dst.Interface().(AdvancedCount)
+		srcC := src.Interface().(AdvancedCount)
+		if err := mergo.Merge(&dstC, srcC, opts(advancedCountTransformer{})...); err != nil {
+			return err
+		}
+		dst.Set(reflect.ValueOf(dstC))
+		return nil
+	}
+	et.resetExclusiveFields = func(dst, src reflect.Value) error {
+		return resetExclusiveFields(dst, src, []string{"Spot"}, []string{"Range", "CPU", "Memory", "Requests", "ResponseTime"})
+	}
+	return et.transform
+}
+
+type advancedCountTransformer struct{}
+
+// Transformer returns custom merge logic for volume's fields.
+func (t advancedCountTransformer) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
+	if transform := t.transformCompositeTypes(typ); transform != nil {
+		return transform
+	}
+	return transformBasic(typ)
+}
+
+func (t advancedCountTransformer) transformCompositeTypes(typ reflect.Type) func(dst, src reflect.Value) error {
+	if typ != reflect.TypeOf(Range{}) {
+		return nil
+	}
+
+	var et exclusiveTransformer
+	et.merge = func(dst, src reflect.Value) error {
+		dstHC := dst.Interface().(Range)
+		srcHC := src.Interface().(Range)
+		if err := mergo.Merge(&dstHC, srcHC, opts(basicTransformer{})...); err != nil {
+			return err
+		}
+		dst.Set(reflect.ValueOf(dstHC))
+		return nil
+	}
+	et.resetExclusiveFields = func(dst, src reflect.Value) error {
+		return resetExclusiveFields(dst, src, []string{"Value"}, []string{"RangeConfig"})
+	}
+	return et.transform
+}
+
 // transformBasic implements customized merge logic for manifest fields that are number, string, bool, array, and duration.
 func transformBasic(typ reflect.Type) func(dst, src reflect.Value) error {
 	if typ.Kind() == reflect.Slice {
-		return transformSlice()
+		return transformSlice
 	}
 
 	if typ.Kind() == reflect.Ptr {
@@ -109,40 +315,36 @@ func transformBasic(typ reflect.Type) func(dst, src reflect.Value) error {
 	return nil
 }
 
-func transformSlice() func(dst, src reflect.Value) error {
-	return func(dst, src reflect.Value) error {
-		if !src.IsNil() {
-			dst.Set(src)
-		}
-		return nil
+func transformSlice(dst, src reflect.Value) error {
+	if !src.IsNil() {
+		dst.Set(src)
 	}
+	return nil
 }
 
-func transformMapStringToVolume() func(dst, src reflect.Value) error {
-	return func(dst, src reflect.Value) error {
-		for _, key := range src.MapKeys() {
-			srcElement := src.MapIndex(key)
-			if !srcElement.IsValid() {
-				continue
-			}
-			dstElement := dst.MapIndex(key)
-			if !dstElement.IsValid() {
-				dst.SetMapIndex(key, srcElement)
-				continue
-			}
-
-			// Perform default merge
-			dstV := dstElement.Interface().(Volume)
-			srcV := srcElement.Interface().(Volume)
-			if err := mergo.Merge(&dstV, srcV, opts(volumeTransformer{})...); err != nil {
-				return err
-			}
-
-			// Set merged value for the key
-			dst.SetMapIndex(key, reflect.ValueOf(dstV))
+func transformMapStringToVolume(dst, src reflect.Value) error {
+	for _, key := range src.MapKeys() {
+		srcElement := src.MapIndex(key)
+		if !srcElement.IsValid() {
+			continue
 		}
-		return nil
+		dstElement := dst.MapIndex(key)
+		if !dstElement.IsValid() {
+			dst.SetMapIndex(key, srcElement)
+			continue
+		}
+
+		// Perform default merge
+		dstV := dstElement.Interface().(Volume)
+		srcV := srcElement.Interface().(Volume)
+		if err := mergo.Merge(&dstV, srcV, opts(volumeTransformer{})...); err != nil {
+			return err
+		}
+
+		// Set merged value for the key
+		dst.SetMapIndex(key, reflect.ValueOf(dstV))
 	}
+	return nil
 }
 
 func transformPStruct() func(dst, src reflect.Value) error {
@@ -194,7 +396,7 @@ func transformPStruct() func(dst, src reflect.Value) error {
 		case "Range":
 			dstElem := dst.Interface().(*Range)
 			srcElem := src.Elem().Interface().(Range)
-			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithTransformers(workloadTransformer{}))
+			err = mergo.Merge(dstElem, srcElem, mergo.WithOverride, mergo.WithTransformers(advancedCountTransformer{}))
 		case "SidecarConfig":
 			dstElem := dst.Interface().(*SidecarConfig)
 			srcElem := src.Elem().Interface().(SidecarConfig)
@@ -234,185 +436,28 @@ func transformPBasic() func(dst, src reflect.Value) error {
 	}
 }
 
-func transformCompositeType(originalType reflect.Type) func(dst, src reflect.Value) error {
-	switch originalType {
-	case reflect.TypeOf(EntryPointOverride{}), reflect.TypeOf(CommandOverride{}), reflect.TypeOf(Alias{}):
-		return func(dst, src reflect.Value) error {
-			// Perform default merge
-			dstStruct := dst.Convert(reflect.TypeOf(stringSliceOrString{})).Interface().(stringSliceOrString)
-			srcStruct := src.Convert(reflect.TypeOf(stringSliceOrString{})).Interface().(stringSliceOrString)
-			if err := mergo.Merge(&dstStruct, srcStruct, opts(basicTransformer{})...); err != nil {
-				return err
-			}
-			dst.Set(reflect.ValueOf(dstStruct).Convert(originalType))
+type exclusiveTransformer struct {
+	merge                func(dst, src reflect.Value) error
+	resetExclusiveFields func(dst, src reflect.Value) error
+}
 
-			// Perform customized merge
-			resetComposite(dst, src, "String", "StringSlice")
-			return nil
-		}
-	case reflect.TypeOf(PlatformArgsOrString{}):
-		return func(dst, src reflect.Value) error {
-			// Perform default merge
-			dstPlatformArgsOrString := dst.Interface().(PlatformArgsOrString)
-			srcPlatformArgsOrString := src.Interface().(PlatformArgsOrString)
-			if err := mergo.Merge(&dstPlatformArgsOrString, srcPlatformArgsOrString, opts(basicTransformer{})...); err != nil {
-				return err
-			}
-			dst.Set(reflect.ValueOf(dstPlatformArgsOrString))
-
-			// Perform customized merge
-			resetComposite(dst, src, "PlatformString", "PlatformArgs")
-			return nil
-		}
-	case reflect.TypeOf(BuildArgsOrString{}):
-		return func(dst, src reflect.Value) error {
-			// Perform default merge
-			dstBuildArgsOrString := dst.Interface().(BuildArgsOrString)
-			srcBuildArgsOrString := src.Interface().(BuildArgsOrString)
-			if err := mergo.Merge(&dstBuildArgsOrString, srcBuildArgsOrString, opts(basicTransformer{})...); err != nil {
-				return err
-			}
-			dst.Set(reflect.ValueOf(dstBuildArgsOrString))
-
-			// Perform customized merge
-			resetComposite(dst, src, "BuildString", "BuildArgs")
-			return nil
-		}
-	case reflect.TypeOf(EFSConfigOrBool{}):
-		return func(dst, src reflect.Value) error {
-			// Perform default merge
-			dstEFSConfigOrBool := dst.Interface().(EFSConfigOrBool)
-			srcEFSConfigOrBool := src.Interface().(EFSConfigOrBool)
-			if err := mergo.Merge(&dstEFSConfigOrBool, srcEFSConfigOrBool, opts(efsConfigOrBoolTransformer{})...); err != nil {
-				return err
-			}
-			dst.Set(reflect.ValueOf(dstEFSConfigOrBool))
-
-			// Perform customized merge
-			resetComposite(dst, src, "Enabled", "Advanced")
-			return nil
-		}
-	case reflect.TypeOf(HealthCheckArgsOrString{}):
-		return func(dst, src reflect.Value) error {
-			// Perform default merge
-			dstHC := dst.Interface().(HealthCheckArgsOrString)
-			srcHC := src.Interface().(HealthCheckArgsOrString)
-			if err := mergo.Merge(&dstHC, srcHC, opts(basicTransformer{})...); err != nil {
-				return err
-			}
-			dst.Set(reflect.ValueOf(dstHC))
-
-			// Perform customized merge
-			resetComposite(dst, src, "HealthCheckPath", "HealthCheckArgs")
-			return nil
-		}
-	case reflect.TypeOf(Range{}):
-		return func(dst, src reflect.Value) error {
-			// Perform default merge
-			dstHC := dst.Interface().(Range)
-			srcHC := src.Interface().(Range)
-			if err := mergo.Merge(&dstHC, srcHC, opts(basicTransformer{})...); err != nil {
-				return err
-			}
-			dst.Set(reflect.ValueOf(dstHC))
-
-			// Perform customized merge
-			resetComposite(dst, src, "Value", "RangeConfig")
-			return nil
-		}
-	case reflect.TypeOf(Count{}):
-		return func(dst, src reflect.Value) error {
-			// Perform default merge
-			dstC := dst.Interface().(Count)
-			srcC := src.Interface().(Count)
-			if err := mergo.Merge(&dstC, srcC, opts(countTransformer{})...); err != nil {
-				return err
-			}
-			dst.Set(reflect.ValueOf(dstC))
-
-			// Perform customized merge
-			resetComposite(dst, src, "Value", "AdvancedCount")
-			return nil
-		}
+func (t exclusiveTransformer) transform(dst, src reflect.Value) error {
+	// Perform default merge
+	if err := t.merge(dst, src); err != nil {
+		return err
+	}
+	// Set or unset exclusive fields
+	if err := t.resetExclusiveFields(dst, src); err != nil {
+		return err
 	}
 	return nil
 }
 
-func transformExclusiveType(originalType reflect.Type) func(dst, src reflect.Value) error {
-	switch originalType {
-	case reflect.TypeOf(Image{}):
-		return func(dst, src reflect.Value) error {
-			// It merges `DockerLabels` and `DependsOn` in the default manager (i.e. with configurations mergo.WithOverride, mergo.WithOverwriteWithEmptyValue)
-			// And then overrides both `Build` and `Location` fields at the same time with the src values, given that they are non-empty themselves.
+type basicTransformer struct{}
 
-			// Perform default merge
-			dstImage := dst.Interface().(Image)
-			srcImage := src.Interface().(Image)
-			if err := mergo.Merge(&dstImage, srcImage, opts(imageTransformer{})...); err != nil {
-				return err
-			}
-			dst.Set(reflect.ValueOf(dstImage))
-
-			// Perform customized merge
-			resetComposite(dst, src, "Build", "Location")
-			return nil
-		}
-	case reflect.TypeOf(EFSVolumeConfiguration{}):
-		return func(dst, src reflect.Value) error {
-			// It merges `DockerLabels` and `DependsOn` in the default manager (i.e. with configurations mergo.WithOverride, mergo.WithOverwriteWithEmptyValue)
-			// And then overrides both `Build` and `Location` fields at the same time with the src values, given that they are non-empty themselves.
-
-			// Perform default merge
-			dstV := dst.Interface().(EFSVolumeConfiguration)
-			srcV := src.Interface().(EFSVolumeConfiguration)
-			if err := mergo.Merge(&dstV, srcV, opts(volumeTransformer{})...); err != nil {
-				return err
-			}
-			dst.Set(reflect.ValueOf(dstV))
-
-			// Perform customized merge
-			// TODO: these two conditionals shouldn't return true at the same time if the manifest is not malformed.
-			if !src.FieldByName("UID").IsZero() || !src.FieldByName("GID").IsZero() {
-				dst.FieldByName("FileSystemID").Set(src.FieldByName("FileSystemID"))
-				dst.FieldByName("RootDirectory").Set(src.FieldByName("RootDirectory"))
-				dst.FieldByName("AuthConfig").Set(src.FieldByName("AuthConfig"))
-			} else if !src.FieldByName("FileSystemID").IsZero() ||
-				!src.FieldByName("RootDirectory").IsZero() ||
-				!src.FieldByName("AuthConfig").IsZero() {
-				dst.FieldByName("UID").Set(src.FieldByName("UID"))
-				dst.FieldByName("GID").Set(src.FieldByName("GID"))
-			}
-			return nil
-		}
-	case reflect.TypeOf(AdvancedCount{}):
-		return func(dst, src reflect.Value) error {
-			// Perform default merge
-			dstC := dst.Interface().(AdvancedCount)
-			srcC := src.Interface().(AdvancedCount)
-			if err := mergo.Merge(&dstC, srcC, opts(basicTransformer{})...); err != nil {
-				return err
-			}
-			dst.Set(reflect.ValueOf(dstC))
-
-			// Perform customized merge
-			// TODO: these two conditionals shouldn't return true at the same time if the manifest is not malformed.
-			if !src.FieldByName("Spot").IsZero() {
-				dst.FieldByName("Range").Set(src.FieldByName("Range"))
-				dst.FieldByName("CPU").Set(src.FieldByName("CPU"))
-				dst.FieldByName("Memory").Set(src.FieldByName("Memory"))
-				dst.FieldByName("Requests").Set(src.FieldByName("Requests"))
-				dst.FieldByName("ResponseTime").Set(src.FieldByName("ResponseTime"))
-			} else if !src.FieldByName("Range").IsZero() ||
-				!src.FieldByName("CPU").IsZero() ||
-				!src.FieldByName("Memory").IsZero() ||
-				!src.FieldByName("Requests").IsZero() ||
-				!src.FieldByName("ResponseTime").IsZero() {
-				dst.FieldByName("Spot").Set(src.FieldByName("Spot"))
-			}
-			return nil
-		}
-	}
-	return nil
+// Transformer returns custom merge logic for volume's fields.
+func (t basicTransformer) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
+	return transformBasic(typ)
 }
 
 func opts(transformers mergo.Transformers) []func(*mergo.Config) {
@@ -422,17 +467,41 @@ func opts(transformers mergo.Transformers) []func(*mergo.Config) {
 	}
 }
 
-func resetComposite(dst, src reflect.Value, fieldA, fieldB string) {
-	dstA := dst.FieldByName(fieldA)
-	dstB := dst.FieldByName(fieldB)
-
-	srcA := src.FieldByName(fieldA)
-	srcB := src.FieldByName(fieldB)
-
-	// TODO: `srcArgs.IsZero()` and `srcString.IsZero()` shouldn't return true at the same time if the manifest is not malformed.
-	if !srcB.IsZero() {
-		dstA.Set(srcA)
-	} else if !srcA.IsZero() {
-		dstB.Set(srcB)
+func resetExclusiveFields(dst, src reflect.Value, fieldsA, fieldsB []string) error {
+	var fieldsASpecifiedInSrc, fieldsBSpecifiedInSrc bool
+	for _, a := range fieldsA {
+		if !src.FieldByName(a).IsZero() {
+			fieldsASpecifiedInSrc = true
+			break
+		}
 	}
+
+	for _, b := range fieldsB {
+		if !src.FieldByName(b).IsZero() {
+			fieldsBSpecifiedInSrc = true
+			break
+		}
+	}
+
+	// TODO: we should validate that they are not specified at the same time at an earlier stage, possibly in `manifest.validate`.
+	if fieldsASpecifiedInSrc && fieldsBSpecifiedInSrc {
+		return fmt.Errorf(fmtExclusiveFieldsSpecifiedTogether,
+			english.WordSeries(fieldsA, "and"),
+			english.Plural(len(fieldsA), "is", "are"),
+			english.WordSeries(fieldsB, "and"))
+	}
+
+	if fieldsASpecifiedInSrc {
+		for _, b := range fieldsB {
+			dst.FieldByName(b).Set(reflect.Zero(dst.FieldByName(b).Type()))
+		}
+	}
+
+	if fieldsBSpecifiedInSrc {
+		for _, a := range fieldsA {
+			dst.FieldByName(a).Set(reflect.Zero(dst.FieldByName(a).Type()))
+		}
+	}
+
+	return nil
 }

--- a/internal/pkg/manifest/transform.go
+++ b/internal/pkg/manifest/transform.go
@@ -123,19 +123,6 @@ func (t workloadTransformer) transformExclusiveTypes(originalType reflect.Type) 
 		et.resetExclusiveFields = func(dst, src reflect.Value) error {
 			return resetExclusiveFields(dst, src, []string{"Build"}, []string{"Location"})
 		}
-	//case reflect.TypeOf(AdvancedCount{}):
-	//	et.merge = func(dst, src reflect.Value) error {
-	//		dstC := dst.Interface().(AdvancedCount)
-	//		srcC := src.Interface().(AdvancedCount)
-	//		if err := mergo.Merge(&dstC, srcC, opts(basicTransformer{})...); err != nil {
-	//			return err
-	//		}
-	//		dst.Set(reflect.ValueOf(dstC))
-	//		return nil
-	//	}
-	//	et.resetExclusiveFields = func(dst, src reflect.Value) error {
-	//		return resetExclusiveFields(dst, src, []string{"Spot"}, []string{"Range", "CPU", "Memory", "Requests", "ResponseTime"})
-	//	}
 	default:
 		return nil
 	}

--- a/internal/pkg/manifest/transform.go
+++ b/internal/pkg/manifest/transform.go
@@ -49,7 +49,6 @@ func (t imageTransformer) Transformer(typ reflect.Type) func(dst, src reflect.Va
 	}
 
 	return func(dst, src reflect.Value) error {
-		// NOTE: Since `dst` comes from an exported field (all manifest fields are exported), `Interface{}` won't panic.
 		dstStruct, srcStruct := dst.Interface().(Image), src.Interface().(Image)
 
 		if !srcStruct.Build.isEmpty() && srcStruct.Location != nil {

--- a/internal/pkg/manifest/worker_svc.go
+++ b/internal/pkg/manifest/worker_svc.go
@@ -46,13 +46,13 @@ type WorkerServiceConfig struct {
 type WorkerServiceProps struct {
 	WorkloadProps
 	HealthCheck *ContainerHealthCheck // Optional healthcheck configuration.
-	Topics      *[]TopicSubscription  // Optional topics for subscriptions
+	Topics      []TopicSubscription   // Optional topics for subscriptions
 }
 
 // SubscribeConfig represents the configurable options for setting up subscriptions.
 type SubscribeConfig struct {
-	Topics *[]TopicSubscription `yaml:"topics"`
-	Queue  *SQSQueue            `yaml:"queue"`
+	Topics []TopicSubscription `yaml:"topics"`
+	Queue  *SQSQueue           `yaml:"queue"`
 }
 
 // TopicSubscription represents the configurable options for setting up a SNS Topic Subscription.

--- a/internal/pkg/manifest/worker_svc.go
+++ b/internal/pkg/manifest/worker_svc.go
@@ -193,12 +193,14 @@ func (s WorkerService) ApplyEnv(envName string) (WorkloadManifest, error) {
 	}
 
 	// Apply overrides to the original service s.
-	err := mergo.Merge(&s, WorkerService{
-		WorkerServiceConfig: *overrideConfig,
-	}, mergo.WithOverride, mergo.WithOverwriteWithEmptyValue, mergo.WithTransformers(workloadTransformer{}))
+	for _, t := range TT {
+		err := mergo.Merge(&s, WorkerService{
+			WorkerServiceConfig: *overrideConfig,
+		}, mergo.WithOverride, mergo.WithTransformers(t))
 
-	if err != nil {
-		return nil, err
+		if err != nil {
+			return nil, err
+		}
 	}
 	s.Environments = nil
 	return &s, nil

--- a/internal/pkg/manifest/worker_svc.go
+++ b/internal/pkg/manifest/worker_svc.go
@@ -193,7 +193,7 @@ func (s WorkerService) ApplyEnv(envName string) (WorkloadManifest, error) {
 	}
 
 	// Apply overrides to the original service s.
-	for _, t := range TT {
+	for _, t := range defaultTransformers {
 		err := mergo.Merge(&s, WorkerService{
 			WorkerServiceConfig: *overrideConfig,
 		}, mergo.WithOverride, mergo.WithTransformers(t))

--- a/internal/pkg/manifest/worker_svc.go
+++ b/internal/pkg/manifest/worker_svc.go
@@ -192,11 +192,6 @@ func (s WorkerService) ApplyEnv(envName string) (WorkloadManifest, error) {
 		return &s, nil
 	}
 
-	envCount := overrideConfig.TaskConfig.Count
-	if !envCount.IsEmpty() {
-		s.TaskConfig.Count = envCount
-	}
-
 	// Apply overrides to the original service s.
 	err := mergo.Merge(&s, WorkerService{
 		WorkerServiceConfig: *overrideConfig,

--- a/internal/pkg/manifest/worker_svc_applyenv_test.go
+++ b/internal/pkg/manifest/worker_svc_applyenv_test.go
@@ -1,0 +1,102 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package manifest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyEnv_SubscribeConfig(t *testing.T) {
+	testCases := map[string]struct {
+		inSvc  func(svc *WorkerService)
+		wanted func(svc *WorkerService)
+	}{
+		"topics overridden": {
+			inSvc: func(svc *WorkerService) {
+				svc.Subscribe = &SubscribeConfig{
+					Topics: []TopicSubscription{
+						{
+							Name: "topic",
+						},
+					},
+				}
+				svc.Environments["test"].Subscribe = &SubscribeConfig{
+					Topics: []TopicSubscription{
+						{
+							Name: "topicTest",
+						},
+					},
+				}
+			},
+			wanted: func(svc *WorkerService) {
+				svc.Subscribe = &SubscribeConfig{
+					Topics: []TopicSubscription{
+						{
+							Name: "topicTest",
+						},
+					},
+				}
+			},
+		},
+		"topics explicitly overridden by zero slice": {
+			inSvc: func(svc *WorkerService) {
+				svc.Subscribe = &SubscribeConfig{
+					Topics: []TopicSubscription{
+						{
+							Name: "topic",
+						},
+					},
+				}
+				svc.Environments["test"].Subscribe = &SubscribeConfig{
+					Topics: []TopicSubscription{},
+				}
+			},
+			wanted: func(svc *WorkerService) {
+				svc.Subscribe = &SubscribeConfig{
+					Topics: []TopicSubscription{},
+				}
+			},
+		},
+		"topics not overridden": {
+			inSvc: func(svc *WorkerService) {
+				svc.Subscribe = &SubscribeConfig{
+					Topics: []TopicSubscription{
+						{
+							Name: "topic",
+						},
+					},
+				}
+				svc.Environments["test"].Subscribe = &SubscribeConfig{}
+			},
+			wanted: func(svc *WorkerService) {
+				svc.Subscribe = &SubscribeConfig{
+					Topics: []TopicSubscription{
+						{
+							Name: "topic",
+						},
+					},
+				}
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			var inSvc, wantedSvc WorkerService
+			inSvc.Environments = map[string]*WorkerServiceConfig{
+				"test": {},
+			}
+
+			tc.inSvc(&inSvc)
+			tc.wanted(&wantedSvc)
+
+			got, err := inSvc.ApplyEnv("test")
+
+			require.NoError(t, err)
+			require.Equal(t, &wantedSvc, got)
+		})
+	}
+}

--- a/internal/pkg/manifest/worker_svc_test.go
+++ b/internal/pkg/manifest/worker_svc_test.go
@@ -140,7 +140,7 @@ func TestWorkerSvc_MarshalBinary(t *testing.T) {
 					Name:       "testers",
 					Dockerfile: "./testers/Dockerfile",
 				},
-				Topics: &[]TopicSubscription{
+				Topics: []TopicSubscription{
 					{
 						Name:    "testTopic",
 						Service: "service4TestTopic",
@@ -259,7 +259,7 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 				},
 			},
 			Subscribe: &SubscribeConfig{
-				Topics: &[]TopicSubscription{
+				Topics: []TopicSubscription{
 					{
 						Name:    "topicName",
 						Service: "bestService",
@@ -299,7 +299,7 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 					},
 				},
 				Subscribe: &SubscribeConfig{
-					Topics: &[]TopicSubscription{
+					Topics: []TopicSubscription{
 						{
 							Name:    "topicName2",
 							Service: "bestService2",
@@ -418,7 +418,7 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 		},
 		WorkerServiceConfig: WorkerServiceConfig{
 			Subscribe: &SubscribeConfig{
-				Topics: &[]TopicSubscription{
+				Topics: []TopicSubscription{
 					{
 						Name:    "name",
 						Service: "svc",
@@ -450,7 +450,7 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 		Environments: map[string]*WorkerServiceConfig{
 			"test-sub": {
 				Subscribe: &SubscribeConfig{
-					Topics: &[]TopicSubscription{
+					Topics: []TopicSubscription{
 						{
 							Name:    "name",
 							Service: "svc",
@@ -474,7 +474,7 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 		},
 		WorkerServiceConfig: WorkerServiceConfig{
 			Subscribe: &SubscribeConfig{
-				Topics: &[]TopicSubscription{
+				Topics: []TopicSubscription{
 					{
 						Name:    "name",
 						Service: "svc",
@@ -508,7 +508,7 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 		Environments: map[string]*WorkerServiceConfig{
 			"test-sub": {
 				Subscribe: &SubscribeConfig{
-					Topics: &[]TopicSubscription{
+					Topics: []TopicSubscription{
 						{
 							Name:    "name",
 							Service: "svc",
@@ -532,7 +532,7 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 		},
 		WorkerServiceConfig: WorkerServiceConfig{
 			Subscribe: &SubscribeConfig{
-				Topics: &[]TopicSubscription{
+				Topics: []TopicSubscription{
 					{
 						Name:    "name",
 						Service: "svc",
@@ -562,13 +562,13 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 		},
 		WorkerServiceConfig: WorkerServiceConfig{
 			Subscribe: &SubscribeConfig{
-				Topics: &[]TopicSubscription{},
+				Topics: []TopicSubscription{},
 			},
 		},
 		Environments: map[string]*WorkerServiceConfig{
 			"test-sub": {
 				Subscribe: &SubscribeConfig{
-					Topics: &[]TopicSubscription{
+					Topics: []TopicSubscription{
 						{
 							Name:    "name",
 							Service: "svc",
@@ -731,7 +731,7 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 						},
 					},
 					Subscribe: &SubscribeConfig{
-						Topics: &[]TopicSubscription{
+						Topics: []TopicSubscription{
 							{
 								Name:    "topicName2",
 								Service: "bestService2",
@@ -830,7 +830,7 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 				},
 				WorkerServiceConfig: WorkerServiceConfig{
 					Subscribe: &SubscribeConfig{
-						Topics: &[]TopicSubscription{
+						Topics: []TopicSubscription{
 							{
 								Name:    "name",
 								Service: "svc",
@@ -859,7 +859,7 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 				},
 				WorkerServiceConfig: WorkerServiceConfig{
 					Subscribe: &SubscribeConfig{
-						Topics: &[]TopicSubscription{
+						Topics: []TopicSubscription{
 							{
 								Name:    "name",
 								Service: "svc",
@@ -891,7 +891,7 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 						Image: Image{},
 					},
 					Subscribe: &SubscribeConfig{
-						Topics: &[]TopicSubscription{
+						Topics: []TopicSubscription{
 							{
 								Name:    "name",
 								Service: "svc",
@@ -920,7 +920,7 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 				},
 				WorkerServiceConfig: WorkerServiceConfig{
 					Subscribe: &SubscribeConfig{
-						Topics: &[]TopicSubscription{
+						Topics: []TopicSubscription{
 							{
 								Name:    "name",
 								Service: "svc",
@@ -949,7 +949,7 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 				},
 				WorkerServiceConfig: WorkerServiceConfig{
 					Subscribe: &SubscribeConfig{
-						Topics: &[]TopicSubscription{
+						Topics: []TopicSubscription{
 							{
 								Name:    "name",
 								Service: "svc",
@@ -981,7 +981,7 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 						Image: Image{},
 					},
 					Subscribe: &SubscribeConfig{
-						Topics: &[]TopicSubscription{
+						Topics: []TopicSubscription{
 							{
 								Name:    "name",
 								Service: "svc",


### PR DESCRIPTION
This PR This PR is part of the second step (writing units test) to address #2492. It:
1. Fix previously found `ApplyEnv` bugs by implementing transformers needed
2. Refactor `transform.go`

Previous: #2738 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
