### PR TITLE
chore: friendly message when alias is used while domain is not associated with the app

### DIFF
--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -51,7 +51,7 @@ const (
 	fmtForceUpdateSvcComplete = "Forced an update for service %s from environment %s.\n"
 )
 
-var aliasUsedWithoutDomainFriendlyTest = fmt.Sprintf("To use %s, your application must be associated with a domain: %s.\n",
+var aliasUsedWithoutDomainFriendlyText = fmt.Sprintf("To use %s, your application must be associated with a domain: %s.\n",
 	color.HighlightCode("http.alias"),
 	color.HighlightCode("copilot app init --domain example.com"))
 
@@ -539,7 +539,7 @@ func (o *deploySvcOpts) stackConfiguration(addonsURL string) (cloudformation.Sta
 	switch t := mft.(type) {
 	case *manifest.LoadBalancedWebService:
 		if o.targetApp.Domain == "" && !t.Alias.IsEmpty() {
-			log.Errorf(aliasUsedWithoutDomainFriendlyTest)
+			log.Errorf(aliasUsedWithoutDomainFriendlyText)
 			return nil, errors.New("alias specified when application is not associated with a domain")
 		}
 		if o.targetApp.RequiresDNSDelegation() {
@@ -556,7 +556,7 @@ func (o *deploySvcOpts) stackConfiguration(addonsURL string) (cloudformation.Sta
 		}
 	case *manifest.RequestDrivenWebService:
 		if o.targetApp.Domain == "" && t.Alias != nil {
-			log.Errorf(aliasUsedWithoutDomainFriendlyTest)
+			log.Errorf(aliasUsedWithoutDomainFriendlyText)
 			return nil, errors.New("alias specified when application is not associated with a domain")
 		}
 		o.newSvcUpdater(func(s *session.Session) serviceUpdater {

--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -540,6 +540,7 @@ func (o *deploySvcOpts) stackConfiguration(addonsURL string) (cloudformation.Sta
 	case *manifest.LoadBalancedWebService:
 		if o.targetApp.Domain == "" && !t.Alias.IsEmpty() {
 			log.Errorf(aliasUsedWithoutDomainFriendlyTest)
+			return nil, errors.New("alias specified when application is not associated with a domain")
 		}
 		if o.targetApp.RequiresDNSDelegation() {
 			var appVersionGetter versionGetter

--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -53,7 +53,7 @@ const (
 
 var aliasUsedWithoutDomainFriendlyTest = fmt.Sprintf("To use %s, first run %s to associate your application with your own domain.\n",
 	color.HighlightCode("alias"),
-	color.HighlightCode("copilot app init --domain <your.domain>"))
+	color.HighlightCode("copilot app init --domain example.com"))
 
 type deployWkldVars struct {
 	appName        string

--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -51,8 +51,8 @@ const (
 	fmtForceUpdateSvcComplete = "Forced an update for service %s from environment %s.\n"
 )
 
-var aliasUsedWithoutDomainFriendlyTest = fmt.Sprintf("To use %s, first run %s to associate your application with your own domain.\n",
-	color.HighlightCode("alias"),
+var aliasUsedWithoutDomainFriendlyTest = fmt.Sprintf("To use %s, your application must be associated with a domain: %s.\n",
+	color.HighlightCode("http.alias"),
 	color.HighlightCode("copilot app init --domain example.com"))
 
 type deployWkldVars struct {


### PR DESCRIPTION
We should display a friendly message when we detect that `alias` is specified in manifest while the app is not associated with a domain.

Previously, when this happens, an RDWS deployment fails when CloudFormation tries to create the custom resource. On the other hand, for LBWS, we swallow the alias input when domain is not associated. 

Therefore in this PR, we error out early for RDWS while displaying the message. For LBWS, we only display messages while not failing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
