### PR TITLE
docs: update logging field description

### DIFF
--- a/site/content/docs/include/logging.en.md
+++ b/site/content/docs/include/logging.en.md
@@ -1,7 +1,7 @@
 <div class="separator"></div>
 
 <a id="logging" href="#logging" class="field">`logging`</a> <span class="type">Map</span>  
-The logging section contains log configuration parameters for your container's [FireLens](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_firelens.html) log driver (see examples [here](../developing/sidecars.en.md#sidecar-patterns)).
+The logging section contains log configuration. You can also configure parameters for your container's [FireLens](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_firelens.html) log driver in this section (see examples [here](../developing/sidecars.en.md#sidecar-patterns)).
 
 <span class="parent-field">logging.</span><a id="retention" href="#logging-retention" class="field">`retention`</a> <span class="type">Integer</span>  
 Optional. The number of days to retain the log events. See [this page](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-logs-loggroup.html#cfn-logs-loggroup-retentionindays) for all accepted values. If omitted, the default is 30.


### PR DESCRIPTION
This PR copies the same `logging` field description from #2850 to the file where it's supposed to be.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
