### PR TITLE
chore: use forward slashes in file paths for go:embed

### DIFF
--- a/internal/pkg/template/template.go
+++ b/internal/pkg/template/template.go
@@ -238,7 +238,7 @@ func newTextTemplate(name string) *template.Template {
 }
 
 func (t *Template) read(path string) (string, error) {
-	dat, err := t.fs.ReadFile(filepath.Join("templates", path))
+	dat, err := t.fs.ReadFile(filepath.ToSlash(filepath.Join("templates", path))) // We need to use "/" even on Windows with go:embed.
 	if err != nil {
 		return "", fmt.Errorf("read template %s: %w", path, err)
 	}


### PR DESCRIPTION
Fixes https://github.com/aws/copilot-cli/issues/2803.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
