### PR TITLE
test(e2e): custom domain suite better retry if fail to push to ECR

### DIFF
--- a/e2e/app-with-domain/app_with_domain_suite_test.go
+++ b/e2e/app-with-domain/app_with_domain_suite_test.go
@@ -51,10 +51,14 @@ func BeforeAll(fn func()) {
 	})
 }
 
-func isOperationInProgress(s string) bool {
+// isStackSetOperationInProgress returns if the current stack set is in operation.
+func isStackSetOperationInProgress(s string) bool {
 	return strings.Contains(s, cloudformation.ErrCodeOperationInProgressException)
 }
 
-func isImagePushingInProgress(s string) bool {
-	return strings.Contains(s, "denied: Your authorization token has expired. Reauthenticate and try again.")
+// isImagePushingToECRInProgress returns if we are pushing images to ECR. Pushing images concurrently would fail because
+// of credential verification issue.
+func isImagePushingToECRInProgress(s string) bool {
+	return strings.Contains(s, "denied: Your authorization token has expired. Reauthenticate and try again.") ||
+		strings.Contains(s, "no basic auth credentials")
 }

--- a/e2e/app-with-domain/app_with_domain_test.go
+++ b/e2e/app-with-domain/app_with_domain_test.go
@@ -66,7 +66,7 @@ var _ = Describe("App With Domain", func() {
 					if err == nil {
 						break
 					}
-					if !isOperationInProgress(content) {
+					if !isStackSetOperationInProgress(content) {
 						fatalErrors <- err
 					}
 					time.Sleep(waitingInterval)
@@ -84,7 +84,7 @@ var _ = Describe("App With Domain", func() {
 					if err == nil {
 						break
 					}
-					if !isOperationInProgress(content) {
+					if !isStackSetOperationInProgress(content) {
 						fatalErrors <- err
 					}
 					time.Sleep(waitingInterval)
@@ -146,7 +146,7 @@ var _ = Describe("App With Domain", func() {
 					if err == nil {
 						break
 					}
-					if !isOperationInProgress(content) && !isImagePushingInProgress(content) {
+					if !isStackSetOperationInProgress(content) && !isImagePushingToECRInProgress(content) {
 						fatalErrors <- err
 					}
 					time.Sleep(waitingInterval)
@@ -164,7 +164,7 @@ var _ = Describe("App With Domain", func() {
 					if err == nil {
 						break
 					}
-					if !isOperationInProgress(content) && !isImagePushingInProgress(content) {
+					if !isStackSetOperationInProgress(content) && !isImagePushingToECRInProgress(content) {
 						fatalErrors <- err
 					}
 					time.Sleep(waitingInterval)
@@ -182,7 +182,7 @@ var _ = Describe("App With Domain", func() {
 					if err == nil {
 						break
 					}
-					if !isOperationInProgress(content) && !isImagePushingInProgress(content) {
+					if !isStackSetOperationInProgress(content) && !isImagePushingToECRInProgress(content) {
 						fatalErrors <- err
 					}
 					time.Sleep(waitingInterval)


### PR DESCRIPTION
<!-- Provide summary of changes -->
Pushing to ECR concurrently would fail because of the following reason. We should retry in our e2e custom domain suite.
```
The push refers to repository [1234567890.dkr.ecr.us-west-2.amazonaws.com/e2e-domain-1632160296/frontend]
--
863 | d164a303952c: Preparing
864 | fac15b2caa0c: Preparing
865 | f8bf5746ac5a: Preparing
866 | d11eedadbd34: Preparing
867 | 797e583d8c50: Preparing
868 | bf9ce92e8516: Preparing
869 | d000633a5681: Preparing
870 | bf9ce92e8516: Waiting
871 | 797e583d8c50: Waiting
872 | d000633a5681: Waiting
873 | d11eedadbd34: Waiting
874 | f8bf5746ac5a: Waiting
875 | no basic auth credentials
876 | ✘ build and push image: push to repo e2e-domain-1632160296/frontend: docker push 1234567890.dkr.ecr.us-west-2.amazonaws.com/e2e-domain-1632160296/frontend:frontend: exit status 1
```

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
