### PR TITLE
docs: remove unexpected worker svc port

### DIFF
--- a/site/content/docs/include/image-config-with-port.en.md
+++ b/site/content/docs/include/image-config-with-port.en.md
@@ -1,0 +1,4 @@
+{% include 'image-config.en.md' %}
+
+<span class="parent-field">image.</span><a id="image-port" href="#image-port" class="field">`port`</a> <span class="type">Integer</span>  
+The port exposed in your Dockerfile. Copilot should parse this value for you from your `EXPOSE` instruction.

--- a/site/content/docs/include/image-config-with-port.ja.md
+++ b/site/content/docs/include/image-config-with-port.ja.md
@@ -1,0 +1,4 @@
+{% include 'image-config.ja.md' %}
+
+<span class="parent-field">image.</span><a id="image-port" href="#image-port" class="field">`port`</a> <span class="type">Integer</span>  
+公開するポート番号。Dockerfile 内に `EXPOSE` インストラクションが記述されている場合、Copilot はそれをパースした値をここに挿入します。

--- a/site/content/docs/include/image-config.en.md
+++ b/site/content/docs/include/image-config.en.md
@@ -37,9 +37,6 @@ The `location` field follows the same definition as the [`image` parameter](http
 <span class="parent-field">image.</span><a id="image-credential" href="#image-credential" class="field">`credentials`</a> <span class="type">String</span>
 An optional credentials ARN for a private repository. The `credentials` field follows the same definition as the [`credentialsParameter`](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/private-auth.html) in the Amazon ECS task definition.
 
-<span class="parent-field">image.</span><a id="image-port" href="#image-port" class="field">`port`</a> <span class="type">Integer</span>  
-The port exposed in your Dockerfile. Copilot should parse this value for you from your `EXPOSE` instruction.
-
 <span class="parent-field">image.</span><a id="image-labels" href="#image-labels" class="field">`labels`</a> <span class="type">Map</span>  
 An optional key/value map of [Docker labels](https://docs.docker.com/config/labels-custom-metadata/) to add to the container.
 

--- a/site/content/docs/include/image-config.ja.md
+++ b/site/content/docs/include/image-config.ja.md
@@ -35,10 +35,7 @@ Dockerfile からコンテナイメージをビルドする代わりに、既存
 `location` フィールドの制約を含む指定方法は Amazon ECS タスク定義の [`image` パラメータ](https://docs.aws.amazon.com/ja_jp/AmazonECS/latest/developerguide/task_definition_parameters.html#container_definition_image)のそれに従います。
 
 <span class="parent-field">image.</span><a id="image-credential" href="#image-credential" class="field">`credentials`</a> <span class="type">String</span>  
-任意項目です。プライベートリポジトリの認証情報の ARN。`credentials` フィールドは、Amazon ECS タスク定義の [`credentialsParameter`](https://docs.aws.amazon.com/ja_jp/AmazonECS/latest/developerguide/private-auth.html) と同じです。
-
-<span class="parent-field">image.</span><a id="image-port" href="#image-port" class="field">`port`</a> <span class="type">Integer</span>  
-公開するポート番号。Dockerfile 内に `EXPOSE` インストラクションが記述されている場合、Copilot はそれをパースした値をここに挿入します。  
+任意項目です。プライベートリポジトリの認証情報の ARN。`credentials` フィールドは、Amazon ECS タスク定義の [`credentialsParameter`](https://docs.aws.amazon.com/ja_jp/AmazonECS/latest/developerguide/private-auth.html) と同じです。 
 
 <span class="parent-field">image.</span><a id="image-labels" href="#image-labels" class="field">`labels`</a> <span class="type">Map</span>  
 コンテナに付与したい [Docker ラベル](https://docs.docker.com/config/labels-custom-metadata/)を key/value の Map で指定できます。これは任意設定項目です。

--- a/site/content/docs/manifest/backend-service.en.md
+++ b/site/content/docs/manifest/backend-service.en.md
@@ -64,7 +64,7 @@ The name of your service.
 <a id="type" href="#type" class="field">`type`</a> <span class="type">String</span>  
 The architecture type for your service. [Backend Services](../concepts/services.en.md#backend-service) are not reachable from the internet, but can be reached with [service discovery](../developing/service-discovery.en.md) from your other services.
 
-{% include 'image-config.en.md' %}
+{% include 'image-config-with-port.en.md' %}
 
 {% include 'image-healthcheck.en.md' %}
 
@@ -155,4 +155,3 @@ Scale up or down based on the average memory your service should maintain.
 {% include 'taskdef-overrides.en.md' %}
 
 {% include 'environments.en.md' %}
-

--- a/site/content/docs/manifest/backend-service.ja.md
+++ b/site/content/docs/manifest/backend-service.ja.md
@@ -66,7 +66,7 @@ Service 名。
 <a id="type" href="#type" class="field">`type`</a> <span class="type">String</span>  
 Service のアーキテクチャ。[Backend Services](../concepts/services.ja.md#backend-service) はインターネット側からはアクセスできませんが、[サービス検出](../developing/service-discovery.ja.md)の利用により他の Service からはアクセスできます。
 
-{% include 'image-config.ja.md' %}
+{% include 'image-config-with-port.ja.md' %}
 
 {% include 'image-healthcheck.ja.md' %}
 

--- a/site/content/docs/manifest/lb-web-service.en.md
+++ b/site/content/docs/manifest/lb-web-service.en.md
@@ -70,7 +70,7 @@ The architecture type for your service. A [Load Balanced Web Service](../concept
 
 {% include 'http-config.en.md' %}
 
-{% include 'image-config.en.md' %}
+{% include 'image-config-with-port.en.md' %}
 
 {% include 'image-healthcheck.en.md' %}
 

--- a/site/content/docs/manifest/lb-web-service.ja.md
+++ b/site/content/docs/manifest/lb-web-service.ja.md
@@ -68,7 +68,7 @@ Service のアーキテクチャタイプ。 [Load Balanced Web Service](../conc
 
 {% include 'http-config.ja.md' %}
 
-{% include 'image-config.ja.md' %}
+{% include 'image-config-with-port.ja.md' %}
 
 {% include 'image-healthcheck.ja.md' %}
 

--- a/site/content/docs/manifest/scheduled-job.en.md
+++ b/site/content/docs/manifest/scheduled-job.en.md
@@ -62,61 +62,7 @@ Alternatively, you can specify a cron schedule if you'd like to trigger the job 
 
 <div class="separator"></div>
 
-<a id="image" href="#image" class="field">`image`</a> <span class="type">Map</span>  
-The image section contains parameters relating to the Docker build configuration.
-
-<span class="parent-field">image.</span><a id="image-build" href="#image-build" class="field">`build`</a> <span class="type">String or Map</span>  
-If you specify a string, Copilot interprets it as the path to your Dockerfile. It will assume that the dirname of the string you specify should be the build context. The manifest:
-```yaml
-image:
-  build: path/to/dockerfile
-```
-will result in the following call to docker build: `$ docker build --file path/to/dockerfile path/to`
-
-You can also specify build as a map:
-```yaml
-image:
-  build:
-    dockerfile: path/to/dockerfile
-    context: context/dir
-    target: build-stage
-    cache_from:
-      - image:tag
-    args:
-      key: value
-```
-In this case, Copilot will use the context directory you specified and convert the key-value pairs under args to --build-arg overrides. The equivalent docker build call will be:
-`$ docker build --file path/to/dockerfile --target build-stage --cache-from image:tag --build-arg key=value context/dir`.
-
-You can omit fields and Copilot will do its best to understand what you mean. For example, if you specify `context` but not `dockerfile`, Copilot will run Docker in the context directory and assume that your Dockerfile is named "Dockerfile." If you specify `dockerfile` but no `context`, Copilot assumes you want to run Docker in the directory that contains `dockerfile`.
-
-All paths are relative to your workspace root.
-
-<span class="parent-field">image.</span><a id="image-location" href="#image-location" class="field">`location`</a> <span class="type">String</span>  
-Instead of building a container from a Dockerfile, you can specify an existing image name. Mutually exclusive with [`image.build`](#image-build).
-The `location` field follows the same definition as the [`image` parameter](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#container_definition_image) in the Amazon ECS task definition.
-
-<span class="parent-field">image.</span><a id="image-credential" href="#image-credential" class="field">`credentials`</a> <span class="type">String</span>
-An optional credentials ARN for a private repository. The `credentials` field follows the same definition as the [`credentialsParameter`](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/private-auth.html) in the Amazon ECS task definition.
-
-<span class="parent-field">image.</span><a id="image-labels" href="#image-labels" class="field">`labels`</a><span class="type">Map</span>  
-An optional key/value map of [Docker labels](https://docs.docker.com/config/labels-custom-metadata/) to add to the container.
-
-<span class="parent-field">image.</span><a id="image-depends-on" href="#image-depends-on" class="field">`depends_on`</a><span class="type">Map</span>  
-An optional key/value map of [Container Dependencies](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ContainerDependency.html) to add to the container. The key of the map is a container name and the value is the condition to depend on. Valid conditions are: `start`, `healthy`, `complete`, and `success`. You cannot specify a `complete` or `success` dependency on an essential container.
-
-!!! note
-    Container health checks for sidecars are not currently supported in Copilot. This means that `healthy` is not a valid sidecar dependency condition.
-
-For example:
-```yaml
-image:
-  build: ./Dockerfile
-  depends_on:
-    nginx: start
-    startup: success
-```
-In the above example, the task's main container will only start after the `nginx` sidecar has started and the `startup` container has completed successfully.  
+{% include 'image-config.en.md' %}
 
 <div class="separator"></div>  
 

--- a/site/content/docs/manifest/scheduled-job.ja.md
+++ b/site/content/docs/manifest/scheduled-job.ja.md
@@ -62,62 +62,7 @@ Job をトリガするイベントの設定。
 * `"cron({fields})"` 6 つフィールドからなる CloudWatch の[cron 式](https://docs.aws.amazon.com/ja_jp/AmazonCloudWatch/latest/events/ScheduledEvents.html#CronExpressions) を利用する
 <div class="separator"></div>
 
-<a id="image" href="#image" class="field">`image`</a> <span class="type">Map</span>  
-image セクションは Docker の build に関するパラメータを持ちます。
-
-<span class="parent-field">image.</span><a id="image-build" href="#image-build" class="field">`build`</a> <span class="type">String or Map</span>  
-String 型を設定した場合、Copilot はそれを Dockerfile へのパスと解釈します。指定したディレクトリがビルドコンテキストとなります。下記の Manifest を指定した場合:
-```yaml
-image:
-  build: path/to/dockerfile
-```
-このコマンドを実行した場合と同じ結果になります。  
-`$ docker build --file path/to/dockerfile path/to`
-
-Map 型も指定できます:
-
-```yaml
-image:
-  build:
-    dockerfile: path/to/dockerfile
-    context: context/dir
-    target: build-stage
-    cache_from:
-      - image:tag
-    args:
-      key: value
-```
-
-この場合、Copilot は指定したコンテキストディレクトリを使用します。また、args で指定した key-value のペアで `--build-arg` を上書きします。これは下記の docker コマンドの実行と同等です。
-
-`$ docker build --file path/to/dockerfile --target build-stage --cache-from image:tag --build-arg key=value context/dir`.
-
-フィールドは省略できます。その場合、Copilot は可能な限り意図を汲み取ろうと試みます。例えば、`context` を指定しても、`dockerfile`を指定しなかった場合、Copilot はコンテキストディレクトリで Docker を実行し、”Dockerfile”という名前のファイルを Dockerfile とみなします。逆に、`dockerfile`を指定し、`context`を指定しなかった場合、Copilot は `dockerfile` が配置されたディレクトリで Docker を実行したいのだと推測します。
-
-全てのパスはワークスペースをルートとした相対パスで記述できます。
-
-<span class="parent-field">image.</span><a id="image-location" href="#image-location" class="field">`location`</a> <span class="type">String</span>  
-Dockerfile からコンテナイメージをビルドする代わりに、既存のコンテナイメージ名の指定も可能です。`image.location` と [`image.build`](#image-build) の同時利用はできません。
-`location` フィールドの制約を含む指定方法は Amazon ECS タスク定義の [`image` パラメータ](https://docs.aws.amazon.com/ja_jp/AmazonECS/latest/developerguide/task_definition_parameters.html#container_definition_image)のそれに従います。
-
-<span class="parent-field">image.</span><a id="image-labels" href="#image-labels" class="field">`labels`</a><span class="type">Map</span>  
-コンテナに付与したい [Docker ラベル](https://docs.docker.com/config/labels-custom-metadata/)を key/value の Map で指定できます。これは任意設定項目です。
-
-<span class="parent-field">image.</span><a id="image-depends-on" href="#image-depends-on" class="field">`depends_on`</a> <span class="type">Map</span>  
-任意項目。コンテナに追加する [Container Dependencies](https://docs.aws.amazon.com/ja_jp/AmazonECS/latest/APIReference/API_ContainerDependency.html) の任意の key/value の Map。Map の key はコンテナ名で、value は依存関係を表す値 (依存条件) として `start`、`healthy`、`complete`、`success` のいずれかを指定できます。なお、必須コンテナに `complete` や `success` の依存条件を指定することはできません。
-
-!!! note
-    サイドカーのコンテナヘルスチェックは、現在 Copilot ではサポートされていません。つまり、`healthy` はサイドカーの有効な依存条件ではありません。
-
-設定例:
-```yaml
-image:
-  build: ./Dockerfile
-  depends_on:
-    nginx: start
-    startup: success
-```
-上記の例では、タスクのメインコンテナは `nginx` サイドカーが起動し、`startup` コンテナが正常に完了してから起動します。
+{% include 'image-config.ja.md' %}
 
 <div class="separator"></div>
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
Worker svc doesn't have `image.port` exposed. This PR removes unexpected `image.port` in worker svc doc.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
