### PR TITLE
chore: validate Dockerfile parsing against Docker's parser

### DIFF
--- a/internal/pkg/cli/init.go
+++ b/internal/pkg/cli/init.go
@@ -233,7 +233,7 @@ func newInitOpts(vars initVars) (*initOpts, error) {
 					prompt:       prompt,
 					dockerEngine: dockerengine.New(cmd),
 					initParser: func(s string) dockerfileParser {
-						return dockerfile.NewDockerfile(fs, s)
+						return dockerfile.New(fs, s)
 					},
 				}
 				o.initWlCmd = &opts
@@ -258,7 +258,7 @@ func newInitOpts(vars initVars) (*initOpts, error) {
 					if opts.df != nil {
 						return opts.df
 					}
-					opts.df = dockerfile.NewDockerfile(opts.fs, opts.dockerfilePath)
+					opts.df = dockerfile.New(opts.fs, opts.dockerfilePath)
 					return opts.df
 				}
 				o.initWlCmd = &opts

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -407,7 +407,7 @@ type domainHostedZoneGetter interface {
 }
 
 type dockerfileParser interface {
-	GetExposedPorts() ([]uint16, error)
+	GetExposedPorts() ([]dockerfile.Port, error)
 	GetHealthCheck() (*dockerfile.HealthCheck, error)
 }
 

