### PR TITLE
feat: enable `StartCommand` configuration for App Runner workloads

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/rd_web_svc.go
+++ b/internal/pkg/deploy/cloudformation/stack/rd_web_svc.go
@@ -117,6 +117,7 @@ func (s *RequestDrivenWebService) Template() (string, error) {
 
 	content, err := s.parser.ParseRequestDrivenWebService(template.ParseRequestDrivenWebServiceInput{
 		Variables:         s.manifest.Variables,
+		StartCommand:      s.manifest.StartCommand,
 		Tags:              s.manifest.Tags,
 		NestedStack:       outputs,
 		EnableHealthCheck: !s.healthCheckConfig.IsEmpty(),

--- a/internal/pkg/deploy/cloudformation/stack/rd_web_svc_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/rd_web_svc_integration_test.go
@@ -20,6 +20,7 @@ import (
 
 func TestRDWS_Template(t *testing.T) {
 	const (
+		envName               = "test"
 		manifestFileName      = "rdws-manifest.yml"
 		stackTemplateFileName = "rdws.stack.yml"
 	)

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/rdws-manifest.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/rdws-manifest.yml
@@ -42,5 +42,6 @@ publish:
 # You can override any of the values defined above by environment.
 environments:
   test:
+    start_command: "echo es by pink floyd"
     variables:
       LOG_LEVEL: debug        # Log level for the "test" environment.

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/rdws-manifest.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/rdws-manifest.yml
@@ -40,7 +40,7 @@ publish:
 #   project: project-name
 
 # You can override any of the values defined above by environment.
-# environments:
-#   test:
-#     variables:
-#       LOG_LEVEL: debug        # Log level for the "test" environment.
+environments:
+  test:
+    variables:
+      LOG_LEVEL: debug        # Log level for the "test" environment.

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/rdws-manifest.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/rdws-manifest.yml
@@ -26,6 +26,7 @@ image:
 cpu: 1024
 # Amount of memory in MiB used by the task.
 memory: 2048
+command: "shine on you"
 
 publish:
   topics:
@@ -42,6 +43,6 @@ publish:
 # You can override any of the values defined above by environment.
 environments:
   test:
-    start_command: "echo es by pink floyd"
+    command: crazy diamond
     variables:
       LOG_LEVEL: debug        # Log level for the "test" environment.

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/rdws.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/rdws.stack.yml
@@ -140,6 +140,7 @@ Resources:
                 Value: '{"customers":"arn:aws:sns:us-west-2:123456789123:my-app-test-frontend-customers"}'
               - Name: LOG_LEVEL
                 Value: debug
+            StartCommand: echo es by pink floyd
       InstanceConfiguration:
         Cpu: !Ref InstanceCPU
         Memory: !Ref InstanceMemory

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/rdws.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/rdws.stack.yml
@@ -140,7 +140,7 @@ Resources:
                 Value: '{"customers":"arn:aws:sns:us-west-2:123456789123:my-app-test-frontend-customers"}'
               - Name: LOG_LEVEL
                 Value: debug
-            StartCommand: echo es by pink floyd
+            StartCommand: crazy diamond
       InstanceConfiguration:
         Cpu: !Ref InstanceCPU
         Memory: !Ref InstanceMemory

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/rdws.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/rdws.stack.yml
@@ -138,6 +138,8 @@ Resources:
                 Value: !Ref WorkloadName
               - Name: COPILOT_SNS_TOPIC_ARNS
                 Value: '{"customers":"arn:aws:sns:us-west-2:123456789123:my-app-test-frontend-customers"}'
+              - Name: LOG_LEVEL
+                Value: debug
       InstanceConfiguration:
         Cpu: !Ref InstanceCPU
         Memory: !Ref InstanceMemory

--- a/internal/pkg/deploy/cloudformation/stack/transformers.go
+++ b/internal/pkg/deploy/cloudformation/stack/transformers.go
@@ -620,7 +620,7 @@ func convertNetworkConfig(network manifest.NetworkConfig) *template.NetworkOpts 
 func convertAlias(alias manifest.Alias) ([]string, error) {
 	out, err := alias.ToStringSlice()
 	if err != nil {
-		return nil, fmt.Errorf(`convert 'http.alias' to string slice: %w`, err)
+		return nil, fmt.Errorf(`convert "http.alias" to string slice: %w`, err)
 	}
 	return out, nil
 }
@@ -628,7 +628,7 @@ func convertAlias(alias manifest.Alias) ([]string, error) {
 func convertEntryPoint(entrypoint manifest.EntryPointOverride) ([]string, error) {
 	out, err := entrypoint.ToStringSlice()
 	if err != nil {
-		return nil, fmt.Errorf(`convert 'entrypoint' to string slice: %w`, err)
+		return nil, fmt.Errorf(`convert "entrypoint" to string slice: %w`, err)
 	}
 	return out, nil
 }
@@ -636,7 +636,7 @@ func convertEntryPoint(entrypoint manifest.EntryPointOverride) ([]string, error)
 func convertCommand(command manifest.CommandOverride) ([]string, error) {
 	out, err := command.ToStringSlice()
 	if err != nil {
-		return nil, fmt.Errorf(`convert 'command' to string slice: %w`, err)
+		return nil, fmt.Errorf(`convert "command" to string slice: %w`, err)
 	}
 	return out, nil
 }

--- a/internal/pkg/manifest/rd_web_svc.go
+++ b/internal/pkg/manifest/rd_web_svc.go
@@ -28,7 +28,7 @@ type RequestDrivenWebServiceConfig struct {
 	InstanceConfig                    AppRunnerInstanceConfig `yaml:",inline"`
 	ImageConfig                       ImageWithPort           `yaml:"image"`
 	Variables                         map[string]string       `yaml:"variables"`
-	StartCommand                      string                  `yaml:"start_command"`
+	StartCommand                      string                  `yaml:"command"`
 	Tags                              map[string]string       `yaml:"tags"`
 	PublishConfig                     PublishConfig           `yaml:"publish"`
 }

--- a/internal/pkg/manifest/rd_web_svc.go
+++ b/internal/pkg/manifest/rd_web_svc.go
@@ -28,6 +28,7 @@ type RequestDrivenWebServiceConfig struct {
 	InstanceConfig                    AppRunnerInstanceConfig `yaml:",inline"`
 	ImageConfig                       ImageWithPort           `yaml:"image"`
 	Variables                         map[string]string       `yaml:"variables"`
+	StartCommand                      string                  `yaml:"start_command"`
 	Tags                              map[string]string       `yaml:"tags"`
 	PublishConfig                     PublishConfig           `yaml:"publish"`
 }

--- a/internal/pkg/manifest/rd_web_svc.go
+++ b/internal/pkg/manifest/rd_web_svc.go
@@ -28,7 +28,7 @@ type RequestDrivenWebServiceConfig struct {
 	InstanceConfig                    AppRunnerInstanceConfig `yaml:",inline"`
 	ImageConfig                       ImageWithPort           `yaml:"image"`
 	Variables                         map[string]string       `yaml:"variables"`
-	StartCommand                      string                  `yaml:"command"`
+	StartCommand                      *string                 `yaml:"command"`
 	Tags                              map[string]string       `yaml:"tags"`
 	PublishConfig                     PublishConfig           `yaml:"publish"`
 }

--- a/internal/pkg/manifest/workload.go
+++ b/internal/pkg/manifest/workload.go
@@ -185,16 +185,16 @@ type ImageOverride struct {
 	Command    CommandOverride    `yaml:"command"`
 }
 
-// EntryPointOverride is a custom type which supports unmarshaling "entrypoint" yaml which
+// EntryPointOverride is a custom type which supports unmarshalling "entrypoint" yaml which
 // can either be of type string or type slice of string.
 type EntryPointOverride stringSliceOrString
 
-// CommandOverride is a custom type which supports unmarshaling "command" yaml which
+// CommandOverride is a custom type which supports unmarshalling "command" yaml which
 // can either be of type string or type slice of string.
 type CommandOverride stringSliceOrString
 
-// UnmarshalYAML overrides the default YAML unmarshaling logic for the EntryPointOverride
-// struct, allowing it to perform more complex unmarshaling behavior.
+// UnmarshalYAML overrides the default YAML unmarshalling logic for the EntryPointOverride
+// struct, allowing it to perform more complex unmarshalling behavior.
 // This method implements the yaml.Unmarshaler (v2) interface.
 func (e *EntryPointOverride) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	if err := unmarshalYAMLToStringSliceOrString((*stringSliceOrString)(e), unmarshal); err != nil {

--- a/internal/pkg/template/templates/workloads/services/rd-web/cf.yml
+++ b/internal/pkg/template/templates/workloads/services/rd-web/cf.yml
@@ -103,6 +103,9 @@ Resources:
                   Fn::GetAtt: [ {{$stackName}}, Outputs.{{$var}}]
               {{- end}}
               {{- end}}
+            {{- if .StartCommand }}
+            StartCommand: {{.StartCommand}}
+            {{- end }}
       InstanceConfiguration:
         Cpu: !Ref InstanceCPU
         Memory: !Ref InstanceMemory

--- a/internal/pkg/template/workload.go
+++ b/internal/pkg/template/workload.go
@@ -348,6 +348,7 @@ type WorkloadOpts struct {
 // ParseRequestDrivenWebServiceInput holds data that can be provided to enable features for a request-driven web service stack.
 type ParseRequestDrivenWebServiceInput struct {
 	Variables           map[string]string
+	StartCommand        string
 	Tags                map[string]string        // Used by App Runner workloads to tag App Runner service resources
 	NestedStack         *WorkloadNestedStackOpts // Outputs from nested stacks such as the addons stack.
 	EnableHealthCheck   bool

--- a/internal/pkg/template/workload.go
+++ b/internal/pkg/template/workload.go
@@ -348,7 +348,7 @@ type WorkloadOpts struct {
 // ParseRequestDrivenWebServiceInput holds data that can be provided to enable features for a request-driven web service stack.
 type ParseRequestDrivenWebServiceInput struct {
 	Variables           map[string]string
-	StartCommand        string
+	StartCommand        *string
 	Tags                map[string]string        // Used by App Runner workloads to tag App Runner service resources
 	NestedStack         *WorkloadNestedStackOpts // Outputs from nested stacks such as the addons stack.
 	EnableHealthCheck   bool


### PR DESCRIPTION
This PR adds [`StartCommand`](https://docs.aws.amazon.com/apprunner/latest/api/API_ImageConfiguration.html#apprunner-Type-ImageConfiguration-StartCommand) configuration for App Runner workloads.

It is configurable as `start_command` in request-driven web service's manifest, accepting either a string or a slice of string, just like `command` in other workloads.

Resolves #2709 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
