### PR TITLE
chore(manifest): UnmarshalYAML should validate mutual exclusive

### DIFF
--- a/internal/pkg/manifest/storage.go
+++ b/internal/pkg/manifest/storage.go
@@ -94,7 +94,7 @@ func (e *EFSConfigOrBool) UnmarshalYAML(unmarshal func(interface{}) error) error
 	}
 
 	if !e.Advanced.IsEmpty() {
-		// Unmarshaled successfully to e.Config, unset e.ID, and return.
+		// TODO: remove when manifest validate is applied.
 		if err := e.Advanced.isValid(); err != nil {
 			return err
 		}

--- a/internal/pkg/manifest/validate.go
+++ b/internal/pkg/manifest/validate.go
@@ -667,7 +667,12 @@ func (r *RequestDrivenWebServiceHttpConfig) Validate() error {
 }
 
 // Validate returns nil if JobTriggerConfig is configured correctly.
-func (*JobTriggerConfig) Validate() error {
+func (c *JobTriggerConfig) Validate() error {
+	if c.Schedule == nil {
+		return &errFieldMustBeSpecified{
+			missingField: "schedule",
+		}
+	}
 	return nil
 }
 

--- a/internal/pkg/manifest/validate_test.go
+++ b/internal/pkg/manifest/validate_test.go
@@ -241,6 +241,13 @@ func TestScheduledJobConfig_Validate(t *testing.T) {
 			},
 			wantedErrorPrefix: `validate "network": `,
 		},
+		"error if fail to validate on": {
+			config: ScheduledJobConfig{
+				ImageConfig: testImageConfig,
+				On:          JobTriggerConfig{},
+			},
+			wantedErrorPrefix: `validate "on": `,
+		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
@@ -921,6 +928,29 @@ func TestPlacement_Validate(t *testing.T) {
 		"should return an error if placement is invalid": {
 			in:     &mockInvalidPlacement,
 			wanted: errors.New(`"placement" external must be one of public, private`),
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			err := tc.in.Validate()
+
+			if tc.wanted != nil {
+				require.EqualError(t, err, tc.wanted.Error())
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestJobTriggerConfig_Validate(t *testing.T) {
+	testCases := map[string]struct {
+		in     *JobTriggerConfig
+		wanted error
+	}{
+		"should return an error if schedule is empty": {
+			in:     &JobTriggerConfig{},
+			wanted: errors.New(`"schedule" must be specified`),
 		},
 	}
 	for name, tc := range testCases {

--- a/internal/pkg/manifest/workload.go
+++ b/internal/pkg/manifest/workload.go
@@ -90,6 +90,25 @@ type ImageWithHealthcheck struct {
 	HealthCheck ContainerHealthCheck `yaml:"healthcheck"`
 }
 
+// UnmarshalYAML implements the yaml(v2) interface.
+func (i *ImageWithHealthcheck) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	type imageWithHC ImageWithHealthcheck
+	var im imageWithHC
+	if err := unmarshal(&im); err != nil {
+		return err
+	}
+	img := ImageWithHealthcheck(im)
+	*i = img
+	if !i.Build.isEmpty() && i.Location != nil {
+		return &errFieldMutualExclusive{
+			firstField:  "build",
+			secondField: "location",
+			mustExist:   true,
+		}
+	}
+	return nil
+}
+
 // ImageWithPortAndHealthcheck represents a container image with an exposed port and health check.
 type ImageWithPortAndHealthcheck struct {
 	ImageWithPort `yaml:",inline"`
@@ -100,6 +119,25 @@ type ImageWithPortAndHealthcheck struct {
 type ImageWithPort struct {
 	Image `yaml:",inline"`
 	Port  *uint16 `yaml:"port"`
+}
+
+// UnmarshalYAML implements the yaml(v2) interface.
+func (i *ImageWithPort) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	type imageWithPort ImageWithPort
+	var im imageWithPort
+	if err := unmarshal(&im); err != nil {
+		return err
+	}
+	img := ImageWithPort(im)
+	*i = img
+	if !i.Build.isEmpty() && i.Location != nil {
+		return &errFieldMutualExclusive{
+			firstField:  "build",
+			secondField: "location",
+			mustExist:   true,
+		}
+	}
+	return nil
 }
 
 // GetLocation returns the location of the image.

--- a/internal/pkg/manifest/workload_test.go
+++ b/internal/pkg/manifest/workload_test.go
@@ -5,6 +5,7 @@ package manifest
 
 import (
 	"errors"
+	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -60,6 +61,73 @@ func TestEntryPointOverride_UnmarshalYAML(t *testing.T) {
 				// check memberwise dereferenced pointer equality
 				require.Equal(t, tc.wantedStruct.StringSlice, e.EntryPoint.StringSlice)
 				require.Equal(t, tc.wantedStruct.String, e.EntryPoint.String)
+			}
+		})
+	}
+}
+
+func TestImageWithHealthcheck_UnmarshalYAML(t *testing.T) {
+	testCases := map[string]struct {
+		inContent []byte
+
+		wantedError error
+	}{
+		"error if both build and location are set": {
+			inContent: []byte(`build: mockBuild
+location: mockLocation`),
+			wantedError: fmt.Errorf(`must specify one of "build" and "location"`),
+		},
+		"success": {
+			inContent: []byte(`location: mockLocation
+healthcheck:
+  command:
+    - foo
+    - bar`),
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			i := ImageWithHealthcheck{}
+			err := yaml.Unmarshal(tc.inContent, &i)
+			if tc.wantedError != nil {
+				require.EqualError(t, err, tc.wantedError.Error())
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, "mockLocation", aws.StringValue(i.Location))
+				require.Equal(t, []string{"foo", "bar"}, i.HealthCheck.Command)
+			}
+		})
+	}
+}
+
+func TestImageWithPort_UnmarshalYAML(t *testing.T) {
+	testCases := map[string]struct {
+		inContent []byte
+
+		wantedError error
+	}{
+		"error if both build and location are set": {
+			inContent: []byte(`build: mockBuild
+location: mockLocation`),
+			wantedError: fmt.Errorf(`must specify one of "build" and "location"`),
+		},
+		"success": {
+			inContent: []byte(`location: mockLocation
+port: 80`),
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			i := ImageWithPort{}
+			err := yaml.Unmarshal(tc.inContent, &i)
+			if tc.wantedError != nil {
+				require.EqualError(t, err, tc.wantedError.Error())
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, "mockLocation", aws.StringValue(i.Location))
+				require.Equal(t, 80, int(aws.Uint16Value(i.Port)))
 			}
 		})
 	}


### PR DESCRIPTION
<!-- Provide summary of changes -->
part of #2818. Finish manifest validation boilerplate and make sure `UnmarshalYAML` handles mutually exclusive fields validation before applying environment override.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