--- a/internal/pkg/cli/job_init.go
+++ b/internal/pkg/cli/job_init.go
@@ -112,7 +112,7 @@ func newInitJobOpts(vars initJobVars) (*initJobOpts, error) {
 		sel:          sel,
 		dockerEngine: dockerengine.New(exec.NewCmd()),
 		initParser: func(path string) dockerfileParser {
-			return dockerfile.NewDockerfile(fs, path)
+			return dockerfile.New(fs, path)
 		},
 	}, nil
 }

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -9,8 +9,6 @@ import (
 	io "io"
 	reflect "reflect"
 
-	"github.com/aws/copilot-cli/internal/pkg/docker/dockerfile"
-
 	session "github.com/aws/aws-sdk-go/aws/session"
 	cloudformation "github.com/aws/copilot-cli/internal/pkg/aws/cloudformation"
 	codepipeline "github.com/aws/copilot-cli/internal/pkg/aws/codepipeline"
@@ -23,6 +21,7 @@ import (
 	stack "github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation/stack"
 	describe "github.com/aws/copilot-cli/internal/pkg/describe"
 	dockerengine "github.com/aws/copilot-cli/internal/pkg/docker/dockerengine"
+	dockerfile "github.com/aws/copilot-cli/internal/pkg/docker/dockerfile"
 	ecs0 "github.com/aws/copilot-cli/internal/pkg/ecs"
 	exec "github.com/aws/copilot-cli/internal/pkg/exec"
 	initialize "github.com/aws/copilot-cli/internal/pkg/initialize"
@@ -4311,10 +4310,10 @@ func (m *MockdockerfileParser) EXPECT() *MockdockerfileParserMockRecorder {
 }
 
 // GetExposedPorts mocks base method.
-func (m *MockdockerfileParser) GetExposedPorts() ([]uint16, error) {
+func (m *MockdockerfileParser) GetExposedPorts() ([]dockerfile.Port, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetExposedPorts")
-	ret0, _ := ret[0].([]uint16)
+	ret0, _ := ret[0].([]dockerfile.Port)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -4835,43 +4834,6 @@ func (m *Mockexecutor) Execute() error {
 func (mr *MockexecutorMockRecorder) Execute() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Execute", reflect.TypeOf((*Mockexecutor)(nil).Execute))
-}
-
-// MockdeletePipelineRunner is a mock of deletePipelineRunner interface.
-type MockdeletePipelineRunner struct {
-	ctrl     *gomock.Controller
-	recorder *MockdeletePipelineRunnerMockRecorder
-}
-
-// MockdeletePipelineRunnerMockRecorder is the mock recorder for MockdeletePipelineRunner.
-type MockdeletePipelineRunnerMockRecorder struct {
-	mock *MockdeletePipelineRunner
-}
-
-// NewMockdeletePipelineRunner creates a new mock instance.
-func NewMockdeletePipelineRunner(ctrl *gomock.Controller) *MockdeletePipelineRunner {
-	mock := &MockdeletePipelineRunner{ctrl: ctrl}
-	mock.recorder = &MockdeletePipelineRunnerMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockdeletePipelineRunner) EXPECT() *MockdeletePipelineRunnerMockRecorder {
-	return m.recorder
-}
-
-// Run mocks base method.
-func (m *MockdeletePipelineRunner) Run() error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Run")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Run indicates an expected call of Run.
-func (mr *MockdeletePipelineRunnerMockRecorder) Run() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Run", reflect.TypeOf((*MockdeletePipelineRunner)(nil).Run))
 }
 
 // MockexecuteAsker is a mock of executeAsker interface.

--- a/internal/pkg/cli/svc_init.go
+++ b/internal/pkg/cli/svc_init.go
@@ -169,7 +169,7 @@ func newInitSvcOpts(vars initSvcVars) (*initSvcOpts, error) {
 		if opts.df != nil {
 			return opts.df
 		}
-		opts.df = dockerfile.NewDockerfile(opts.fs, opts.dockerfilePath)
+		opts.df = dockerfile.New(opts.fs, opts.dockerfilePath)
 		return opts.df
 	}
 	return opts, nil
@@ -402,7 +402,7 @@ func (o *initSvcOpts) askSvcPort() (err error) {
 		return nil
 	}
 
-	var ports []uint16
+	var ports []dockerfile.Port
 	if o.dockerfilePath != "" && o.image == "" {
 		// Check for exposed ports.
 		ports, err = o.dockerfile(o.dockerfilePath).GetExposedPorts()
@@ -418,10 +418,10 @@ func (o *initSvcOpts) askSvcPort() (err error) {
 		case 0:
 			// There were no ports detected, keep the default port prompt.
 		case 1:
-			o.port = ports[0]
+			o.port = ports[0].Port
 			return nil
 		default:
-			defaultPort = strconv.Itoa(int(ports[0]))
+			defaultPort = strconv.Itoa(int(ports[0].Port))
 		}
 	}
 	// Skip asking if it is a backend or worker service.

--- a/internal/pkg/cli/svc_init_test.go
+++ b/internal/pkg/cli/svc_init_test.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/aws/copilot-cli/internal/pkg/docker/dockerfile"
+
 	"github.com/aws/copilot-cli/internal/pkg/deploy"
 	"github.com/aws/copilot-cli/internal/pkg/docker/dockerengine"
 
@@ -393,7 +395,7 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 
 			mockPrompt: func(m *mocks.Mockprompter) {},
 			mockDockerfile: func(m *mocks.MockdockerfileParser) {
-				m.EXPECT().GetExposedPorts().Return([]uint16{}, errors.New("no expose"))
+				m.EXPECT().GetExposedPorts().Return(nil, errors.New("no expose"))
 			},
 			mockSel:          func(m *mocks.MockdockerfileSelector) {},
 			mocktopicSel:     func(m *mocks.MocktopicSelector) {},
@@ -411,7 +413,7 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 					Return(defaultSvcPortString, nil)
 			},
 			mockDockerfile: func(m *mocks.MockdockerfileParser) {
-				m.EXPECT().GetExposedPorts().Return([]uint16{}, errors.New("no expose"))
+				m.EXPECT().GetExposedPorts().Return(nil, errors.New("no expose"))
 			},
 			mockSel:          func(m *mocks.MockdockerfileSelector) {},
 			mocktopicSel:     func(m *mocks.MocktopicSelector) {},
@@ -429,7 +431,7 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 					Return("", errors.New("some error"))
 			},
 			mockDockerfile: func(m *mocks.MockdockerfileParser) {
-				m.EXPECT().GetExposedPorts().Return([]uint16{}, errors.New("expose error"))
+				m.EXPECT().GetExposedPorts().Return(nil, errors.New("expose error"))
 			},
 			mockSel:          func(m *mocks.MockdockerfileSelector) {},
 			mocktopicSel:     func(m *mocks.MocktopicSelector) {},
@@ -447,7 +449,7 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 					Return("100000", errors.New("some error"))
 			},
 			mockDockerfile: func(m *mocks.MockdockerfileParser) {
-				m.EXPECT().GetExposedPorts().Return([]uint16{}, errors.New("no expose"))
+				m.EXPECT().GetExposedPorts().Return(nil, errors.New("no expose"))
 			},
 			mockSel:          func(m *mocks.MockdockerfileSelector) {},
 			mocktopicSel:     func(m *mocks.MocktopicSelector) {},
