### PR TITLE
fix: pipeline manifest updates no longer require re-generating a buildspec

### DIFF
--- a/internal/pkg/cli/pipeline_init.go
+++ b/internal/pkg/cli/pipeline_init.go
@@ -101,12 +101,6 @@ type initPipelineOpts struct {
 	envConfigs []*config.Environment
 }
 
-type artifactBucket struct {
-	BucketName   string
-	Region       string
-	Environments []string
-}
-
 func newInitPipelineOpts(vars initPipelineVars) (*initPipelineOpts, error) {
 	ws, err := workspace.New()
 	if err != nil {

--- a/internal/pkg/deploy/cloudformation/cc_pipeline_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/cc_pipeline_integration_test.go
@@ -203,7 +203,7 @@ func TestCCPipelineCreation(t *testing.T) {
 
 		resources, err := appDeployer.GetRegionalAppResources(&app)
 		require.NoError(t, err)
-		artifactBuckets := regionalResourcesToArtifactBuckets(t, resources)
+		artifactBuckets := regionalResourcesToArtifactBuckets(t, environmentToDeploy.Name, resources)
 
 		pipelineInput := &deploy.CreatePipelineInput{
 			AppName: app.Name,

--- a/internal/pkg/deploy/cloudformation/ghV1_pipeline_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/ghV1_pipeline_integration_test.go
@@ -220,7 +220,7 @@ func TestGHv1PipelineCreation(t *testing.T) {
 
 		resources, err := appDeployer.GetRegionalAppResources(&app)
 		require.NoError(t, err)
-		artifactBuckets := regionalResourcesToArtifactBuckets(t, resources)
+		artifactBuckets := regionalResourcesToArtifactBuckets(t, environmentToDeploy.Name, resources)
 
 		pipelineInput := &deploy.CreatePipelineInput{
 			AppName: app.Name,
@@ -304,14 +304,16 @@ func assertStackExists(t *testing.T, cfClient *awsCF.CloudFormation, stackName s
 	return resp
 }
 
-func regionalResourcesToArtifactBuckets(t *testing.T, resources []*stack.AppRegionalResources) []deploy.ArtifactBucket {
-	buckets := make([]deploy.ArtifactBucket, 0, len(resources))
+func regionalResourcesToArtifactBuckets(t *testing.T, envName string, resources []*stack.AppRegionalResources) []deploy.Bucket {
+	buckets := make([]deploy.Bucket, 0, len(resources))
 	for _, res := range resources {
 		require.True(t, res.S3Bucket != "", "S3 Bucket shouldn't be blank")
 		require.True(t, res.KMSKeyARN != "", "KMSKey ARN shouldn't be blank")
-		buckets = append(buckets, deploy.ArtifactBucket{
-			BucketName: res.S3Bucket,
-			KeyArn:     res.KMSKeyARN,
+		buckets = append(buckets, deploy.Bucket{
+			Region:       res.Region,
+			Name:         res.S3Bucket,
+			Environments: []string{envName},
+			KeyARN:       res.KMSKeyARN,
 		})
 	}
 	return buckets

--- a/internal/pkg/deploy/cloudformation/stack/bb_pipeline_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/bb_pipeline_integration_test.go
@@ -41,10 +41,12 @@ func TestBB_Pipeline_Template(t *testing.T) {
 				TestCommands:     []string{`echo "test"`},
 			},
 		},
-		ArtifactBuckets: []deploy.ArtifactBucket{
+		ArtifactBuckets: []deploy.Bucket{
 			{
-				BucketName: "fancy-bucket",
-				KeyArn:     "arn:aws:kms:us-west-2:1111:key/abcd",
+				Region:       "us-west-2",
+				Name:         "fancy-bucket",
+				Environments: []string{"test"},
+				KeyARN:       "arn:aws:kms:us-west-2:1111:key/abcd",
 			},
 		},
 		AdditionalTags: nil,

--- a/internal/pkg/deploy/cloudformation/stack/cc_pipeline_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/cc_pipeline_integration_test.go
@@ -41,10 +41,12 @@ func TestCC_Pipeline_Template(t *testing.T) {
 				TestCommands:     []string{`echo "test"`},
 			},
 		},
-		ArtifactBuckets: []deploy.ArtifactBucket{
+		ArtifactBuckets: []deploy.Bucket{
 			{
-				BucketName: "fancy-bucket",
-				KeyArn:     "arn:aws:kms:us-west-2:1111:key/abcd",
+				Region:       "us-west-2",
+				Name:         "fancy-bucket",
+				Environments: []string{"test"},
+				KeyARN:       "arn:aws:kms:us-west-2:1111:key/abcd",
 			},
 		},
 		AdditionalTags: nil,

--- a/internal/pkg/deploy/cloudformation/stack/gh_pipeline_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/gh_pipeline_integration_test.go
@@ -41,10 +41,12 @@ func TestGHPipeline_Template(t *testing.T) {
 				TestCommands:     []string{`echo "test"`},
 			},
 		},
-		ArtifactBuckets: []deploy.ArtifactBucket{
+		ArtifactBuckets: []deploy.Bucket{
 			{
-				BucketName: "fancy-bucket",
-				KeyArn:     "arn:aws:kms:us-west-2:1111:key/abcd",
+				Region:       "us-west-2",
+				Name:         "fancy-bucket",
+				Environments: []string{"test"},
+				KeyARN:       "arn:aws:kms:us-west-2:1111:key/abcd",
 			},
 		},
 		AdditionalTags: nil,

--- a/internal/pkg/deploy/cloudformation/stack/ghv1_pipeline_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/ghv1_pipeline_integration_test.go
@@ -1,3 +1,5 @@
+// +build integration localintegration
+
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
@@ -42,10 +44,12 @@ func TestGHv1Pipeline_Template(t *testing.T) {
 				TestCommands:     []string{`echo "test"`},
 			},
 		},
-		ArtifactBuckets: []deploy.ArtifactBucket{
+		ArtifactBuckets: []deploy.Bucket{
 			{
-				BucketName: "fancy-bucket",
-				KeyArn:     "arn:aws:kms:us-west-2:1111:key/abcd",
+				Region:       "us-west-2",
+				Name:         "fancy-bucket",
+				Environments: []string{"test"},
+				KeyARN:       "arn:aws:kms:us-west-2:1111:key/abcd",
 			},
 		},
 		AdditionalTags: nil,

--- a/internal/pkg/deploy/cloudformation/stack/pipeline.go
+++ b/internal/pkg/deploy/cloudformation/stack/pipeline.go
@@ -4,6 +4,8 @@
 package stack
 
 import (
+	"encoding/json"
+
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/copilot-cli/internal/pkg/template"
 
@@ -38,6 +40,14 @@ func (p *pipelineStackConfig) Template() (string, error) {
 			}
 			_, ok := source.(connectionName)
 			return ok
+		},
+		"jsonArtifactBuckets": func(buckets []deploy.Bucket) (string, error) {
+			out, err := json.Marshal(struct {
+				Buckets []deploy.Bucket `json:"buckets"`
+			}{
+				Buckets: buckets,
+			})
+			return string(out), err
 		},
 	}))
 	if err != nil {

--- a/internal/pkg/deploy/cloudformation/stack/pipeline_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/pipeline_test.go
@@ -140,19 +140,19 @@ func mockCreatePipelineInput() *deploy.CreatePipelineInput {
 				LocalWorkloads:        []string{"frontend", "backend"},
 			},
 		},
-		ArtifactBuckets: []deploy.ArtifactBucket{
+		ArtifactBuckets: []deploy.Bucket{
 			{
-				BucketName: "chicken-us-east-1",
-				KeyArn:     fmt.Sprintf("arn:aws:kms:us-east-1:%s:key/30131d3f-c30f-4d49-beaa-cf4bfc07f34e", toolsAccountID),
+				Name:   "chicken-us-east-1",
+				KeyARN: fmt.Sprintf("arn:aws:kms:us-east-1:%s:key/30131d3f-c30f-4d49-beaa-cf4bfc07f34e", toolsAccountID),
 			},
 			{
-				BucketName: "chicken-us-west-2",
-				KeyArn:     fmt.Sprintf("arn:aws:kms:us-west-2:%s:key/80de5f7f-422d-4dff-8f4d-01f6ec5715bc", toolsAccountID),
+				Name:   "chicken-us-west-2",
+				KeyARN: fmt.Sprintf("arn:aws:kms:us-west-2:%s:key/80de5f7f-422d-4dff-8f4d-01f6ec5715bc", toolsAccountID),
 			},
 			// assume the pipeline is hosted in a region that does not contain any copilot environment
 			{
-				BucketName: "chicken-us-west-1",
-				KeyArn:     fmt.Sprintf("arn:aws:kms:us-west-1:%s:key/75668c57-ec4b-4d0c-b880-8dc3fa78f6d1", toolsAccountID),
+				Name:   "chicken-us-west-1",
+				KeyARN: fmt.Sprintf("arn:aws:kms:us-west-1:%s:key/75668c57-ec4b-4d0c-b880-8dc3fa78f6d1", toolsAccountID),
 			},
 		},
 		AdditionalTags: map[string]string{

--- a/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/bb_template.yaml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/bb_template.yaml
@@ -123,6 +123,8 @@ Resources:
         EnvironmentVariables:
           - Name: AWS_ACCOUNT_ID
             Value: !Sub '${AWS::AccountId}'
+          - Name: COPILOT_PIPELINE_BUCKETS
+            Value: "{\"buckets\":[{\"name\":\"fancy-bucket\",\"region\":\"us-west-2\",\"environments\":[\"test\"],\"KeyARN\":\"arn:aws:kms:us-west-2:1111:key/abcd\"}]}"
       Source:
         Type: CODEPIPELINE
         BuildSpec: copilot/buildspec.yml

--- a/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/cc_template.yaml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/cc_template.yaml
@@ -118,6 +118,8 @@ Resources:
         EnvironmentVariables:
           - Name: AWS_ACCOUNT_ID
             Value: !Sub '${AWS::AccountId}'
+          - Name: COPILOT_PIPELINE_BUCKETS
+            Value: "{\"buckets\":[{\"name\":\"fancy-bucket\",\"region\":\"us-west-2\",\"environments\":[\"test\"],\"KeyARN\":\"arn:aws:kms:us-west-2:1111:key/abcd\"}]}"
       Source:
         Type: CODEPIPELINE
         BuildSpec: copilot/buildspec.yml

--- a/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/gh_template.yaml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/gh_template.yaml
@@ -123,6 +123,8 @@ Resources:
         EnvironmentVariables:
           - Name: AWS_ACCOUNT_ID
             Value: !Sub '${AWS::AccountId}'
+          - Name: COPILOT_PIPELINE_BUCKETS
+            Value: "{\"buckets\":[{\"name\":\"fancy-bucket\",\"region\":\"us-west-2\",\"environments\":[\"test\"],\"KeyARN\":\"arn:aws:kms:us-west-2:1111:key/abcd\"}]}"
       Source:
         Type: CODEPIPELINE
         BuildSpec: copilot/buildspec.yml

--- a/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/ghv1_template.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/ghv1_template.yml
@@ -118,6 +118,8 @@ Resources:
         EnvironmentVariables:
           - Name: AWS_ACCOUNT_ID
             Value: !Sub '${AWS::AccountId}'
+          - Name: COPILOT_PIPELINE_BUCKETS
+            Value: "{\"buckets\":[{\"name\":\"fancy-bucket\",\"region\":\"us-west-2\",\"environments\":[\"test\"],\"KeyARN\":\"arn:aws:kms:us-west-2:1111:key/abcd\"}]}"
       Source:
         Type: CODEPIPELINE
         BuildSpec: copilot/buildspec.yml

--- a/internal/pkg/deploy/pipeline.go
+++ b/internal/pkg/deploy/pipeline.go
@@ -11,8 +11,6 @@ import (
 	"regexp"
 
 	"github.com/aws/copilot-cli/internal/pkg/manifest"
-
-	"github.com/aws/aws-sdk-go/aws/arn"
 )
 
 const (
@@ -51,7 +49,7 @@ type CreatePipelineInput struct {
 
 	// A list of artifact buckets and corresponding KMS keys that will
 	// be used in this pipeline.
-	ArtifactBuckets []ArtifactBucket
+	ArtifactBuckets []Bucket
 
 	// AdditionalTags are labels applied to resources under the application.
 	AdditionalTags map[string]string
@@ -64,26 +62,14 @@ type Build struct {
 	Image string
 }
 
-// ArtifactBucket represents an S3 bucket used by the CodePipeline to store
+// Bucket represents an S3 bucket used by the CodePipeline to store
 // intermediate artifacts produced by the pipeline.
-type ArtifactBucket struct {
-	// The name of the S3 bucket.
-	BucketName string
+type Bucket struct {
+	Name         string   `json:"name"`
+	Region       string   `json:"region"`
+	Environments []string `json:"environments"` // Name of stages in the pipeline that use this artifact bucket.
 
-	// The ARN of the KMS key used to en/decrypt artifacts stored in this bucket.
-	KeyArn string
-}
-
-// Region parses out the region from the ARN of the KMS key associated with
-// the artifact bucket.
-func (a *ArtifactBucket) Region() (string, error) {
-	// We assume the bucket and the key are in the same AWS region.
-	parsedArn, err := arn.Parse(a.KeyArn)
-	if err != nil {
-		return "", fmt.Errorf("failed to parse region out of key ARN: %s, error: %w",
-			a.BucketName, err)
-	}
-	return parsedArn.Region, nil
+	KeyARN string // The ARN of the KMS key used to en/decrypt artifacts stored in this bucket.
 }
 
 // GitHubV1Source defines the source of the artifacts to be built and deployed. This version uses personal access tokens

--- a/internal/pkg/template/templates/cicd/buildspec.yml
+++ b/internal/pkg/template/templates/cicd/buildspec.yml
@@ -54,9 +54,15 @@ phases:
           ADDONSFILE=./infrastructure/$workload.addons.stack.yml
           if [ -f "$ADDONSFILE" ]; then
             tmp=$(mktemp)
-            timestamp=$(date +%s){{range $bucket := .ArtifactBuckets}}
-            aws s3 cp "$ADDONSFILE" "s3://{{$bucket.BucketName}}/manual/$timestamp/$workload.addons.stack.yml";{{range $envName := $bucket.Environments}}
-            jq --arg a "https://{{$bucket.BucketName}}.s3.{{$bucket.Region}}.amazonaws.com/manual/$timestamp/$workload.addons.stack.yml" '.Parameters.AddonsTemplateURL = $a' ./infrastructure/$workload-{{$envName}}.params.json > "$tmp" && mv "$tmp" ./infrastructure/$workload-{{$envName}}.params.json{{end}}{{end}}
+            timestamp=$(date +%s)
+            for bucket in $(echo $COPILOT_PIPELINE_BUCKETS | jq -c .buckets[]); do
+              s3URL="s3://$(echo $bucket | jq -r .name)/";
+              aws s3 cp "$ADDONSFILE" "$s3URL/manual/$timestamp/$workload.addons.stack.yml";
+              httpsURL="https://$(echo $bucket | jq -r .name).s3.$(echo $bucket | jq -r .region).amazonaws.com/";
+              for env in $(echo $bucket | jq -r -c .environments[]); do
+                jq --arg a "$httpsURL/manual/$timestamp/$workload.addons.stack.yml" '.Parameters.AddonsTemplateURL = $a' ./infrastructure/$workload-$env.params.json > "$tmp" && mv "$tmp" ./infrastructure/$workload-$env.params.json{{end}}{{end}}
+              done;
+            done;
           fi
         done;
       # Build images

--- a/internal/pkg/template/templates/cicd/buildspec.yml
+++ b/internal/pkg/template/templates/cicd/buildspec.yml
@@ -60,7 +60,7 @@ phases:
               aws s3 cp "$ADDONSFILE" "$s3URL/manual/$timestamp/$workload.addons.stack.yml";
               httpsURL="https://$(echo $bucket | jq -r .name).s3.$(echo $bucket | jq -r .region).amazonaws.com/";
               for env in $(echo $bucket | jq -r -c .environments[]); do
-                jq --arg a "$httpsURL/manual/$timestamp/$workload.addons.stack.yml" '.Parameters.AddonsTemplateURL = $a' ./infrastructure/$workload-$env.params.json > "$tmp" && mv "$tmp" ./infrastructure/$workload-$env.params.json{{end}}{{end}}
+                jq --arg a "$httpsURL/manual/$timestamp/$workload.addons.stack.yml" '.Parameters.AddonsTemplateURL = $a' ./infrastructure/$workload-$env.params.json > "$tmp" && mv "$tmp" ./infrastructure/$workload-$env.params.json
               done;
             done;
           fi

--- a/internal/pkg/template/templates/cicd/pipeline_cfn.yml
+++ b/internal/pkg/template/templates/cicd/pipeline_cfn.yml
@@ -64,8 +64,8 @@ Resources:
             # that is in the same region as the pipeline.
             # Loop through all the artifact buckets created in the stackset
             Resource:{{range .ArtifactBuckets}}
-              - !Join ['', ['arn:aws:s3:::', '{{.BucketName}}']]
-              - !Join ['', ['arn:aws:s3:::', '{{.BucketName}}', '/*']]{{end}}
+              - !Join ['', ['arn:aws:s3:::', '{{.Name}}']]
+              - !Join ['', ['arn:aws:s3:::', '{{.Name}}', '/*']]{{end}}
           - Effect: Allow
             Action:
               # TODO: scope this down if possible
@@ -76,7 +76,7 @@ Resources:
             # across (cross-regional) pipeline stages, with each stage
             # backed by a (regional) S3 bucket.
             Resource:{{range .ArtifactBuckets}}
-              - {{.KeyArn}}{{end}}
+              - {{.KeyARN}}{{end}}
           - Effect: Allow
             Action:
               - logs:CreateLogGroup
@@ -129,6 +129,8 @@ Resources:
         EnvironmentVariables:
           - Name: AWS_ACCOUNT_ID
             Value: !Sub '${AWS::AccountId}'
+          - Name: COPILOT_PIPELINE_BUCKETS
+            Value: {{jsonArtifactBuckets .ArtifactBuckets | printf "%q"}}
       Source:
         Type: CODEPIPELINE
         BuildSpec: copilot/buildspec.yml
@@ -213,7 +215,7 @@ Resources:
               - kms:Encrypt
               - kms:GenerateDataKey
             Resource:{{range .ArtifactBuckets}}
-              - {{.KeyArn}}{{end}}
+              - {{.KeyARN}}{{end}}
           - Effect: Allow
             Action:
               - s3:PutObject
@@ -225,8 +227,8 @@ Resources:
               - s3:GetObjectAcl
               {{- end}}
             Resource:{{range .ArtifactBuckets}}
-              - !Join ['', ['arn:aws:s3:::', '{{.BucketName}}']]
-              - !Join ['', ['arn:aws:s3:::', '{{.BucketName}}', '/*']]{{end}}
+              - !Join ['', ['arn:aws:s3:::', '{{.Name}}']]
+              - !Join ['', ['arn:aws:s3:::', '{{.Name}}', '/*']]{{end}}
           - Effect: Allow
             Action:
               - sts:AssumeRole
@@ -273,9 +275,9 @@ Resources:
         - Region: {{.Region}}
           ArtifactStore:
             Type: S3
-            Location: {{.BucketName}}
+            Location: {{.Name}}
             EncryptionKey:
-              Id: {{.KeyArn}}
+              Id: {{.KeyARN}}
               Type: KMS{{end}}
       RoleArn: !GetAtt PipelineRole.Arn
       Name: !Ref AWS::StackName


### PR DESCRIPTION
Fixes #1824

### TL;DR
Previously, when a customer updated the `pipeline.yml` file they would need to re-create the entire buildspec.yml file because the old buildspec wasn't aware of the new stages.

Instead, now we inject an environment variable `COPILOT_PIPELINE_BUCKETS` to the build stage so that on `pipeline update` we can dynamically inject the list of stages.

### Long version
See https://github.com/aws/copilot-cli/issues/1824#issuecomment-901297006

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
