### PR TITLE
chore: PR template to specify the correct license

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,4 +2,4 @@
 
 <!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->
 
-By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
+By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License..


### PR DESCRIPTION
<!-- Provide summary of changes -->

This fixes the PR template to specify the Apache 2.0 License rather than leaving it the default "under the terms of your choice". 

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