@@ -463,7 +465,7 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 			mockPrompt: func(m *mocks.Mockprompter) {
 			},
 			mockDockerfile: func(m *mocks.MockdockerfileParser) {
-				m.EXPECT().GetExposedPorts().Return([]uint16{80}, nil)
+				m.EXPECT().GetExposedPorts().Return([]dockerfile.Port{{Port: 80, Protocol: "", RawString: "80"}}, nil)
 			},
 			mockSel:          func(m *mocks.MockdockerfileSelector) {},
 			mocktopicSel:     func(m *mocks.MocktopicSelector) {},

--- a/internal/pkg/docker/dockerfile/dockerfile.go
+++ b/internal/pkg/docker/dockerfile/dockerfile.go
@@ -85,7 +85,6 @@ func New(fs afero.Fs, path string) *Dockerfile {
 		healthCheck:  nil,
 		fs:           fs,
 		path:         path,
-		parsed:       false,
 	}
 }
 

--- a/internal/pkg/docker/dockerfile/dockerfile.go
+++ b/internal/pkg/docker/dockerfile/dockerfile.go
@@ -62,8 +62,8 @@ type HealthCheck struct {
 
 // Dockerfile represents a parsed Dockerfile.
 type Dockerfile struct {
-	ExposedPorts []portConfig
-	HealthCheck  *HealthCheck
+	exposedPorts []portConfig
+	healthCheck  *HealthCheck
 	parsed       bool
 	path         string
 
@@ -73,8 +73,8 @@ type Dockerfile struct {
 // NewDockerfile returns an empty Dockerfile.
 func NewDockerfile(fs afero.Fs, path string) *Dockerfile {
 	return &Dockerfile{
-		ExposedPorts: []portConfig{},
-		HealthCheck:  nil,
+		exposedPorts: []portConfig{},
+		healthCheck:  nil,
 		fs:           fs,
 		path:         path,
 		parsed:       false,
@@ -90,14 +90,14 @@ func (df *Dockerfile) GetExposedPorts() ([]uint16, error) {
 	}
 	var ports []uint16
 
-	if len(df.ExposedPorts) == 0 {
+	if len(df.exposedPorts) == 0 {
 		return nil, ErrNoExpose{
 			Dockerfile: df.path,
 		}
 	}
 
 	var err error
-	for _, port := range df.ExposedPorts {
+	for _, port := range df.exposedPorts {
 		// ensure we register that there is an error (will only be ErrNoExpose) if
 		// any ports were unparseable or invalid
 		if port.err != nil {
@@ -116,7 +116,7 @@ func (df *Dockerfile) GetHealthCheck() (*HealthCheck, error) {
 			return nil, err
 		}
 	}
-	return df.HealthCheck, nil
+	return df.healthCheck, nil
 }
 
 // parse takes a Dockerfile and fills in struct members based on methods like parseExpose and parseHealthcheck.
@@ -142,8 +142,8 @@ func (df *Dockerfile) parse() error {
 		return err
 	}
 
-	df.ExposedPorts = parsedDockerfile.ExposedPorts
-	df.HealthCheck = parsedDockerfile.HealthCheck
+	df.exposedPorts = parsedDockerfile.exposedPorts
+	df.healthCheck = parsedDockerfile.healthCheck
 	df.parsed = true
 	return nil
 }
@@ -151,7 +151,7 @@ func (df *Dockerfile) parse() error {
 // parse parses the contents of a Dockerfile into a Dockerfile struct.
 func parse(content string) (*Dockerfile, error) {
 	var df Dockerfile
-	df.ExposedPorts = []portConfig{}
+	df.exposedPorts = []portConfig{}
 
 	ast, err := parser.Parse(strings.NewReader(content))
 	if err != nil {
@@ -172,13 +172,13 @@ func parse(content string) (*Dockerfile, error) {
 		switch d := child.Value; d {
 		case "expose":
 			currentPorts := parseExpose(inst)
-			df.ExposedPorts = append(df.ExposedPorts, currentPorts...)
+			df.exposedPorts = append(df.exposedPorts, currentPorts...)
 		case "healthcheck":
 			healthcheckOptions, err := parseHealthCheck(inst)
 			if err != nil {
 				return nil, err
 			}
-			df.HealthCheck = healthcheckOptions
+			df.healthCheck = healthcheckOptions
 		}
 	}
 	return &df, nil

--- a/internal/pkg/docker/dockerfile/dockerfile.go
+++ b/internal/pkg/docker/dockerfile/dockerfile.go
@@ -271,8 +271,10 @@ func parseHealthCheck(content string) (*HealthCheck, error) {
 	// Or, it can also be an exec array: HEALTHCHECK CMD ["/bin/check-running"]
 	cmdIndex := strings.Index(content, cmdInstructionPrefix)
 	cmdArgs := strings.TrimSpace(content[cmdIndex+len(cmdInstructionPrefix):])
+	cmdExecutor := "CMD"
 	var args []string
 	if err := json.Unmarshal([]byte(cmdArgs), &args); err != nil {
+		cmdExecutor = cmdShell // In string form, use CMD-SHELL.
 		args = []string{cmdArgs}
 	}
 
@@ -281,6 +283,6 @@ func parseHealthCheck(content string) (*HealthCheck, error) {
 		Timeout:     timeout,
 		StartPeriod: startPeriod,
 		Retries:     retries,
-		Cmd:         append([]string{cmdShell}, args...),
+		Cmd:         append([]string{cmdExecutor}, args...),
 	}, nil
 }

--- a/internal/pkg/docker/dockerfile/dockerfile.go
+++ b/internal/pkg/docker/dockerfile/dockerfile.go
@@ -249,8 +249,8 @@ func parseHealthCheck(content string) (*HealthCheck, error) {
 	if strings.TrimSpace(content[hcInstrStartIndex:]) == "NONE" {
 		return nil, nil
 	}
-	if strings.Index(content, "CMD") == -1 {
-		return nil, errors.New(`HEALTHCHECK instruction must container either CMD or NONE`)
+	if !strings.Contains(content, "CMD") {
+		return nil, errors.New("HEALTHCHECK instruction must contain either CMD or NONE")
 	}
 
 	var retries int

--- a/internal/pkg/docker/dockerfile/dockerfile.go
+++ b/internal/pkg/docker/dockerfile/dockerfile.go
@@ -108,6 +108,17 @@ func (df *Dockerfile) GetExposedPorts() ([]uint16, error) {
 	return ports, err
 }
 
+// GetHealthCheck parses the HEALTHCHECK instruction from the Dockerfile and returns it.
+// If the HEALTHCHECK is NONE or there is no instruction, returns nil.
+func (df *Dockerfile) GetHealthCheck() (*HealthCheck, error) {
+	if !df.parsed {
+		if err := df.parse(); err != nil {
+			return nil, err
+		}
+	}
+	return df.HealthCheck, nil
+}
+
 // parse takes a Dockerfile and fills in struct members based on methods like parseExpose and parseHealthcheck.
 func (df *Dockerfile) parse() error {
 	if df.parsed {
@@ -257,15 +268,4 @@ func parseHealthCheck(content string) (*HealthCheck, error) {
 		Retries:     retries,
 		Cmd:         []string{cmdShell, command},
 	}, nil
-}
-
-// GetHealthCheck parses the HEALTHCHECK instruction from the Dockerfile and returns it.
-// If the HEALTHCHECK is NONE or there is no instruction, returns nil.
-func (df *Dockerfile) GetHealthCheck() (*HealthCheck, error) {
-	if !df.parsed {
-		if err := df.parse(); err != nil {
-			return nil, err
-		}
-	}
-	return df.HealthCheck, nil
 }

--- a/internal/pkg/docker/dockerfile/dockerfile_test.go
+++ b/internal/pkg/docker/dockerfile/dockerfile_test.go
@@ -85,15 +85,8 @@ EXPOSE 80/tcp 3000`),
 FROM nginx
 EXPOSE $arg
 `),
-			wantedPorts: []Port{
-				{
-					RawString: "EXPOSE $arg",
-					err: ErrInvalidPort{
-						Match: "EXPOSE $arg",
-					},
-				},
-			},
-			wantedErr: ErrInvalidPort{Match: "EXPOSE $arg"},
+			wantedPorts: nil,
+			wantedErr:   ErrInvalidPort{Match: "EXPOSE $arg"},
 		},
 		"bad expose token multiple ports": {
 			dockerfilePath: wantedPath,
@@ -125,6 +118,7 @@ EXPOSE 8080/tcp 5000`),
 			ports, err := New(fs, "./Dockerfile").GetExposedPorts()
 			if tc.wantedErr != nil {
 				require.EqualError(t, err, tc.wantedErr.Error())
+				require.Nil(t, ports)
 			} else {
 				require.NoError(t, err)
 				require.ElementsMatch(t, tc.wantedPorts, ports, "expected ports do not match")


### PR DESCRIPTION
This PR contains some small refactors, but more importantly adds additional unit tests to ensure that our `EXPOSE` and `HEALTHCHECK` parsers match Docker's.

Once this change is merged, a follow-up will remove Docker as a dependency from the CLI.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
