### PR TITLE
fix: use role ARN (not name) for execution/task role in ECS task defs

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/testdata/stacklocal/override-cf.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/stacklocal/override-cf.yml
@@ -10,8 +10,8 @@
         - FARGATE
       Cpu: !Ref TaskCPU
       Memory: !Ref TaskMemory
-      ExecutionRoleArn: !Ref ExecutionRole
-      TaskRoleArn: !Ref TaskRole
+      ExecutionRoleArn: !GetAtt ExecutionRole.Arn
+      TaskRoleArn: !GetAtt TaskRole.Arn
       ContainerDefinitions:
         - Name: !Ref WorkloadName
           Image: !Ref ContainerImage

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/job-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/job-test.stack.yml
@@ -117,8 +117,8 @@ Resources:
       Memory: !Ref TaskMemory
       EphemeralStorage:
         SizeInGiB: 200
-      ExecutionRoleArn: !Ref ExecutionRole
-      TaskRoleArn: !Ref TaskRole
+      ExecutionRoleArn: !GetAtt ExecutionRole.Arn
+      TaskRoleArn: !GetAtt TaskRole.Arn
       ContainerDefinitions:
         - Name: !Ref WorkloadName
           Image: !Ref ContainerImage

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-prod.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-prod.stack.yml
@@ -68,8 +68,8 @@ Resources:
         - FARGATE
       Cpu: !Ref TaskCPU
       Memory: !Ref TaskMemory
-      ExecutionRoleArn: !Ref ExecutionRole
-      TaskRoleArn: !Ref TaskRole
+      ExecutionRoleArn: !GetAtt ExecutionRole.Arn
+      TaskRoleArn: !GetAtt TaskRole.Arn
       ContainerDefinitions:
         - Name: !Ref WorkloadName
           Image: !Ref ContainerImage

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-staging.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-staging.stack.yml
@@ -68,8 +68,8 @@ Resources:
         - FARGATE
       Cpu: !Ref TaskCPU
       Memory: !Ref TaskMemory
-      ExecutionRoleArn: !Ref ExecutionRole
-      TaskRoleArn: !Ref TaskRole
+      ExecutionRoleArn: !GetAtt ExecutionRole.Arn
+      TaskRoleArn: !GetAtt TaskRole.Arn
       ContainerDefinitions:
         - Name: !Ref WorkloadName
           Image: !Ref ContainerImage

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-test.stack.yml
@@ -68,8 +68,8 @@ Resources:
         - FARGATE
       Cpu: !Ref TaskCPU
       Memory: !Ref TaskMemory
-      ExecutionRoleArn: !Ref ExecutionRole
-      TaskRoleArn: !Ref TaskRole
+      ExecutionRoleArn: !GetAtt ExecutionRole.Arn
+      TaskRoleArn: !GetAtt TaskRole.Arn
       ContainerDefinitions:
         - Name: !Ref WorkloadName
           Image: !Ref ContainerImage

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/worker-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/worker-test.stack.yml
@@ -48,8 +48,8 @@ Resources:
         - FARGATE
       Cpu: !Ref TaskCPU
       Memory: !Ref TaskMemory
-      ExecutionRoleArn: !Ref ExecutionRole
-      TaskRoleArn: !Ref TaskRole
+      ExecutionRoleArn: !GetAtt ExecutionRole.Arn
+      TaskRoleArn: !GetAtt TaskRole.Arn
       ContainerDefinitions:
         - Name: !Ref WorkloadName
           Image: !Ref ContainerImage

--- a/internal/pkg/template/templates/task/cf.yml
+++ b/internal/pkg/template/templates/task/cf.yml
@@ -67,8 +67,8 @@ Resources:
       NetworkMode: awsvpc
       Cpu: !Ref TaskCPU
       Memory: !Ref TaskMemory
-      ExecutionRoleArn: !If [HasExecutionRole, !Ref ExecutionRole, !Ref DefaultExecutionRole]
-      TaskRoleArn: !If [HasTaskRole, !Ref TaskRole, !Ref DefaultTaskRole]
+      ExecutionRoleArn: !If [HasExecutionRole, !Ref ExecutionRole, !GetAtt DefaultExecutionRole.Arn]
+      TaskRoleArn: !If [HasTaskRole, !Ref TaskRole, !GetAtt DefaultTaskRole.Arn]
   DefaultExecutionRole:
     Metadata:
       'aws:copilot:description': 'An IAM Role for the Fargate agent to make AWS API calls on your behalf'

--- a/internal/pkg/template/templates/workloads/partials/cf/fargate-taskdef-base-properties.yml
+++ b/internal/pkg/template/templates/workloads/partials/cf/fargate-taskdef-base-properties.yml
@@ -10,5 +10,5 @@ EphemeralStorage:
   SizeInGiB: {{.Storage.Ephemeral}}
 {{- end}}
 {{- end}}
-ExecutionRoleArn: !Ref ExecutionRole
-TaskRoleArn: !Ref TaskRole
+ExecutionRoleArn: !GetAtt ExecutionRole.Arn
+TaskRoleArn: !GetAtt TaskRole.Arn


### PR DESCRIPTION
Using the role name in the ECS task definition results in CloudFormation stack drift.  ECS returns the fully-qualified ARN when describing the task def, which fails the comparison to the stack template's value.

Example drift seen in the CFN console for a Copilot-created service stack:

```
Expected:
  "ExecutionRoleArn": "proton-pilot-example-test-front-end-ExecutionRole-1CY6ZXWZU4YQF",
  "TaskRoleArn": "proton-pilot-example-test-front-end-TaskRole-1NMILHSCBDBTT"

Actual:
  "ExecutionRoleArn": "arn:aws:iam::123456789012:role/proton-pilot-example-test-front-end-ExecutionRole-1CY6ZXWZU4YQF",
  "TaskRoleArn": "arn:aws:iam::123456789012:role/proton-pilot-example-test-front-end-TaskRole-1NMILHSCBDBTT"
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
