### PR TITLE
chore: fix the credential unit test that causes integration test failure

### DIFF
--- a/internal/pkg/aws/sessions/sessions_test.go
+++ b/internal/pkg/aws/sessions/sessions_test.go
@@ -145,20 +145,26 @@ func TestCreds(t *testing.T) {
 func TestProvider_FromProfile(t *testing.T) {
 	t.Run("error if region is missing", func(t *testing.T) {
 		ogRegion := os.Getenv("AWS_REGION")
+		ogSessionToken := os.Getenv("AWS_SESSION_TOKEN")
 		defer func() {
 			err := restoreEnvVar("AWS_REGION", ogRegion)
+			require.NoError(t, err)
+
+			err = restoreEnvVar("AWS_SESSION_TOKEN", ogSessionToken)
 			require.NoError(t, err)
 		}()
 
 		// Since "walk-like-an-egyptian" is (very likely) a non-existent profile, whether the region information
 		// is missing depends on whether the `AWS_REGION` environment variable is set.
 		err := os.Unsetenv("AWS_REGION")
+		err = os.Unsetenv("AWS_SESSION_TOKEN")
 		require.NoError(t, err)
 
 		// When
 		sess, err := NewProvider().FromProfile("walk-like-an-egyptian")
 
 		// THEN
+		require.NotNil(t, err)
 		require.EqualError(t, errors.New("missing region configuration"), err.Error())
 		require.Nil(t, sess)
 	})

--- a/internal/pkg/aws/sessions/sessions_test.go
+++ b/internal/pkg/aws/sessions/sessions_test.go
@@ -157,6 +157,7 @@ func TestProvider_FromProfile(t *testing.T) {
 		// Since "walk-like-an-egyptian" is (very likely) a non-existent profile, whether the region information
 		// is missing depends on whether the `AWS_REGION` environment variable is set.
 		err := os.Unsetenv("AWS_REGION")
+		require.NoError(t, err)
 		err = os.Unsetenv("AWS_SESSION_TOKEN")
 		require.NoError(t, err)
 


### PR DESCRIPTION
The unit test `TestProvider_FromProfile/error_if_region_is_missing` failed in integration test because the integration test uses IAM role session to provide credential configurations. The unit test didn't take this into consideration, only setting/unsetting `AWS_REGION`. This PR fixes that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
