### PR TITLE
chore: fix example of import-public-subnets

### DIFF
--- a/internal/pkg/cli/env_init.go
+++ b/internal/pkg/cli/env_init.go
@@ -694,7 +694,7 @@ func buildEnvInitCmd() *cobra.Command {
 
   Creates an environment with imported VPC resources.
   /code $ copilot env init --import-vpc-id vpc-099c32d2b98cdcf47 \
-  /code --import-public-subnets subnet-013e8b691862966cf,subnet -014661ebb7ab8681a \
+  /code --import-public-subnets subnet-013e8b691862966cf,subnet-014661ebb7ab8681a \
   /code --import-private-subnets subnet-055fafef48fb3c547,subnet-00c9e76f288363e7f
 
   Creates an environment with overridden CIDRs.


### PR DESCRIPTION
<!-- Provide summary of changes -->

Fixed typo in `copilot env init` that there's space in subnet id. `subnet -014661ebb7ab8681a `


```bash
$ copilot env init --help
...
  Creates an environment with imported VPC resources.
  `$ copilot env init --import-vpc-id vpc-099c32d2b98cdcf47 \`
  `--import-public-subnets subnet-013e8b691862966cf,subnet -014661ebb7ab8681a \`
  `--import-private-subnets subnet-055fafef48fb3c547,subnet-00c9e76f288363e7f`
```

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
