### PR TITLE
test(manifest): add integ test making sure all structs implement Validate

### DIFF
--- a/internal/pkg/manifest/validate.go
+++ b/internal/pkg/manifest/validate.go
@@ -44,7 +44,26 @@ var (
 )
 
 // Validate returns nil if LoadBalancedWebService is configured correctly.
-func (l *LoadBalancedWebService) Validate() error {
+func (l LoadBalancedWebService) Validate() error {
+	var err error
+	if err = l.LoadBalancedWebServiceConfig.Validate(); err != nil {
+		return err
+	}
+	if err = l.Workload.Validate(); err != nil {
+		return err
+	}
+	if err = validateContainerDeps(validateDependenciesOpts{
+		sidecarConfig:     l.Sidecars,
+		imageConfig:       l.ImageConfig.Image,
+		mainContainerName: aws.StringValue(l.Name),
+	}); err != nil {
+		return fmt.Errorf("validate container dependencies: %w", err)
+	}
+	return nil
+}
+
+// Validate returns nil if LoadBalancedWebServiceConfig is configured correctly.
+func (l LoadBalancedWebServiceConfig) Validate() error {
 	var err error
 	if err = l.ImageConfig.Validate(); err != nil {
 		return fmt.Errorf(`validate "image": %w`, err)
@@ -77,24 +96,30 @@ func (l *LoadBalancedWebService) Validate() error {
 			return fmt.Errorf(`validate "taskdef_overrides[%d]": %w`, ind, err)
 		}
 	}
-	name := aws.StringValue(l.Name)
-	if name == "" {
-		return &errFieldMustBeSpecified{
-			missingField: "name",
-		}
+	return nil
+}
+
+// Validate returns nil if BackendService is configured correctly.
+func (b BackendService) Validate() error {
+	var err error
+	if err = b.BackendServiceConfig.Validate(); err != nil {
+		return err
+	}
+	if err = b.Workload.Validate(); err != nil {
+		return err
 	}
 	if err = validateContainerDeps(validateDependenciesOpts{
-		sidecarConfig:     l.Sidecars,
-		imageConfig:       l.ImageConfig.Image,
-		mainContainerName: name,
+		sidecarConfig:     b.Sidecars,
+		imageConfig:       b.ImageConfig.Image,
+		mainContainerName: aws.StringValue(b.Name),
 	}); err != nil {
 		return fmt.Errorf("validate container dependencies: %w", err)
 	}
 	return nil
 }
 
-// Validate returns nil if BackendService is configured correctly.
-func (b *BackendService) Validate() error {
+// Validate returns nil if BackendServiceConfig is configured correctly.
+func (b BackendServiceConfig) Validate() error {
 	var err error
 	if err = b.ImageConfig.Validate(); err != nil {
 		return fmt.Errorf(`validate "image": %w`, err)
@@ -124,24 +149,19 @@ func (b *BackendService) Validate() error {
 			return fmt.Errorf(`validate "taskdef_overrides[%d]": %w`, ind, err)
 		}
 	}
-	name := aws.StringValue(b.Name)
-	if name == "" {
-		return &errFieldMustBeSpecified{
-			missingField: "name",
-		}
-	}
-	if err = validateContainerDeps(validateDependenciesOpts{
-		sidecarConfig:     b.Sidecars,
-		imageConfig:       b.ImageConfig.Image,
-		mainContainerName: name,
-	}); err != nil {
-		return fmt.Errorf("validate container dependencies: %w", err)
-	}
 	return nil
 }
 
 // Validate returns nil if RequestDrivenWebService is configured correctly.
-func (r *RequestDrivenWebService) Validate() error {
+func (r RequestDrivenWebService) Validate() error {
+	if err := r.RequestDrivenWebServiceConfig.Validate(); err != nil {
+		return err
+	}
+	return r.Workload.Validate()
+}
+
+// Validate returns nil if RequestDrivenWebServiceConfig is configured correctly.
+func (r RequestDrivenWebServiceConfig) Validate() error {
 	var err error
 	if err = r.ImageConfig.Validate(); err != nil {
 		return fmt.Errorf(`validate "image": %w`, err)
@@ -152,16 +172,30 @@ func (r *RequestDrivenWebService) Validate() error {
 	if err = r.PublishConfig.Validate(); err != nil {
 		return fmt.Errorf(`validate "publish": %w`, err)
 	}
-	if aws.StringValue(r.Name) == "" {
-		return &errFieldMustBeSpecified{
-			missingField: "name",
-		}
+	return nil
+}
+
+// Validate returns nil if WorkerService is configured correctly.
+func (w WorkerService) Validate() error {
+	var err error
+	if err = w.WorkerServiceConfig.Validate(); err != nil {
+		return err
+	}
+	if err = w.Workload.Validate(); err != nil {
+		return err
+	}
+	if err = validateContainerDeps(validateDependenciesOpts{
+		sidecarConfig:     w.Sidecars,
+		imageConfig:       w.ImageConfig.Image,
+		mainContainerName: aws.StringValue(w.Name),
+	}); err != nil {
+		return fmt.Errorf("validate container dependencies: %w", err)
 	}
 	return nil
 }
 
 // Validate returns nil if WorkerServiceConfig is configured correctly.
-func (w *WorkerService) Validate() error {
+func (w WorkerServiceConfig) Validate() error {
 	var err error
 	if err = w.ImageConfig.Validate(); err != nil {
 		return fmt.Errorf(`validate "image": %w`, err)
@@ -191,24 +225,30 @@ func (w *WorkerService) Validate() error {
 			return fmt.Errorf(`validate "taskdef_overrides[%d]": %w`, ind, err)
 		}
 	}
-	name := aws.StringValue(w.Name)
-	if name == "" {
-		return &errFieldMustBeSpecified{
-			missingField: "name",
-		}
+	return nil
+}
+
+// Validate returns nil if ScheduledJob is configured correctly.
+func (s ScheduledJob) Validate() error {
+	var err error
+	if err = s.ScheduledJobConfig.Validate(); err != nil {
+		return err
+	}
+	if err = s.Workload.Validate(); err != nil {
+		return err
 	}
 	if err = validateContainerDeps(validateDependenciesOpts{
-		sidecarConfig:     w.Sidecars,
-		imageConfig:       w.ImageConfig.Image,
-		mainContainerName: name,
+		sidecarConfig:     s.Sidecars,
+		imageConfig:       s.ImageConfig.Image,
+		mainContainerName: aws.StringValue(s.Name),
 	}); err != nil {
 		return fmt.Errorf("validate container dependencies: %w", err)
 	}
 	return nil
 }
 
-// Validate returns nil if ScheduledJob is configured correctly.
-func (s *ScheduledJob) Validate() error {
+// Validate returns nil if ScheduledJobConfig is configured correctly.
+func (s ScheduledJobConfig) Validate() error {
 	var err error
 	if err = s.ImageConfig.Validate(); err != nil {
 		return fmt.Errorf(`validate "image": %w`, err)
@@ -244,24 +284,21 @@ func (s *ScheduledJob) Validate() error {
 			return fmt.Errorf(`validate "taskdef_overrides[%d]": %w`, ind, err)
 		}
 	}
-	name := aws.StringValue(s.Name)
-	if name == "" {
+	return nil
+}
+
+// Validate returns nil if Workload is configured correctly.
+func (w Workload) Validate() error {
+	if w.Name == nil {
 		return &errFieldMustBeSpecified{
 			missingField: "name",
 		}
-	}
-	if err = validateContainerDeps(validateDependenciesOpts{
-		sidecarConfig:     s.Sidecars,
-		imageConfig:       s.ImageConfig.Image,
-		mainContainerName: name,
-	}); err != nil {
-		return fmt.Errorf("validate container dependencies: %w", err)
 	}
 	return nil
 }
 
 // Validate returns nil if ImageWithPortAndHealthcheck is configured correctly.
-func (i *ImageWithPortAndHealthcheck) Validate() error {
+func (i ImageWithPortAndHealthcheck) Validate() error {
 	var err error
 	if err = i.ImageWithPort.Validate(); err != nil {
 		return err
@@ -273,7 +310,7 @@ func (i *ImageWithPortAndHealthcheck) Validate() error {
 }
 
 // Validate returns nil if ImageWithHealthcheckAndOptionalPort is configured correctly.
-func (i *ImageWithHealthcheckAndOptionalPort) Validate() error {
+func (i ImageWithHealthcheckAndOptionalPort) Validate() error {
 	var err error
 	if err = i.ImageWithOptionalPort.Validate(); err != nil {
 		return err
@@ -285,7 +322,7 @@ func (i *ImageWithHealthcheckAndOptionalPort) Validate() error {
 }
 
 // Validate returns nil if ImageWithHealthcheck is configured correctly.
-func (i *ImageWithHealthcheck) Validate() error {
+func (i ImageWithHealthcheck) Validate() error {
 	if err := i.Image.Validate(); err != nil {
 		return err
 	}
@@ -293,7 +330,7 @@ func (i *ImageWithHealthcheck) Validate() error {
 }
 
 // Validate returns nil if ImageWithOptionalPort is configured correctly.
-func (i *ImageWithOptionalPort) Validate() error {
+func (i ImageWithOptionalPort) Validate() error {
 	if err := i.Image.Validate(); err != nil {
 		return err
 	}
@@ -301,7 +338,7 @@ func (i *ImageWithOptionalPort) Validate() error {
 }
 
 // Validate returns nil if ImageWithPort is configured correctly.
-func (i *ImageWithPort) Validate() error {
+func (i ImageWithPort) Validate() error {
 	if err := i.Image.Validate(); err != nil {
 		return err
 	}
@@ -314,7 +351,7 @@ func (i *ImageWithPort) Validate() error {
 }
 
 // Validate returns nil if Image is configured correctly.
-func (i *Image) Validate() error {
+func (i Image) Validate() error {
 	var err error
 	if err = i.Build.Validate(); err != nil {
 		return fmt.Errorf(`validate "build": %w`, err)
@@ -333,11 +370,11 @@ func (i *Image) Validate() error {
 }
 
 // Validate returns nil if DependsOn is configured correctly.
-func (d *DependsOn) Validate() error {
+func (d DependsOn) Validate() error {
 	if d == nil {
 		return nil
 	}
-	for _, v := range *d {
+	for _, v := range d {
 		status := strings.ToUpper(v)
 		var isValid bool
 		for _, allowed := range dependsOnValidStatuses {
@@ -354,7 +391,7 @@ func (d *DependsOn) Validate() error {
 }
 
 // Validate returns nil if BuildArgsOrString is configured correctly.
-func (b *BuildArgsOrString) Validate() error {
+func (b BuildArgsOrString) Validate() error {
 	if b.isEmpty() {
 		return nil
 	}
@@ -365,17 +402,17 @@ func (b *BuildArgsOrString) Validate() error {
 }
 
 // Validate returns nil if DockerBuildArgs is configured correctly.
-func (*DockerBuildArgs) Validate() error {
+func (DockerBuildArgs) Validate() error {
 	return nil
 }
 
 // Validate returns nil if ContainerHealthCheck is configured correctly.
-func (*ContainerHealthCheck) Validate() error {
+func (ContainerHealthCheck) Validate() error {
 	return nil
 }
 
 // Validate returns nil if ImageOverride is configured correctly.
-func (i *ImageOverride) Validate() error {
+func (i ImageOverride) Validate() error {
 	var err error
 	if err = i.EntryPoint.Validate(); err != nil {
 		return fmt.Errorf(`validate "entrypoint": %w`, err)
@@ -387,17 +424,17 @@ func (i *ImageOverride) Validate() error {
 }
 
 // Validate returns nil if EntryPointOverride is configured correctly.
-func (*EntryPointOverride) Validate() error {
+func (EntryPointOverride) Validate() error {
 	return nil
 }
 
 // Validate returns nil if CommandOverride is configured correctly.
-func (*CommandOverride) Validate() error {
+func (CommandOverride) Validate() error {
 	return nil
 }
 
 // Validate returns nil if RoutingRule is configured correctly.
-func (r *RoutingRule) Validate() error {
+func (r RoutingRule) Validate() error {
 	var err error
 	if err = r.HealthCheck.Validate(); err != nil {
 		return fmt.Errorf(`validate "healthcheck": %w`, err)
@@ -421,7 +458,7 @@ func (r *RoutingRule) Validate() error {
 }
 
 // Validate returns nil if HealthCheckArgsOrString is configured correctly.
-func (h *HealthCheckArgsOrString) Validate() error {
+func (h HealthCheckArgsOrString) Validate() error {
 	if h.IsEmpty() {
 		return nil
 	}
@@ -429,7 +466,7 @@ func (h *HealthCheckArgsOrString) Validate() error {
 }
 
 // Validate returns nil if HTTPHealthCheckArgs is configured correctly.
-func (h *HTTPHealthCheckArgs) Validate() error {
+func (h HTTPHealthCheckArgs) Validate() error {
 	if h.isEmpty() {
 		return nil
 	}
@@ -437,23 +474,20 @@ func (h *HTTPHealthCheckArgs) Validate() error {
 }
 
 // Validate returns nil if Alias is configured correctly.
-func (*Alias) Validate() error {
+func (Alias) Validate() error {
 	return nil
 }
 
 // Validate returns nil if IPNet is configured correctly.
-func (ip *IPNet) Validate() error {
-	if ip == nil {
-		return nil
-	}
-	if _, _, err := net.ParseCIDR(string(*ip)); err != nil {
-		return fmt.Errorf("parse IPNet %s: %w", string(*ip), err)
+func (ip IPNet) Validate() error {
+	if _, _, err := net.ParseCIDR(string(ip)); err != nil {
+		return fmt.Errorf("parse IPNet %s: %w", string(ip), err)
 	}
 	return nil
 }
 
 // Validate returns nil if TaskConfig is configured correctly.
-func (t *TaskConfig) Validate() error {
+func (t TaskConfig) Validate() error {
 	var err error
 	if err = t.Platform.Validate(); err != nil {
 		return fmt.Errorf(`validate "platform": %w`, err)
@@ -471,26 +505,25 @@ func (t *TaskConfig) Validate() error {
 }
 
 // Validate returns nil if PlatformArgsOrString is configured correctly.
-func (p *PlatformArgsOrString) Validate() error {
-	if err := p.PlatformString.Validate(); err != nil {
-		return err
+func (p PlatformArgsOrString) Validate() error {
+	if p.PlatformString != nil {
+		if err := p.PlatformString.Validate(); err != nil {
+			return err
+		}
 	}
 	return p.PlatformArgs.Validate()
 }
 
 // Validate returns nil if PlatformString is configured correctly.
-func (p *PlatformString) Validate() error {
-	if p == nil {
-		return nil
-	}
-	if err := validatePlatform(p); err != nil {
+func (p PlatformString) Validate() error {
+	if err := validatePlatform(&p); err != nil {
 		return err
 	}
 	return nil
 }
 
 // Validate returns nil if PlatformArgsOrString is configured correctly.
-func (p *PlatformArgs) Validate() error {
+func (p PlatformArgs) Validate() error {
 	if p.isEmpty() {
 		return nil
 	}
@@ -507,12 +540,12 @@ func (p *PlatformArgs) Validate() error {
 }
 
 // Validate returns nil if Count is configured correctly.
-func (c *Count) Validate() error {
+func (c Count) Validate() error {
 	return c.AdvancedCount.Validate()
 }
 
 // Validate returns nil if AdvancedCount is configured correctly.
-func (a *AdvancedCount) Validate() error {
+func (a AdvancedCount) Validate() error {
 	if a.IsEmpty() {
 		return nil
 	}
@@ -548,29 +581,29 @@ func (a *AdvancedCount) Validate() error {
 	if err := a.QueueScaling.Validate(); err != nil {
 		return fmt.Errorf(`validate "queue_delay": %w`, err)
 	}
-
-	if err := a.CPU.Validate(); err != nil {
-		return fmt.Errorf(`validate "cpu_percentage": %w`, err)
+	if a.CPU != nil {
+		if err := a.CPU.Validate(); err != nil {
+			return fmt.Errorf(`validate "cpu_percentage": %w`, err)
+		}
 	}
-	if err := a.Memory.Validate(); err != nil {
-		return fmt.Errorf(`validate "memory_percentage": %w`, err)
+	if a.Memory != nil {
+		if err := a.Memory.Validate(); err != nil {
+			return fmt.Errorf(`validate "memory_percentage": %w`, err)
+		}
 	}
 	return nil
 }
 
 // Validate returns nil if Percentage is configured correctly.
-func (p *Percentage) Validate() error {
-	if p == nil {
-		return nil
-	}
-	if val := int(*p); val < 0 || val > 100 {
+func (p Percentage) Validate() error {
+	if val := int(p); val < 0 || val > 100 {
 		return fmt.Errorf("percentage value %v must be an integer from 0 to 100", val)
 	}
 	return nil
 }
 
 // Validate returns nil if QueueScaling is configured correctly.
-func (qs *QueueScaling) Validate() error {
+func (qs QueueScaling) Validate() error {
 	if qs.IsEmpty() {
 		return nil
 	}
@@ -600,7 +633,7 @@ func (qs *QueueScaling) Validate() error {
 }
 
 // Validate returns nil if Range is configured correctly.
-func (r *Range) Validate() error {
+func (r Range) Validate() error {
 	if r.IsEmpty() {
 		return nil
 	}
@@ -611,8 +644,8 @@ func (r *Range) Validate() error {
 }
 
 // Validate returns nil if IntRangeBand is configured correctly.
-func (r *IntRangeBand) Validate() error {
-	str := string(*r)
+func (r IntRangeBand) Validate() error {
+	str := string(r)
 	minMax := intRangeBandRegexp.FindStringSubmatch(str)
 	// Valid minMax example: ["1-2", "1", "2"]
 	if len(minMax) != 3 {
@@ -637,7 +670,7 @@ func (r *IntRangeBand) Validate() error {
 }
 
 // Validate returns nil if RangeConfig is configured correctly.
-func (r *RangeConfig) Validate() error {
+func (r RangeConfig) Validate() error {
 	if r.Min == nil || r.Max == nil {
 		return &errFieldMustBeSpecified{
 			missingField: "min/max",
@@ -654,7 +687,7 @@ func (r *RangeConfig) Validate() error {
 }
 
 // Validate returns nil if ExecuteCommand is configured correctly.
-func (e *ExecuteCommand) Validate() error {
+func (e ExecuteCommand) Validate() error {
 	if !e.Config.IsEmpty() {
 		return e.Config.Validate()
 	}
@@ -662,12 +695,12 @@ func (e *ExecuteCommand) Validate() error {
 }
 
 // Validate returns nil if ExecuteCommandConfig is configured correctly.
-func (*ExecuteCommandConfig) Validate() error {
+func (ExecuteCommandConfig) Validate() error {
 	return nil
 }
 
 // Validate returns nil if Storage is configured correctly.
-func (s *Storage) Validate() error {
+func (s Storage) Validate() error {
 	if s.IsEmpty() {
 		return nil
 	}
@@ -693,7 +726,7 @@ func (s *Storage) Validate() error {
 }
 
 // Validate returns nil if Volume is configured correctly.
-func (v *Volume) Validate() error {
+func (v Volume) Validate() error {
 	if err := v.EFS.Validate(); err != nil {
 		return fmt.Errorf(`validate "efs": %w`, err)
 	}
@@ -701,10 +734,7 @@ func (v *Volume) Validate() error {
 }
 
 // Validate returns nil if MountPointOpts is configured correctly.
-func (m *MountPointOpts) Validate() error {
-	if m == nil {
-		return nil
-	}
+func (m MountPointOpts) Validate() error {
 	path := aws.StringValue(m.ContainerPath)
 	if path == "" {
 		return &errFieldMustBeSpecified{
@@ -718,7 +748,7 @@ func (m *MountPointOpts) Validate() error {
 }
 
 // Validate returns nil if EFSConfigOrBool is configured correctly.
-func (e *EFSConfigOrBool) Validate() error {
+func (e EFSConfigOrBool) Validate() error {
 	if e.IsEmpty() {
 		return nil
 	}
@@ -726,7 +756,7 @@ func (e *EFSConfigOrBool) Validate() error {
 }
 
 // Validate returns nil if EFSVolumeConfiguration is configured correctly.
-func (e *EFSVolumeConfiguration) Validate() error {
+func (e EFSVolumeConfiguration) Validate() error {
 	if e.IsEmpty() {
 		return nil
 	}
@@ -770,7 +800,7 @@ func (e *EFSVolumeConfiguration) Validate() error {
 }
 
 // Validate returns nil if AuthorizationConfig is configured correctly.
-func (a *AuthorizationConfig) Validate() error {
+func (a AuthorizationConfig) Validate() error {
 	if a.IsEmpty() {
 		return nil
 	}
@@ -778,7 +808,7 @@ func (a *AuthorizationConfig) Validate() error {
 }
 
 // Validate returns nil if Logging is configured correctly.
-func (l *Logging) Validate() error {
+func (l Logging) Validate() error {
 	if l.IsEmpty() {
 		return nil
 	}
@@ -786,7 +816,7 @@ func (l *Logging) Validate() error {
 }
 
 // Validate returns nil if SidecarConfig is configured correctly.
-func (s *SidecarConfig) Validate() error {
+func (s SidecarConfig) Validate() error {
 	for ind, mp := range s.MountPoints {
 		if err := mp.Validate(); err != nil {
 			return fmt.Errorf(`validate "mount_points[%d]": %w`, ind, err)
@@ -802,10 +832,7 @@ func (s *SidecarConfig) Validate() error {
 }
 
 // Validate returns nil if SidecarMountPoint is configured correctly.
-func (s *SidecarMountPoint) Validate() error {
-	if s == nil {
-		return nil
-	}
+func (s SidecarMountPoint) Validate() error {
 	if aws.StringValue(s.SourceVolume) == "" {
 		return &errFieldMustBeSpecified{
 			missingField: "source_volume",
@@ -815,7 +842,7 @@ func (s *SidecarMountPoint) Validate() error {
 }
 
 // Validate returns nil if NetworkConfig is configured correctly.
-func (n *NetworkConfig) Validate() error {
+func (n NetworkConfig) Validate() error {
 	if n.IsEmpty() {
 		return nil
 	}
@@ -826,36 +853,46 @@ func (n *NetworkConfig) Validate() error {
 }
 
 // Validate returns nil if vpcConfig is configured correctly.
-func (v *vpcConfig) Validate() error {
+func (v vpcConfig) Validate() error {
 	if v.isEmpty() {
 		return nil
 	}
-	if err := v.Placement.Validate(); err != nil {
-		return fmt.Errorf(`validate "placement": %w`, err)
+	if v.Placement != nil {
+		if err := v.Placement.Validate(); err != nil {
+			return fmt.Errorf(`validate "placement": %w`, err)
+		}
 	}
 	return nil
 }
 
 // Validate returns nil if Placement is configured correctly.
-func (p *Placement) Validate() error {
-	if p == nil {
+func (p Placement) Validate() error {
+	if string(p) == "" {
 		return fmt.Errorf(`"placement" cannot be empty`)
 	}
 	for _, allowed := range subnetPlacements {
-		if string(*p) == allowed {
+		if string(p) == allowed {
 			return nil
 		}
 	}
-	return fmt.Errorf(`"placement" %s must be one of %s`, string(*p), strings.Join(subnetPlacements, ", "))
+	return fmt.Errorf(`"placement" %s must be one of %s`, string(p), strings.Join(subnetPlacements, ", "))
+}
+
+// Validate returns nil if AppRunnerInstanceConfig is configured correctly.
+func (r AppRunnerInstanceConfig) Validate() error {
+	if err := r.Platform.Validate(); err != nil {
+		return fmt.Errorf(`validate "platform": %w`, err)
+	}
+	return nil
 }
 
 // Validate returns nil if RequestDrivenWebServiceHttpConfig is configured correctly.
-func (r *RequestDrivenWebServiceHttpConfig) Validate() error {
+func (r RequestDrivenWebServiceHttpConfig) Validate() error {
 	return r.HealthCheckConfiguration.Validate()
 }
 
 // Validate returns nil if JobTriggerConfig is configured correctly.
-func (c *JobTriggerConfig) Validate() error {
+func (c JobTriggerConfig) Validate() error {
 	if c.Schedule == nil {
 		return &errFieldMustBeSpecified{
 			missingField: "schedule",
@@ -865,12 +902,12 @@ func (c *JobTriggerConfig) Validate() error {
 }
 
 // Validate returns nil if JobFailureHandlerConfig is configured correctly.
-func (*JobFailureHandlerConfig) Validate() error {
+func (JobFailureHandlerConfig) Validate() error {
 	return nil
 }
 
 // Validate returns nil if PublishConfig is configured correctly.
-func (p *PublishConfig) Validate() error {
+func (p PublishConfig) Validate() error {
 	for ind, topic := range p.Topics {
 		if err := topic.Validate(); err != nil {
 			return fmt.Errorf(`validate "topics[%d]": %w`, ind, err)
@@ -880,12 +917,12 @@ func (p *PublishConfig) Validate() error {
 }
 
 // Validate returns nil if Topic is configured correctly.
-func (t *Topic) Validate() error {
+func (t Topic) Validate() error {
 	return validatePubSubName(aws.StringValue(t.Name))
 }
 
 // Validate returns nil if SubscribeConfig is configured correctly.
-func (s *SubscribeConfig) Validate() error {
+func (s SubscribeConfig) Validate() error {
 	if s.IsEmpty() {
 		return nil
 	}
@@ -901,7 +938,7 @@ func (s *SubscribeConfig) Validate() error {
 }
 
 // Validate returns nil if TopicSubscription is configured correctly.
-func (t *TopicSubscription) Validate() error {
+func (t TopicSubscription) Validate() error {
 	if err := validatePubSubName(aws.StringValue(t.Name)); err != nil {
 		return err
 	}
@@ -921,7 +958,7 @@ func (t *TopicSubscription) Validate() error {
 }
 
 // Validate returns nil if SQSQueue is configured correctly.
-func (q *SQSQueueOrBool) Validate() error {
+func (q SQSQueueOrBool) Validate() error {
 	if q.IsEmpty() {
 		return nil
 	}
@@ -929,7 +966,7 @@ func (q *SQSQueueOrBool) Validate() error {
 }
 
 // Validate returns nil if SQSQueue is configured correctly.
-func (q *SQSQueue) Validate() error {
+func (q SQSQueue) Validate() error {
 	if q.IsEmpty() {
 		return nil
 	}
@@ -940,7 +977,7 @@ func (q *SQSQueue) Validate() error {
 }
 
 // Validate returns nil if DeadLetterQueue is configured correctly.
-func (d *DeadLetterQueue) Validate() error {
+func (d DeadLetterQueue) Validate() error {
 	if d.IsEmpty() {
 		return nil
 	}
@@ -948,10 +985,7 @@ func (d *DeadLetterQueue) Validate() error {
 }
 
 // Validate returns nil if OverrideRule is configured correctly.
-func (r *OverrideRule) Validate() error {
-	if r == nil {
-		return nil
-	}
+func (r OverrideRule) Validate() error {
 	for _, s := range invalidTaskDefOverridePathRegexp {
 		re := regexp.MustCompile(fmt.Sprintf(`^%s$`, s))
 		if re.MatchString(r.Path) {

--- a/internal/pkg/manifest/validate_integration_test.go
+++ b/internal/pkg/manifest/validate_integration_test.go
@@ -78,7 +78,7 @@ func isValid(typ reflect.Type) error {
 			return nil
 		}
 	}
-	// For slice and map, validate individual member.
+	// For slice and map, validate its member type.
 	if typ.Kind() == reflect.Array || typ.Kind() == reflect.Slice || typ.Kind() == reflect.Map {
 		if err := isValid(typ.Elem()); err != nil {
 			return err

--- a/internal/pkg/manifest/validate_integration_test.go
+++ b/internal/pkg/manifest/validate_integration_test.go
@@ -1,0 +1,87 @@
+// +build integration localintegration
+
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package manifest_test
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/aws/copilot-cli/internal/pkg/manifest"
+	"github.com/aws/copilot-cli/internal/pkg/template"
+	"github.com/stretchr/testify/require"
+)
+
+var basicKinds = []reflect.Kind{
+	reflect.Bool,
+	reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+	reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+	reflect.Float32, reflect.Float64,
+	reflect.Complex64, reflect.Complex128,
+	reflect.Array, reflect.String, reflect.Slice, reflect.Map,
+}
+
+type validator interface {
+	Validate() error
+}
+
+// Test_ValidateAudit ensures that every manifest struct implements "Validate()" method.
+func Test_ValidateAudit(t *testing.T) {
+	testCases := map[string]struct {
+		mft manifest.WorkloadManifest
+	}{
+		"backend service": {
+			mft: manifest.BackendService{},
+		},
+		"load balanced web service": {
+			mft: manifest.LoadBalancedWebService{},
+		},
+		"request-driven web service": {
+			mft: manifest.RequestDrivenWebService{},
+		},
+		"schedule job": {
+			mft: manifest.ScheduledJob{},
+		},
+		"worker service": {
+			mft: manifest.WorkerService{},
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			err := isValid(reflect.ValueOf(tc.mft))
+			require.NoError(t, err)
+		})
+	}
+}
+
+func isValid(v reflect.Value) error {
+	typ := v.Type()
+	if typ.Kind() == reflect.Ptr {
+		typ = typ.Elem()
+	}
+	for _, k := range basicKinds {
+		if typ.Kind() == k {
+			return nil
+		}
+	}
+	var val validator
+	validatorType := reflect.TypeOf(&val).Elem()
+	// template.Parser is not a manifest struct.
+	var tpl template.Parser
+	templaterType := reflect.TypeOf(&tpl).Elem()
+	if !typ.Implements(templaterType) && !typ.Implements(validatorType) {
+		return fmt.Errorf(`%v does not implement "Validate()"`, typ)
+	}
+	if typ.Kind() != reflect.Struct {
+		return nil
+	}
+	for i := 0; i < v.NumField(); i++ {
+		if err := isValid(v.Field(i)); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/pkg/manifest/validate_test.go
+++ b/internal/pkg/manifest/validate_test.go
@@ -827,28 +827,29 @@ func TestTaskConfig_Validate(t *testing.T) {
 		})
 	}
 }
-func TestPlatformString_Validate(t *testing.T) {
-	testCases := map[string]struct {
-		in     PlatformString
-		wanted error
-	}{
-		"error if platform string is invalid": {
-			in:     PlatformString("foobar"),
-			wanted: fmt.Errorf("platform foobar is invalid; the valid platform is: linux/amd64"),
-		},
-	}
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			err := tc.in.Validate()
 
-			if tc.wanted != nil {
-				require.EqualError(t, err, tc.wanted.Error())
-			} else {
-				require.NoError(t, err)
-			}
-		})
-	}
-}
+// func TestPlatformString_Validate(t *testing.T) {
+// 	testCases := map[string]struct {
+// 		in     PlatformString
+// 		wanted error
+// 	}{
+// 		"error if platform string is invalid": {
+// 			in:     PlatformString("foobar"),
+// 			wanted: fmt.Errorf("platform foobar is invalid; the valid platform is: linux/amd64"),
+// 		},
+// 	}
+// 	for name, tc := range testCases {
+// 		t.Run(name, func(t *testing.T) {
+// 			err := tc.in.Validate()
+
+// 			if tc.wanted != nil {
+// 				require.EqualError(t, err, tc.wanted.Error())
+// 			} else {
+// 				require.NoError(t, err)
+// 			}
+// 		})
+// 	}
+// }
 func TestPlatformArgs_Validate(t *testing.T) {
 	testCases := map[string]struct {
 		in     PlatformArgs

--- a/internal/pkg/manifest/validate_test.go
+++ b/internal/pkg/manifest/validate_test.go
@@ -828,28 +828,28 @@ func TestTaskConfig_Validate(t *testing.T) {
 	}
 }
 
-// func TestPlatformString_Validate(t *testing.T) {
-// 	testCases := map[string]struct {
-// 		in     PlatformString
-// 		wanted error
-// 	}{
-// 		"error if platform string is invalid": {
-// 			in:     PlatformString("foobar"),
-// 			wanted: fmt.Errorf("platform foobar is invalid; the valid platform is: linux/amd64"),
-// 		},
-// 	}
-// 	for name, tc := range testCases {
-// 		t.Run(name, func(t *testing.T) {
-// 			err := tc.in.Validate()
+func TestPlatformString_Validate(t *testing.T) {
+	testCases := map[string]struct {
+		in     PlatformString
+		wanted error
+	}{
+		"error if platform string is invalid": {
+			in:     PlatformString("foobar"),
+			wanted: fmt.Errorf("platform foobar is invalid; the valid platform is: linux/amd64"),
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			err := tc.in.Validate()
 
-// 			if tc.wanted != nil {
-// 				require.EqualError(t, err, tc.wanted.Error())
-// 			} else {
-// 				require.NoError(t, err)
-// 			}
-// 		})
-// 	}
-// }
+			if tc.wanted != nil {
+				require.EqualError(t, err, tc.wanted.Error())
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
 func TestPlatformArgs_Validate(t *testing.T) {
 	testCases := map[string]struct {
 		in     PlatformArgs

--- a/internal/pkg/manifest/validate_test.go
+++ b/internal/pkg/manifest/validate_test.go
@@ -76,7 +76,7 @@ func TestLoadBalancedWebServiceConfig_Validate(t *testing.T) {
 					ImageConfig: testImageConfig,
 					Network: NetworkConfig{
 						vpcConfig{
-							SecurityGroups: []string{},
+							Placement: (*Placement)(aws.String("")),
 						},
 					},
 				},
@@ -205,7 +205,7 @@ func TestBackendServiceConfig_Validate(t *testing.T) {
 					ImageConfig: testImageConfig,
 					Network: NetworkConfig{
 						vpcConfig{
-							SecurityGroups: []string{},
+							Placement: (*Placement)(aws.String("")),
 						},
 					},
 				},
@@ -383,7 +383,7 @@ func TestWorkerServiceConfig_Validate(t *testing.T) {
 					ImageConfig: testImageConfig,
 					Network: NetworkConfig{
 						vpcConfig{
-							SecurityGroups: []string{},
+							Placement: (*Placement)(aws.String("")),
 						},
 					},
 				},
@@ -508,7 +508,7 @@ func TestScheduledJobConfig_Validate(t *testing.T) {
 					ImageConfig: testImageConfig,
 					Network: NetworkConfig{
 						vpcConfig{
-							SecurityGroups: []string{},
+							Placement: (*Placement)(aws.String("")),
 						},
 					},
 				},
@@ -1462,7 +1462,7 @@ func TestNetworkConfig_Validate(t *testing.T) {
 		"error if fail to validate vpc": {
 			config: NetworkConfig{
 				VPC: vpcConfig{
-					SecurityGroups: []string{},
+					Placement: (*Placement)(aws.String("")),
 				},
 			},
 			wantedErrorPrefix: `validate "vpc": `,
@@ -1489,7 +1489,7 @@ func TestVpcConfig_Validate(t *testing.T) {
 	}{
 		"error if fail to validate placement": {
 			config: vpcConfig{
-				SecurityGroups: []string{},
+				Placement: (*Placement)(aws.String("")),
 			},
 			wantedErrorPrefix: `validate "placement": `,
 		},
@@ -1508,12 +1508,14 @@ func TestVpcConfig_Validate(t *testing.T) {
 }
 
 func TestPlacement_Validate(t *testing.T) {
+	mockEmptyPlacement := Placement("")
 	mockInvalidPlacement := Placement("external")
 	testCases := map[string]struct {
 		in     *Placement
 		wanted error
 	}{
 		"should return an error if placement is empty": {
+			in:     &mockEmptyPlacement,
 			wanted: errors.New(`"placement" cannot be empty`),
 		},
 		"should return an error if placement is invalid": {
@@ -1529,6 +1531,34 @@ func TestPlacement_Validate(t *testing.T) {
 				require.EqualError(t, err, tc.wanted.Error())
 			} else {
 				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestAppRunnerInstanceConfig_Validate(t *testing.T) {
+	testCases := map[string]struct {
+		config AppRunnerInstanceConfig
+
+		wantedErrorPrefix string
+	}{
+		"error if fail to validate platforms": {
+			config: AppRunnerInstanceConfig{
+				Platform: PlatformArgsOrString{
+					PlatformString: (*PlatformString)(aws.String("")),
+				},
+			},
+			wantedErrorPrefix: `validate "platform": `,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			gotErr := tc.config.Validate()
+
+			if tc.wantedErrorPrefix != "" {
+				require.Contains(t, gotErr.Error(), tc.wantedErrorPrefix)
+			} else {
+				require.NoError(t, gotErr)
 			}
 		})
 	}


### PR DESCRIPTION
<!-- Provide summary of changes -->
This PR
1. Add integ test to make sure every manifest struct or advanced type implements `Validate()`.
2. Fix a bug that `network.placement` should not be required even if `network` is not empty.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
