### PR TITLE
feat: add worker services to `svc init`

### DIFF
--- a/internal/pkg/cli/flag.go
+++ b/internal/pkg/cli/flag.go
@@ -52,7 +52,7 @@ const (
 	deleteSecretFlag      = "delete-secret"
 	svcPortFlag           = "port"
 
-	noSubscriptionFlag = "no-subscriptions"
+	noSubscriptionFlag = "no-subscribe"
 	subscribeFlag      = "subscribe"
 
 	storageTypeFlag              = "storage-type"
@@ -222,7 +222,8 @@ Defaults to all logs. Only one of end-time / follow may be used.`
 	svcPortFlagDescription           = "The port on which your service listens."
 
 	noSubscriptionFlagDescription = "Optional. Turn off selection for adding subscriptions for worker services."
-	subscribeFlagDescription      = "Optional. Publishers for worker services to subscribe to. Must be of format '<svcName>:<publisherName>"
+	subscribeFlagDescription      = `Optional. Events to subscribe to from services in your application. 
+Must be of format '<svcName>:<topicName>'`
 
 	storageFlagDescription             = "Name of the storage resource to create."
 	storageWorkloadFlagDescription     = "Name of the service or job to associate with storage."

--- a/internal/pkg/cli/flag.go
+++ b/internal/pkg/cli/flag.go
@@ -52,8 +52,8 @@ const (
 	deleteSecretFlag      = "delete-secret"
 	svcPortFlag           = "port"
 
-	noSubscriptionFlag = "no-subscribe"
-	subscribeFlag      = "subscribe"
+	noSubscriptionFlag  = "no-subscribe"
+	subscribeTopicsFlag = "subscribe-topics"
 
 	storageTypeFlag              = "storage-type"
 	storagePartitionKeyFlag      = "partition-key"
@@ -221,8 +221,8 @@ Defaults to all logs. Only one of end-time / follow may be used.`
 	deleteSecretFlagDescription      = "Deletes AWS Secrets Manager secret associated with a pipeline source repository."
 	svcPortFlagDescription           = "The port on which your service listens."
 
-	noSubscriptionFlagDescription = "Optional. Turn off selection for adding subscriptions for worker services."
-	subscribeFlagDescription      = `Optional. Events to subscribe to from services in your application. 
+	noSubscriptionFlagDescription  = "Optional. Turn off selection for adding subscriptions for worker services."
+	subscribeTopicsFlagDescription = `Optional. SNS Topics to subscribe to from other services in your application.
 Must be of format '<svcName>:<topicName>'`
 
 	storageFlagDescription             = "Name of the storage resource to create."

--- a/internal/pkg/cli/flag.go
+++ b/internal/pkg/cli/flag.go
@@ -52,6 +52,9 @@ const (
 	deleteSecretFlag      = "delete-secret"
 	svcPortFlag           = "port"
 
+	noSubscriptionFlag = "no-subscriptions"
+	subscribeFlag      = "subscribe"
+
 	storageTypeFlag              = "storage-type"
 	storagePartitionKeyFlag      = "partition-key"
 	storageSortKeyFlag           = "sort-key"
@@ -217,6 +220,9 @@ Defaults to all logs. Only one of end-time / follow may be used.`
 	localJobFlagDescription          = "Only show jobs in the workspace."
 	deleteSecretFlagDescription      = "Deletes AWS Secrets Manager secret associated with a pipeline source repository."
 	svcPortFlagDescription           = "The port on which your service listens."
+
+	noSubscriptionFlagDescription = "Optional. Turn off selection for adding subscriptions for worker services."
+	subscribeFlagDescription      = "Optional. Publishers for worker services to subscribe to. Must be of format '<svcName>:<publisherName>"
 
 	storageFlagDescription             = "Name of the storage resource to create."
 	storageWorkloadFlagDescription     = "Name of the service or job to associate with storage."

--- a/internal/pkg/cli/init.go
+++ b/internal/pkg/cli/init.go
@@ -7,6 +7,7 @@ package cli
 import (
 	"fmt"
 
+	"github.com/aws/copilot-cli/internal/pkg/deploy"
 	"github.com/aws/copilot-cli/internal/pkg/docker/dockerengine"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -103,6 +104,11 @@ func newInitOpts(vars initVars) (*initOpts, error) {
 	}
 	prompt := prompt.New()
 	sel := selector.NewWorkspaceSelect(prompt, ssm, ws)
+	deployStore, err := deploy.NewStore(ssm)
+	if err != nil {
+		return nil, err
+	}
+	snsSel := selector.NewDeploySelect(prompt, ssm, deployStore)
 	spin := termprogress.NewSpinner(log.DiagnosticWriter)
 	id := identity.New(defaultSess)
 	deployer := cloudformation.New(defaultSess)
@@ -240,6 +246,7 @@ func newInitOpts(vars initVars) (*initOpts, error) {
 					fs:           fs,
 					init:         wlInitializer,
 					sel:          sel,
+					topicSel:     snsSel,
 					prompt:       prompt,
 					dockerEngine: dockerengine.New(cmd),
 				}

--- a/internal/pkg/cli/init_test.go
+++ b/internal/pkg/cli/init_test.go
@@ -122,6 +122,10 @@ func TestInitOpts_Run(t *testing.T) {
 						Hint:  "ECS on Fargate",
 					},
 					{
+						Value: manifest.WorkerServiceType,
+						Hint:  "Consumes Events",
+					},
+					{
 						Value: manifest.ScheduledJobType,
 						Hint:  "Scheduled event to State Machine to Fargate",
 					},

--- a/internal/pkg/cli/init_test.go
+++ b/internal/pkg/cli/init_test.go
@@ -123,7 +123,7 @@ func TestInitOpts_Run(t *testing.T) {
 					},
 					{
 						Value: manifest.WorkerServiceType,
-						Hint:  "Consumes Events",
+						Hint:  "Events to SQS to ECS on Fargate",
 					},
 					{
 						Value: manifest.ScheduledJobType,

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/docker/dockerengine"
 
 	"github.com/aws/copilot-cli/internal/pkg/aws/ssm"
+	"github.com/aws/copilot-cli/internal/pkg/manifest"
 
 	"github.com/aws/aws-sdk-go/aws/session"
 	awscloudformation "github.com/aws/copilot-cli/internal/pkg/aws/cloudformation"
@@ -504,6 +505,10 @@ type cfTaskSelector interface {
 
 type dockerfileSelector interface {
 	Dockerfile(selPrompt, notFoundPrompt, selHelp, notFoundHelp string, pv prompt.ValidatorFunc) (string, error)
+}
+
+type topicSelector interface {
+	Topics(prompt, help, app string) ([]manifest.TopicSubscription, error)
 }
 
 type ec2Selector interface {

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/docker/dockerengine"
 
 	"github.com/aws/copilot-cli/internal/pkg/aws/ssm"
-	"github.com/aws/copilot-cli/internal/pkg/manifest"
 
 	"github.com/aws/aws-sdk-go/aws/session"
 	awscloudformation "github.com/aws/copilot-cli/internal/pkg/aws/cloudformation"
@@ -508,7 +507,7 @@ type dockerfileSelector interface {
 }
 
 type topicSelector interface {
-	Topics(prompt, help, app string) ([]manifest.TopicSubscription, error)
+	Topics(prompt, help, app string) ([]deploy.Topic, error)
 }
 
 type ec2Selector interface {

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -25,6 +25,7 @@ import (
 	exec "github.com/aws/copilot-cli/internal/pkg/exec"
 	initialize "github.com/aws/copilot-cli/internal/pkg/initialize"
 	logging "github.com/aws/copilot-cli/internal/pkg/logging"
+	manifest "github.com/aws/copilot-cli/internal/pkg/manifest"
 	repository "github.com/aws/copilot-cli/internal/pkg/repository"
 	task "github.com/aws/copilot-cli/internal/pkg/task"
 	progress "github.com/aws/copilot-cli/internal/pkg/term/progress"
@@ -5383,6 +5384,44 @@ func (m *MockdockerfileSelector) Dockerfile(selPrompt, notFoundPrompt, selHelp, 
 func (mr *MockdockerfileSelectorMockRecorder) Dockerfile(selPrompt, notFoundPrompt, selHelp, notFoundHelp, pv interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dockerfile", reflect.TypeOf((*MockdockerfileSelector)(nil).Dockerfile), selPrompt, notFoundPrompt, selHelp, notFoundHelp, pv)
+}
+
+// MocktopicSelector is a mock of topicSelector interface.
+type MocktopicSelector struct {
+	ctrl     *gomock.Controller
+	recorder *MocktopicSelectorMockRecorder
+}
+
+// MocktopicSelectorMockRecorder is the mock recorder for MocktopicSelector.
+type MocktopicSelectorMockRecorder struct {
+	mock *MocktopicSelector
+}
+
+// NewMocktopicSelector creates a new mock instance.
+func NewMocktopicSelector(ctrl *gomock.Controller) *MocktopicSelector {
+	mock := &MocktopicSelector{ctrl: ctrl}
+	mock.recorder = &MocktopicSelectorMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MocktopicSelector) EXPECT() *MocktopicSelectorMockRecorder {
+	return m.recorder
+}
+
+// Topics mocks base method.
+func (m *MocktopicSelector) Topics(prompt, help, app string) ([]manifest.TopicSubscription, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Topics", prompt, help, app)
+	ret0, _ := ret[0].([]manifest.TopicSubscription)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Topics indicates an expected call of Topics.
+func (mr *MocktopicSelectorMockRecorder) Topics(prompt, help, app interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Topics", reflect.TypeOf((*MocktopicSelector)(nil).Topics), prompt, help, app)
 }
 
 // Mockec2Selector is a mock of ec2Selector interface.

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -25,7 +25,6 @@ import (
 	exec "github.com/aws/copilot-cli/internal/pkg/exec"
 	initialize "github.com/aws/copilot-cli/internal/pkg/initialize"
 	logging "github.com/aws/copilot-cli/internal/pkg/logging"
-	manifest "github.com/aws/copilot-cli/internal/pkg/manifest"
 	repository "github.com/aws/copilot-cli/internal/pkg/repository"
 	task "github.com/aws/copilot-cli/internal/pkg/task"
 	progress "github.com/aws/copilot-cli/internal/pkg/term/progress"
@@ -5410,10 +5409,10 @@ func (m *MocktopicSelector) EXPECT() *MocktopicSelectorMockRecorder {
 }
 
 // Topics mocks base method.
-func (m *MocktopicSelector) Topics(prompt, help, app string) ([]manifest.TopicSubscription, error) {
+func (m *MocktopicSelector) Topics(prompt, help, app string) ([]deploy.Topic, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Topics", prompt, help, app)
-	ret0, _ := ret[0].([]manifest.TopicSubscription)
+	ret0, _ := ret[0].([]deploy.Topic)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/internal/pkg/cli/svc_init.go
+++ b/internal/pkg/cli/svc_init.go
@@ -452,7 +452,7 @@ func (o *initSvcOpts) askSvcPublishers() (err error) {
 	if len(o.subscriptions) > 0 {
 		var topicSubscriptions []manifest.TopicSubscription
 		for _, sub := range o.subscriptions {
-			sub, err := subscriptionFromKey(sub)
+			sub, err := parseSerializedSubscription(sub)
 			if err != nil {
 				return err
 			}
@@ -484,8 +484,8 @@ func (o *initSvcOpts) askSvcPublishers() (err error) {
 	return nil
 }
 
-// subscriptionFromKey parses the service and topic name out of keys specified in the form "service:topicName"
-func subscriptionFromKey(input string) (manifest.TopicSubscription, error) {
+// parseSerializedSubscription parses the service and topic name out of keys specified in the form "service:topicName"
+func parseSerializedSubscription(input string) (manifest.TopicSubscription, error) {
 	attrs := regexpMatchSubscription.FindStringSubmatch(input)
 	if len(attrs) == 0 {
 		return manifest.TopicSubscription{}, fmt.Errorf("parse subscription from key: %s", input)

--- a/internal/pkg/cli/svc_init.go
+++ b/internal/pkg/cli/svc_init.go
@@ -64,14 +64,15 @@ Deployed resources (such as your ECR repository, logs) will contain this %[1]s's
 You should set this to the port which your Dockerfile uses to communicate with the internet.`
 
 	svcInitPublisherPrompt     = "Which publishers do you want to subscribe to?"
-	svcInitPublisherHelpPrompt = `A publisher is an existing SNS Topic that the designated service publishes messages to. These messages can be consumed by the Worker Service.`
+	svcInitPublisherHelpPrompt = `A publisher is an existing SNS Topic to which a service publishes messages. 
+These messages can be consumed by the Worker Service.`
 )
 
 var serviceTypeHints = map[string]string{
 	manifest.RequestDrivenWebServiceType: "App Runner",
 	manifest.LoadBalancedWebServiceType:  "Internet to ECS on Fargate",
 	manifest.BackendServiceType:          "ECS on Fargate",
-	manifest.WorkerServiceType:           "Consumes Events",
+	manifest.WorkerServiceType:           "Events to SQS to ECS on Fargate",
 }
 
 type initWkldVars struct {

--- a/internal/pkg/cli/svc_init.go
+++ b/internal/pkg/cli/svc_init.go
@@ -566,7 +566,7 @@ This command is also run as part of "copilot init".`,
 	cmd.Flags().StringVarP(&vars.dockerfilePath, dockerFileFlag, dockerFileFlagShort, "", dockerFileFlagDescription)
 	cmd.Flags().StringVarP(&vars.image, imageFlag, imageFlagShort, "", imageFlagDescription)
 	cmd.Flags().Uint16Var(&vars.port, svcPortFlag, 0, svcPortFlagDescription)
-	cmd.Flags().StringArrayVar(&vars.subscriptions, subscribeFlag, []string{}, subscribeFlagDescription)
+	cmd.Flags().StringArrayVar(&vars.subscriptions, subscribeTopicsFlag, []string{}, subscribeTopicsFlagDescription)
 	cmd.Flags().BoolVar(&vars.noSubscribe, noSubscriptionFlag, false, noSubscriptionFlagDescription)
 
 	return cmd

--- a/internal/pkg/cli/svc_init.go
+++ b/internal/pkg/cli/svc_init.go
@@ -470,7 +470,16 @@ func (o *initSvcOpts) askSvcPublishers() (err error) {
 	if err != nil {
 		return fmt.Errorf("select publisher: %w", err)
 	}
-	o.topics = &topics
+
+	subscriptions := make([]manifest.TopicSubscription, 0, len(topics))
+	for _, t := range topics {
+		subscriptions = append(subscriptions, manifest.TopicSubscription{
+			Name:    t.Name(),
+			Service: t.Workload(),
+		})
+	}
+	o.topics = &subscriptions
+
 	return nil
 }
 

--- a/internal/pkg/cli/svc_init.go
+++ b/internal/pkg/cli/svc_init.go
@@ -81,8 +81,8 @@ type initWkldVars struct {
 	name           string
 	dockerfilePath string
 	image          string
-	subscribeTags  []string
-	noSubscription bool
+	subscriptions  []string
+	noSubscribe    bool
 }
 
 type initSvcVars struct {
@@ -105,7 +105,7 @@ type initSvcOpts struct {
 	// Outputs stored on successful actions.
 	manifestPath string
 	platform     *string
-	topics       *[]manifest.TopicSubscription
+	topics       []manifest.TopicSubscription
 
 	// Cache variables
 	df dockerfileParser
@@ -198,7 +198,7 @@ func (o *initSvcOpts) Validate() error {
 			return err
 		}
 	}
-	if err := validateSubscribe(o.noSubscription, o.subscribeTags); err != nil {
+	if err := validateSubscribe(o.noSubscribe, o.subscriptions); err != nil {
 		return err
 	}
 	return nil
@@ -449,21 +449,21 @@ func (o *initSvcOpts) askSvcPublishers() (err error) {
 		return nil
 	}
 	// publishers already specified by flags
-	if len(o.subscribeTags) > 0 {
+	if len(o.subscriptions) > 0 {
 		var topicSubscriptions []manifest.TopicSubscription
-		for _, sub := range o.subscribeTags {
+		for _, sub := range o.subscriptions {
 			sub, err := subscriptionFromKey(sub)
 			if err != nil {
 				return err
 			}
 			topicSubscriptions = append(topicSubscriptions, sub)
 		}
-		o.topics = &topicSubscriptions
+		o.topics = topicSubscriptions
 		return nil
 	}
 
 	// if --no-subscriptions flag specified, no need to ask for publishers
-	if o.noSubscription {
+	if o.noSubscribe {
 		return nil
 	}
 
@@ -479,7 +479,7 @@ func (o *initSvcOpts) askSvcPublishers() (err error) {
 			Service: t.Workload(),
 		})
 	}
-	o.topics = &subscriptions
+	o.topics = subscriptions
 
 	return nil
 }
@@ -566,8 +566,8 @@ This command is also run as part of "copilot init".`,
 	cmd.Flags().StringVarP(&vars.dockerfilePath, dockerFileFlag, dockerFileFlagShort, "", dockerFileFlagDescription)
 	cmd.Flags().StringVarP(&vars.image, imageFlag, imageFlagShort, "", imageFlagDescription)
 	cmd.Flags().Uint16Var(&vars.port, svcPortFlag, 0, svcPortFlagDescription)
-	cmd.Flags().StringArrayVar(&vars.subscribeTags, subscribeFlag, []string{}, subscribeFlagDescription)
-	cmd.Flags().BoolVar(&vars.noSubscription, noSubscriptionFlag, false, noSubscriptionFlagDescription)
+	cmd.Flags().StringArrayVar(&vars.subscriptions, subscribeFlag, []string{}, subscribeFlagDescription)
+	cmd.Flags().BoolVar(&vars.noSubscribe, noSubscriptionFlag, false, noSubscriptionFlagDescription)
 
 	return cmd
 }

--- a/internal/pkg/cli/svc_init_test.go
+++ b/internal/pkg/cli/svc_init_test.go
@@ -66,12 +66,12 @@ func TestSvcInitOpts_Validate(t *testing.T) {
 			inAppName: "",
 			wantedErr: errNoAppInWorkspace,
 		},
-		"fail if both no subscriptions and subscriptions are set": {
+		"fail if both no-subscribe and subscribe are set": {
 			inAppName:         "phonetool",
 			inSvcName:         "service",
 			inSubscribeTags:   []string{"name:svc"},
 			inNoSubscriptions: true,
-			wantedErr:         errors.New("validate subscribe configuration: cannot specify --no-subscriptions and --subscribe options at once"),
+			wantedErr:         errors.New("validate subscribe configuration: cannot specify both --no-subscribe and --subscribe"),
 		},
 		"valid flags": {
 			inSvcName:        "frontend",
@@ -169,7 +169,7 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 					},
 					{
 						Value: manifest.WorkerServiceType,
-						Hint:  "Consumes Events",
+						Hint:  "Events to SQS to ECS on Fargate",
 					},
 				}), gomock.Any()).
 					Return(wantedSvcType, nil)

--- a/internal/pkg/cli/svc_init_test.go
+++ b/internal/pkg/cli/svc_init_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/aws/copilot-cli/internal/pkg/deploy"
 	"github.com/aws/copilot-cli/internal/pkg/docker/dockerengine"
 
 	"github.com/aws/copilot-cli/internal/pkg/term/prompt"
@@ -128,6 +129,7 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 		wantedSvcPort        = 80
 		wantedImage          = "mockImage"
 	)
+	mockTopic, _ := deploy.NewTopic("arn:aws:sns:us-west-2:123456789012:mockApp-mockEnv-mockWkld-orders", "mockApp", "mockEnv", "mockWkld")
 	testCases := map[string]struct {
 		inSvcType         string
 		inSvcName         string
@@ -524,12 +526,7 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 					gomock.Eq(svcInitPublisherPrompt),
 					gomock.Eq(svcInitPublisherHelpPrompt),
 					gomock.Any(),
-				).Return([]manifest.TopicSubscription{
-					{
-						Name:    "thetopic",
-						Service: "theservice",
-					},
-				}, nil)
+				).Return([]deploy.Topic{*mockTopic}, nil)
 			},
 			wantedErr: nil,
 		},

--- a/internal/pkg/cli/svc_init_test.go
+++ b/internal/pkg/cli/svc_init_test.go
@@ -23,14 +23,14 @@ import (
 
 func TestSvcInitOpts_Validate(t *testing.T) {
 	testCases := map[string]struct {
-		inSvcType         string
-		inSvcName         string
-		inDockerfilePath  string
-		inImage           string
-		inAppName         string
-		inSvcPort         uint16
-		inSubscribeTags   []string
-		inNoSubscriptions bool
+		inSvcType        string
+		inSvcName        string
+		inDockerfilePath string
+		inImage          string
+		inAppName        string
+		inSvcPort        uint16
+		inSubscribeTags  []string
+		inNoSubscribe    bool
 
 		mockFileSystem func(mockFS afero.Fs)
 		wantedErr      error
@@ -67,11 +67,11 @@ func TestSvcInitOpts_Validate(t *testing.T) {
 			wantedErr: errNoAppInWorkspace,
 		},
 		"fail if both no-subscribe and subscribe are set": {
-			inAppName:         "phonetool",
-			inSvcName:         "service",
-			inSubscribeTags:   []string{"name:svc"},
-			inNoSubscriptions: true,
-			wantedErr:         errors.New("validate subscribe configuration: cannot specify both --no-subscribe and --subscribe"),
+			inAppName:       "phonetool",
+			inSvcName:       "service",
+			inSubscribeTags: []string{"name:svc"},
+			inNoSubscribe:   true,
+			wantedErr:       errors.New("validate subscribe configuration: cannot specify both --no-subscribe and --subscribe"),
 		},
 		"valid flags": {
 			inSvcName:        "frontend",
@@ -97,8 +97,8 @@ func TestSvcInitOpts_Validate(t *testing.T) {
 						dockerfilePath: tc.inDockerfilePath,
 						image:          tc.inImage,
 						appName:        tc.inAppName,
-						subscribeTags:  tc.inSubscribeTags,
-						noSubscription: tc.inNoSubscriptions,
+						subscriptions:  tc.inSubscribeTags,
+						noSubscribe:    tc.inNoSubscribe,
 					},
 					port: tc.inSvcPort,
 				},
@@ -131,13 +131,13 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 	)
 	mockTopic, _ := deploy.NewTopic("arn:aws:sns:us-west-2:123456789012:mockApp-mockEnv-mockWkld-orders", "mockApp", "mockEnv", "mockWkld")
 	testCases := map[string]struct {
-		inSvcType         string
-		inSvcName         string
-		inDockerfilePath  string
-		inImage           string
-		inSvcPort         uint16
-		inSubscribeTags   []string
-		inNoSubscriptions bool
+		inSvcType        string
+		inSvcName        string
+		inDockerfilePath string
+		inImage          string
+		inSvcPort        uint16
+		inSubscribeTags  []string
+		inNoSubscribe    bool
 
 		mockPrompt       func(m *mocks.Mockprompter)
 		mockSel          func(m *mocks.MockdockerfileSelector)
@@ -482,11 +482,11 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 			mockDockerEngine: func(m *mocks.MockdockerEngine) {},
 		},
 		"skip selecting subscriptions if no-subscriptions flag is set": {
-			inSvcType:         "Worker Service",
-			inSvcName:         wantedSvcName,
-			inSvcPort:         wantedSvcPort,
-			inImage:           "mockImage",
-			inNoSubscriptions: true,
+			inSvcType:     "Worker Service",
+			inSvcName:     wantedSvcName,
+			inSvcPort:     wantedSvcPort,
+			inImage:       "mockImage",
+			inNoSubscribe: true,
 
 			mockPrompt:       func(m *mocks.Mockprompter) {},
 			mockSel:          func(m *mocks.MockdockerfileSelector) {},
@@ -496,12 +496,12 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 			wantedErr:        nil,
 		},
 		"skip selecting subscriptions if subscribe flag is set": {
-			inSvcType:         "Worker Service",
-			inSvcName:         wantedSvcName,
-			inSvcPort:         wantedSvcPort,
-			inImage:           "mockImage",
-			inNoSubscriptions: false,
-			inSubscribeTags:   []string{"svc:name"},
+			inSvcType:       "Worker Service",
+			inSvcName:       wantedSvcName,
+			inSvcPort:       wantedSvcPort,
+			inImage:         "mockImage",
+			inNoSubscribe:   false,
+			inSubscribeTags: []string{"svc:name"},
 
 			mockPrompt:       func(m *mocks.Mockprompter) {},
 			mockSel:          func(m *mocks.MockdockerfileSelector) {},
@@ -550,8 +550,8 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 						name:           tc.inSvcName,
 						image:          tc.inImage,
 						dockerfilePath: tc.inDockerfilePath,
-						noSubscription: tc.inNoSubscriptions,
-						subscribeTags:  tc.inSubscribeTags,
+						noSubscribe:    tc.inNoSubscribe,
+						subscriptions:  tc.inSubscribeTags,
 					},
 					port: tc.inSvcPort,
 				},

--- a/internal/pkg/cli/svc_init_test.go
+++ b/internal/pkg/cli/svc_init_test.go
@@ -71,7 +71,7 @@ func TestSvcInitOpts_Validate(t *testing.T) {
 			inSvcName:       "service",
 			inSubscribeTags: []string{"name:svc"},
 			inNoSubscribe:   true,
-			wantedErr:       errors.New("validate subscribe configuration: cannot specify both --no-subscribe and --subscribe"),
+			wantedErr:       errors.New("validate subscribe configuration: cannot specify both --no-subscribe and --subscribe-topics"),
 		},
 		"valid flags": {
 			inSvcName:        "frontend",

--- a/internal/pkg/cli/svc_init_test.go
+++ b/internal/pkg/cli/svc_init_test.go
@@ -22,12 +22,14 @@ import (
 
 func TestSvcInitOpts_Validate(t *testing.T) {
 	testCases := map[string]struct {
-		inSvcType        string
-		inSvcName        string
-		inDockerfilePath string
-		inImage          string
-		inAppName        string
-		inSvcPort        uint16
+		inSvcType         string
+		inSvcName         string
+		inDockerfilePath  string
+		inImage           string
+		inAppName         string
+		inSvcPort         uint16
+		inSubscribeTags   []string
+		inNoSubscriptions bool
 
 		mockFileSystem func(mockFS afero.Fs)
 		wantedErr      error
@@ -35,7 +37,7 @@ func TestSvcInitOpts_Validate(t *testing.T) {
 		"invalid service type": {
 			inAppName: "phonetool",
 			inSvcType: "TestSvcType",
-			wantedErr: errors.New(`invalid service type TestSvcType: must be one of "Request-Driven Web Service", "Load Balanced Web Service", "Backend Service"`),
+			wantedErr: errors.New(`invalid service type TestSvcType: must be one of "Request-Driven Web Service", "Load Balanced Web Service", "Backend Service", "Worker Service"`),
 		},
 		"invalid service name": {
 			inAppName: "phonetool",
@@ -63,6 +65,13 @@ func TestSvcInitOpts_Validate(t *testing.T) {
 			inAppName: "",
 			wantedErr: errNoAppInWorkspace,
 		},
+		"fail if both no subscriptions and subscriptions are set": {
+			inAppName:         "phonetool",
+			inSvcName:         "service",
+			inSubscribeTags:   []string{"name:svc"},
+			inNoSubscriptions: true,
+			wantedErr:         errors.New("validate subscribe configuration: cannot specify --no-subscriptions and --subscribe options at once"),
+		},
 		"valid flags": {
 			inSvcName:        "frontend",
 			inSvcType:        "Load Balanced Web Service",
@@ -87,6 +96,8 @@ func TestSvcInitOpts_Validate(t *testing.T) {
 						dockerfilePath: tc.inDockerfilePath,
 						image:          tc.inImage,
 						appName:        tc.inAppName,
+						subscribeTags:  tc.inSubscribeTags,
+						noSubscription: tc.inNoSubscriptions,
 					},
 					port: tc.inSvcPort,
 				},
@@ -118,14 +129,17 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 		wantedImage          = "mockImage"
 	)
 	testCases := map[string]struct {
-		inSvcType        string
-		inSvcName        string
-		inDockerfilePath string
-		inImage          string
-		inSvcPort        uint16
+		inSvcType         string
+		inSvcName         string
+		inDockerfilePath  string
+		inImage           string
+		inSvcPort         uint16
+		inSubscribeTags   []string
+		inNoSubscriptions bool
 
 		mockPrompt       func(m *mocks.Mockprompter)
 		mockSel          func(m *mocks.MockdockerfileSelector)
+		mocktopicSel     func(m *mocks.MocktopicSelector)
 		mockDockerfile   func(m *mocks.MockdockerfileParser)
 		mockDockerEngine func(m *mocks.MockdockerEngine)
 
@@ -151,11 +165,16 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 						Value: manifest.BackendServiceType,
 						Hint:  "ECS on Fargate",
 					},
+					{
+						Value: manifest.WorkerServiceType,
+						Hint:  "Consumes Events",
+					},
 				}), gomock.Any()).
 					Return(wantedSvcType, nil)
 			},
 			mockDockerfile:   func(m *mocks.MockdockerfileParser) {},
 			mockSel:          func(m *mocks.MockdockerfileSelector) {},
+			mocktopicSel:     func(m *mocks.MocktopicSelector) {},
 			mockDockerEngine: func(m *mocks.MockdockerEngine) {},
 			wantedErr:        nil,
 		},
@@ -171,6 +190,7 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 			},
 			mockDockerfile:   func(m *mocks.MockdockerfileParser) {},
 			mockSel:          func(m *mocks.MockdockerfileSelector) {},
+			mocktopicSel:     func(m *mocks.MocktopicSelector) {},
 			mockDockerEngine: func(m *mocks.MockdockerEngine) {},
 			wantedErr:        fmt.Errorf("select service type: some error"),
 		},
@@ -187,6 +207,7 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 			mockDockerfile: func(m *mocks.MockdockerfileParser) {
 			},
 			mockSel:          func(m *mocks.MockdockerfileSelector) {},
+			mocktopicSel:     func(m *mocks.MocktopicSelector) {},
 			mockDockerEngine: func(m *mocks.MockdockerEngine) {},
 			wantedErr:        nil,
 		},
@@ -203,6 +224,7 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 			mockDockerfile:   func(m *mocks.MockdockerfileParser) {},
 			mockSel:          func(m *mocks.MockdockerfileSelector) {},
 			mockDockerEngine: func(m *mocks.MockdockerEngine) {},
+			mocktopicSel:     func(m *mocks.MocktopicSelector) {},
 			wantedErr:        fmt.Errorf("get service name: some error"),
 		},
 		"skip selecting Dockerfile if image flag is set": {
@@ -214,6 +236,7 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 
 			mockPrompt:       func(m *mocks.Mockprompter) {},
 			mockSel:          func(m *mocks.MockdockerfileSelector) {},
+			mocktopicSel:     func(m *mocks.MocktopicSelector) {},
 			mockDockerfile:   func(m *mocks.MockdockerfileParser) {},
 			mockDockerEngine: func(m *mocks.MockdockerEngine) {},
 			wantedErr:        nil,
@@ -225,6 +248,7 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 
 			mockPrompt:     func(m *mocks.Mockprompter) {},
 			mockSel:        func(m *mocks.MockdockerfileSelector) {},
+			mocktopicSel:   func(m *mocks.MocktopicSelector) {},
 			mockDockerfile: func(m *mocks.MockdockerfileParser) {},
 			mockDockerEngine: func(m *mocks.MockdockerEngine) {
 				m.EXPECT().CheckDockerEngineRunning().Return(errors.New("some error"))
@@ -241,6 +265,7 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 					Return("mockImage", nil)
 			},
 			mockSel:        func(m *mocks.MockdockerfileSelector) {},
+			mocktopicSel:   func(m *mocks.MocktopicSelector) {},
 			mockDockerfile: func(m *mocks.MockdockerfileParser) {},
 			mockDockerEngine: func(m *mocks.MockdockerEngine) {
 				m.EXPECT().CheckDockerEngineRunning().Return(dockerengine.ErrDockerCommandNotFound)
@@ -257,6 +282,7 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 					Return("mockImage", nil)
 			},
 			mockSel:        func(m *mocks.MockdockerfileSelector) {},
+			mocktopicSel:   func(m *mocks.MocktopicSelector) {},
 			mockDockerfile: func(m *mocks.MockdockerfileParser) {},
 			mockDockerEngine: func(m *mocks.MockdockerEngine) {
 				m.EXPECT().CheckDockerEngineRunning().Return(&dockerengine.ErrDockerDaemonNotResponsive{})
@@ -282,6 +308,7 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 					gomock.Any(),
 				).Return("Use an existing image instead", nil)
 			},
+			mocktopicSel:   func(m *mocks.MocktopicSelector) {},
 			mockDockerfile: func(m *mocks.MockdockerfileParser) {},
 			mockDockerEngine: func(m *mocks.MockdockerEngine) {
 				m.EXPECT().CheckDockerEngineRunning().Return(nil)
@@ -308,6 +335,7 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 					gomock.Any(),
 				).Return("Use an existing image instead", nil)
 			},
+			mocktopicSel:   func(m *mocks.MocktopicSelector) {},
 			mockDockerfile: func(m *mocks.MockdockerfileParser) {},
 			mockDockerEngine: func(m *mocks.MockdockerEngine) {
 				m.EXPECT().CheckDockerEngineRunning().Return(nil)
@@ -329,6 +357,7 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 					gomock.Any(),
 				).Return("frontend/Dockerfile", nil)
 			},
+			mocktopicSel:   func(m *mocks.MocktopicSelector) {},
 			mockDockerfile: func(m *mocks.MockdockerfileParser) {},
 			mockDockerEngine: func(m *mocks.MockdockerEngine) {
 				m.EXPECT().CheckDockerEngineRunning().Return(nil)
@@ -346,6 +375,7 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return("", errors.New("some error"))
 			},
+			mocktopicSel:   func(m *mocks.MocktopicSelector) {},
 			mockPrompt:     func(m *mocks.Mockprompter) {},
 			mockDockerfile: func(m *mocks.MockdockerfileParser) {},
 			mockDockerEngine: func(m *mocks.MockdockerEngine) {
@@ -363,6 +393,7 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 				m.EXPECT().GetExposedPorts().Return([]uint16{}, errors.New("no expose"))
 			},
 			mockSel:          func(m *mocks.MockdockerfileSelector) {},
+			mocktopicSel:     func(m *mocks.MocktopicSelector) {},
 			mockDockerEngine: func(m *mocks.MockdockerEngine) {},
 			wantedErr:        nil,
 		},
@@ -380,6 +411,7 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 				m.EXPECT().GetExposedPorts().Return([]uint16{}, errors.New("no expose"))
 			},
 			mockSel:          func(m *mocks.MockdockerfileSelector) {},
+			mocktopicSel:     func(m *mocks.MocktopicSelector) {},
 			mockDockerEngine: func(m *mocks.MockdockerEngine) {},
 			wantedErr:        nil,
 		},
@@ -397,6 +429,7 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 				m.EXPECT().GetExposedPorts().Return([]uint16{}, errors.New("expose error"))
 			},
 			mockSel:          func(m *mocks.MockdockerfileSelector) {},
+			mocktopicSel:     func(m *mocks.MocktopicSelector) {},
 			mockDockerEngine: func(m *mocks.MockdockerEngine) {},
 			wantedErr:        fmt.Errorf("get port: some error"),
 		},
@@ -414,6 +447,7 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 				m.EXPECT().GetExposedPorts().Return([]uint16{}, errors.New("no expose"))
 			},
 			mockSel:          func(m *mocks.MockdockerfileSelector) {},
+			mocktopicSel:     func(m *mocks.MocktopicSelector) {},
 			mockDockerEngine: func(m *mocks.MockdockerEngine) {},
 			wantedErr:        fmt.Errorf("get port: some error"),
 		},
@@ -429,6 +463,7 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 				m.EXPECT().GetExposedPorts().Return([]uint16{80}, nil)
 			},
 			mockSel:          func(m *mocks.MockdockerfileSelector) {},
+			mocktopicSel:     func(m *mocks.MocktopicSelector) {},
 			mockDockerEngine: func(m *mocks.MockdockerEngine) {},
 		},
 		"don't use dockerfile port if flag specified": {
@@ -441,7 +476,62 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 			},
 			mockDockerfile:   func(m *mocks.MockdockerfileParser) {},
 			mockSel:          func(m *mocks.MockdockerfileSelector) {},
+			mocktopicSel:     func(m *mocks.MocktopicSelector) {},
 			mockDockerEngine: func(m *mocks.MockdockerEngine) {},
+		},
+		"skip selecting subscriptions if no-subscriptions flag is set": {
+			inSvcType:         "Worker Service",
+			inSvcName:         wantedSvcName,
+			inSvcPort:         wantedSvcPort,
+			inImage:           "mockImage",
+			inNoSubscriptions: true,
+
+			mockPrompt:       func(m *mocks.Mockprompter) {},
+			mockSel:          func(m *mocks.MockdockerfileSelector) {},
+			mockDockerfile:   func(m *mocks.MockdockerfileParser) {},
+			mockDockerEngine: func(m *mocks.MockdockerEngine) {},
+			mocktopicSel:     func(m *mocks.MocktopicSelector) {},
+			wantedErr:        nil,
+		},
+		"skip selecting subscriptions if subscribe flag is set": {
+			inSvcType:         "Worker Service",
+			inSvcName:         wantedSvcName,
+			inSvcPort:         wantedSvcPort,
+			inImage:           "mockImage",
+			inNoSubscriptions: false,
+			inSubscribeTags:   []string{"svc:name"},
+
+			mockPrompt:       func(m *mocks.Mockprompter) {},
+			mockSel:          func(m *mocks.MockdockerfileSelector) {},
+			mockDockerfile:   func(m *mocks.MockdockerfileParser) {},
+			mockDockerEngine: func(m *mocks.MockdockerEngine) {},
+			mocktopicSel:     func(m *mocks.MocktopicSelector) {},
+			wantedErr:        nil,
+		},
+		"select subscriptions": {
+			inSvcType:        "Worker Service",
+			inSvcName:        wantedSvcName,
+			inSvcPort:        wantedSvcPort,
+			inImage:          "mockImage",
+			inDockerfilePath: "",
+
+			mockPrompt:       func(m *mocks.Mockprompter) {},
+			mockSel:          func(m *mocks.MockdockerfileSelector) {},
+			mockDockerfile:   func(m *mocks.MockdockerfileParser) {},
+			mockDockerEngine: func(m *mocks.MockdockerEngine) {},
+			mocktopicSel: func(m *mocks.MocktopicSelector) {
+				m.EXPECT().Topics(
+					gomock.Eq(svcInitPublisherPrompt),
+					gomock.Eq(svcInitPublisherHelpPrompt),
+					gomock.Any(),
+				).Return([]manifest.TopicSubscription{
+					{
+						Name:    "thetopic",
+						Service: "theservice",
+					},
+				}, nil)
+			},
+			wantedErr: nil,
 		},
 	}
 
@@ -454,6 +544,7 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 			mockPrompt := mocks.NewMockprompter(ctrl)
 			mockDockerfile := mocks.NewMockdockerfileParser(ctrl)
 			mockSel := mocks.NewMockdockerfileSelector(ctrl)
+			mockTopicSel := mocks.NewMocktopicSelector(ctrl)
 			mockDockerEngine := mocks.NewMockdockerEngine(ctrl)
 			opts := &initSvcOpts{
 				initSvcVars: initSvcVars{
@@ -462,6 +553,8 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 						name:           tc.inSvcName,
 						image:          tc.inImage,
 						dockerfilePath: tc.inDockerfilePath,
+						noSubscription: tc.inNoSubscriptions,
+						subscribeTags:  tc.inSubscribeTags,
 					},
 					port: tc.inSvcPort,
 				},
@@ -472,9 +565,11 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 				df:           mockDockerfile,
 				prompt:       mockPrompt,
 				sel:          mockSel,
+				topicSel:     mockTopicSel,
 				dockerEngine: mockDockerEngine,
 			}
 			tc.mockSel(mockSel)
+			tc.mocktopicSel(mockTopicSel)
 			tc.mockPrompt(mockPrompt)
 			tc.mockDockerfile(mockDockerfile)
 			tc.mockDockerEngine(mockDockerEngine)
@@ -504,6 +599,7 @@ func TestSvcInitOpts_Execute(t *testing.T) {
 		mockSvcInit      func(m *mocks.MocksvcInitializer)
 		mockDockerfile   func(m *mocks.MockdockerfileParser)
 		mockDockerEngine func(m *mocks.MockdockerEngine)
+		mockTopicSel     func(m *mocks.MocktopicSelector)
 		inSvcPort        uint16
 		inSvcType        string
 		inSvcName        string
@@ -565,6 +661,44 @@ func TestSvcInitOpts_Execute(t *testing.T) {
 			},
 			mockDockerEngine: func(m *mocks.MockdockerEngine) {
 				m.EXPECT().RedirectPlatform("").Return(nil, nil)
+			},
+
+			wantedManifestPath: "manifest/path",
+		},
+		"Worker service": {
+			inAppName:        "sample",
+			inSvcName:        "frontend",
+			inDockerfilePath: "./Dockerfile",
+			inSvcType:        manifest.WorkerServiceType,
+
+			mockSvcInit: func(m *mocks.MocksvcInitializer) {
+				m.EXPECT().Service(&initialize.ServiceProps{
+					WorkloadProps: initialize.WorkloadProps{
+						App:            "sample",
+						Name:           "frontend",
+						Type:           "Worker Service",
+						DockerfilePath: "./Dockerfile",
+						Platform:       nil,
+					},
+				}).Return("manifest/path", nil)
+			},
+			mockDockerfile: func(m *mocks.MockdockerfileParser) {
+				m.EXPECT().GetHealthCheck().Return(nil, nil)
+			},
+			mockDockerEngine: func(m *mocks.MockdockerEngine) {
+				m.EXPECT().RedirectPlatform("").Return(nil, nil)
+			},
+			mockTopicSel: func(m *mocks.MocktopicSelector) {
+				m.EXPECT().Topics(
+					gomock.Eq(svcInitPublisherPrompt),
+					gomock.Eq(svcInitPublisherHelpPrompt),
+					gomock.Any(),
+				).Return([]manifest.TopicSubscription{
+					{
+						Name:    "thetopic",
+						Service: "theservice",
+					},
+				}, nil)
 			},
 
 			wantedManifestPath: "manifest/path",
@@ -646,6 +780,7 @@ func TestSvcInitOpts_Execute(t *testing.T) {
 			mockSvcInitializer := mocks.NewMocksvcInitializer(ctrl)
 			mockDockerfile := mocks.NewMockdockerfileParser(ctrl)
 			mockDockerEngine := mocks.NewMockdockerEngine(ctrl)
+			mockTopicSel := mocks.NewMocktopicSelector(ctrl)
 
 			if tc.mockSvcInit != nil {
 				tc.mockSvcInit(mockSvcInitializer)
@@ -673,6 +808,7 @@ func TestSvcInitOpts_Execute(t *testing.T) {
 				},
 				df:           mockDockerfile,
 				dockerEngine: mockDockerEngine,
+				topicSel:     mockTopicSel,
 			}
 
 			// WHEN

--- a/internal/pkg/cli/validate.go
+++ b/internal/pkg/cli/validate.go
@@ -669,7 +669,7 @@ func validateSubscriptionKey(val interface{}) error {
 	if !ok {
 		return errValueNotAString
 	}
-	sub, err := subscriptionFromKey(s)
+	sub, err := parseSerializedSubscription(s)
 	if err != nil {
 		return errSubscribeBadFormat
 	}

--- a/internal/pkg/cli/validate.go
+++ b/internal/pkg/cli/validate.go
@@ -63,7 +63,7 @@ var (
 
 	// Topic subscription errors.
 	errMissingPublishTopicField = errors.New("field `publish.topics[].name` cannot be empty")
-	errInvalidPubSubTopicName   = errors.New("topic names can only contain letters, numbers, underscores, and hypthens")
+	errInvalidPubSubTopicName   = errors.New("topic names can only contain letters, numbers, underscores, and hyphens")
 	errSubscribeBadFormat       = errors.New("value must be of the form <serviceName>:<topicName>")
 )
 
@@ -639,7 +639,7 @@ func validateLSIs(val interface{}) error {
 func validateSubscribe(noSubscription bool, subscribeTags []string) error {
 	// --no-subscriptions and --subscribe are mutually exclusive.
 	if noSubscription && len(subscribeTags) != 0 {
-		return fmt.Errorf("validate subscribe configuration: cannot specify --%s and --%s options at once", noSubscriptionFlag, subscribeFlag)
+		return fmt.Errorf("validate subscribe configuration: cannot specify both --%s and --%s", noSubscriptionFlag, subscribeFlag)
 	}
 	if len(subscribeTags) != 0 {
 		if err := validateSubscriptions(subscribeTags); err != nil {

--- a/internal/pkg/cli/validate.go
+++ b/internal/pkg/cli/validate.go
@@ -639,7 +639,7 @@ func validateLSIs(val interface{}) error {
 func validateSubscribe(noSubscription bool, subscribeTags []string) error {
 	// --no-subscriptions and --subscribe are mutually exclusive.
 	if noSubscription && len(subscribeTags) != 0 {
-		return fmt.Errorf("validate subscribe configuration: cannot specify both --%s and --%s", noSubscriptionFlag, subscribeFlag)
+		return fmt.Errorf("validate subscribe configuration: cannot specify both --%s and --%s", noSubscriptionFlag, subscribeTopicsFlag)
 	}
 	if len(subscribeTags) != 0 {
 		if err := validateSubscriptions(subscribeTags); err != nil {

--- a/internal/pkg/cli/validate_test.go
+++ b/internal/pkg/cli/validate_test.go
@@ -674,3 +674,112 @@ func TestValidateSecretName(t *testing.T) {
 		})
 	}
 }
+
+func Test_validatePubSubTopicName(t *testing.T) {
+	testCases := map[string]struct {
+		inName string
+
+		wantErr error
+	}{
+		"valid topic name": {
+			inName: "a-Perfectly_V4l1dString",
+		},
+		"error when no topic name": {
+			inName:  "",
+			wantErr: errMissingPublishTopicField,
+		},
+		"error when invalid topic name": {
+			inName:  "OHNO~/`...,",
+			wantErr: errInvalidPubSubTopicName,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			err := validatePubSubName(tc.inName)
+			if tc.wantErr == nil {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, tc.wantErr.Error())
+			}
+		})
+	}
+}
+
+func Test_validateSubscriptioKey(t *testing.T) {
+	testCases := map[string]struct {
+		inSub interface{}
+
+		wantErr error
+	}{
+		"valid subscription": {
+			inSub:   "svc:topic",
+			wantErr: nil,
+		},
+		"error when non string": {
+			inSub:   true,
+			wantErr: errValueNotAString,
+		},
+		"error when bad format": {
+			inSub:   "svctopic",
+			wantErr: errSubscribeBadFormat,
+		},
+		"error when bad publisher name": {
+			inSub:   "svc:@@@@@@@h",
+			wantErr: fmt.Errorf("invalid topic subscription topic name `@@@@@@@h`: %w", errInvalidPubSubTopicName),
+		},
+		"error when bad svc name": {
+			inSub:   "n#######:topic",
+			wantErr: fmt.Errorf("invalid topic subscription service name `n#######`: %w", errValueBadFormat),
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			err := validateSubscriptionKey(tc.inSub)
+			if tc.wantErr == nil {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, tc.wantErr.Error())
+			}
+		})
+	}
+}
+
+func Test_validateSubscribe(t *testing.T) {
+	testCases := map[string]struct {
+		inNoSubscriptions bool
+		inSubscribeTags   []string
+
+		wantErr error
+	}{
+		"valid subscription": {
+			inNoSubscriptions: false,
+			inSubscribeTags:   []string{"svc1:topic1", "svc2:topic2"},
+			wantErr:           nil,
+		},
+		"no error when no subscriptions": {
+			inNoSubscriptions: true,
+			inSubscribeTags:   nil,
+			wantErr:           nil,
+		},
+		"error when no-subscriptions and subscribe": {
+			inNoSubscriptions: true,
+			inSubscribeTags:   []string{"svc1:topic1", "svc2:topic2"},
+			wantErr:           errors.New("validate subscribe configuration: cannot specify --no-subscriptions and --subscribe options at once"),
+		},
+		"error when bad subscription tag": {
+			inNoSubscriptions: false,
+			inSubscribeTags:   []string{"svc:topic", "svc:@@@@@@@h"},
+			wantErr:           fmt.Errorf("invalid topic subscription topic name `@@@@@@@h`: %w", errInvalidPubSubTopicName),
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			err := validateSubscribe(tc.inNoSubscriptions, tc.inSubscribeTags)
+			if tc.wantErr == nil {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, tc.wantErr.Error())
+			}
+		})
+	}
+}

--- a/internal/pkg/cli/validate_test.go
+++ b/internal/pkg/cli/validate_test.go
@@ -764,7 +764,7 @@ func Test_validateSubscribe(t *testing.T) {
 		"error when no-subscriptions and subscribe": {
 			inNoSubscriptions: true,
 			inSubscribeTags:   []string{"svc1:topic1", "svc2:topic2"},
-			wantErr:           errors.New("validate subscribe configuration: cannot specify --no-subscriptions and --subscribe options at once"),
+			wantErr:           errors.New("validate subscribe configuration: cannot specify both --no-subscribe and --subscribe"),
 		},
 		"error when bad subscription tag": {
 			inNoSubscriptions: false,

--- a/internal/pkg/cli/validate_test.go
+++ b/internal/pkg/cli/validate_test.go
@@ -764,7 +764,7 @@ func Test_validateSubscribe(t *testing.T) {
 		"error when no-subscriptions and subscribe": {
 			inNoSubscriptions: true,
 			inSubscribeTags:   []string{"svc1:topic1", "svc2:topic2"},
-			wantErr:           errors.New("validate subscribe configuration: cannot specify both --no-subscribe and --subscribe"),
+			wantErr:           errors.New("validate subscribe configuration: cannot specify both --no-subscribe and --subscribe-topics"),
 		},
 		"error when bad subscription tag": {
 			inNoSubscriptions: false,

--- a/internal/pkg/deploy/sns.go
+++ b/internal/pkg/deploy/sns.go
@@ -73,6 +73,12 @@ func (t Topic) String() string {
 	return fmt.Sprintf(fmtTopicDescription, t.name, t.wkld)
 }
 
+// Workload returns the workload associated with the given topic.
+func (t Topic) Workload() string { return t.wkld }
+
+// Name returns the name of the given topic.
+func (t Topic) Name() string { return t.name }
+
 // validateAndExtractName determines whether the given ARN is a Copilot-valid SNS topic ARN.
 // It extracts the topic name from the ARN resource field.
 func (t *Topic) validateAndExtractName() error {

--- a/internal/pkg/initialize/workload.go
+++ b/internal/pkg/initialize/workload.go
@@ -67,6 +67,7 @@ type WorkloadProps struct {
 	DockerfilePath string
 	Image          string
 	Platform       *string
+	Topics         *[]manifest.TopicSubscription
 }
 
 // JobProps contains the information needed to represent a Job.
@@ -288,6 +289,8 @@ func (w *WorkloadInitializer) newServiceManifest(i *ServiceProps) (encoding.Bina
 		return w.newRequestDrivenWebServiceManifest(i), nil
 	case manifest.BackendServiceType:
 		return newBackendServiceManifest(i)
+	case manifest.WorkerServiceType:
+		return newWorkerServiceManifest(i)
 	default:
 		return nil, fmt.Errorf("service type %s doesn't have a manifest", i.Type)
 	}
@@ -340,6 +343,18 @@ func newBackendServiceManifest(i *ServiceProps) (*manifest.BackendService, error
 		},
 		Port:        i.Port,
 		HealthCheck: i.HealthCheck,
+	}), nil
+}
+
+func newWorkerServiceManifest(i *ServiceProps) (*manifest.WorkerService, error) {
+	return manifest.NewWorkerService(manifest.WorkerServiceProps{
+		WorkloadProps: manifest.WorkloadProps{
+			Name:       i.Name,
+			Dockerfile: i.DockerfilePath,
+			Image:      i.Image,
+		},
+		HealthCheck: i.HealthCheck,
+		Topics:      i.Topics,
 	}), nil
 }
 

--- a/internal/pkg/initialize/workload.go
+++ b/internal/pkg/initialize/workload.go
@@ -67,7 +67,7 @@ type WorkloadProps struct {
 	DockerfilePath string
 	Image          string
 	Platform       *string
-	Topics         *[]manifest.TopicSubscription
+	Topics         []manifest.TopicSubscription
 }
 
 // JobProps contains the information needed to represent a Job.
@@ -354,7 +354,7 @@ func newWorkerServiceManifest(i *ServiceProps) (*manifest.WorkerService, error) 
 			Image:      i.Image,
 		},
 		HealthCheck: i.HealthCheck,
-		Topics:      i.Topics,
+		Topics:      &i.Topics,
 	}), nil
 }
 

--- a/internal/pkg/initialize/workload_test.go
+++ b/internal/pkg/initialize/workload_test.go
@@ -444,7 +444,7 @@ func TestWorkloadInitializer_Service(t *testing.T) {
 		inAppName        string
 		inImage          string
 		inHealthCheck    *manifest.ContainerHealthCheck
-		inTopics         *[]manifest.TopicSubscription
+		inTopics         []manifest.TopicSubscription
 
 		mockWriter      func(m *mocks.MockWorkspace)
 		mockstore       func(m *mocks.MockStore)
@@ -721,7 +721,7 @@ func TestWorkloadInitializer_Service(t *testing.T) {
 			inSvcName:        "worker",
 			inDockerfilePath: "worker/Dockerfile",
 			inSvcPort:        80,
-			inTopics: &[]manifest.TopicSubscription{
+			inTopics: []manifest.TopicSubscription{
 				{
 					Name:    "theTopic",
 					Service: "publisher",

--- a/internal/pkg/manifest/svc.go
+++ b/internal/pkg/manifest/svc.go
@@ -30,6 +30,7 @@ var ServiceTypes = []string{
 	RequestDrivenWebServiceType,
 	LoadBalancedWebServiceType,
 	BackendServiceType,
+	WorkerServiceType,
 }
 
 // Range contains either a Range or a range configuration for Autoscaling ranges

--- a/internal/pkg/manifest/svc_test.go
+++ b/internal/pkg/manifest/svc_test.go
@@ -266,6 +266,88 @@ secrets:
 				require.Equal(t, wantedManifest, actualManifest)
 			},
 		},
+		"Worker Service": {
+			inContent: `
+name: dogcategorizer
+type: Worker Service
+image:
+  build: ./dogcategorizer/Dockerfile
+cpu: 1024
+memory: 1024
+exec: true     # Enable running commands in your container.
+count: 1
+
+subscribe:
+  queue:
+    delay: 15s
+    dead_letter:
+          tries: 5
+  topics:
+    - name: publisher1
+      service: testpubsvc
+    - name: publisher2
+      service: testpubjob
+      queue:
+        timeout: 15s`,
+			requireCorrectValues: func(t *testing.T, i interface{}) {
+				actualManifest, ok := i.(*WorkerService)
+				duration15Seconds := 15 * time.Second
+				require.True(t, ok)
+				wantedManifest := &WorkerService{
+					Workload: Workload{
+						Name: aws.String("dogcategorizer"),
+						Type: aws.String(WorkerServiceType),
+					},
+					WorkerServiceConfig: WorkerServiceConfig{
+						ImageConfig: ImageWithHealthcheck{
+							Image: Image{
+								Build: BuildArgsOrString{
+									BuildString: aws.String("./dogcategorizer/Dockerfile"),
+								},
+							},
+						},
+						TaskConfig: TaskConfig{
+							CPU:      aws.Int(1024),
+							Memory:   aws.Int(1024),
+							Platform: nil,
+							Count: Count{
+								Value: aws.Int(1),
+							},
+							ExecuteCommand: ExecuteCommand{
+								Enable: aws.Bool(true),
+							},
+						},
+						Network: &NetworkConfig{
+							VPC: &vpcConfig{
+								Placement: stringP("public"),
+							},
+						},
+						Subscribe: &SubscribeConfig{
+							Topics: &[]TopicSubscription{
+								{
+									Name:    "publisher1",
+									Service: "testpubsvc",
+								},
+								{
+									Name:    "publisher2",
+									Service: "testpubjob",
+									Queue: &SQSQueue{
+										Timeout: &duration15Seconds,
+									},
+								},
+							},
+							Queue: &SQSQueue{
+								Delay: &duration15Seconds,
+								DeadLetter: &DeadLetterQueue{
+									Tries: aws.Uint16(5),
+								},
+							},
+						},
+					},
+				}
+				require.Equal(t, wantedManifest, actualManifest)
+			},
+		},
 		"invalid svc type": {
 			inContent: `
 name: CowSvc

--- a/internal/pkg/term/selector/selector.go
+++ b/internal/pkg/term/selector/selector.go
@@ -7,6 +7,7 @@ package selector
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	awsecs "github.com/aws/copilot-cli/internal/pkg/aws/ecs"
@@ -62,15 +63,15 @@ For example: 0 17 ? * MON-FRI (5 pm on weekdays)
 
 // Final messages displayed after prompting.
 const (
-	appNameFinalMessage  = "Application:"
-	envNameFinalMessage  = "Environment:"
-	svcNameFinalMsg      = "Service name:"
-	jobNameFinalMsg      = "Job name:"
-	deployedSvcFinalMsg  = "Service:"
-	taskFinalMsg         = "Task:"
-	workloadFinalMsg     = "Name:"
-	dockerfileFinalMsg   = "Dockerfile:"
-	fmtTopicFinalmessage = "Environment %s subscriptions:"
+	appNameFinalMessage = "Application:"
+	envNameFinalMessage = "Environment:"
+	svcNameFinalMsg     = "Service name:"
+	jobNameFinalMsg     = "Job name:"
+	deployedSvcFinalMsg = "Service:"
+	taskFinalMsg        = "Task:"
+	workloadFinalMsg    = "Name:"
+	dockerfileFinalMsg  = "Dockerfile:"
+	topicFinalmessage   = "Topic subscriptions:"
 )
 
 var scheduleTypes = []string{
@@ -1022,38 +1023,80 @@ func filterDeployedServices(filter DeployedServiceFilter, inServices []*Deployed
 	return outServices, nil
 }
 
-// Topics asks the user to select from all Copilot-managed SNS topics and returns the ARNs
-// of those topics.
-func (s *DeploySelect) Topics(promptMsg, help, app, env string) ([]string, error) {
-	topics, err := s.deployStoreSvc.ListSNSTopics(app, env)
+// Topics asks the user to select from all Copilot-managed SNS topics *which are deployed
+// across all environments* and returns the topic structs.
+func (s *DeploySelect) Topics(promptMsg, help, app string) ([]deploy.Topic, error) {
+	envs, err := s.config.ListEnvironments(app)
 	if err != nil {
-		return nil, fmt.Errorf("list SNS topics: %w", err)
+		return nil, fmt.Errorf("list environments: %w", err)
 	}
-	if len(topics) == 0 {
+	if len(envs) == 0 {
+		log.Infoln("No environments are currently deployed. Skipping subscription selection.")
 		return nil, nil
 	}
-	// Create the list of options and the map from option to full topic specification.
-	var topicDescriptions []string
-	topicMap := make(map[string]deploy.Topic)
-	for _, t := range topics {
-		topicDescriptions = append(topicDescriptions, t.String())
-		topicMap[t.String()] = t
+
+	envTopics := make(map[string][]deploy.Topic, len(envs))
+	for _, env := range envs {
+		topics, err := s.deployStoreSvc.ListSNSTopics(app, env.Name)
+		if err != nil {
+			return nil, fmt.Errorf("list SNS topics: %w", err)
+		}
+		envTopics[env.Name] = topics
 	}
+
+	// Get only topics deployed in all environments.
+	// Computes the intersection of the `envTopics` lists.
+	overallTopics := make(map[string]deploy.Topic)
+	// Initialize the list of topics.
+	for _, topic := range envTopics[envs[0].Name] {
+		overallTopics[topic.String()] = topic
+	}
+	// Then do the pairwise intersection of all other envs.
+	for _, env := range envs[1:] {
+		topics := envTopics[env.Name]
+		overallTopics = intersect(overallTopics, topics)
+	}
+
+	if len(overallTopics) == 0 {
+		log.Infoln("No SNS topics are currently deployed in all environments. You can customize subscriptions in your manifest.")
+		return nil, nil
+	}
+	// Create the list of options.
+	var topicDescriptions []string
+	for t := range overallTopics {
+		topicDescriptions = append(topicDescriptions, t)
+	}
+	// Sort descriptions by ARN, which implies sorting by workload name and then by topic name due to
+	// behavior of `intersect`. That is, the `overallTopics` map is guaranteed to contain topics
+	// referencing the same environment.
+	sort.Slice(topicDescriptions, func(i, j int) bool {
+		return overallTopics[topicDescriptions[i]].ARN() < overallTopics[topicDescriptions[j]].ARN()
+	})
 
 	selectedTopics, err := s.prompt.MultiSelect(
 		promptMsg,
 		help,
 		topicDescriptions,
-		prompt.WithFinalMessage(fmt.Sprintf(fmtTopicFinalmessage, env)),
+		prompt.WithFinalMessage(topicFinalmessage),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("select SNS topics: %w", err)
 	}
 
-	// Get the ARNs from the topic descriptions again.
-	var topicARNs []string
+	// Get the topics from the topic descriptions again.
+	var topics []deploy.Topic
 	for _, t := range selectedTopics {
-		topicARNs = append(topicARNs, topicMap[t].ARN())
+		topics = append(topics, overallTopics[t])
 	}
-	return topicARNs, nil
+	return topics, nil
+}
+
+func intersect(firstMap map[string]deploy.Topic, secondArr []deploy.Topic) map[string]deploy.Topic {
+	out := make(map[string]deploy.Topic)
+	for _, topic := range secondArr {
+		if _, ok := firstMap[topic.String()]; ok {
+			out[topic.String()] = topic
+		}
+	}
+	return out
 }

--- a/internal/pkg/term/selector/selector.go
+++ b/internal/pkg/term/selector/selector.go
@@ -1050,7 +1050,7 @@ func (s *DeploySelect) Topics(promptMsg, help, app, env string) ([]string, error
 		return nil, fmt.Errorf("select SNS topics: %w", err)
 	}
 
-	// Get the ARNs from the topic slugs again.
+	// Get the ARNs from the topic descriptions again.
 	var topicARNs []string
 	for _, t := range selectedTopics {
 		topicARNs = append(topicARNs, topicMap[t].ARN())


### PR DESCRIPTION
<!-- Provide summary of changes -->
Subsumes #2704. 

Also refactors SNS selector to a single prompt, where we only ask the customer to select topics that are deployed across all existing environments.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
