### PR TITLE
fix: error out if the credential is invalid

### DIFF
--- a/internal/pkg/cli/app_init.go
+++ b/internal/pkg/cli/app_init.go
@@ -104,7 +104,12 @@ func (o *initAppOpts) Validate() error {
 
 // Ask prompts the user for any required arguments that they didn't provide.
 func (o *initAppOpts) Ask() error {
-	if ok, _ := o.isSessionFromEnvVars(); ok { // Ignore the error, we do not want to crash for a warning.
+	ok, err := o.isSessionFromEnvVars()
+	if err != nil {
+		return err
+	}
+
+	if ok {
 		log.Warningln(`Looks like you're creating an application using credentials set by environment variables.
 Copilot will store your application metadata in this account.
 We recommend using credentials from named profiles. To learn more:


### PR DESCRIPTION
Previously, we don't error out if the credential is invalid or we fail to get credentials because of time out. 

A result of this is that we will keep using the session with the **invalid/empty credential**, which eventually causes the CLI to hang during a call to `GetCallerIdentity()` https://github.com/aws/copilot-cli/blob/77983421537d9f34575655ab8cba309f30610f33/internal/pkg/aws/identity/identity.go#L40

The hanging issue is reported in #2686 and #1419.

An  **invalid/empty credential** happens when:
1. The profile is not found, AND
2. The environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are NOT set.

The profile is not found when:
1. The file `~/.aws/credentials` is not found
2. The file is found, but the profile is not defined


After this fix, the output from `copilot app init` or `copilot init` in the case of  an **invalid/empty credential** would be:
```
Welcome to the Copilot CLI! We're going to walk you through some questions
to help you get set up with a containerized application on AWS. An application is a collection of
containerized services that operate together.

✘ ask app init: get credentials of session: RequestCanceled: request context canceled
caused by: context deadline exceeded
```

instead of hanging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License..
