### PR TITLE
chore: add pointer to map to volume to take advantage of mergo's merge logic

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/transformers.go
+++ b/internal/pkg/deploy/cloudformation/stack/transformers.go
@@ -441,7 +441,7 @@ func convertMountPoint(sourceVolume, containerPath *string, readOnly *bool) *tem
 	}
 }
 
-func convertMountPoints(input map[string]manifest.Volume) ([]*template.MountPoint, error) {
+func convertMountPoints(input map[string]*manifest.Volume) ([]*template.MountPoint, error) {
 	if len(input) == 0 {
 		return nil, nil
 	}
@@ -452,7 +452,7 @@ func convertMountPoints(input map[string]manifest.Volume) ([]*template.MountPoin
 	return output, nil
 }
 
-func convertEFSPermissions(input map[string]manifest.Volume) ([]*template.EFSPermission, error) {
+func convertEFSPermissions(input map[string]*manifest.Volume) ([]*template.EFSPermission, error) {
 	var output []*template.EFSPermission
 	for _, volume := range input {
 		// If there's no EFS configuration, we don't need to generate any permissions.
@@ -486,7 +486,7 @@ func convertEFSPermissions(input map[string]manifest.Volume) ([]*template.EFSPer
 	return output, nil
 }
 
-func convertManagedFSInfo(wlName *string, input map[string]manifest.Volume) (*template.ManagedVolumeCreationInfo, error) {
+func convertManagedFSInfo(wlName *string, input map[string]*manifest.Volume) (*template.ManagedVolumeCreationInfo, error) {
 	var output *template.ManagedVolumeCreationInfo
 	for name, volume := range input {
 		if volume.EmptyVolume() {
@@ -525,7 +525,7 @@ func getRandomUIDGID(name *string) uint32 {
 	return crc32.ChecksumIEEE([]byte(aws.StringValue(name)))
 }
 
-func convertVolumes(input map[string]manifest.Volume) ([]*template.Volume, error) {
+func convertVolumes(input map[string]*manifest.Volume) ([]*template.Volume, error) {
 	var output []*template.Volume
 	for name, volume := range input {
 		// Volumes can contain either:

--- a/internal/pkg/deploy/cloudformation/stack/transformers_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/transformers_test.go
@@ -735,13 +735,13 @@ func Test_convertHTTPHealthCheck(t *testing.T) {
 
 func Test_convertManagedFSInfo(t *testing.T) {
 	testCases := map[string]struct {
-		inVolumes         map[string]manifest.Volume
+		inVolumes         map[string]*manifest.Volume
 		wantManagedConfig *template.ManagedVolumeCreationInfo
 		wantVolumes       map[string]manifest.Volume
 		wantErr           string
 	}{
 		"no managed config": {
-			inVolumes: map[string]manifest.Volume{
+			inVolumes: map[string]*manifest.Volume{
 				"wordpress": {
 					EFS: &manifest.EFSConfigOrBool{
 						Advanced: manifest.EFSVolumeConfiguration{
@@ -768,7 +768,7 @@ func Test_convertManagedFSInfo(t *testing.T) {
 			},
 		},
 		"with managed config": {
-			inVolumes: map[string]manifest.Volume{
+			inVolumes: map[string]*manifest.Volume{
 				"wordpress": {
 					EFS: &manifest.EFSConfigOrBool{
 						Enabled: aws.Bool(true),
@@ -787,7 +787,7 @@ func Test_convertManagedFSInfo(t *testing.T) {
 			wantVolumes: map[string]manifest.Volume{},
 		},
 		"with custom UID": {
-			inVolumes: map[string]manifest.Volume{
+			inVolumes: map[string]*manifest.Volume{
 				"wordpress": {
 					EFS: &manifest.EFSConfigOrBool{
 						Advanced: manifest.EFSVolumeConfiguration{
@@ -826,13 +826,13 @@ func Test_convertManagedFSInfo(t *testing.T) {
 }
 func Test_convertStorageOpts(t *testing.T) {
 	testCases := map[string]struct {
-		inVolumes   map[string]manifest.Volume
+		inVolumes   map[string]*manifest.Volume
 		inEphemeral *int
 		wantOpts    template.StorageOpts
 		wantErr     string
 	}{
 		"minimal configuration": {
-			inVolumes: map[string]manifest.Volume{
+			inVolumes: map[string]*manifest.Volume{
 				"wordpress": {
 					EFS: &manifest.EFSConfigOrBool{
 						Advanced: manifest.EFSVolumeConfiguration{
@@ -871,7 +871,7 @@ func Test_convertStorageOpts(t *testing.T) {
 			},
 		},
 		"empty volume for shareable storage between sidecar and main container": {
-			inVolumes: map[string]manifest.Volume{
+			inVolumes: map[string]*manifest.Volume{
 				"scratch": {
 					MountPointOpts: manifest.MountPointOpts{
 						ContainerPath: aws.String("/var/scratch"),
@@ -897,7 +897,7 @@ func Test_convertStorageOpts(t *testing.T) {
 			},
 		},
 		"container path not specified": {
-			inVolumes: map[string]manifest.Volume{
+			inVolumes: map[string]*manifest.Volume{
 				"wordpress": {
 					EFS: &manifest.EFSConfigOrBool{
 						Advanced: manifest.EFSVolumeConfiguration{
@@ -909,7 +909,7 @@ func Test_convertStorageOpts(t *testing.T) {
 			wantErr: fmt.Sprintf("validate container configuration for volume wordpress: %s", errNoContainerPath.Error()),
 		},
 		"full specification with access point renders correctly": {
-			inVolumes: map[string]manifest.Volume{
+			inVolumes: map[string]*manifest.Volume{
 				"wordpress": {
 					EFS: &manifest.EFSConfigOrBool{
 						Advanced: manifest.EFSVolumeConfiguration{
@@ -956,7 +956,7 @@ func Test_convertStorageOpts(t *testing.T) {
 			},
 		},
 		"full specification without access point renders correctly": {
-			inVolumes: map[string]manifest.Volume{
+			inVolumes: map[string]*manifest.Volume{
 				"wordpress": {
 					EFS: &manifest.EFSConfigOrBool{
 						Advanced: manifest.EFSVolumeConfiguration{
@@ -1000,7 +1000,7 @@ func Test_convertStorageOpts(t *testing.T) {
 			},
 		},
 		"managed EFS": {
-			inVolumes: map[string]manifest.Volume{
+			inVolumes: map[string]*manifest.Volume{
 				"efs": {
 					EFS: &manifest.EFSConfigOrBool{
 						Enabled: aws.Bool(true),
@@ -1028,7 +1028,7 @@ func Test_convertStorageOpts(t *testing.T) {
 			},
 		},
 		"managed EFS with config": {
-			inVolumes: map[string]manifest.Volume{
+			inVolumes: map[string]*manifest.Volume{
 				"efs": {
 					EFS: &manifest.EFSConfigOrBool{
 						Advanced: manifest.EFSVolumeConfiguration{
@@ -1059,7 +1059,7 @@ func Test_convertStorageOpts(t *testing.T) {
 			},
 		},
 		"error when multiple managed volumes specified": {
-			inVolumes: map[string]manifest.Volume{
+			inVolumes: map[string]*manifest.Volume{
 				"efs": {
 					EFS: &manifest.EFSConfigOrBool{
 						Enabled: aws.Bool(true),
@@ -1081,7 +1081,7 @@ func Test_convertStorageOpts(t *testing.T) {
 			wantErr: "cannot specify more than one managed volume per service",
 		},
 		"managed EFS and BYO": {
-			inVolumes: map[string]manifest.Volume{
+			inVolumes: map[string]*manifest.Volume{
 				"efs": {
 					EFS: &manifest.EFSConfigOrBool{
 						Enabled: aws.Bool(true),
@@ -1156,7 +1156,7 @@ func Test_convertStorageOpts(t *testing.T) {
 			},
 		},
 		"efs specified with just ID": {
-			inVolumes: map[string]manifest.Volume{
+			inVolumes: map[string]*manifest.Volume{
 				"wordpress": {
 					EFS: &manifest.EFSConfigOrBool{
 						Advanced: manifest.EFSVolumeConfiguration{

--- a/internal/pkg/deploy/cloudformation/stack/validate.go
+++ b/internal/pkg/deploy/cloudformation/stack/validate.go
@@ -93,9 +93,12 @@ func validateStorageConfig(in *manifest.Storage) error {
 	return validateVolumes(in.Volumes)
 }
 
-func validateVolumes(in map[string]manifest.Volume) error {
+func validateVolumes(in map[string]*manifest.Volume) error {
 	for name, v := range in {
-		if err := validateVolume(name, v); err != nil {
+		if v == nil {
+			return fmt.Errorf("validate configuration for volume %s: configuration cannot be empty", name)
+		}
+		if err := validateVolume(name, *v); err != nil {
 			return err
 		}
 	}

--- a/internal/pkg/manifest/applyenv_test.go
+++ b/internal/pkg/manifest/applyenv_test.go
@@ -41,10 +41,7 @@ Expected Behaviors:
 
 func TestEnsureTransformersOrder(t *testing.T) {
 	t.Run("ensure we transform volumes first", func(t *testing.T) {
-		_, ok := defaultTransformers[0].(mapToVolumeTransformer)
-		require.True(t, ok, "mapToVolumeTransformer need has to be the first transformer. Otherwise `mergo` will overwrite the `dst` map completely and we will lose `dst`'s values.")
-
-		_, ok = defaultTransformers[1].(basicTransformer)
+		_, ok := defaultTransformers[0].(basicTransformer)
 		require.True(t, ok, "basicTransformer needs to used before the rest of the custom transformers, because the other transformers do not merge anything - they just unset the fields that do not get specified in source manifest.")
 	})
 }

--- a/internal/pkg/manifest/lb_web_svc_test.go
+++ b/internal/pkg/manifest/lb_web_svc_test.go
@@ -227,7 +227,7 @@ func TestLoadBalancedWebService_ApplyEnv(t *testing.T) {
 							Value: aws.Int(1),
 						},
 						Storage: &Storage{
-							Volumes: map[string]Volume{
+							Volumes: map[string]*Volume{
 								"myEFSVolume": {
 									MountPointOpts: MountPointOpts{
 										ContainerPath: aws.String("/path/to/files"),
@@ -277,7 +277,7 @@ func TestLoadBalancedWebService_ApplyEnv(t *testing.T) {
 							Value: aws.Int(1),
 						},
 						Storage: &Storage{
-							Volumes: map[string]Volume{
+							Volumes: map[string]*Volume{
 								"myEFSVolume": {
 									MountPointOpts: MountPointOpts{
 										ContainerPath: aws.String("/path/to/files"),
@@ -335,7 +335,7 @@ func TestLoadBalancedWebService_ApplyEnv(t *testing.T) {
 							"TWILIO_TOKEN": "1111",
 						},
 						Storage: &Storage{
-							Volumes: map[string]Volume{
+							Volumes: map[string]*Volume{
 								"myEFSVolume": {
 									MountPointOpts: MountPointOpts{
 										ContainerPath: aws.String("/path/to/files"),
@@ -397,7 +397,7 @@ func TestLoadBalancedWebService_ApplyEnv(t *testing.T) {
 								"DDB_TABLE_NAME": "awards-prod",
 							},
 							Storage: &Storage{
-								Volumes: map[string]Volume{
+								Volumes: map[string]*Volume{
 									"myEFSVolume": {
 										EFS: &EFSConfigOrBool{
 											Advanced: EFSVolumeConfiguration{
@@ -480,7 +480,7 @@ func TestLoadBalancedWebService_ApplyEnv(t *testing.T) {
 							"TWILIO_TOKEN": "1111",
 						},
 						Storage: &Storage{
-							Volumes: map[string]Volume{
+							Volumes: map[string]*Volume{
 								"myEFSVolume": {
 									MountPointOpts: MountPointOpts{
 										ContainerPath: aws.String("/path/to/files"),

--- a/internal/pkg/manifest/storage.go
+++ b/internal/pkg/manifest/storage.go
@@ -17,8 +17,8 @@ var (
 
 // Storage represents the options for external and native storage.
 type Storage struct {
-	Ephemeral *int              `yaml:"ephemeral"`
-	Volumes   map[string]Volume `yaml:"volumes"`
+	Ephemeral *int               `yaml:"ephemeral"`
+	Volumes   map[string]*Volume `yaml:"volumes"`
 }
 
 // Volume is an abstraction which merges the MountPoint and Volumes concepts from the ECS Task Definition

--- a/internal/pkg/manifest/storage_applyenv_test.go
+++ b/internal/pkg/manifest/storage_applyenv_test.go
@@ -61,7 +61,7 @@ func Test_ApplyEnv_Storage(t *testing.T) {
 		"FIXED_BUG: volumes overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							MountPointOpts: MountPointOpts{
 								ReadOnly: aws.Bool(true),
@@ -75,7 +75,7 @@ func Test_ApplyEnv_Storage(t *testing.T) {
 					},
 				}
 				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Enabled: aws.Bool(true),
@@ -91,7 +91,7 @@ func Test_ApplyEnv_Storage(t *testing.T) {
 			},
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Enabled: aws.Bool(true),
@@ -117,7 +117,7 @@ func Test_ApplyEnv_Storage(t *testing.T) {
 		"volumes not overridden by empty map": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							MountPointOpts: MountPointOpts{
 								ReadOnly: aws.Bool(true),
@@ -131,12 +131,12 @@ func Test_ApplyEnv_Storage(t *testing.T) {
 					},
 				}
 				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{},
+					Volumes: map[string]*Volume{},
 				}
 			},
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							MountPointOpts: MountPointOpts{
 								ReadOnly: aws.Bool(true),
@@ -154,7 +154,7 @@ func Test_ApplyEnv_Storage(t *testing.T) {
 		"volumes not overridden by nil": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							MountPointOpts: MountPointOpts{
 								ReadOnly: aws.Bool(true),
@@ -171,7 +171,7 @@ func Test_ApplyEnv_Storage(t *testing.T) {
 			},
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							MountPointOpts: MountPointOpts{
 								ReadOnly: aws.Bool(true),
@@ -213,7 +213,7 @@ func Test_ApplyEnv_Storage_Volume(t *testing.T) {
 		"FAILED_AFTER_TRANSFORM_POINTER: path overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							MountPointOpts: MountPointOpts{
 								ContainerPath: aws.String("mockPath"),
@@ -222,7 +222,7 @@ func Test_ApplyEnv_Storage_Volume(t *testing.T) {
 					},
 				}
 				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							MountPointOpts: MountPointOpts{
 								ContainerPath: aws.String("mockPathTest"),
@@ -233,7 +233,7 @@ func Test_ApplyEnv_Storage_Volume(t *testing.T) {
 			},
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							MountPointOpts: MountPointOpts{
 								ContainerPath: aws.String("mockPathTest"),
@@ -246,7 +246,7 @@ func Test_ApplyEnv_Storage_Volume(t *testing.T) {
 		"FAILED_AFTER_TRANSFORM_POINTER： path explicitly overridden by zero value": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							MountPointOpts: MountPointOpts{
 								ContainerPath: aws.String("mockPath"),
@@ -255,7 +255,7 @@ func Test_ApplyEnv_Storage_Volume(t *testing.T) {
 					},
 				}
 				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							MountPointOpts: MountPointOpts{
 								ContainerPath: aws.String(""),
@@ -266,7 +266,7 @@ func Test_ApplyEnv_Storage_Volume(t *testing.T) {
 			},
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							MountPointOpts: MountPointOpts{
 								ContainerPath: aws.String(""),
@@ -279,7 +279,7 @@ func Test_ApplyEnv_Storage_Volume(t *testing.T) {
 		"FAILED_AFTER_UPGRADE: path not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							MountPointOpts: MountPointOpts{
 								ContainerPath: aws.String("mockPath"),
@@ -288,7 +288,7 @@ func Test_ApplyEnv_Storage_Volume(t *testing.T) {
 					},
 				}
 				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							MountPointOpts: MountPointOpts{},
 						},
@@ -297,7 +297,7 @@ func Test_ApplyEnv_Storage_Volume(t *testing.T) {
 			},
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							MountPointOpts: MountPointOpts{
 								ContainerPath: aws.String("mockPath"),
@@ -310,7 +310,7 @@ func Test_ApplyEnv_Storage_Volume(t *testing.T) {
 		"read_only overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							MountPointOpts: MountPointOpts{
 								ReadOnly: aws.Bool(false),
@@ -319,7 +319,7 @@ func Test_ApplyEnv_Storage_Volume(t *testing.T) {
 					},
 				}
 				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							MountPointOpts: MountPointOpts{
 								ReadOnly: aws.Bool(true),
@@ -330,7 +330,7 @@ func Test_ApplyEnv_Storage_Volume(t *testing.T) {
 			},
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							MountPointOpts: MountPointOpts{
 								ReadOnly: aws.Bool(true),
@@ -343,7 +343,7 @@ func Test_ApplyEnv_Storage_Volume(t *testing.T) {
 		"read_only explicitly overridden by empty value": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							MountPointOpts: MountPointOpts{
 								ReadOnly: aws.Bool(true),
@@ -352,7 +352,7 @@ func Test_ApplyEnv_Storage_Volume(t *testing.T) {
 					},
 				}
 				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							MountPointOpts: MountPointOpts{
 								ReadOnly: aws.Bool(false),
@@ -363,7 +363,7 @@ func Test_ApplyEnv_Storage_Volume(t *testing.T) {
 			},
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							MountPointOpts: MountPointOpts{
 								ReadOnly: aws.Bool(false),
@@ -376,7 +376,7 @@ func Test_ApplyEnv_Storage_Volume(t *testing.T) {
 		"FAILED_AFTER_UPGRADE: read_only not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							MountPointOpts: MountPointOpts{
 								ReadOnly: aws.Bool(false),
@@ -385,7 +385,7 @@ func Test_ApplyEnv_Storage_Volume(t *testing.T) {
 					},
 				}
 				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							MountPointOpts: MountPointOpts{},
 						},
@@ -394,7 +394,7 @@ func Test_ApplyEnv_Storage_Volume(t *testing.T) {
 			},
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							MountPointOpts: MountPointOpts{
 								ReadOnly: aws.Bool(false),
@@ -407,7 +407,7 @@ func Test_ApplyEnv_Storage_Volume(t *testing.T) {
 		"efs overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -418,7 +418,7 @@ func Test_ApplyEnv_Storage_Volume(t *testing.T) {
 					},
 				}
 				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -432,7 +432,7 @@ func Test_ApplyEnv_Storage_Volume(t *testing.T) {
 			},
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -448,7 +448,7 @@ func Test_ApplyEnv_Storage_Volume(t *testing.T) {
 		"FAILED_AFTER_UPGRADE: efs not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -459,14 +459,14 @@ func Test_ApplyEnv_Storage_Volume(t *testing.T) {
 					},
 				}
 				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {},
 					},
 				}
 			},
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -505,7 +505,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 		"FIXED_BUG: composite fields: efs bool is overridden if efs config is not nil": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Enabled: aws.Bool(true),
@@ -514,7 +514,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 					},
 				}
 				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -528,7 +528,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 			},
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Enabled: nil,
@@ -545,7 +545,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 		"FIXED_BUG: composite fields: efs config is overridden if efs bool is not nil": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -557,7 +557,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 					},
 				}
 				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Enabled: aws.Bool(true),
@@ -568,7 +568,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 			},
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Enabled:  aws.Bool(true),
@@ -582,7 +582,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 		"efs bool overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Enabled: aws.Bool(false),
@@ -591,7 +591,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 					},
 				}
 				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Enabled: aws.Bool(true),
@@ -602,7 +602,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 			},
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Enabled: aws.Bool(true),
@@ -615,7 +615,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 		"efs bool explicitly overridden by zero value": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Enabled: aws.Bool(true),
@@ -624,7 +624,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 					},
 				}
 				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Enabled: aws.Bool(false),
@@ -635,7 +635,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 			},
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Enabled: aws.Bool(false),
@@ -648,7 +648,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 		"FAILED_AFTER_UPGRADE: efs bool not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Enabled: aws.Bool(true),
@@ -657,14 +657,14 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 					},
 				}
 				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {},
 					},
 				}
 			},
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Enabled: aws.Bool(true),
@@ -677,7 +677,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 		"efs config overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -688,7 +688,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 					},
 				}
 				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -702,7 +702,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 			},
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -718,7 +718,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 		"FAILED_AFTER_UPGRADE: efs config not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -729,14 +729,14 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 					},
 				}
 				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {},
 					},
 				}
 			},
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -751,7 +751,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 		"FIXED_BUG: exclusive fields: id overridden if uid is not nil": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -762,7 +762,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 					},
 				}
 				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -775,7 +775,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 			},
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -791,7 +791,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 		"FIXED_BUG: exclusive fields: uid overridden if id is not nil": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -802,7 +802,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 					},
 				}
 				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -815,7 +815,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 			},
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -831,7 +831,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 		"FIXED_BUG: exclusive fields: root_dir overridden if uid is not nil": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -842,7 +842,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 					},
 				}
 				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -855,7 +855,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 			},
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -871,7 +871,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 		"FIXED_BUG: exclusive fields: udi overridden if root_dir is not nil": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -882,7 +882,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 					},
 				}
 				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -895,7 +895,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 			},
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -911,7 +911,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 		"FIXED_BUG: exclusive fields: auth overridden if uid is not nil": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -925,7 +925,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 					},
 				}
 				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -938,7 +938,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 			},
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -954,7 +954,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 		"FIXED_BUG: exclusive fields: udi overridden if auth is not nil": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -965,7 +965,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 					},
 				}
 				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -981,7 +981,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 			},
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1000,7 +1000,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 		"FIXED_BUG: exclusive fields: id overridden if gid is not nil": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1011,7 +1011,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 					},
 				}
 				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1024,7 +1024,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 			},
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1040,7 +1040,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 		"FIXED_BUG: exclusive fields: gid overridden if id is not nil": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1051,7 +1051,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 					},
 				}
 				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1064,7 +1064,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 			},
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1080,7 +1080,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 		"FIXED_BUG exclusive fields: root_dir overridden if gid is not nil": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1091,7 +1091,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 					},
 				}
 				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1104,7 +1104,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 			},
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1120,7 +1120,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 		"FIXED_BUG: exclusive fields: gid overridden if root_dir is not nil": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1131,7 +1131,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 					},
 				}
 				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1144,7 +1144,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 			},
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1160,7 +1160,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 		"FIXED_BUG: exclusive fields: auth overridden if gid is not nil": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1174,7 +1174,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 					},
 				}
 				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1187,7 +1187,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 			},
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1203,7 +1203,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 		"FIXED_BUG: exclusive fields: gid overridden if auth is not nil": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1214,7 +1214,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 					},
 				}
 				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1230,7 +1230,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 			},
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1249,7 +1249,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 		"id overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1260,7 +1260,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 					},
 				}
 				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1273,7 +1273,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 			},
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1288,7 +1288,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 		"id explicitly overridden by zero value": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1299,7 +1299,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 					},
 				}
 				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1312,7 +1312,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 			},
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1327,7 +1327,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 		"FAILED_AFTER_UPGRADE: id not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1338,7 +1338,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 					},
 				}
 				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{},
@@ -1349,7 +1349,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 			},
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1364,7 +1364,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 		"root_dir overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1375,7 +1375,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 					},
 				}
 				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1388,7 +1388,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 			},
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1403,7 +1403,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 		"root_dir explicitly overridden by empty value": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1414,7 +1414,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 					},
 				}
 				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1427,7 +1427,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 			},
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1442,7 +1442,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 		"FAILED_AFTER_UPGRADE: root_dir not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1453,7 +1453,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 					},
 				}
 				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{},
@@ -1464,7 +1464,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 			},
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1479,7 +1479,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 		"uid overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1490,7 +1490,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 					},
 				}
 				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1503,7 +1503,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 			},
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1518,7 +1518,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 		"uid explicitly overridden by empty value": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1529,7 +1529,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 					},
 				}
 				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1542,7 +1542,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 			},
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1557,7 +1557,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 		"FAILED_AFTER_UPGRADE: uid not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1568,7 +1568,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 					},
 				}
 				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{},
@@ -1579,7 +1579,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 			},
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1594,7 +1594,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 		"gid overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1605,7 +1605,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 					},
 				}
 				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1618,7 +1618,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 			},
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1633,7 +1633,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 		"gid explicitly overridden by empty value": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1644,7 +1644,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 					},
 				}
 				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1657,7 +1657,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 			},
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1672,7 +1672,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 		"FAILED_AFTER_UPGRADE: gid not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1683,7 +1683,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 					},
 				}
 				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{},
@@ -1694,7 +1694,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 			},
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1709,7 +1709,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 		"auth overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1722,7 +1722,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 					},
 				}
 				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1738,7 +1738,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 			},
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1756,7 +1756,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 		"FAILED_AFTER_UPGRADE: auth not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1769,7 +1769,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 					},
 				}
 				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{},
@@ -1780,7 +1780,7 @@ func Test_ApplyEnv_Storage_Volume_EFS(t *testing.T) {
 			},
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1821,7 +1821,7 @@ func Test_ApplyEnv_Storage_Volume_EFS_Auth(t *testing.T) {
 		"iam overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1834,7 +1834,7 @@ func Test_ApplyEnv_Storage_Volume_EFS_Auth(t *testing.T) {
 					},
 				}
 				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1849,7 +1849,7 @@ func Test_ApplyEnv_Storage_Volume_EFS_Auth(t *testing.T) {
 			},
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1866,7 +1866,7 @@ func Test_ApplyEnv_Storage_Volume_EFS_Auth(t *testing.T) {
 		"iam explicitly overridden by empty value": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1879,7 +1879,7 @@ func Test_ApplyEnv_Storage_Volume_EFS_Auth(t *testing.T) {
 					},
 				}
 				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1894,7 +1894,7 @@ func Test_ApplyEnv_Storage_Volume_EFS_Auth(t *testing.T) {
 			},
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1911,7 +1911,7 @@ func Test_ApplyEnv_Storage_Volume_EFS_Auth(t *testing.T) {
 		"FAILED_AFTER_UPGRADE: iam not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1924,7 +1924,7 @@ func Test_ApplyEnv_Storage_Volume_EFS_Auth(t *testing.T) {
 					},
 				}
 				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1937,7 +1937,7 @@ func Test_ApplyEnv_Storage_Volume_EFS_Auth(t *testing.T) {
 			},
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1954,7 +1954,7 @@ func Test_ApplyEnv_Storage_Volume_EFS_Auth(t *testing.T) {
 		"access_point_id overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1967,7 +1967,7 @@ func Test_ApplyEnv_Storage_Volume_EFS_Auth(t *testing.T) {
 					},
 				}
 				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1982,7 +1982,7 @@ func Test_ApplyEnv_Storage_Volume_EFS_Auth(t *testing.T) {
 			},
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -1999,7 +1999,7 @@ func Test_ApplyEnv_Storage_Volume_EFS_Auth(t *testing.T) {
 		"access_point_id explicitly overridden by empty value": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -2012,7 +2012,7 @@ func Test_ApplyEnv_Storage_Volume_EFS_Auth(t *testing.T) {
 					},
 				}
 				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -2027,7 +2027,7 @@ func Test_ApplyEnv_Storage_Volume_EFS_Auth(t *testing.T) {
 			},
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -2044,7 +2044,7 @@ func Test_ApplyEnv_Storage_Volume_EFS_Auth(t *testing.T) {
 		"FAILED_AFTER_UPGRADE: access_point_id not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -2057,7 +2057,7 @@ func Test_ApplyEnv_Storage_Volume_EFS_Auth(t *testing.T) {
 					},
 				}
 				svc.Environments["test"].Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{
@@ -2070,7 +2070,7 @@ func Test_ApplyEnv_Storage_Volume_EFS_Auth(t *testing.T) {
 			},
 			wanted: func(svc *LoadBalancedWebService) {
 				svc.Storage = &Storage{
-					Volumes: map[string]Volume{
+					Volumes: map[string]*Volume{
 						"mockVolume1": {
 							EFS: &EFSConfigOrBool{
 								Advanced: EFSVolumeConfiguration{

--- a/internal/pkg/manifest/transform.go
+++ b/internal/pkg/manifest/transform.go
@@ -13,10 +13,6 @@ import (
 var fmtExclusiveFieldsSpecifiedTogether = "invalid manifest: %s %s mutually exclusive with %s and shouldn't be specified at the same time"
 
 var defaultTransformers = []mergo.Transformers{
-	// NOTE: mapToVolumeTransformer needs to be the first transformer. Otherwise `mergo` will overwrite the `dst` map
-	// completely and we will lose `dst`'s values.
-	mapToVolumeTransformer{},
-
 	// NOTE: basicTransformer needs to be used before the rest of the custom transformers, because the other transformers
 	// do not merge anything - they just unset the fields that do not get specified in source manifest.
 	basicTransformer{},
@@ -28,6 +24,8 @@ var defaultTransformers = []mergo.Transformers{
 	countTransformer{},
 	advancedCountTransformer{},
 	rangeTransformer{},
+	efsConfigOrBoolTransformer{},
+	efsVolumeConfigurationTransformer{},
 }
 
 // See a complete list of `reflect.Kind` here: https://pkg.go.dev/reflect#Kind.
@@ -248,85 +246,6 @@ func (t rangeTransformer) Transformer(typ reflect.Type) func(dst, src reflect.Va
 
 		if dst.CanSet() { // For extra safety to prevent panicking.
 			dst.Set(reflect.ValueOf(dstStruct))
-		}
-		return nil
-	}
-}
-
-type mapToVolumeTransformer struct{}
-
-// Transformer returns custom merge logic for map[string]Volume.
-func (t mapToVolumeTransformer) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
-	/**
-	There are two things to notice:
-	1. Custom logic for `map[string]Volume` is needed because when `withOverride` flag is specified, `mergo` set
-	dst map's value directly by src map's value, instead of continuing deep merging `Volume`.
-	For example, given that
-			dst = map[string]Volume{
-				"volume1": {
-					prop1: 1,
-					prop2: 2,
-				},
-			}
-	and 	src = map[string]Volume{
-				"volume1": {
-					prop1: 3,
-				},
-			}
-	Without this transformer, the result would be
-			res = map[string]Volume{
-				"volume1": {
-					prop1: 3,
-				}
-			}
-	The merge stops at `map`, while we expect `Volume` to be merged instead of overwritten.
-	2. Note that at the end the transformer sets src map's value as well by `src.SetMapIndex(key, reflect.ValueOf(dstV))`.
-	This is because when `withOverride` flag is specified, `mergo` stops merging at map instead of `Volume`. The merged
-	value will get overwritten by any other transformers.
-	*/
-	if typ.Kind() != reflect.Map {
-		return nil
-	}
-
-	if typ.Key().Kind() != reflect.String || typ.Elem() != reflect.TypeOf(Volume{}) {
-		return nil
-	}
-
-	return func(dst, src reflect.Value) error {
-		for _, key := range src.MapKeys() {
-			srcElement := src.MapIndex(key)
-			if !srcElement.IsValid() {
-				continue
-			}
-
-			dstElement := dst.MapIndex(key)
-			if !dstElement.IsValid() {
-				dst.SetMapIndex(key, srcElement)
-				continue
-			}
-
-			// Perform default merge
-			dstV := dstElement.Interface().(Volume)
-			srcV := srcElement.Interface().(Volume)
-
-			transformers := []mergo.Transformers{
-				efsConfigOrBoolTransformer{},
-				efsVolumeConfigurationTransformer{},
-				basicTransformer{},
-			}
-
-			for _, t := range transformers {
-				if err := mergo.Merge(&dstV, srcV, mergo.WithOverride, mergo.WithTransformers(t)); err != nil {
-					return err
-				}
-			}
-
-			// Set merged value for the key
-			dst.SetMapIndex(key, reflect.ValueOf(dstV))
-
-			// NOTE: if we don't set the merged value for `src`, `dst`'s value for this key will be completely overwritten
-			// (instead of merging) by other transformers.
-			src.SetMapIndex(key, reflect.ValueOf(dstV))
 		}
 		return nil
 	}


### PR DESCRIPTION
In `mergo`, if the map is to pointer-to-struct, then it performs deep merge on the pointer. By changing `map[string]Volume` to `map[string]*Volume`, we can take advantage of this logic instead of implementing a custom transformer.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
