### PR TITLE
chore(manifest): move more validation from template pkg

### DIFF
--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -899,11 +899,11 @@ func (o *deploySvcOpts) buildWorkerQueueNames() string {
 	sb := new(strings.Builder)
 	first := true
 	for _, subscription := range o.subscriptions {
-		if subscription.Queue == nil {
+		if subscription.Queue.IsEmpty() {
 			continue
 		}
-		topicSvc := template.StripNonAlphaNumFunc(subscription.Service)
-		topicName := template.StripNonAlphaNumFunc(subscription.Name)
+		topicSvc := template.StripNonAlphaNumFunc(aws.StringValue(subscription.Service))
+		topicName := template.StripNonAlphaNumFunc(aws.StringValue(subscription.Name))
 		subName := fmt.Sprintf("%s%sEventsQueue", topicSvc, strings.Title(topicName))
 		if first {
 			sb.WriteString(subName)

--- a/internal/pkg/cli/svc_init.go
+++ b/internal/pkg/cli/svc_init.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/copilot-cli/internal/pkg/docker/dockerfile"
 
 	"github.com/aws/copilot-cli/internal/pkg/docker/dockerengine"
@@ -484,8 +485,8 @@ func (o *initSvcOpts) askSvcPublishers() (err error) {
 	subscriptions := make([]manifest.TopicSubscription, 0, len(topics))
 	for _, t := range topics {
 		subscriptions = append(subscriptions, manifest.TopicSubscription{
-			Name:    t.Name(),
-			Service: t.Workload(),
+			Name:    aws.String(t.Name()),
+			Service: aws.String(t.Workload()),
 		})
 	}
 	o.topics = subscriptions
@@ -500,8 +501,8 @@ func parseSerializedSubscription(input string) (manifest.TopicSubscription, erro
 		return manifest.TopicSubscription{}, fmt.Errorf("parse subscription from key: %s", input)
 	}
 	return manifest.TopicSubscription{
-		Name:    attrs[2],
-		Service: attrs[1],
+		Name:    aws.String(attrs[2]),
+		Service: aws.String(attrs[1]),
 	}, nil
 }
 

--- a/internal/pkg/cli/svc_init_test.go
+++ b/internal/pkg/cli/svc_init_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/copilot-cli/internal/pkg/docker/dockerfile"
 
 	"github.com/aws/copilot-cli/internal/pkg/deploy"
@@ -695,8 +696,8 @@ func TestSvcInitOpts_Execute(t *testing.T) {
 					gomock.Any(),
 				).Return([]manifest.TopicSubscription{
 					{
-						Name:    "thetopic",
-						Service: "theservice",
+						Name:    aws.String("thetopic"),
+						Service: aws.String("theservice"),
 					},
 				}, nil)
 			},

--- a/internal/pkg/cli/validate.go
+++ b/internal/pkg/cli/validate.go
@@ -679,12 +679,10 @@ func validateSubscriptionKey(val interface{}) error {
 	if err != nil {
 		return errSubscribeBadFormat
 	}
-	err = validatePubSubName(aws.StringValue(sub.Name))
-	if err != nil {
+	if err := validatePubSubName(aws.StringValue(sub.Name)); err != nil {
 		return fmt.Errorf("invalid topic subscription topic name `%s`: %w", aws.StringValue(sub.Name), err)
 	}
-	err = basicNameValidation(aws.StringValue(sub.Service))
-	if err != nil {
+	if err = basicNameValidation(aws.StringValue(sub.Service)); err != nil {
 		return fmt.Errorf("invalid topic subscription service name `%s`: %w", aws.StringValue(sub.Service), err)
 	}
 	return nil

--- a/internal/pkg/cli/validate.go
+++ b/internal/pkg/cli/validate.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/spf13/afero"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/copilot-cli/internal/pkg/addon"
 	"github.com/aws/copilot-cli/internal/pkg/aws/apprunner"
@@ -678,13 +679,13 @@ func validateSubscriptionKey(val interface{}) error {
 	if err != nil {
 		return errSubscribeBadFormat
 	}
-	err = validatePubSubName(sub.Name)
+	err = validatePubSubName(aws.StringValue(sub.Name))
 	if err != nil {
-		return fmt.Errorf("invalid topic subscription topic name `%s`: %w", sub.Name, err)
+		return fmt.Errorf("invalid topic subscription topic name `%s`: %w", aws.StringValue(sub.Name), err)
 	}
-	err = basicNameValidation(sub.Service)
+	err = basicNameValidation(aws.StringValue(sub.Service))
 	if err != nil {
-		return fmt.Errorf("invalid topic subscription service name `%s`: %w", sub.Service, err)
+		return fmt.Errorf("invalid topic subscription service name `%s`: %w", aws.StringValue(sub.Service), err)
 	}
 	return nil
 }
@@ -715,7 +716,7 @@ func validateTopicsExist(subscriptions []manifest.TopicSubscription, topicARNs [
 	}
 
 	for _, ts := range subscriptions {
-		topicName := fmt.Sprintf(resourceNameFormat, app, env, ts.Service, ts.Name)
+		topicName := fmt.Sprintf(resourceNameFormat, app, env, aws.StringValue(ts.Service), aws.StringValue(ts.Name))
 		if !contains(topicName, validTopicResources) {
 			return fmt.Errorf(fmtErrTopicSubscriptionNotAllowed, topicName, env)
 		}

--- a/internal/pkg/cli/validate_test.go
+++ b/internal/pkg/cli/validate_test.go
@@ -803,8 +803,10 @@ func Test_validateTopicsExist(t *testing.T) {
 		{
 			Name:    aws.String("orders"),
 			Service: aws.String("database"),
-			Queue: manifest.SQSQueue{
-				Retention: &duration10Hours,
+			Queue: manifest.SQSQueueOrBool{
+				Advanced: manifest.SQSQueue{
+					Retention: &duration10Hours,
+				},
 			},
 		},
 	}

--- a/internal/pkg/cli/validate_test.go
+++ b/internal/pkg/cli/validate_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/copilot-cli/internal/pkg/manifest"
 
 	"github.com/spf13/afero"
@@ -796,13 +797,13 @@ func Test_validateTopicsExist(t *testing.T) {
 	duration10Hours := 10 * time.Hour
 	testGoodTopics := []manifest.TopicSubscription{
 		{
-			Name:    "events",
-			Service: "database",
+			Name:    aws.String("events"),
+			Service: aws.String("database"),
 		},
 		{
-			Name:    "orders",
-			Service: "database",
-			Queue: &manifest.SQSQueue{
+			Name:    aws.String("orders"),
+			Service: aws.String("database"),
+			Queue: manifest.SQSQueue{
 				Retention: &duration10Hours,
 			},
 		},

--- a/internal/pkg/deploy/cloudformation/stack/transformers.go
+++ b/internal/pkg/deploy/cloudformation/stack/transformers.go
@@ -725,11 +725,13 @@ func convertTopicSubscription(t manifest.TopicSubscription, url, accountID, app,
 	if err != nil {
 		return nil, fmt.Errorf(`invalid topic subscription "%s": %w`, aws.StringValue(t.Name), err)
 	}
-	queue, err := convertQueue(t.Queue)
+	queue, err := convertQueue(t.Queue.Advanced)
 	if err != nil {
 		return nil, fmt.Errorf(`invalid topic subscription "%s": %w`, aws.StringValue(t.Name), err)
 	}
-
+	if aws.BoolValue(t.Queue.Enabled) {
+		queue = &template.SQSQueue{}
+	}
 	return &template.TopicSubscription{
 		Name:    t.Name,
 		Service: t.Service,

--- a/internal/pkg/deploy/cloudformation/stack/transformers.go
+++ b/internal/pkg/deploy/cloudformation/stack/transformers.go
@@ -725,12 +725,16 @@ func convertTopicSubscription(t manifest.TopicSubscription, url, accountID, app,
 	if err != nil {
 		return nil, fmt.Errorf(`invalid topic subscription "%s": %w`, aws.StringValue(t.Name), err)
 	}
+	if aws.BoolValue(t.Queue.Enabled) {
+		return &template.TopicSubscription{
+			Name:    t.Name,
+			Service: t.Service,
+			Queue:   &template.SQSQueue{},
+		}, nil
+	}
 	queue, err := convertQueue(t.Queue.Advanced)
 	if err != nil {
 		return nil, fmt.Errorf(`invalid topic subscription "%s": %w`, aws.StringValue(t.Name), err)
-	}
-	if aws.BoolValue(t.Queue.Enabled) {
-		queue = &template.SQSQueue{}
 	}
 	return &template.TopicSubscription{
 		Name:    t.Name,

--- a/internal/pkg/deploy/cloudformation/stack/transformers.go
+++ b/internal/pkg/deploy/cloudformation/stack/transformers.go
@@ -723,22 +723,22 @@ func convertSubscribe(s manifest.SubscribeConfig, validTopicARNs []string, accou
 func convertTopicSubscription(t manifest.TopicSubscription, url, accountID, app, env, svc string) (*template.TopicSubscription, error) {
 	err := validateTopicSubscription(t)
 	if err != nil {
-		return nil, fmt.Errorf(`invalid topic subscription "%s": %w`, t.Name, err)
+		return nil, fmt.Errorf(`invalid topic subscription "%s": %w`, aws.StringValue(t.Name), err)
 	}
 	queue, err := convertQueue(t.Queue)
 	if err != nil {
-		return nil, fmt.Errorf(`invalid topic subscription "%s": %w`, t.Name, err)
+		return nil, fmt.Errorf(`invalid topic subscription "%s": %w`, aws.StringValue(t.Name), err)
 	}
 
 	return &template.TopicSubscription{
-		Name:    aws.String(t.Name),
-		Service: aws.String(t.Service),
+		Name:    t.Name,
+		Service: t.Service,
 		Queue:   queue,
 	}, nil
 }
 
-func convertQueue(q *manifest.SQSQueue) (*template.SQSQueue, error) {
-	if q == nil {
+func convertQueue(q manifest.SQSQueue) (*template.SQSQueue, error) {
+	if q.IsEmpty() {
 		return nil, nil
 	}
 	retention, err := convertRetention(q.Retention)

--- a/internal/pkg/deploy/cloudformation/stack/transformers_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/transformers_test.go
@@ -1661,11 +1661,11 @@ func Test_convertSubscribe(t *testing.T) {
 			inSubscribe: manifest.SubscribeConfig{
 				Topics: []manifest.TopicSubscription{
 					{
-						Name:    "name",
-						Service: "svc",
+						Name:    aws.String("name"),
+						Service: aws.String("svc"),
 					},
 				},
-				Queue: &manifest.SQSQueue{
+				Queue: manifest.SQSQueue{
 					Retention: &duration111Seconds,
 					Delay:     &duration111Seconds,
 					Timeout:   &duration111Seconds,
@@ -1695,11 +1695,11 @@ func Test_convertSubscribe(t *testing.T) {
 			inSubscribe: manifest.SubscribeConfig{
 				Topics: []manifest.TopicSubscription{
 					{
-						Name:    "name",
-						Service: "svc",
+						Name:    aws.String("name"),
+						Service: aws.String("svc"),
 					},
 				},
-				Queue: &manifest.SQSQueue{},
+				Queue: manifest.SQSQueue{},
 			},
 			wanted: &template.SubscribeOpts{
 				Topics: []*template.TopicSubscription{
@@ -1708,15 +1708,15 @@ func Test_convertSubscribe(t *testing.T) {
 						Service: aws.String("svc"),
 					},
 				},
-				Queue: &template.SQSQueue{},
+				Queue: nil,
 			},
 		},
 		"invalid topic name": {
 			inSubscribe: manifest.SubscribeConfig{
 				Topics: []manifest.TopicSubscription{
 					{
-						Name:    "t@p!c1~",
-						Service: "service1",
+						Name:    aws.String("t@p!c1~"),
+						Service: aws.String("service1"),
 					},
 				},
 			},
@@ -1726,8 +1726,8 @@ func Test_convertSubscribe(t *testing.T) {
 			inSubscribe: manifest.SubscribeConfig{
 				Topics: []manifest.TopicSubscription{
 					{
-						Name:    "topic1",
-						Service: "s#rv!ce1~",
+						Name:    aws.String("topic1"),
+						Service: aws.String("s#rv!ce1~"),
 					},
 				},
 			},
@@ -1737,11 +1737,11 @@ func Test_convertSubscribe(t *testing.T) {
 			inSubscribe: manifest.SubscribeConfig{
 				Topics: []manifest.TopicSubscription{
 					{
-						Name:    "name",
-						Service: "svc",
+						Name:    aws.String("name"),
+						Service: aws.String("svc"),
 					},
 				},
-				Queue: &manifest.SQSQueue{
+				Queue: manifest.SQSQueue{
 					Delay: &duration5Days,
 				},
 			},

--- a/internal/pkg/deploy/cloudformation/stack/transformers_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/transformers_test.go
@@ -1697,6 +1697,9 @@ func Test_convertSubscribe(t *testing.T) {
 					{
 						Name:    aws.String("name"),
 						Service: aws.String("svc"),
+						Queue: manifest.SQSQueueOrBool{
+							Enabled: aws.Bool(true),
+						},
 					},
 				},
 				Queue: manifest.SQSQueue{},
@@ -1706,6 +1709,7 @@ func Test_convertSubscribe(t *testing.T) {
 					{
 						Name:    aws.String("name"),
 						Service: aws.String("svc"),
+						Queue:   &template.SQSQueue{},
 					},
 				},
 				Queue: nil,

--- a/internal/pkg/deploy/cloudformation/stack/validate.go
+++ b/internal/pkg/deploy/cloudformation/stack/validate.go
@@ -444,11 +444,11 @@ func isCorrectSvcNameFormat(s string) bool {
 }
 
 func validateTopicSubscription(ts manifest.TopicSubscription) error {
-	if err := validatePubSubName(ts.Name); err != nil {
+	if err := validatePubSubName(aws.StringValue(ts.Name)); err != nil {
 		return err
 	}
 
-	if err := validateSvcName(ts.Service); err != nil {
+	if err := validateSvcName(aws.StringValue(ts.Service)); err != nil {
 		return err
 	}
 

--- a/internal/pkg/deploy/cloudformation/stack/validate_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/validate_test.go
@@ -533,20 +533,20 @@ func TestValidateTopicSubscription(t *testing.T) {
 	}{
 		"good case": {
 			inTS: manifest.TopicSubscription{
-				Name:    "name2",
-				Service: "svc",
+				Name:    aws.String("name2"),
+				Service: aws.String("svc"),
 			},
 			wantErr: nil,
 		},
 		"empty name": {
 			inTS: manifest.TopicSubscription{
-				Service: "svc",
+				Service: aws.String("svc"),
 			},
 			wantErr: errMissingPublishTopicField,
 		},
 		"empty svc name": {
 			inTS: manifest.TopicSubscription{
-				Name: "theName",
+				Name: aws.String("theName"),
 			},
 			wantErr: errInvalidSvcName,
 		},

--- a/internal/pkg/deploy/cloudformation/stack/worker_svc_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/worker_svc_test.go
@@ -108,8 +108,8 @@ Outputs:
 				testWorkerSvcManifestWithBadSubscribe.Subscribe = manifest.SubscribeConfig{
 					Topics: []manifest.TopicSubscription{
 						{
-							Name:    "name",
-							Service: "un@cept#ble",
+							Name:    aws.String("name"),
+							Service: aws.String("un@cept#ble"),
 						},
 					},
 				}

--- a/internal/pkg/initialize/workload_test.go
+++ b/internal/pkg/initialize/workload_test.go
@@ -722,8 +722,8 @@ func TestWorkloadInitializer_Service(t *testing.T) {
 			inSvcPort:        80,
 			inTopics: []manifest.TopicSubscription{
 				{
-					Name:    "theTopic",
-					Service: "publisher",
+					Name:    aws.String("theTopic"),
+					Service: aws.String("publisher"),
 				},
 			},
 

--- a/internal/pkg/manifest/storage_test.go
+++ b/internal/pkg/manifest/storage_test.go
@@ -15,7 +15,7 @@ type testVolume struct {
 	EFS EFSConfigOrBool `yaml:"efs"`
 }
 
-func Test_UnmarshalEFS(t *testing.T) {
+func TestEFSConfigOrBool_UnmarshalYAML(t *testing.T) {
 	testCases := map[string]struct {
 		manifest []byte
 		want     testVolume
@@ -47,7 +47,7 @@ efs:
 				},
 			},
 		},
-		"with just managed ": {
+		"with just managed": {
 			manifest: []byte(`
 efs: true`),
 			want: testVolume{

--- a/internal/pkg/manifest/svc_test.go
+++ b/internal/pkg/manifest/svc_test.go
@@ -337,18 +337,18 @@ subscribe:
 						Subscribe: SubscribeConfig{
 							Topics: []TopicSubscription{
 								{
-									Name:    "publisher1",
-									Service: "testpubsvc",
+									Name:    aws.String("publisher1"),
+									Service: aws.String("testpubsvc"),
 								},
 								{
-									Name:    "publisher2",
-									Service: "testpubjob",
-									Queue: &SQSQueue{
+									Name:    aws.String("publisher2"),
+									Service: aws.String("testpubjob"),
+									Queue: SQSQueue{
 										Timeout: &duration15Seconds,
 									},
 								},
 							},
-							Queue: &SQSQueue{
+							Queue: SQSQueue{
 								Delay: &duration15Seconds,
 								DeadLetter: DeadLetterQueue{
 									Tries: aws.Uint16(5),

--- a/internal/pkg/manifest/svc_test.go
+++ b/internal/pkg/manifest/svc_test.go
@@ -343,8 +343,10 @@ subscribe:
 								{
 									Name:    aws.String("publisher2"),
 									Service: aws.String("testpubjob"),
-									Queue: SQSQueue{
-										Timeout: &duration15Seconds,
+									Queue: SQSQueueOrBool{
+										Advanced: SQSQueue{
+											Timeout: &duration15Seconds,
+										},
 									},
 								},
 							},

--- a/internal/pkg/manifest/validate.go
+++ b/internal/pkg/manifest/validate.go
@@ -627,7 +627,15 @@ func (v *Volume) Validate() error {
 }
 
 // Validate returns nil if MountPointOpts is configured correctly.
-func (*MountPointOpts) Validate() error {
+func (m *MountPointOpts) Validate() error {
+	if m == nil {
+		return nil
+	}
+	if aws.StringValue(m.ContainerPath) == "" {
+		return &errFieldMustBeSpecified{
+			missingField: "path",
+		}
+	}
 	return nil
 }
 
@@ -695,7 +703,7 @@ func (l *Logging) Validate() error {
 func (s *SidecarConfig) Validate() error {
 	for ind, mp := range s.MountPoints {
 		if err := mp.Validate(); err != nil {
-			return fmt.Errorf(`validate "mount_points[%d]: %w`, ind, err)
+			return fmt.Errorf(`validate "mount_points[%d]": %w`, ind, err)
 		}
 	}
 	if err := s.HealthCheck.Validate(); err != nil {
@@ -705,6 +713,19 @@ func (s *SidecarConfig) Validate() error {
 		return fmt.Errorf(`validate "depends_on": %w`, err)
 	}
 	return s.ImageOverride.Validate()
+}
+
+// Validate returns nil if SidecarMountPoint is configured correctly.
+func (s *SidecarMountPoint) Validate() error {
+	if s == nil {
+		return nil
+	}
+	if aws.StringValue(s.SourceVolume) == "" {
+		return &errFieldMustBeSpecified{
+			missingField: "source_volume",
+		}
+	}
+	return s.MountPointOpts.Validate()
 }
 
 // Validate returns nil if NetworkConfig is configured correctly.

--- a/internal/pkg/manifest/validate.go
+++ b/internal/pkg/manifest/validate.go
@@ -30,6 +30,8 @@ var (
 
 	essentialContainerDependsOnValidStatuses = []string{dependsOnStart, dependsOnHealthy}
 	dependsOnValidStatuses                   = []string{dependsOnStart, dependsOnComplete, dependsOnSuccess, dependsOnHealthy}
+
+	invalidTaskDefOverridePathRegexp = []string{`Family`, `ContainerDefinitions\[\d+\].Name`}
 )
 
 // Validate returns nil if LoadBalancedWebServiceConfig is configured correctly.
@@ -810,7 +812,16 @@ func (d *DeadLetterQueue) Validate() error {
 }
 
 // Validate returns nil if OverrideRule is configured correctly.
-func (*OverrideRule) Validate() error {
+func (r *OverrideRule) Validate() error {
+	if r == nil {
+		return nil
+	}
+	for _, s := range invalidTaskDefOverridePathRegexp {
+		re := regexp.MustCompile(fmt.Sprintf(`^%s$`, s))
+		if re.MatchString(r.Path) {
+			return fmt.Errorf("%s cannot be overidden with a custom value", s)
+		}
+	}
 	return nil
 }
 

--- a/internal/pkg/manifest/validate.go
+++ b/internal/pkg/manifest/validate.go
@@ -855,11 +855,19 @@ func (t *TopicSubscription) Validate() error {
 }
 
 // Validate returns nil if SQSQueue is configured correctly.
-func (s *SQSQueue) Validate() error {
-	if s.IsEmpty() {
+func (q *SQSQueueOrBool) Validate() error {
+	if q.IsEmpty() {
 		return nil
 	}
-	if err := s.DeadLetter.Validate(); err != nil {
+	return q.Advanced.Validate()
+}
+
+// Validate returns nil if SQSQueue is configured correctly.
+func (q *SQSQueue) Validate() error {
+	if q.IsEmpty() {
+		return nil
+	}
+	if err := q.DeadLetter.Validate(); err != nil {
 		return fmt.Errorf(`validate "dead_letter": %w`, err)
 	}
 	return nil

--- a/internal/pkg/manifest/validate_test.go
+++ b/internal/pkg/manifest/validate_test.go
@@ -1136,6 +1136,14 @@ func TestSidecarConfig_Validate(t *testing.T) {
 
 		wantedErrorPrefix string
 	}{
+		"error if fail to validate mount_points": {
+			config: SidecarConfig{
+				MountPoints: []SidecarMountPoint{
+					{},
+				},
+			},
+			wantedErrorPrefix: `validate "mount_points[0]": `,
+		},
 		"error if fail to validate depends_on": {
 			config: SidecarConfig{
 				DependsOn: DependsOn{
@@ -1153,6 +1161,52 @@ func TestSidecarConfig_Validate(t *testing.T) {
 				require.Contains(t, gotErr.Error(), tc.wantedErrorPrefix)
 			} else {
 				require.NoError(t, gotErr)
+			}
+		})
+	}
+}
+
+func TestSidecarMountPoint_Validate(t *testing.T) {
+	testCases := map[string]struct {
+		in     SidecarMountPoint
+		wanted error
+	}{
+		"should return an error if source_volume is not set": {
+			in:     SidecarMountPoint{},
+			wanted: errors.New(`"source_volume" must be specified`),
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			err := tc.in.Validate()
+
+			if tc.wanted != nil {
+				require.EqualError(t, err, tc.wanted.Error())
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestMountPointOpts_Validate(t *testing.T) {
+	testCases := map[string]struct {
+		in     MountPointOpts
+		wanted error
+	}{
+		"should return an error if path is not set": {
+			in:     MountPointOpts{},
+			wanted: errors.New(`"path" must be specified`),
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			err := tc.in.Validate()
+
+			if tc.wanted != nil {
+				require.EqualError(t, err, tc.wanted.Error())
+			} else {
+				require.NoError(t, err)
 			}
 		})
 	}

--- a/internal/pkg/manifest/validate_test.go
+++ b/internal/pkg/manifest/validate_test.go
@@ -1508,7 +1508,7 @@ func TestOverrideRule_Validate(t *testing.T) {
 			in: OverrideRule{
 				Path: "ContainerDefinitions[1].Name",
 			},
-			wanted: errors.New(`ContainerDefinitions\[\d+\].Name cannot be overidden with a custom value`),
+			wanted: errors.New(`"ContainerDefinitions\[\d+\].Name" cannot be overridden with a custom value`),
 		},
 	}
 	for name, tc := range testCases {

--- a/internal/pkg/manifest/validate_test.go
+++ b/internal/pkg/manifest/validate_test.go
@@ -75,6 +75,17 @@ func TestLoadBalancedWebServiceConfig_Validate(t *testing.T) {
 			},
 			wantedErrorMsgPrefix: `validate "network": `,
 		},
+		"error if fail to validate taskdef override": {
+			lbConfig: LoadBalancedWebServiceConfig{
+				ImageConfig: testImageConfig,
+				TaskDefOverrides: []OverrideRule{
+					{
+						Path: "Family",
+					},
+				},
+			},
+			wantedErrorMsgPrefix: `validate "taskdef_overrides[0]": `,
+		},
 		"error if fail to validate dependencies": {
 			lbConfig: LoadBalancedWebServiceConfig{
 				ImageConfig: testImageConfig,
@@ -161,6 +172,17 @@ func TestBackendServiceConfig_Validate(t *testing.T) {
 				},
 			},
 			wantedErrorMsgPrefix: `validate "network": `,
+		},
+		"error if fail to validate taskdef override": {
+			config: BackendServiceConfig{
+				ImageConfig: testImageConfig,
+				TaskDefOverrides: []OverrideRule{
+					{
+						Path: "Family",
+					},
+				},
+			},
+			wantedErrorMsgPrefix: `validate "taskdef_overrides[0]": `,
 		},
 		"error if fail to validate dependencies": {
 			config: BackendServiceConfig{
@@ -273,6 +295,17 @@ func TestWorkerServiceConfig_Validate(t *testing.T) {
 			},
 			wantedErrorMsgPrefix: `validate "network": `,
 		},
+		"error if fail to validate taskdef override": {
+			config: WorkerServiceConfig{
+				ImageConfig: testImageConfig,
+				TaskDefOverrides: []OverrideRule{
+					{
+						Path: "Family",
+					},
+				},
+			},
+			wantedErrorMsgPrefix: `validate "taskdef_overrides[0]": `,
+		},
 		"error if fail to validate dependencies": {
 			config: WorkerServiceConfig{
 				ImageConfig: testImageConfig,
@@ -359,6 +392,20 @@ func TestScheduledJobConfig_Validate(t *testing.T) {
 				On:          JobTriggerConfig{},
 			},
 			wantedErrorMsgPrefix: `validate "on": `,
+		},
+		"error if fail to validate taskdef override": {
+			config: ScheduledJobConfig{
+				ImageConfig: testImageConfig,
+				On: JobTriggerConfig{
+					Schedule: aws.String("mockSchedule"),
+				},
+				TaskDefOverrides: []OverrideRule{
+					{
+						Path: "Family",
+					},
+				},
+			},
+			wantedErrorMsgPrefix: `validate "taskdef_overrides[0]": `,
 		},
 		"error if fail to validate dependencies": {
 			config: ScheduledJobConfig{
@@ -1200,6 +1247,31 @@ func TestJobTriggerConfig_Validate(t *testing.T) {
 		"should return an error if schedule is empty": {
 			in:     &JobTriggerConfig{},
 			wanted: errors.New(`"schedule" must be specified`),
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			err := tc.in.Validate()
+
+			if tc.wanted != nil {
+				require.EqualError(t, err, tc.wanted.Error())
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestOverrideRule_Validate(t *testing.T) {
+	testCases := map[string]struct {
+		in     OverrideRule
+		wanted error
+	}{
+		"should return an error if override rule is invalid": {
+			in: OverrideRule{
+				Path: "ContainerDefinitions[1].Name",
+			},
+			wanted: errors.New(`ContainerDefinitions\[\d+\].Name cannot be overidden with a custom value`),
 		},
 	}
 	for name, tc := range testCases {

--- a/internal/pkg/manifest/worker_svc.go
+++ b/internal/pkg/manifest/worker_svc.go
@@ -41,14 +41,19 @@ type WorkerServiceConfig struct {
 // SubscribeConfig represents the configurable options for setting up subscriptions.
 type SubscribeConfig struct {
 	Topics []TopicSubscription `yaml:"topics"`
-	Queue  *SQSQueue           `yaml:"queue"`
+	Queue  SQSQueue            `yaml:"queue"`
+}
+
+// IsEmpty returns empty if the struct has all zero members.
+func (s *SubscribeConfig) IsEmpty() bool {
+	return s.Topics == nil && s.Queue.IsEmpty()
 }
 
 // TopicSubscription represents the configurable options for setting up a SNS Topic Subscription.
 type TopicSubscription struct {
-	Name    string    `yaml:"name"`
-	Service string    `yaml:"service"`
-	Queue   *SQSQueue `yaml:"queue"`
+	Name    *string  `yaml:"name"`
+	Service *string  `yaml:"service"`
+	Queue   SQSQueue `yaml:"queue"`
 }
 
 // SQSQueue represents the configurable options for setting up a SQS Queue.
@@ -57,6 +62,12 @@ type SQSQueue struct {
 	Delay      *time.Duration  `yaml:"delay"`
 	Timeout    *time.Duration  `yaml:"timeout"`
 	DeadLetter DeadLetterQueue `yaml:"dead_letter"`
+}
+
+// IsEmpty returns empty if the struct has all zero members.
+func (q *SQSQueue) IsEmpty() bool {
+	return q.Retention == nil && q.Delay == nil && q.Timeout == nil &&
+		q.DeadLetter.IsEmpty()
 }
 
 // DeadLetterQueue represents the configurable options for setting up a Dead-Letter Queue.

--- a/internal/pkg/manifest/worker_svc_test.go
+++ b/internal/pkg/manifest/worker_svc_test.go
@@ -156,12 +156,12 @@ func TestWorkerSvc_MarshalBinary(t *testing.T) {
 				},
 				Topics: []TopicSubscription{
 					{
-						Name:    "testTopic",
-						Service: "service4TestTopic",
+						Name:    aws.String("testTopic"),
+						Service: aws.String("service4TestTopic"),
 					},
 					{
-						Name:    "testTopic2",
-						Service: "service4TestTopic2",
+						Name:    aws.String("testTopic2"),
+						Service: aws.String("service4TestTopic2"),
 					},
 				},
 			},
@@ -276,8 +276,8 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 			Subscribe: SubscribeConfig{
 				Topics: []TopicSubscription{
 					{
-						Name:    "topicName",
-						Service: "bestService",
+						Name:    aws.String("topicName"),
+						Service: aws.String("bestService"),
 					},
 				},
 			},
@@ -316,8 +316,8 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 				Subscribe: SubscribeConfig{
 					Topics: []TopicSubscription{
 						{
-							Name:    "topicName2",
-							Service: "bestService2",
+							Name:    aws.String("topicName2"),
+							Service: aws.String("bestService2"),
 						},
 					},
 				},
@@ -435,9 +435,9 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 			Subscribe: SubscribeConfig{
 				Topics: []TopicSubscription{
 					{
-						Name:    "name",
-						Service: "svc",
-						Queue: &SQSQueue{
+						Name:    aws.String("name"),
+						Service: aws.String("svc"),
+						Queue: SQSQueue{
 							Retention:  &duration111Seconds,
 							Delay:      &duration111Seconds,
 							Timeout:    &duration111Seconds,
@@ -466,9 +466,9 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 				Subscribe: SubscribeConfig{
 					Topics: []TopicSubscription{
 						{
-							Name:    "name",
-							Service: "svc",
-							Queue: &SQSQueue{
+							Name:    aws.String("name"),
+							Service: aws.String("svc"),
+							Queue: SQSQueue{
 								Retention:  &duration111Seconds,
 								Delay:      &duration111Seconds,
 								Timeout:    &duration111Seconds,
@@ -489,9 +489,9 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 			Subscribe: SubscribeConfig{
 				Topics: []TopicSubscription{
 					{
-						Name:    "name",
-						Service: "svc",
-						Queue: &SQSQueue{
+						Name:    aws.String("name"),
+						Service: aws.String("svc"),
+						Queue: SQSQueue{
 							Retention:  &duration111Seconds,
 							Delay:      &duration111Seconds,
 							Timeout:    &duration111Seconds,
@@ -522,9 +522,9 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 				Subscribe: SubscribeConfig{
 					Topics: []TopicSubscription{
 						{
-							Name:    "name",
-							Service: "svc",
-							Queue: &SQSQueue{
+							Name:    aws.String("name"),
+							Service: aws.String("svc"),
+							Queue: SQSQueue{
 								Retention:  &duration111Seconds,
 								Delay:      &duration111Seconds,
 								Timeout:    &duration111Seconds,
@@ -545,9 +545,9 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 			Subscribe: SubscribeConfig{
 				Topics: []TopicSubscription{
 					{
-						Name:    "name",
-						Service: "svc",
-						Queue: &SQSQueue{
+						Name:    aws.String("name"),
+						Service: aws.String("svc"),
+						Queue: SQSQueue{
 							Retention:  &duration111Seconds,
 							Delay:      &duration111Seconds,
 							Timeout:    &duration111Seconds,
@@ -580,9 +580,9 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 				Subscribe: SubscribeConfig{
 					Topics: []TopicSubscription{
 						{
-							Name:    "name",
-							Service: "svc",
-							Queue: &SQSQueue{
+							Name:    aws.String("name"),
+							Service: aws.String("svc"),
+							Queue: SQSQueue{
 								Retention:  &duration111Seconds,
 								Delay:      &duration111Seconds,
 								Timeout:    &duration111Seconds,
@@ -601,13 +601,13 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 		},
 		WorkerServiceConfig: WorkerServiceConfig{
 			Subscribe: SubscribeConfig{
-				Queue: nil,
+				Queue: SQSQueue{},
 			},
 		},
 		Environments: map[string]*WorkerServiceConfig{
 			"test-sub": {
 				Subscribe: SubscribeConfig{
-					Queue: &SQSQueue{
+					Queue: SQSQueue{
 						Retention:  &duration111Seconds,
 						Delay:      &duration111Seconds,
 						Timeout:    &duration111Seconds,
@@ -624,7 +624,7 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 		},
 		WorkerServiceConfig: WorkerServiceConfig{
 			Subscribe: SubscribeConfig{
-				Queue: &SQSQueue{
+				Queue: SQSQueue{
 					Retention:  &duration111Seconds,
 					Delay:      &duration111Seconds,
 					Timeout:    &duration111Seconds,
@@ -635,7 +635,7 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 		Environments: map[string]*WorkerServiceConfig{
 			"test-sub": {
 				Subscribe: SubscribeConfig{
-					Queue: nil,
+					Queue: SQSQueue{},
 				},
 			},
 		},
@@ -647,13 +647,13 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 		},
 		WorkerServiceConfig: WorkerServiceConfig{
 			Subscribe: SubscribeConfig{
-				Queue: &SQSQueue{},
+				Queue: SQSQueue{},
 			},
 		},
 		Environments: map[string]*WorkerServiceConfig{
 			"test-sub": {
 				Subscribe: SubscribeConfig{
-					Queue: &SQSQueue{
+					Queue: SQSQueue{
 						Retention:  &duration111Seconds,
 						Delay:      &duration111Seconds,
 						Timeout:    &duration111Seconds,
@@ -739,8 +739,8 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 					Subscribe: SubscribeConfig{
 						Topics: []TopicSubscription{
 							{
-								Name:    "topicName2",
-								Service: "bestService2",
+								Name:    aws.String("topicName2"),
+								Service: aws.String("bestService2"),
 							},
 						},
 					},
@@ -838,9 +838,9 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 					Subscribe: SubscribeConfig{
 						Topics: []TopicSubscription{
 							{
-								Name:    "name",
-								Service: "svc",
-								Queue: &SQSQueue{
+								Name:    aws.String("name"),
+								Service: aws.String("svc"),
+								Queue: SQSQueue{
 									Retention:  &duration111Seconds,
 									Delay:      &duration111Seconds,
 									Timeout:    &duration111Seconds,
@@ -866,9 +866,9 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 					Subscribe: SubscribeConfig{
 						Topics: []TopicSubscription{
 							{
-								Name:    "name",
-								Service: "svc",
-								Queue: &SQSQueue{
+								Name:    aws.String("name"),
+								Service: aws.String("svc"),
+								Queue: SQSQueue{
 									Retention:  &duration111Seconds,
 									Delay:      &duration111Seconds,
 									Timeout:    &duration111Seconds,
@@ -897,9 +897,9 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 					Subscribe: SubscribeConfig{
 						Topics: []TopicSubscription{
 							{
-								Name:    "name",
-								Service: "svc",
-								Queue: &SQSQueue{
+								Name:    aws.String("name"),
+								Service: aws.String("svc"),
+								Queue: SQSQueue{
 									Retention:  &duration111Seconds,
 									Delay:      &duration111Seconds,
 									Timeout:    &duration111Seconds,
@@ -925,9 +925,9 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 					Subscribe: SubscribeConfig{
 						Topics: []TopicSubscription{
 							{
-								Name:    "name",
-								Service: "svc",
-								Queue: &SQSQueue{
+								Name:    aws.String("name"),
+								Service: aws.String("svc"),
+								Queue: SQSQueue{
 									Retention:  &duration111Seconds,
 									Delay:      &duration111Seconds,
 									Timeout:    &duration111Seconds,
@@ -953,9 +953,9 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 					Subscribe: SubscribeConfig{
 						Topics: []TopicSubscription{
 							{
-								Name:    "name",
-								Service: "svc",
-								Queue: &SQSQueue{
+								Name:    aws.String("name"),
+								Service: aws.String("svc"),
+								Queue: SQSQueue{
 									Retention:  &duration111Seconds,
 									Delay:      &duration111Seconds,
 									Timeout:    &duration111Seconds,
@@ -984,9 +984,9 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 					Subscribe: SubscribeConfig{
 						Topics: []TopicSubscription{
 							{
-								Name:    "name",
-								Service: "svc",
-								Queue: &SQSQueue{
+								Name:    aws.String("name"),
+								Service: aws.String("svc"),
+								Queue: SQSQueue{
 									Retention:  &duration111Seconds,
 									Delay:      &duration111Seconds,
 									Timeout:    &duration111Seconds,
@@ -1010,7 +1010,7 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 				},
 				WorkerServiceConfig: WorkerServiceConfig{
 					Subscribe: SubscribeConfig{
-						Queue: &SQSQueue{
+						Queue: SQSQueue{
 							Retention:  &duration111Seconds,
 							Delay:      &duration111Seconds,
 							Timeout:    &duration111Seconds,
@@ -1032,7 +1032,7 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 				},
 				WorkerServiceConfig: WorkerServiceConfig{
 					Subscribe: SubscribeConfig{
-						Queue: &SQSQueue{
+						Queue: SQSQueue{
 							Retention:  &duration111Seconds,
 							Delay:      &duration111Seconds,
 							Timeout:    &duration111Seconds,
@@ -1057,7 +1057,7 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 						Image: Image{},
 					},
 					Subscribe: SubscribeConfig{
-						Queue: &SQSQueue{
+						Queue: SQSQueue{
 							Retention:  &duration111Seconds,
 							Delay:      &duration111Seconds,
 							Timeout:    &duration111Seconds,
@@ -1237,60 +1237,6 @@ func TestWorkerSvc_ApplyEnv_CountOverrides(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			// WHEN
 			actual, _ := svc.ApplyEnv("test")
-
-			// THEN
-			require.Equal(t, tc.expected, actual)
-		})
-	}
-}
-
-func TestWorkerSvc_Subscriptions(t *testing.T) {
-	testCases := map[string]struct {
-		inSubscription SubscribeConfig
-		expected       []TopicSubscription
-	}{
-		"subscription specified": {
-			inSubscription: SubscribeConfig{
-				Topics: []TopicSubscription{
-					{
-						Name:    "orders",
-						Service: "database",
-					},
-					{
-						Name:    "events",
-						Service: "api",
-					},
-				},
-				Queue: &SQSQueue{
-					Retention: durationp(4 * 24 * time.Hour),
-				},
-			},
-			expected: []TopicSubscription{
-				{
-					Name:    "orders",
-					Service: "database",
-				},
-				{
-					Name:    "events",
-					Service: "api",
-				},
-			},
-		},
-		"no topics": {
-			inSubscription: SubscribeConfig{},
-			expected:       nil,
-		},
-	}
-	for name, tc := range testCases {
-		// GIVEN
-		svc := WorkerService{
-			WorkerServiceConfig: WorkerServiceConfig{
-				Subscribe: tc.inSubscription,
-			},
-		}
-		t.Run(name, func(t *testing.T) {
-			// WHEN
-			actual := svc.Subscriptions()
 
 			// THEN
 			require.Equal(t, tc.expected, actual)

--- a/internal/pkg/manifest/worker_svc_test.go
+++ b/internal/pkg/manifest/worker_svc_test.go
@@ -14,6 +14,22 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+func newMockSQSQueueOrBool() SQSQueueOrBool {
+	return SQSQueueOrBool{
+		Advanced: newMockSQSQueue(),
+	}
+}
+
+func newMockSQSQueue() SQSQueue {
+	duration111Seconds := 111 * time.Second
+	return SQSQueue{
+		Retention:  &duration111Seconds,
+		Delay:      &duration111Seconds,
+		Timeout:    &duration111Seconds,
+		DeadLetter: DeadLetterQueue{Tries: aws.Uint16(10)},
+	}
+}
+
 func TestNewWorkerSvc(t *testing.T) {
 	testCases := map[string]struct {
 		inProps WorkerServiceProps
@@ -425,7 +441,6 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 			},
 		},
 	}
-	duration111Seconds := 111 * time.Second
 	mockWorkerServiceWithSubscribeNilOverride := WorkerService{
 		Workload: Workload{
 			Name: aws.String("phonetool"),
@@ -437,12 +452,7 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 					{
 						Name:    aws.String("name"),
 						Service: aws.String("svc"),
-						Queue: SQSQueue{
-							Retention:  &duration111Seconds,
-							Delay:      &duration111Seconds,
-							Timeout:    &duration111Seconds,
-							DeadLetter: DeadLetterQueue{Tries: aws.Uint16(10)},
-						},
+						Queue:   newMockSQSQueueOrBool(),
 					},
 				},
 			},
@@ -468,12 +478,7 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 						{
 							Name:    aws.String("name"),
 							Service: aws.String("svc"),
-							Queue: SQSQueue{
-								Retention:  &duration111Seconds,
-								Delay:      &duration111Seconds,
-								Timeout:    &duration111Seconds,
-								DeadLetter: DeadLetterQueue{Tries: aws.Uint16(10)},
-							},
+							Queue:   newMockSQSQueueOrBool(),
 						},
 					},
 				},
@@ -491,12 +496,7 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 					{
 						Name:    aws.String("name"),
 						Service: aws.String("svc"),
-						Queue: SQSQueue{
-							Retention:  &duration111Seconds,
-							Delay:      &duration111Seconds,
-							Timeout:    &duration111Seconds,
-							DeadLetter: DeadLetterQueue{Tries: aws.Uint16(10)},
-						},
+						Queue:   newMockSQSQueueOrBool(),
 					},
 				},
 			},
@@ -524,12 +524,7 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 						{
 							Name:    aws.String("name"),
 							Service: aws.String("svc"),
-							Queue: SQSQueue{
-								Retention:  &duration111Seconds,
-								Delay:      &duration111Seconds,
-								Timeout:    &duration111Seconds,
-								DeadLetter: DeadLetterQueue{Tries: aws.Uint16(10)},
-							},
+							Queue:   newMockSQSQueueOrBool(),
 						},
 					},
 				},
@@ -547,12 +542,7 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 					{
 						Name:    aws.String("name"),
 						Service: aws.String("svc"),
-						Queue: SQSQueue{
-							Retention:  &duration111Seconds,
-							Delay:      &duration111Seconds,
-							Timeout:    &duration111Seconds,
-							DeadLetter: DeadLetterQueue{Tries: aws.Uint16(10)},
-						},
+						Queue:   newMockSQSQueueOrBool(),
 					},
 				},
 			},
@@ -582,12 +572,7 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 						{
 							Name:    aws.String("name"),
 							Service: aws.String("svc"),
-							Queue: SQSQueue{
-								Retention:  &duration111Seconds,
-								Delay:      &duration111Seconds,
-								Timeout:    &duration111Seconds,
-								DeadLetter: DeadLetterQueue{Tries: aws.Uint16(10)},
-							},
+							Queue:   newMockSQSQueueOrBool(),
 						},
 					},
 				},
@@ -607,12 +592,7 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 		Environments: map[string]*WorkerServiceConfig{
 			"test-sub": {
 				Subscribe: SubscribeConfig{
-					Queue: SQSQueue{
-						Retention:  &duration111Seconds,
-						Delay:      &duration111Seconds,
-						Timeout:    &duration111Seconds,
-						DeadLetter: DeadLetterQueue{Tries: aws.Uint16(10)},
-					},
+					Queue: newMockSQSQueue(),
 				},
 			},
 		},
@@ -624,12 +604,7 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 		},
 		WorkerServiceConfig: WorkerServiceConfig{
 			Subscribe: SubscribeConfig{
-				Queue: SQSQueue{
-					Retention:  &duration111Seconds,
-					Delay:      &duration111Seconds,
-					Timeout:    &duration111Seconds,
-					DeadLetter: DeadLetterQueue{Tries: aws.Uint16(10)},
-				},
+				Queue: newMockSQSQueue(),
 			},
 		},
 		Environments: map[string]*WorkerServiceConfig{
@@ -653,12 +628,7 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 		Environments: map[string]*WorkerServiceConfig{
 			"test-sub": {
 				Subscribe: SubscribeConfig{
-					Queue: SQSQueue{
-						Retention:  &duration111Seconds,
-						Delay:      &duration111Seconds,
-						Timeout:    &duration111Seconds,
-						DeadLetter: DeadLetterQueue{Tries: aws.Uint16(10)},
-					},
+					Queue: newMockSQSQueue(),
 				},
 			},
 		},
@@ -840,12 +810,7 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 							{
 								Name:    aws.String("name"),
 								Service: aws.String("svc"),
-								Queue: SQSQueue{
-									Retention:  &duration111Seconds,
-									Delay:      &duration111Seconds,
-									Timeout:    &duration111Seconds,
-									DeadLetter: DeadLetterQueue{Tries: aws.Uint16(10)},
-								},
+								Queue:   newMockSQSQueueOrBool(),
 							},
 						},
 					},
@@ -868,12 +833,7 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 							{
 								Name:    aws.String("name"),
 								Service: aws.String("svc"),
-								Queue: SQSQueue{
-									Retention:  &duration111Seconds,
-									Delay:      &duration111Seconds,
-									Timeout:    &duration111Seconds,
-									DeadLetter: DeadLetterQueue{Tries: aws.Uint16(10)},
-								},
+								Queue:   newMockSQSQueueOrBool(),
 							},
 						},
 					},
@@ -899,12 +859,7 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 							{
 								Name:    aws.String("name"),
 								Service: aws.String("svc"),
-								Queue: SQSQueue{
-									Retention:  &duration111Seconds,
-									Delay:      &duration111Seconds,
-									Timeout:    &duration111Seconds,
-									DeadLetter: DeadLetterQueue{Tries: aws.Uint16(10)},
-								},
+								Queue:   newMockSQSQueueOrBool(),
 							},
 						},
 					},
@@ -927,12 +882,7 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 							{
 								Name:    aws.String("name"),
 								Service: aws.String("svc"),
-								Queue: SQSQueue{
-									Retention:  &duration111Seconds,
-									Delay:      &duration111Seconds,
-									Timeout:    &duration111Seconds,
-									DeadLetter: DeadLetterQueue{Tries: aws.Uint16(10)},
-								},
+								Queue:   newMockSQSQueueOrBool(),
 							},
 						},
 					},
@@ -955,12 +905,7 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 							{
 								Name:    aws.String("name"),
 								Service: aws.String("svc"),
-								Queue: SQSQueue{
-									Retention:  &duration111Seconds,
-									Delay:      &duration111Seconds,
-									Timeout:    &duration111Seconds,
-									DeadLetter: DeadLetterQueue{Tries: aws.Uint16(10)},
-								},
+								Queue:   newMockSQSQueueOrBool(),
 							},
 						},
 					},
@@ -986,12 +931,7 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 							{
 								Name:    aws.String("name"),
 								Service: aws.String("svc"),
-								Queue: SQSQueue{
-									Retention:  &duration111Seconds,
-									Delay:      &duration111Seconds,
-									Timeout:    &duration111Seconds,
-									DeadLetter: DeadLetterQueue{Tries: aws.Uint16(10)},
-								},
+								Queue:   newMockSQSQueueOrBool(),
 							},
 						},
 					},
@@ -1010,12 +950,7 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 				},
 				WorkerServiceConfig: WorkerServiceConfig{
 					Subscribe: SubscribeConfig{
-						Queue: SQSQueue{
-							Retention:  &duration111Seconds,
-							Delay:      &duration111Seconds,
-							Timeout:    &duration111Seconds,
-							DeadLetter: DeadLetterQueue{Tries: aws.Uint16(10)},
-						},
+						Queue: newMockSQSQueue(),
 					},
 				},
 			},
@@ -1032,12 +967,7 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 				},
 				WorkerServiceConfig: WorkerServiceConfig{
 					Subscribe: SubscribeConfig{
-						Queue: SQSQueue{
-							Retention:  &duration111Seconds,
-							Delay:      &duration111Seconds,
-							Timeout:    &duration111Seconds,
-							DeadLetter: DeadLetterQueue{Tries: aws.Uint16(10)},
-						},
+						Queue: newMockSQSQueue(),
 					},
 				},
 			},
@@ -1057,12 +987,7 @@ func TestWorkerSvc_ApplyEnv(t *testing.T) {
 						Image: Image{},
 					},
 					Subscribe: SubscribeConfig{
-						Queue: SQSQueue{
-							Retention:  &duration111Seconds,
-							Delay:      &duration111Seconds,
-							Timeout:    &duration111Seconds,
-							DeadLetter: DeadLetterQueue{Tries: aws.Uint16(10)},
-						},
+						Queue: newMockSQSQueue(),
 					},
 				},
 			},
@@ -1267,6 +1192,64 @@ func TestDeadLetterQueue_IsEmpty(t *testing.T) {
 
 			// THEN
 			require.Equal(t, tc.wanted, got)
+		})
+	}
+}
+
+func TestSQSQueueOrBool_UnmarshalYAML(t *testing.T) {
+	testCases := map[string]struct {
+		inContent []byte
+
+		wantedStruct SQSQueueOrBool
+		wantedError  error
+	}{
+		"with boolean": {
+			inContent: []byte(`queue: true`),
+
+			wantedStruct: SQSQueueOrBool{
+				Enabled: aws.Bool(true),
+			},
+		},
+		"with advanced case": {
+			inContent: []byte(`queue:
+  retention: 5s
+  delay: 1m
+  timeout: 5m
+  dead_letter:
+    tries: 10`),
+
+			wantedStruct: SQSQueueOrBool{
+				Advanced: SQSQueue{
+					Retention: durationp(5 * time.Second),
+					Delay:     durationp(1 * time.Minute),
+					Timeout:   durationp(5 * time.Minute),
+					DeadLetter: DeadLetterQueue{
+						Tries: uint16P(10),
+					},
+				},
+			},
+		},
+		"invalid type": {
+			inContent: []byte(`queue: 10`),
+
+			wantedError: errUnmarshalQueueOpts,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			var sc TopicSubscription
+			err := yaml.Unmarshal(tc.inContent, &sc)
+			if tc.wantedError != nil {
+				require.EqualError(t, err, tc.wantedError.Error())
+			} else {
+				require.NoError(t, err)
+				// check memberwise dereferenced pointer equality
+				require.Equal(t, tc.wantedStruct.Enabled, sc.Queue.Enabled)
+				require.Equal(t, tc.wantedStruct.Advanced.DeadLetter, sc.Queue.Advanced.DeadLetter)
+				require.Equal(t, tc.wantedStruct.Advanced.Delay, sc.Queue.Advanced.Delay)
+				require.Equal(t, tc.wantedStruct.Advanced.Retention, sc.Queue.Advanced.Retention)
+				require.Equal(t, tc.wantedStruct.Advanced.Timeout, sc.Queue.Advanced.Timeout)
+			}
 		})
 	}
 }

--- a/site/content/docs/manifest/worker-service.en.md
+++ b/site/content/docs/manifest/worker-service.en.md
@@ -97,7 +97,7 @@ Required. The name of the SNS topic to subscribe to.
 Required. The service this SNS topic is exposed by. Together with the topic name, this uniquely identifies an SNS topic in the copilot environment.
 
 <span class="parent-field">topic.</span><a id="topic-queue" href="#topic-queue" class="field">`queue`</a> <span class="type">Boolean or Map</span>
-Optional. Define SQS queue for the topic. If specified as a boolean, only default queue configuration will be used. Specify this field as a map for more customization of this topic-specific queue.
+Optional. Specify SQS queue configuration for the topic. If specified as `true`, the queue will be created  with default configuration. Specify this field as a map for customization of certain attributes for this topic-specific queue.
 
 {% include 'image-config.en.md' %}
 

--- a/site/content/docs/manifest/worker-service.en.md
+++ b/site/content/docs/manifest/worker-service.en.md
@@ -55,7 +55,7 @@ The architecture type for your service. [Worker Services](../concepts/services.e
 <div class="separator"></div>
 
 <a id="subscribe" href="#subscribe" class="field">`subscribe`</a> <span class="type">Map</span>
-The `subscribe` section allows worker services to create subscriptions to the SNS topics exposed by other Copilot services in the same application and environment. Each topic can define its own SQS queue, but by default all topics are subscribed to the worker service's default queue. 
+The `subscribe` section allows worker services to create subscriptions to the SNS topics exposed by other Copilot services in the same application and environment. Each topic can define its own SQS queue, but by default all topics are subscribed to the worker service's default queue.
 
 ```yaml
 subscribe:
@@ -63,7 +63,7 @@ subscribe:
     - name: events
       service: api
       queue: # Define a topic-specific queue for the api-events topic.
-        timeout: 20s 
+        timeout: 20s
     - name: events
       service: fe
   queue: # By default, messages from all topics will go to a shared queue.
@@ -95,6 +95,9 @@ Required. The name of the SNS topic to subscribe to.
 
 <span class="parent-field">topic.</span><a id="topic-service" href="#topic-service" class="field">`service`</a> <span class="type">String</span>
 Required. The service this SNS topic is exposed by. Together with the topic name, this uniquely identifies an SNS topic in the copilot environment.
+
+<span class="parent-field">topic.</span><a id="topic-queue" href="#topic-queue" class="field">`queue`</a> <span class="type">Boolean or Map</span>
+Optional. Define SQS queue for the topic. If specified as a boolean, only default queue configuration will be used. Specify this field as a map for more customization of this topic-specific queue.
 
 {% include 'image-config.en.md' %}
 
@@ -171,8 +174,8 @@ Scale up or down based on the average memory your service should maintain.
 
 <span class="parent-field">count.</span><a id="count-queue-delay" href="#count-queue-delay" class="field">`queue_delay`</a> <span class="type">Integer</span>   
 Scale up or down to maintain an acceptable queue latency by tracking against the acceptable backlog per task.  
-The acceptable backlog per task is calculated by dividing `acceptable_latency` by `msg_processing_time`. For example, if you can tolerate consuming a message within 10 minutes 
-of its arrival and it takes your task on average 250 milliseconds to process a message, then `acceptableBacklogPerTask = 10 * 60 / 0.25 = 2400`. Therefore, each task can hold up to 
+The acceptable backlog per task is calculated by dividing `acceptable_latency` by `msg_processing_time`. For example, if you can tolerate consuming a message within 10 minutes
+of its arrival and it takes your task on average 250 milliseconds to process a message, then `acceptableBacklogPerTask = 10 * 60 / 0.25 = 2400`. Therefore, each task can hold up to
 2,400 messages.   
 A target tracking policy is set up on your behalf to ensure your service scales up and down to maintain <= 2400 messages per task. To learn more see [docs](https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-using-sqs-queue.html).
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
Part of #2818. This PR adds validation for
- task def override
- sidecar mount points
- storage config
- publish/subscribe

Also make `topic.queue` to able to accept either bool or map as input so as users can better specify a topic specific queue with default config.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
