### PR TITLE
chore: fix broken homebrew formulae

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ release-docker:
 
 .PHONY: compile-local
 compile-local:
-	go build -ldflags "${LINKER_FLAGS}" -o ${DESTINATION} ./cmd/copilot
+	CGO_ENABLED=0 go build -ldflags "${LINKER_FLAGS}" -o ${DESTINATION} ./cmd/copilot
 
 .PHONY: compile-windows
 compile-windows:


### PR DESCRIPTION
<!-- Provide summary of changes -->
This (hopefully) can fix the broken [homebrew formula](https://formulae.brew.sh/formula/copilot). Reason behind this (I guess) is the formula uses [`make build`](https://github.com/Homebrew/homebrew-core/blob/master/Formula/copilot.rb#L33) which doesn't include `CGO_ENABLED=0` and by default it is set to be `1`, resulting in the fact that the generated binary is not static.

However, our GitHub release doesn't suffer from the same issue because we use `make release` which has `CGO_ENABLED=0` set in all platform versions.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
