### PR TITLE
docs: fix topic name

### DIFF
--- a/site/content/docs/developing/publish-subscribe.en.md
+++ b/site/content/docs/developing/publish-subscribe.en.md
@@ -44,7 +44,7 @@ const out = await client.send(new PublishCommand({
 
 To subscribe to an existing SNS topic with a worker service, you'll need to edit the worker service's manifest.
 Using the [`subscribe`](../manifest/worker-service/#subscribe) field in the manifest, you can define subscriptions to 
-existing SNS topics exposed by other services in your environment.  In this example, we'll use the `orders` topic 
+existing SNS topics exposed by other services in your environment.  In this example, we'll use the `ordersTopic` topic 
 which the `api` service from the last section exposed. We'll also customize the worker service's queue to enable a dead-letter queue. 
 The `tries` field tells SQS how many times to try redelivering a failed message before sending it to the DLQ for further inspection.
 
@@ -61,7 +61,7 @@ subscribe:
       tries: 5
 ```
 
-Copilot will create a subscription between this worker service's queue and the `orders` topic from the `api` service. It will also inject the queue URI into the service container under the environment variable `COPILOT_QUEUE_URI`.
+Copilot will create a subscription between this worker service's queue and the `ordersTopic` topic from the `api` service. It will also inject the queue URI into the service container under the environment variable `COPILOT_QUEUE_URI`.
 
 ### Javascript Example
 


### PR DESCRIPTION
The topic name `order` was actually used in the old version of this page, but was updated to `ordersTopic` recently.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
