### PR TITLE
test(e2e): fix closing file in multi-svc-app test

### DIFF
--- a/e2e/multi-svc-app/front-end/main.go
+++ b/e2e/multi-svc-app/front-end/main.go
@@ -88,13 +88,13 @@ func PutEFSCheck(w http.ResponseWriter, req *http.Request, ps httprouter.Params)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+	defer fileObj.Close()
 	// Resize file to 10M
 	if err := fileObj.Truncate(1e7); err != nil {
 		log.Printf("Resize test file %s in EFS volume FAILED\n", fileName)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-	fileObj.Close()
 
 	// Shred file to write 10MiB of data to the filesystem.
 	shredCmd := exec.Command("shred", "-n", "1", fileName)


### PR DESCRIPTION
<!-- Provide summary of changes -->
defer file.Close()

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
