### PR TITLE
refactor: embed common ecsServiceDescriber struct

### DIFF
--- a/internal/pkg/describe/backend_service.go
+++ b/internal/pkg/describe/backend_service.go
@@ -37,13 +37,13 @@ func NewBackendServiceDescriber(opt NewServiceConfig) (*BackendServiceDescriber,
 			svc:             opt.Svc,
 			enableResources: opt.EnableResources,
 			store:           opt.DeployStore,
-			svcDescriber:    make(map[string]ecsSvcDescriber),
+			svcStackDescriber:    make(map[string]ecsStackDescriber),
 		},
 
 		envDescriber: make(map[string]envDescriber),
 	}
 	describer.initDescribers = func(env string) error {
-		if _, ok := describer.svcDescriber[env]; ok {
+		if _, ok := describer.svcStackDescriber[env]; ok {
 			return nil
 		}
 		d, err := NewECSServiceDescriber(NewServiceConfig{
@@ -55,7 +55,7 @@ func NewBackendServiceDescriber(opt NewServiceConfig) (*BackendServiceDescriber,
 		if err != nil {
 			return err
 		}
-		describer.svcDescriber[env] = d
+		describer.svcStackDescriber[env] = d
 		envDescr, err := NewEnvDescriber(NewEnvDescriberConfig{
 			App:         opt.App,
 			Env:         env,
@@ -76,7 +76,7 @@ func (d *BackendServiceDescriber) URI(envName string) (string, error) {
 	if err := d.initDescribers(envName); err != nil {
 		return "", err
 	}
-	svcStackParams, err := d.svcDescriber[envName].Params()
+	svcStackParams, err := d.svcStackDescriber[envName].Params()
 	if err != nil {
 		return "", fmt.Errorf("get stack parameters for environment %s: %w", envName, err)
 	}
@@ -112,7 +112,7 @@ func (d *BackendServiceDescriber) Describe() (HumanJSONStringer, error) {
 		if err != nil {
 			return nil, err
 		}
-		svcParams, err := d.svcDescriber[env].Params()
+		svcParams, err := d.svcStackDescriber[env].Params()
 		if err != nil {
 			return nil, fmt.Errorf("get stack parameters for environment %s: %w", env, err)
 		}
@@ -138,12 +138,12 @@ func (d *BackendServiceDescriber) Describe() (HumanJSONStringer, error) {
 			},
 			Tasks: svcParams[cfnstack.WorkloadTaskCountParamKey],
 		})
-		backendSvcEnvVars, err := d.svcDescriber[env].EnvVars()
+		backendSvcEnvVars, err := d.svcStackDescriber[env].EnvVars()
 		if err != nil {
 			return nil, fmt.Errorf("retrieve environment variables: %w", err)
 		}
 		envVars = append(envVars, flattenContainerEnvVars(env, backendSvcEnvVars)...)
-		webSvcSecrets, err := d.svcDescriber[env].Secrets()
+		webSvcSecrets, err := d.svcStackDescriber[env].Secrets()
 		if err != nil {
 			return nil, fmt.Errorf("retrieve secrets: %w", err)
 		}
@@ -157,7 +157,7 @@ func (d *BackendServiceDescriber) Describe() (HumanJSONStringer, error) {
 			if err != nil {
 				return nil, err
 			}
-			stackResources, err := d.svcDescriber[env].ServiceStackResources()
+			stackResources, err := d.svcStackDescriber[env].ServiceStackResources()
 			if err != nil {
 				return nil, fmt.Errorf("retrieve service resources: %w", err)
 			}

--- a/internal/pkg/describe/backend_service.go
+++ b/internal/pkg/describe/backend_service.go
@@ -24,25 +24,23 @@ const (
 
 // BackendServiceDescriber retrieves information about a backend service.
 type BackendServiceDescriber struct {
-	app             string
-	svc             string
-	enableResources bool
+	*ecsServiceDescriber
 
-	store          DeployedEnvServicesLister
-	svcDescriber   map[string]ecsSvcDescriber
-	envDescriber   map[string]envDescriber
-	initDescribers func(string) error
+	envDescriber map[string]envDescriber
 }
 
 // NewBackendServiceDescriber instantiates a backend service describer.
 func NewBackendServiceDescriber(opt NewServiceConfig) (*BackendServiceDescriber, error) {
 	describer := &BackendServiceDescriber{
-		app:             opt.App,
-		svc:             opt.Svc,
-		enableResources: opt.EnableResources,
-		store:           opt.DeployStore,
-		svcDescriber:    make(map[string]ecsSvcDescriber),
-		envDescriber:    make(map[string]envDescriber),
+		ecsServiceDescriber: &ecsServiceDescriber{
+			app:             opt.App,
+			svc:             opt.Svc,
+			enableResources: opt.EnableResources,
+			store:           opt.DeployStore,
+			svcDescriber:    make(map[string]ecsSvcDescriber),
+		},
+
+		envDescriber: make(map[string]envDescriber),
 	}
 	describer.initDescribers = func(env string) error {
 		if _, ok := describer.svcDescriber[env]; ok {

--- a/internal/pkg/describe/backend_service_test.go
+++ b/internal/pkg/describe/backend_service_test.go
@@ -314,21 +314,23 @@ func TestBackendServiceDescriber_Describe(t *testing.T) {
 			tc.setupMocks(mocks)
 
 			d := &BackendServiceDescriber{
-				app:             testApp,
-				svc:             testSvc,
-				enableResources: tc.shouldOutputResources,
-				store:           mockStore,
-				svcDescriber: map[string]ecsSvcDescriber{
-					"test":    mockSvcDescriber,
-					"prod":    mockSvcDescriber,
-					"mockEnv": mockSvcDescriber,
+				ecsServiceDescriber: &ecsServiceDescriber{
+					app:             testApp,
+					svc:             testSvc,
+					enableResources: tc.shouldOutputResources,
+					store:           mockStore,
+					svcDescriber: map[string]ecsSvcDescriber{
+						"test":    mockSvcDescriber,
+						"prod":    mockSvcDescriber,
+						"mockEnv": mockSvcDescriber,
+					},
+					initDescribers: func(string) error { return nil },
 				},
 				envDescriber: map[string]envDescriber{
 					"test":    mockEnvDescriber,
 					"prod":    mockEnvDescriber,
 					"mockEnv": mockEnvDescriber,
 				},
-				initDescribers: func(string) error { return nil },
 			}
 
 			// WHEN

--- a/internal/pkg/describe/backend_service_test.go
+++ b/internal/pkg/describe/backend_service_test.go
@@ -46,7 +46,7 @@ func TestBackendServiceDescriber_Describe(t *testing.T) {
 			setupMocks: func(m lbWebSvcDescriberMocks) {
 				gomock.InOrder(
 					m.storeSvc.EXPECT().ListEnvironmentsDeployedTo(testApp, testSvc).Return([]string{testEnv}, nil),
-					m.ecsSvcDescriber.EXPECT().Params().Return(nil, mockErr),
+					m.ecsStackDescriber.EXPECT().Params().Return(nil, mockErr),
 				)
 			},
 			wantedError: fmt.Errorf("get stack parameters for environment test: some error"),
@@ -55,7 +55,7 @@ func TestBackendServiceDescriber_Describe(t *testing.T) {
 			setupMocks: func(m lbWebSvcDescriberMocks) {
 				gomock.InOrder(
 					m.storeSvc.EXPECT().ListEnvironmentsDeployedTo(testApp, testSvc).Return([]string{testEnv}, nil),
-					m.ecsSvcDescriber.EXPECT().Params().Return(map[string]string{
+					m.ecsStackDescriber.EXPECT().Params().Return(map[string]string{
 						cfnstack.LBWebServiceContainerPortParamKey: "80",
 						cfnstack.WorkloadTaskCountParamKey:         "1",
 						cfnstack.WorkloadTaskMemoryParamKey:        "512",
@@ -70,14 +70,14 @@ func TestBackendServiceDescriber_Describe(t *testing.T) {
 			setupMocks: func(m lbWebSvcDescriberMocks) {
 				gomock.InOrder(
 					m.storeSvc.EXPECT().ListEnvironmentsDeployedTo(testApp, testSvc).Return([]string{testEnv}, nil),
-					m.ecsSvcDescriber.EXPECT().Params().Return(map[string]string{
+					m.ecsStackDescriber.EXPECT().Params().Return(map[string]string{
 						cfnstack.LBWebServiceContainerPortParamKey: "80",
 						cfnstack.WorkloadTaskCountParamKey:         "1",
 						cfnstack.WorkloadTaskMemoryParamKey:        "512",
 						cfnstack.WorkloadTaskCPUParamKey:           "256",
 					}, nil),
 					m.envDescriber.EXPECT().ServiceDiscoveryEndpoint().Return("test.phonetool.local", nil),
-					m.ecsSvcDescriber.EXPECT().EnvVars().Return(nil, mockErr),
+					m.ecsStackDescriber.EXPECT().EnvVars().Return(nil, mockErr),
 				)
 			},
 			wantedError: fmt.Errorf("retrieve environment variables: some error"),
@@ -87,21 +87,21 @@ func TestBackendServiceDescriber_Describe(t *testing.T) {
 				gomock.InOrder(
 					m.storeSvc.EXPECT().ListEnvironmentsDeployedTo(testApp, testSvc).Return([]string{testEnv}, nil),
 
-					m.ecsSvcDescriber.EXPECT().Params().Return(map[string]string{
+					m.ecsStackDescriber.EXPECT().Params().Return(map[string]string{
 						cfnstack.LBWebServiceContainerPortParamKey: "80",
 						cfnstack.WorkloadTaskCountParamKey:         "1",
 						cfnstack.WorkloadTaskCPUParamKey:           "256",
 						cfnstack.WorkloadTaskMemoryParamKey:        "512",
 					}, nil),
 					m.envDescriber.EXPECT().ServiceDiscoveryEndpoint().Return("test.phonetool.local", nil),
-					m.ecsSvcDescriber.EXPECT().EnvVars().Return([]*ecs.ContainerEnvVar{
+					m.ecsStackDescriber.EXPECT().EnvVars().Return([]*ecs.ContainerEnvVar{
 						{
 							Name:      "COPILOT_ENVIRONMENT_NAME",
 							Container: "container",
 							Value:     "prod",
 						},
 					}, nil),
-					m.ecsSvcDescriber.EXPECT().Secrets().Return(nil, mockErr),
+					m.ecsStackDescriber.EXPECT().Secrets().Return(nil, mockErr),
 				)
 			},
 			wantedError: fmt.Errorf("retrieve secrets: some error"),
@@ -112,76 +112,76 @@ func TestBackendServiceDescriber_Describe(t *testing.T) {
 				gomock.InOrder(
 					m.storeSvc.EXPECT().ListEnvironmentsDeployedTo(testApp, testSvc).Return([]string{testEnv, prodEnv, mockEnv}, nil),
 
-					m.ecsSvcDescriber.EXPECT().Params().Return(map[string]string{
+					m.ecsStackDescriber.EXPECT().Params().Return(map[string]string{
 						cfnstack.LBWebServiceContainerPortParamKey: "5000",
 						cfnstack.WorkloadTaskCountParamKey:         "1",
 						cfnstack.WorkloadTaskCPUParamKey:           "256",
 						cfnstack.WorkloadTaskMemoryParamKey:        "512",
 					}, nil),
 					m.envDescriber.EXPECT().ServiceDiscoveryEndpoint().Return("test.phonetool.local", nil),
-					m.ecsSvcDescriber.EXPECT().EnvVars().Return([]*ecs.ContainerEnvVar{
+					m.ecsStackDescriber.EXPECT().EnvVars().Return([]*ecs.ContainerEnvVar{
 						{
 							Name:      "COPILOT_ENVIRONMENT_NAME",
 							Container: "container",
 							Value:     testEnv,
 						},
 					}, nil),
-					m.ecsSvcDescriber.EXPECT().Secrets().Return([]*ecs.ContainerSecret{
+					m.ecsStackDescriber.EXPECT().Secrets().Return([]*ecs.ContainerSecret{
 						{
 							Name:      "GITHUB_WEBHOOK_SECRET",
 							Container: "container",
 							ValueFrom: "GH_WEBHOOK_SECRET",
 						},
 					}, nil),
-					m.ecsSvcDescriber.EXPECT().Params().Return(map[string]string{
+					m.ecsStackDescriber.EXPECT().Params().Return(map[string]string{
 						cfnstack.LBWebServiceContainerPortParamKey: "5000",
 						cfnstack.WorkloadTaskCountParamKey:         "2",
 						cfnstack.WorkloadTaskCPUParamKey:           "512",
 						cfnstack.WorkloadTaskMemoryParamKey:        "1024",
 					}, nil),
 					m.envDescriber.EXPECT().ServiceDiscoveryEndpoint().Return("prod.phonetool.local", nil),
-					m.ecsSvcDescriber.EXPECT().EnvVars().Return([]*ecs.ContainerEnvVar{
+					m.ecsStackDescriber.EXPECT().EnvVars().Return([]*ecs.ContainerEnvVar{
 						{
 							Name:      "COPILOT_ENVIRONMENT_NAME",
 							Container: "container",
 							Value:     prodEnv,
 						},
 					}, nil),
-					m.ecsSvcDescriber.EXPECT().Secrets().Return([]*ecs.ContainerSecret{
+					m.ecsStackDescriber.EXPECT().Secrets().Return([]*ecs.ContainerSecret{
 						{
 							Name:      "SOME_OTHER_SECRET",
 							Container: "container",
 							ValueFrom: "SHHHHHHHH",
 						},
 					}, nil),
-					m.ecsSvcDescriber.EXPECT().Params().Return(map[string]string{
+					m.ecsStackDescriber.EXPECT().Params().Return(map[string]string{
 						cfnstack.LBWebServiceContainerPortParamKey: "-1",
 						cfnstack.WorkloadTaskCountParamKey:         "2",
 						cfnstack.WorkloadTaskCPUParamKey:           "512",
 						cfnstack.WorkloadTaskMemoryParamKey:        "1024",
 					}, nil),
-					m.ecsSvcDescriber.EXPECT().EnvVars().Return([]*ecs.ContainerEnvVar{
+					m.ecsStackDescriber.EXPECT().EnvVars().Return([]*ecs.ContainerEnvVar{
 						{
 							Name:      "COPILOT_ENVIRONMENT_NAME",
 							Container: "container",
 							Value:     mockEnv,
 						},
 					}, nil),
-					m.ecsSvcDescriber.EXPECT().Secrets().Return(
+					m.ecsStackDescriber.EXPECT().Secrets().Return(
 						nil, nil),
-					m.ecsSvcDescriber.EXPECT().ServiceStackResources().Return([]*stack.Resource{
+					m.ecsStackDescriber.EXPECT().ServiceStackResources().Return([]*stack.Resource{
 						{
 							Type:       "AWS::EC2::SecurityGroupIngress",
 							PhysicalID: "ContainerSecurityGroupIngressFromPublicALB",
 						},
 					}, nil),
-					m.ecsSvcDescriber.EXPECT().ServiceStackResources().Return([]*stack.Resource{
+					m.ecsStackDescriber.EXPECT().ServiceStackResources().Return([]*stack.Resource{
 						{
 							Type:       "AWS::EC2::SecurityGroup",
 							PhysicalID: "sg-0758ed6b233743530",
 						},
 					}, nil),
-					m.ecsSvcDescriber.EXPECT().ServiceStackResources().Return([]*stack.Resource{
+					m.ecsStackDescriber.EXPECT().ServiceStackResources().Return([]*stack.Resource{
 						{
 							Type:       "AWS::EC2::SecurityGroup",
 							PhysicalID: "sg-2337435300758ed6b",
@@ -303,12 +303,12 @@ func TestBackendServiceDescriber_Describe(t *testing.T) {
 			defer ctrl.Finish()
 
 			mockStore := mocks.NewMockDeployedEnvServicesLister(ctrl)
-			mockSvcDescriber := mocks.NewMockecsSvcDescriber(ctrl)
+			mockSvcDescriber := mocks.NewMockecsStackDescriber(ctrl)
 			mockEnvDescriber := mocks.NewMockenvDescriber(ctrl)
 			mocks := lbWebSvcDescriberMocks{
-				storeSvc:        mockStore,
-				ecsSvcDescriber: mockSvcDescriber,
-				envDescriber:    mockEnvDescriber,
+				storeSvc:          mockStore,
+				ecsStackDescriber: mockSvcDescriber,
+				envDescriber:      mockEnvDescriber,
 			}
 
 			tc.setupMocks(mocks)
@@ -319,7 +319,7 @@ func TestBackendServiceDescriber_Describe(t *testing.T) {
 					svc:             testSvc,
 					enableResources: tc.shouldOutputResources,
 					store:           mockStore,
-					svcDescriber: map[string]ecsSvcDescriber{
+					svcStackDescriber: map[string]ecsStackDescriber{
 						"test":    mockSvcDescriber,
 						"prod":    mockSvcDescriber,
 						"mockEnv": mockSvcDescriber,

--- a/internal/pkg/describe/mocks/mock_service.go
+++ b/internal/pkg/describe/mocks/mock_service.go
@@ -188,31 +188,31 @@ func (mr *MockapprunnerSvcDescriberMockRecorder) ServiceURL() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceURL", reflect.TypeOf((*MockapprunnerSvcDescriber)(nil).ServiceURL))
 }
 
-// MockecsSvcDescriber is a mock of ecsSvcDescriber interface.
-type MockecsSvcDescriber struct {
+// MockecsStackDescriber is a mock of ecsStackDescriber interface.
+type MockecsStackDescriber struct {
 	ctrl     *gomock.Controller
-	recorder *MockecsSvcDescriberMockRecorder
+	recorder *MockecsStackDescriberMockRecorder
 }
 
-// MockecsSvcDescriberMockRecorder is the mock recorder for MockecsSvcDescriber.
-type MockecsSvcDescriberMockRecorder struct {
-	mock *MockecsSvcDescriber
+// MockecsStackDescriberMockRecorder is the mock recorder for MockecsStackDescriber.
+type MockecsStackDescriberMockRecorder struct {
+	mock *MockecsStackDescriber
 }
 
-// NewMockecsSvcDescriber creates a new mock instance.
-func NewMockecsSvcDescriber(ctrl *gomock.Controller) *MockecsSvcDescriber {
-	mock := &MockecsSvcDescriber{ctrl: ctrl}
-	mock.recorder = &MockecsSvcDescriberMockRecorder{mock}
+// NewMockecsStackDescriber creates a new mock instance.
+func NewMockecsStackDescriber(ctrl *gomock.Controller) *MockecsStackDescriber {
+	mock := &MockecsStackDescriber{ctrl: ctrl}
+	mock.recorder = &MockecsStackDescriberMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockecsSvcDescriber) EXPECT() *MockecsSvcDescriberMockRecorder {
+func (m *MockecsStackDescriber) EXPECT() *MockecsStackDescriberMockRecorder {
 	return m.recorder
 }
 
 // EnvVars mocks base method.
-func (m *MockecsSvcDescriber) EnvVars() ([]*ecs.ContainerEnvVar, error) {
+func (m *MockecsStackDescriber) EnvVars() ([]*ecs.ContainerEnvVar, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnvVars")
 	ret0, _ := ret[0].([]*ecs.ContainerEnvVar)
@@ -221,13 +221,13 @@ func (m *MockecsSvcDescriber) EnvVars() ([]*ecs.ContainerEnvVar, error) {
 }
 
 // EnvVars indicates an expected call of EnvVars.
-func (mr *MockecsSvcDescriberMockRecorder) EnvVars() *gomock.Call {
+func (mr *MockecsStackDescriberMockRecorder) EnvVars() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnvVars", reflect.TypeOf((*MockecsSvcDescriber)(nil).EnvVars))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnvVars", reflect.TypeOf((*MockecsStackDescriber)(nil).EnvVars))
 }
 
 // Outputs mocks base method.
-func (m *MockecsSvcDescriber) Outputs() (map[string]string, error) {
+func (m *MockecsStackDescriber) Outputs() (map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Outputs")
 	ret0, _ := ret[0].(map[string]string)
@@ -236,13 +236,13 @@ func (m *MockecsSvcDescriber) Outputs() (map[string]string, error) {
 }
 
 // Outputs indicates an expected call of Outputs.
-func (mr *MockecsSvcDescriberMockRecorder) Outputs() *gomock.Call {
+func (mr *MockecsStackDescriberMockRecorder) Outputs() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Outputs", reflect.TypeOf((*MockecsSvcDescriber)(nil).Outputs))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Outputs", reflect.TypeOf((*MockecsStackDescriber)(nil).Outputs))
 }
 
 // Params mocks base method.
-func (m *MockecsSvcDescriber) Params() (map[string]string, error) {
+func (m *MockecsStackDescriber) Params() (map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Params")
 	ret0, _ := ret[0].(map[string]string)
@@ -251,13 +251,13 @@ func (m *MockecsSvcDescriber) Params() (map[string]string, error) {
 }
 
 // Params indicates an expected call of Params.
-func (mr *MockecsSvcDescriberMockRecorder) Params() *gomock.Call {
+func (mr *MockecsStackDescriberMockRecorder) Params() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Params", reflect.TypeOf((*MockecsSvcDescriber)(nil).Params))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Params", reflect.TypeOf((*MockecsStackDescriber)(nil).Params))
 }
 
 // Secrets mocks base method.
-func (m *MockecsSvcDescriber) Secrets() ([]*ecs.ContainerSecret, error) {
+func (m *MockecsStackDescriber) Secrets() ([]*ecs.ContainerSecret, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Secrets")
 	ret0, _ := ret[0].([]*ecs.ContainerSecret)
@@ -266,13 +266,13 @@ func (m *MockecsSvcDescriber) Secrets() ([]*ecs.ContainerSecret, error) {
 }
 
 // Secrets indicates an expected call of Secrets.
-func (mr *MockecsSvcDescriberMockRecorder) Secrets() *gomock.Call {
+func (mr *MockecsStackDescriberMockRecorder) Secrets() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Secrets", reflect.TypeOf((*MockecsSvcDescriber)(nil).Secrets))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Secrets", reflect.TypeOf((*MockecsStackDescriber)(nil).Secrets))
 }
 
 // ServiceStackResources mocks base method.
-func (m *MockecsSvcDescriber) ServiceStackResources() ([]*stack.Resource, error) {
+func (m *MockecsStackDescriber) ServiceStackResources() ([]*stack.Resource, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ServiceStackResources")
 	ret0, _ := ret[0].([]*stack.Resource)
@@ -281,9 +281,9 @@ func (m *MockecsSvcDescriber) ServiceStackResources() ([]*stack.Resource, error)
 }
 
 // ServiceStackResources indicates an expected call of ServiceStackResources.
-func (mr *MockecsSvcDescriberMockRecorder) ServiceStackResources() *gomock.Call {
+func (mr *MockecsStackDescriberMockRecorder) ServiceStackResources() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceStackResources", reflect.TypeOf((*MockecsSvcDescriber)(nil).ServiceStackResources))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceStackResources", reflect.TypeOf((*MockecsStackDescriber)(nil).ServiceStackResources))
 }
 
 // MockConfigStoreSvc is a mock of ConfigStoreSvc interface.

--- a/internal/pkg/describe/service.go
+++ b/internal/pkg/describe/service.go
@@ -90,7 +90,7 @@ type apprunnerSvcDescriber interface {
 	ServiceURL() (string, error)
 }
 
-type ecsSvcDescriber interface {
+type ecsStackDescriber interface {
 	Params() (map[string]string, error)
 	Outputs() (map[string]string, error)
 	EnvVars() ([]*awsecs.ContainerEnvVar, error)
@@ -166,9 +166,9 @@ type ecsServiceDescriber struct {
 	svc             string
 	enableResources bool
 
-	store          DeployedEnvServicesLister
-	svcDescriber   map[string]ecsSvcDescriber
-	initDescribers func(string) error
+	store             DeployedEnvServicesLister
+	svcStackDescriber map[string]ecsStackDescriber
+	initDescribers    func(string) error
 }
 
 // NewServiceConfig contains fields that initiates ServiceDescriber struct.

--- a/internal/pkg/describe/service.go
+++ b/internal/pkg/describe/service.go
@@ -161,6 +161,16 @@ type ServiceDescriber struct {
 	sess      *session.Session
 }
 
+type ecsServiceDescriber struct {
+	app             string
+	svc             string
+	enableResources bool
+
+	store          DeployedEnvServicesLister
+	svcDescriber   map[string]ecsSvcDescriber
+	initDescribers func(string) error
+}
+
 // NewServiceConfig contains fields that initiates ServiceDescriber struct.
 type NewServiceConfig struct {
 	App         string

--- a/internal/pkg/describe/worker_service_test.go
+++ b/internal/pkg/describe/worker_service_test.go
@@ -283,16 +283,18 @@ func TestWorkerServiceDescriber_Describe(t *testing.T) {
 			tc.setupMocks(mocks)
 
 			d := &WorkerServiceDescriber{
-				app:             testApp,
-				svc:             testSvc,
-				enableResources: tc.shouldOutputResources,
-				store:           mockStore,
-				svcDescriber: map[string]ecsSvcDescriber{
-					"test":    mockSvcDescriber,
-					"prod":    mockSvcDescriber,
-					"mockEnv": mockSvcDescriber,
+				ecsServiceDescriber: &ecsServiceDescriber{
+					app:             testApp,
+					svc:             testSvc,
+					enableResources: tc.shouldOutputResources,
+					store:           mockStore,
+					svcDescriber: map[string]ecsSvcDescriber{
+						"test":    mockSvcDescriber,
+						"prod":    mockSvcDescriber,
+						"mockEnv": mockSvcDescriber,
+					},
+					initDescribers: func(string) error { return nil },
 				},
-				initServiceDescriber: func(string) error { return nil },
 			}
 
 			// WHEN

--- a/internal/pkg/describe/worker_service_test.go
+++ b/internal/pkg/describe/worker_service_test.go
@@ -46,7 +46,7 @@ func TestWorkerServiceDescriber_Describe(t *testing.T) {
 			setupMocks: func(m lbWebSvcDescriberMocks) {
 				gomock.InOrder(
 					m.storeSvc.EXPECT().ListEnvironmentsDeployedTo(testApp, testSvc).Return([]string{testEnv}, nil),
-					m.ecsSvcDescriber.EXPECT().Params().Return(nil, mockErr),
+					m.ecsStackDescriber.EXPECT().Params().Return(nil, mockErr),
 				)
 			},
 			wantedError: fmt.Errorf("get stack parameters for environment test: some error"),
@@ -55,13 +55,13 @@ func TestWorkerServiceDescriber_Describe(t *testing.T) {
 			setupMocks: func(m lbWebSvcDescriberMocks) {
 				gomock.InOrder(
 					m.storeSvc.EXPECT().ListEnvironmentsDeployedTo(testApp, testSvc).Return([]string{testEnv}, nil),
-					m.ecsSvcDescriber.EXPECT().Params().Return(map[string]string{
+					m.ecsStackDescriber.EXPECT().Params().Return(map[string]string{
 						cfnstack.LBWebServiceContainerPortParamKey: "-",
 						cfnstack.WorkloadTaskCountParamKey:         "1",
 						cfnstack.WorkloadTaskMemoryParamKey:        "512",
 						cfnstack.WorkloadTaskCPUParamKey:           "256",
 					}, nil),
-					m.ecsSvcDescriber.EXPECT().EnvVars().Return(nil, mockErr),
+					m.ecsStackDescriber.EXPECT().EnvVars().Return(nil, mockErr),
 				)
 			},
 			wantedError: fmt.Errorf("retrieve environment variables: some error"),
@@ -71,20 +71,20 @@ func TestWorkerServiceDescriber_Describe(t *testing.T) {
 				gomock.InOrder(
 					m.storeSvc.EXPECT().ListEnvironmentsDeployedTo(testApp, testSvc).Return([]string{testEnv}, nil),
 
-					m.ecsSvcDescriber.EXPECT().Params().Return(map[string]string{
+					m.ecsStackDescriber.EXPECT().Params().Return(map[string]string{
 						cfnstack.LBWebServiceContainerPortParamKey: "-",
 						cfnstack.WorkloadTaskCountParamKey:         "1",
 						cfnstack.WorkloadTaskCPUParamKey:           "256",
 						cfnstack.WorkloadTaskMemoryParamKey:        "512",
 					}, nil),
-					m.ecsSvcDescriber.EXPECT().EnvVars().Return([]*ecs.ContainerEnvVar{
+					m.ecsStackDescriber.EXPECT().EnvVars().Return([]*ecs.ContainerEnvVar{
 						{
 							Name:      "COPILOT_ENVIRONMENT_NAME",
 							Container: "container",
 							Value:     "prod",
 						},
 					}, nil),
-					m.ecsSvcDescriber.EXPECT().Secrets().Return(nil, mockErr),
+					m.ecsStackDescriber.EXPECT().Secrets().Return(nil, mockErr),
 				)
 			},
 			wantedError: fmt.Errorf("retrieve secrets: some error"),
@@ -95,74 +95,74 @@ func TestWorkerServiceDescriber_Describe(t *testing.T) {
 				gomock.InOrder(
 					m.storeSvc.EXPECT().ListEnvironmentsDeployedTo(testApp, testSvc).Return([]string{testEnv, prodEnv, mockEnv}, nil),
 
-					m.ecsSvcDescriber.EXPECT().Params().Return(map[string]string{
+					m.ecsStackDescriber.EXPECT().Params().Return(map[string]string{
 						cfnstack.LBWebServiceContainerPortParamKey: "-",
 						cfnstack.WorkloadTaskCountParamKey:         "1",
 						cfnstack.WorkloadTaskCPUParamKey:           "256",
 						cfnstack.WorkloadTaskMemoryParamKey:        "512",
 					}, nil),
-					m.ecsSvcDescriber.EXPECT().EnvVars().Return([]*ecs.ContainerEnvVar{
+					m.ecsStackDescriber.EXPECT().EnvVars().Return([]*ecs.ContainerEnvVar{
 						{
 							Name:      "COPILOT_ENVIRONMENT_NAME",
 							Container: "container",
 							Value:     testEnv,
 						},
 					}, nil),
-					m.ecsSvcDescriber.EXPECT().Secrets().Return([]*ecs.ContainerSecret{
+					m.ecsStackDescriber.EXPECT().Secrets().Return([]*ecs.ContainerSecret{
 						{
 							Name:      "GITHUB_WEBHOOK_SECRET",
 							Container: "container",
 							ValueFrom: "GH_WEBHOOK_SECRET",
 						},
 					}, nil),
-					m.ecsSvcDescriber.EXPECT().Params().Return(map[string]string{
+					m.ecsStackDescriber.EXPECT().Params().Return(map[string]string{
 						cfnstack.LBWebServiceContainerPortParamKey: "-",
 						cfnstack.WorkloadTaskCountParamKey:         "2",
 						cfnstack.WorkloadTaskCPUParamKey:           "512",
 						cfnstack.WorkloadTaskMemoryParamKey:        "1024",
 					}, nil),
-					m.ecsSvcDescriber.EXPECT().EnvVars().Return([]*ecs.ContainerEnvVar{
+					m.ecsStackDescriber.EXPECT().EnvVars().Return([]*ecs.ContainerEnvVar{
 						{
 							Name:      "COPILOT_ENVIRONMENT_NAME",
 							Container: "container",
 							Value:     prodEnv,
 						},
 					}, nil),
-					m.ecsSvcDescriber.EXPECT().Secrets().Return([]*ecs.ContainerSecret{
+					m.ecsStackDescriber.EXPECT().Secrets().Return([]*ecs.ContainerSecret{
 						{
 							Name:      "A_SECRET",
 							Container: "container",
 							ValueFrom: "SECRET",
 						},
 					}, nil),
-					m.ecsSvcDescriber.EXPECT().Params().Return(map[string]string{
+					m.ecsStackDescriber.EXPECT().Params().Return(map[string]string{
 						cfnstack.LBWebServiceContainerPortParamKey: "-",
 						cfnstack.WorkloadTaskCountParamKey:         "2",
 						cfnstack.WorkloadTaskCPUParamKey:           "512",
 						cfnstack.WorkloadTaskMemoryParamKey:        "1024",
 					}, nil),
-					m.ecsSvcDescriber.EXPECT().EnvVars().Return([]*ecs.ContainerEnvVar{
+					m.ecsStackDescriber.EXPECT().EnvVars().Return([]*ecs.ContainerEnvVar{
 						{
 							Name:      "COPILOT_ENVIRONMENT_NAME",
 							Container: "container",
 							Value:     mockEnv,
 						},
 					}, nil),
-					m.ecsSvcDescriber.EXPECT().Secrets().Return(
+					m.ecsStackDescriber.EXPECT().Secrets().Return(
 						nil, nil),
-					m.ecsSvcDescriber.EXPECT().ServiceStackResources().Return([]*stack.Resource{
+					m.ecsStackDescriber.EXPECT().ServiceStackResources().Return([]*stack.Resource{
 						{
 							Type:       "AWS::EC2::SecurityGroupIngress",
 							PhysicalID: "ContainerSecurityGroupIngressFromPublicALB",
 						},
 					}, nil),
-					m.ecsSvcDescriber.EXPECT().ServiceStackResources().Return([]*stack.Resource{
+					m.ecsStackDescriber.EXPECT().ServiceStackResources().Return([]*stack.Resource{
 						{
 							Type:       "AWS::EC2::SecurityGroup",
 							PhysicalID: "sg-0758ed6b233743530",
 						},
 					}, nil),
-					m.ecsSvcDescriber.EXPECT().ServiceStackResources().Return([]*stack.Resource{
+					m.ecsStackDescriber.EXPECT().ServiceStackResources().Return([]*stack.Resource{
 						{
 							Type:       "AWS::EC2::SecurityGroup",
 							PhysicalID: "sg-2337435300758ed6b",
@@ -274,10 +274,10 @@ func TestWorkerServiceDescriber_Describe(t *testing.T) {
 			defer ctrl.Finish()
 
 			mockStore := mocks.NewMockDeployedEnvServicesLister(ctrl)
-			mockSvcDescriber := mocks.NewMockecsSvcDescriber(ctrl)
+			mockSvcDescriber := mocks.NewMockecsStackDescriber(ctrl)
 			mocks := lbWebSvcDescriberMocks{
-				storeSvc:        mockStore,
-				ecsSvcDescriber: mockSvcDescriber,
+				storeSvc:          mockStore,
+				ecsStackDescriber: mockSvcDescriber,
 			}
 
 			tc.setupMocks(mocks)
@@ -288,7 +288,7 @@ func TestWorkerServiceDescriber_Describe(t *testing.T) {
 					svc:             testSvc,
 					enableResources: tc.shouldOutputResources,
 					store:           mockStore,
-					svcDescriber: map[string]ecsSvcDescriber{
+					svcStackDescriber: map[string]ecsStackDescriber{
 						"test":    mockSvcDescriber,
 						"prod":    mockSvcDescriber,
 						"mockEnv": mockSvcDescriber,


### PR DESCRIPTION
<!-- Provide summary of changes -->
As mentioned in #2744, refactors describer structs to remove redundancy.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
