### PR TITLE
chore(cli): skip asking questions if local manifest exists

### DIFF
--- a/internal/pkg/cli/init.go
+++ b/internal/pkg/cli/init.go
@@ -233,6 +233,7 @@ func newInitOpts(vars initVars) (*initOpts, error) {
 					init:         wlInitializer,
 					sel:          sel,
 					prompt:       prompt,
+					mftReader:    ws,
 					dockerEngine: dockerengine.New(cmd),
 					initParser: func(s string) dockerfileParser {
 						return dockerfile.New(fs, s)
@@ -253,6 +254,7 @@ func newInitOpts(vars initVars) (*initOpts, error) {
 					init:         wlInitializer,
 					sel:          sel,
 					topicSel:     snsSel,
+					mftReader:    ws,
 					prompt:       prompt,
 					dockerEngine: dockerengine.New(cmd),
 				}

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -230,7 +230,7 @@ type wsFileDeleter interface {
 }
 
 type manifestReader interface {
-	ReadWorkloadManifest(name string) ([]byte, error)
+	ReadWorkloadManifest(name string) (workspace.WorkloadManifest, error)
 }
 
 type copilotDirGetter interface {

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -229,12 +229,8 @@ type wsFileDeleter interface {
 	DeleteWorkspaceFile() error
 }
 
-type svcManifestReader interface {
-	ReadServiceManifest(svcName string) ([]byte, error)
-}
-
-type jobManifestReader interface {
-	ReadJobManifest(jobName string) ([]byte, error)
+type manifestReader interface {
+	ReadWorkloadManifest(name string) ([]byte, error)
 }
 
 type copilotDirGetter interface {
@@ -250,13 +246,13 @@ type wsPipelineWriter interface {
 	WritePipelineManifest(marshaler encoding.BinaryMarshaler) (string, error)
 }
 
-type wsServiceLister interface {
-	ServiceNames() ([]string, error)
+type serviceLister interface {
+	ListServices() ([]string, error)
 }
 
 type wsSvcReader interface {
-	wsServiceLister
-	svcManifestReader
+	serviceLister
+	manifestReader
 }
 
 type wsSvcDirReader interface {
@@ -264,17 +260,17 @@ type wsSvcDirReader interface {
 	copilotDirGetter
 }
 
-type wsJobLister interface {
-	JobNames() ([]string, error)
+type jobLister interface {
+	ListJobs() ([]string, error)
 }
 
 type wsJobReader interface {
-	jobManifestReader
-	wsJobLister
+	manifestReader
+	jobLister
 }
 
-type wsWlReader interface {
-	WorkloadNames() ([]string, error)
+type wlLister interface {
+	ListWorkloads() ([]string, error)
 }
 
 type wsJobDirReader interface {
@@ -286,14 +282,14 @@ type wsWlDirReader interface {
 	wsJobReader
 	wsSvcReader
 	copilotDirGetter
-	wsWlReader
+	wlLister
 	ListDockerfiles() ([]string, error)
 	Summary() (*workspace.Summary, error)
 }
 
 type wsPipelineReader interface {
 	wsPipelineManifestReader
-	WorkloadNames() ([]string, error)
+	wlLister
 }
 
 type wsAppManager interface {
@@ -303,7 +299,7 @@ type wsAppManager interface {
 
 type wsAddonManager interface {
 	WriteAddon(f encoding.BinaryMarshaler, svc, name string) (string, error)
-	wsWlReader
+	wlLister
 }
 
 type artifactUploader interface {

--- a/internal/pkg/cli/job_deploy.go
+++ b/internal/pkg/cli/job_deploy.go
@@ -354,7 +354,7 @@ func (o *deployJobOpts) runtimeConfig(addonsURL string) (*stack.RuntimeConfig, e
 }
 
 func (o *deployJobOpts) manifest() (interface{}, error) {
-	raw, err := o.ws.ReadJobManifest(o.name)
+	raw, err := o.ws.ReadWorkloadManifest(o.name)
 	if err != nil {
 		return nil, fmt.Errorf("read job %s manifest: %w", o.name, err)
 	}
@@ -382,7 +382,7 @@ func (o *deployJobOpts) RecommendActions() error {
 }
 
 func (o *deployJobOpts) validateJobName() error {
-	names, err := o.ws.JobNames()
+	names, err := o.ws.ListJobs()
 	if err != nil {
 		return fmt.Errorf("list jobs in the workspace: %w", err)
 	}

--- a/internal/pkg/cli/job_deploy_test.go
+++ b/internal/pkg/cli/job_deploy_test.go
@@ -45,7 +45,7 @@ func TestJobDeployOpts_Validate(t *testing.T) {
 			inAppName: "phonetool",
 			inJobName: "resizer",
 			mockWs: func(m *mocks.MockwsJobDirReader) {
-				m.EXPECT().JobNames().Return(nil, errors.New("some error"))
+				m.EXPECT().ListJobs().Return(nil, errors.New("some error"))
 			},
 			mockStore: func(m *mocks.Mockstore) {},
 
@@ -55,7 +55,7 @@ func TestJobDeployOpts_Validate(t *testing.T) {
 			inAppName: "phonetool",
 			inJobName: "resizer",
 			mockWs: func(m *mocks.MockwsJobDirReader) {
-				m.EXPECT().JobNames().Return([]string{}, nil)
+				m.EXPECT().ListJobs().Return([]string{}, nil)
 			},
 			mockStore: func(m *mocks.Mockstore) {},
 
@@ -77,7 +77,7 @@ func TestJobDeployOpts_Validate(t *testing.T) {
 			inJobName: "resizer",
 			inEnvName: "test",
 			mockWs: func(m *mocks.MockwsJobDirReader) {
-				m.EXPECT().JobNames().Return([]string{"resizer"}, nil)
+				m.EXPECT().ListJobs().Return([]string{"resizer"}, nil)
 			},
 			mockStore: func(m *mocks.Mockstore) {
 				m.EXPECT().GetEnvironment("phonetool", "test").
@@ -236,7 +236,7 @@ on:
 			inputSvc: "mailer",
 			setupMocks: func(m deployJobMocks) {
 				gomock.InOrder(
-					m.mockWs.EXPECT().ReadJobManifest("mailer").Return(nil, mockError),
+					m.mockWs.EXPECT().ReadWorkloadManifest("mailer").Return(nil, mockError),
 				)
 			},
 			wantErr: fmt.Errorf("read job %s manifest: %w", "mailer", mockError),
@@ -245,7 +245,7 @@ on:
 			inputSvc: "mailer",
 			setupMocks: func(m deployJobMocks) {
 				gomock.InOrder(
-					m.mockWs.EXPECT().ReadJobManifest(gomock.Any()).Return(mockManifest, nil),
+					m.mockWs.EXPECT().ReadWorkloadManifest(gomock.Any()).Return(mockManifest, nil),
 					m.mockInterpolator.EXPECT().Interpolate(string(mockManifest)).Return("", mockError),
 				)
 			},
@@ -255,7 +255,7 @@ on:
 			inputSvc: "mailer",
 			setupMocks: func(m deployJobMocks) {
 				gomock.InOrder(
-					m.mockWs.EXPECT().ReadJobManifest(gomock.Any()).Return(mockManifest, nil),
+					m.mockWs.EXPECT().ReadWorkloadManifest(gomock.Any()).Return(mockManifest, nil),
 					m.mockInterpolator.EXPECT().Interpolate(string(mockManifest)).Return(string(mockManifest), nil),
 					m.mockWs.EXPECT().CopilotDirPath().Return("", mockError),
 				)
@@ -266,7 +266,7 @@ on:
 			inputSvc: "mailer",
 			setupMocks: func(m deployJobMocks) {
 				gomock.InOrder(
-					m.mockWs.EXPECT().ReadJobManifest("mailer").Return(mockMftNoBuild, nil),
+					m.mockWs.EXPECT().ReadWorkloadManifest("mailer").Return(mockMftNoBuild, nil),
 					m.mockInterpolator.EXPECT().Interpolate(string(mockMftNoBuild)).Return(string(mockMftNoBuild), nil),
 					m.mockWs.EXPECT().CopilotDirPath().Times(0),
 					m.mockimageBuilderPusher.EXPECT().BuildAndPush(gomock.Any(), gomock.Any()).Times(0),
@@ -277,7 +277,7 @@ on:
 			inputSvc: "mailer",
 			setupMocks: func(m deployJobMocks) {
 				gomock.InOrder(
-					m.mockWs.EXPECT().ReadJobManifest("mailer").Return(mockManifest, nil),
+					m.mockWs.EXPECT().ReadWorkloadManifest("mailer").Return(mockManifest, nil),
 					m.mockInterpolator.EXPECT().Interpolate(string(mockManifest)).Return(string(mockManifest), nil),
 					m.mockWs.EXPECT().CopilotDirPath().Return("/ws/root/copilot", nil),
 					m.mockimageBuilderPusher.EXPECT().BuildAndPush(gomock.Any(), gomock.Any()).Return("", mockError),
@@ -289,7 +289,7 @@ on:
 			inputSvc: "mailer",
 			setupMocks: func(m deployJobMocks) {
 				gomock.InOrder(
-					m.mockWs.EXPECT().ReadJobManifest("mailer").Return(mockManifest, nil),
+					m.mockWs.EXPECT().ReadWorkloadManifest("mailer").Return(mockManifest, nil),
 					m.mockInterpolator.EXPECT().Interpolate(string(mockManifest)).Return(string(mockManifest), nil),
 					m.mockWs.EXPECT().CopilotDirPath().Return("/ws/root/copilot", nil),
 					m.mockimageBuilderPusher.EXPECT().BuildAndPush(gomock.Any(), &dockerengine.BuildArguments{
@@ -304,7 +304,7 @@ on:
 			inputSvc: "mailer",
 			setupMocks: func(m deployJobMocks) {
 				gomock.InOrder(
-					m.mockWs.EXPECT().ReadJobManifest("mailer").Return(mockMftBuildString, nil),
+					m.mockWs.EXPECT().ReadWorkloadManifest("mailer").Return(mockMftBuildString, nil),
 					m.mockInterpolator.EXPECT().Interpolate(string(mockMftBuildString)).Return(string(mockMftBuildString), nil),
 					m.mockWs.EXPECT().CopilotDirPath().Return("/ws/root/copilot", nil),
 					m.mockimageBuilderPusher.EXPECT().BuildAndPush(gomock.Any(), &dockerengine.BuildArguments{
@@ -319,7 +319,7 @@ on:
 			inputSvc: "mailer",
 			setupMocks: func(m deployJobMocks) {
 				gomock.InOrder(
-					m.mockWs.EXPECT().ReadJobManifest("mailer").Return(mockMftNoContext, nil),
+					m.mockWs.EXPECT().ReadWorkloadManifest("mailer").Return(mockMftNoContext, nil),
 					m.mockInterpolator.EXPECT().Interpolate(string(mockMftNoContext)).Return(string(mockMftNoContext), nil),
 					m.mockWs.EXPECT().CopilotDirPath().Return("/ws/root/copilot", nil),
 					m.mockimageBuilderPusher.EXPECT().BuildAndPush(gomock.Any(), &dockerengine.BuildArguments{

--- a/internal/pkg/cli/job_init.go
+++ b/internal/pkg/cli/job_init.go
@@ -170,7 +170,7 @@ func (o *initJobOpts) Ask() error {
 			return fmt.Errorf(`read "type" field for job %s from local manifest: %w`, o.name, err)
 		}
 		o.wkldType = jobType
-		log.Infof("Local manifest file for job %s is found; Copilot will create from the existing manifest.", o.name)
+		log.Infof("Manifest file for job %s already exists. Skipping configuration.\n", o.name)
 		return nil
 	}
 	var errNotFound *workspace.ErrFileNotExists

--- a/internal/pkg/cli/job_init.go
+++ b/internal/pkg/cli/job_init.go
@@ -167,14 +167,15 @@ func (o *initJobOpts) Ask() error {
 	if err == nil {
 		jobType, err := localMft.WorkloadType()
 		if err != nil {
-			return fmt.Errorf("read type for service %s from local manifest: %w", o.name, err)
+			return fmt.Errorf(`read "type" field for job %s from local manifest: %w`, o.name, err)
 		}
 		o.wkldType = jobType
+		log.Infof("Local manifest file for job %s is found; Copilot will create from the existing manifest.", o.name)
 		return nil
 	}
-	_, ok := err.(*workspace.ErrFileNotExists)
-	if !ok {
-		return fmt.Errorf("check if local manifest for job %s exists: %w", o.name, err)
+	var errNotFound *workspace.ErrFileNotExists
+	if !errors.As(err, &errNotFound) {
+		return fmt.Errorf("read manifest file for job %s: %w", o.name, err)
 	}
 	if err := o.askJobType(); err != nil {
 		return err

--- a/internal/pkg/cli/job_init_test.go
+++ b/internal/pkg/cli/job_init_test.go
@@ -239,7 +239,7 @@ func TestJobInitOpts_Ask(t *testing.T) {
 				m.mockMftReader.EXPECT().ReadWorkloadManifest(wantedJobName).Return(nil, mockError)
 			},
 
-			wantedErr: fmt.Errorf("check if local manifest for job cuteness-aggregator exists: mock error"),
+			wantedErr: fmt.Errorf("read manifest file for job cuteness-aggregator: mock error"),
 		},
 		"skip asking questions if local manifest file exists": {
 			inJobType:        wantedJobType,

--- a/internal/pkg/cli/job_init_test.go
+++ b/internal/pkg/cli/job_init_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/aws/copilot-cli/internal/pkg/docker/dockerfile"
+	"github.com/aws/copilot-cli/internal/pkg/workspace"
 
 	"github.com/aws/copilot-cli/internal/pkg/docker/dockerengine"
 
@@ -21,6 +22,13 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
 )
+
+type initJobMocks struct {
+	mockPrompt       *mocks.Mockprompter
+	mockSel          *mocks.MockinitJobSelector
+	mockDockerEngine *mocks.MockdockerEngine
+	mockMftReader    *mocks.MockmanifestReader
+}
 
 func TestJobInitOpts_Validate(t *testing.T) {
 	testCases := map[string]struct {
@@ -185,49 +193,65 @@ func TestJobInitOpts_Ask(t *testing.T) {
 		inDockerfilePath string
 		inJobSchedule    string
 
-		mockFileSystem   func(mockFS afero.Fs)
-		mockPrompt       func(m *mocks.Mockprompter)
-		mockSel          func(m *mocks.MockinitJobSelector)
-		mockDockerEngine func(m *mocks.MockdockerEngine)
+		setupMocks func(mocks initJobMocks)
 
 		wantedErr      error
 		wantedSchedule string
 	}{
-		"prompt for job name": {
-			inJobType:        wantedJobType,
-			inJobName:        "",
-			inDockerfilePath: wantedDockerfilePath,
-			inJobSchedule:    wantedCronSchedule,
-
-			mockFileSystem: func(mockFS afero.Fs) {},
-			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().Get(gomock.Eq(
-					fmt.Sprintf(fmtWkldInitNamePrompt, color.Emphasize("name"), color.HighlightUserInput(manifest.ScheduledJobType))),
-					gomock.Any(),
-					gomock.Any(),
-					gomock.Any(),
-				).Return(wantedJobName, nil)
-			},
-			mockSel:          func(m *mocks.MockinitJobSelector) {},
-			mockDockerEngine: func(m *mocks.MockdockerEngine) {},
-
-			wantedSchedule: wantedCronSchedule,
-		},
 		"error if fail to get job name": {
 			inJobType:        wantedJobType,
 			inJobName:        "",
 			inDockerfilePath: wantedDockerfilePath,
 			inJobSchedule:    wantedCronSchedule,
 
-			mockFileSystem: func(mockFS afero.Fs) {},
-			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			setupMocks: func(m initJobMocks) {
+				m.mockPrompt.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return("", errors.New("some error"))
 			},
-			mockSel:          func(m *mocks.MockinitJobSelector) {},
-			mockDockerEngine: func(m *mocks.MockdockerEngine) {},
 
 			wantedErr: fmt.Errorf("get job name: some error"),
+		},
+		"prompt for job name": {
+			inJobType:        wantedJobType,
+			inJobName:        "",
+			inDockerfilePath: wantedDockerfilePath,
+			inJobSchedule:    wantedCronSchedule,
+
+			setupMocks: func(m initJobMocks) {
+				m.mockPrompt.EXPECT().Get(gomock.Eq(
+					fmt.Sprintf(fmtWkldInitNamePrompt, color.Emphasize("name"), color.HighlightUserInput(manifest.ScheduledJobType))),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+				).Return(wantedJobName, nil)
+				m.mockMftReader.EXPECT().ReadWorkloadManifest(wantedJobName).Return(nil, &workspace.ErrFileNotExists{FileName: wantedJobName})
+			},
+
+			wantedSchedule: wantedCronSchedule,
+		},
+		"error if fail to get local manifest": {
+			inJobType:        wantedJobType,
+			inJobName:        wantedJobName,
+			inDockerfilePath: wantedDockerfilePath,
+			inJobSchedule:    wantedCronSchedule,
+
+			setupMocks: func(m initJobMocks) {
+				m.mockMftReader.EXPECT().ReadWorkloadManifest(wantedJobName).Return(nil, mockError)
+			},
+
+			wantedErr: fmt.Errorf("check if local manifest for job cuteness-aggregator exists: mock error"),
+		},
+		"skip asking questions if local manifest file exists": {
+			inJobType:        wantedJobType,
+			inJobName:        wantedJobName,
+			inDockerfilePath: wantedDockerfilePath,
+			inJobSchedule:    wantedCronSchedule,
+
+			setupMocks: func(m initJobMocks) {
+				m.mockMftReader.EXPECT().ReadWorkloadManifest(wantedJobName).Return([]byte(""), nil)
+			},
+
+			wantedSchedule: wantedCronSchedule,
 		},
 		"skip selecting Dockerfile if image flag is set": {
 			inJobType:        wantedJobType,
@@ -236,10 +260,9 @@ func TestJobInitOpts_Ask(t *testing.T) {
 			inDockerfilePath: "",
 			inJobSchedule:    wantedCronSchedule,
 
-			mockPrompt:       func(m *mocks.Mockprompter) {},
-			mockSel:          func(m *mocks.MockinitJobSelector) {},
-			mockFileSystem:   func(mockFS afero.Fs) {},
-			mockDockerEngine: func(m *mocks.MockdockerEngine) {},
+			setupMocks: func(m initJobMocks) {
+				m.mockMftReader.EXPECT().ReadWorkloadManifest(wantedJobName).Return(nil, &workspace.ErrFileNotExists{FileName: wantedJobName})
+			},
 
 			wantedSchedule: wantedCronSchedule,
 		},
@@ -248,11 +271,9 @@ func TestJobInitOpts_Ask(t *testing.T) {
 			inJobName:     wantedJobName,
 			inJobSchedule: wantedCronSchedule,
 
-			mockPrompt:     func(m *mocks.Mockprompter) {},
-			mockSel:        func(m *mocks.MockinitJobSelector) {},
-			mockFileSystem: func(mockFS afero.Fs) {},
-			mockDockerEngine: func(m *mocks.MockdockerEngine) {
-				m.EXPECT().CheckDockerEngineRunning().Return(errors.New("some error"))
+			setupMocks: func(m initJobMocks) {
+				m.mockMftReader.EXPECT().ReadWorkloadManifest(wantedJobName).Return(nil, &workspace.ErrFileNotExists{FileName: wantedJobName})
+				m.mockDockerEngine.EXPECT().CheckDockerEngineRunning().Return(errors.New("some error"))
 			},
 
 			wantedErr: fmt.Errorf("check if docker engine is running: some error"),
@@ -262,14 +283,11 @@ func TestJobInitOpts_Ask(t *testing.T) {
 			inJobName:     wantedJobName,
 			inJobSchedule: wantedCronSchedule,
 
-			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().Get(wkldInitImagePrompt, wkldInitImagePromptHelp, nil, gomock.Any()).
+			setupMocks: func(m initJobMocks) {
+				m.mockMftReader.EXPECT().ReadWorkloadManifest(wantedJobName).Return(nil, &workspace.ErrFileNotExists{FileName: wantedJobName})
+				m.mockPrompt.EXPECT().Get(wkldInitImagePrompt, wkldInitImagePromptHelp, nil, gomock.Any()).
 					Return("mockImage", nil)
-			},
-			mockSel:        func(m *mocks.MockinitJobSelector) {},
-			mockFileSystem: func(mockFS afero.Fs) {},
-			mockDockerEngine: func(m *mocks.MockdockerEngine) {
-				m.EXPECT().CheckDockerEngineRunning().Return(dockerengine.ErrDockerCommandNotFound)
+				m.mockDockerEngine.EXPECT().CheckDockerEngineRunning().Return(dockerengine.ErrDockerCommandNotFound)
 			},
 
 			wantedSchedule: wantedCronSchedule,
@@ -279,14 +297,11 @@ func TestJobInitOpts_Ask(t *testing.T) {
 			inJobName:     wantedJobName,
 			inJobSchedule: wantedCronSchedule,
 
-			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().Get(wkldInitImagePrompt, wkldInitImagePromptHelp, nil, gomock.Any()).
+			setupMocks: func(m initJobMocks) {
+				m.mockMftReader.EXPECT().ReadWorkloadManifest(wantedJobName).Return(nil, &workspace.ErrFileNotExists{FileName: wantedJobName})
+				m.mockPrompt.EXPECT().Get(wkldInitImagePrompt, wkldInitImagePromptHelp, nil, gomock.Any()).
 					Return("mockImage", nil)
-			},
-			mockSel:        func(m *mocks.MockinitJobSelector) {},
-			mockFileSystem: func(mockFS afero.Fs) {},
-			mockDockerEngine: func(m *mocks.MockdockerEngine) {
-				m.EXPECT().CheckDockerEngineRunning().Return(&dockerengine.ErrDockerDaemonNotResponsive{})
+				m.mockDockerEngine.EXPECT().CheckDockerEngineRunning().Return(&dockerengine.ErrDockerDaemonNotResponsive{})
 			},
 
 			wantedSchedule: wantedCronSchedule,
@@ -296,23 +311,19 @@ func TestJobInitOpts_Ask(t *testing.T) {
 			inJobName:        wantedJobName,
 			inDockerfilePath: "",
 
-			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().Get(wkldInitImagePrompt, wkldInitImagePromptHelp, nil, gomock.Any()).
+			setupMocks: func(m initJobMocks) {
+				m.mockMftReader.EXPECT().ReadWorkloadManifest(wantedJobName).Return(nil, &workspace.ErrFileNotExists{FileName: wantedJobName})
+				m.mockPrompt.EXPECT().Get(wkldInitImagePrompt, wkldInitImagePromptHelp, nil, gomock.Any()).
 					Return("", mockError)
-			},
-			mockSel: func(m *mocks.MockinitJobSelector) {
-				m.EXPECT().Dockerfile(
+				m.mockSel.EXPECT().Dockerfile(
 					gomock.Eq(fmt.Sprintf(fmtWkldInitDockerfilePrompt, wantedJobName)),
 					gomock.Eq(fmt.Sprintf(fmtWkldInitDockerfilePathPrompt, wantedJobName)),
 					gomock.Eq(wkldInitDockerfileHelpPrompt),
 					gomock.Eq(wkldInitDockerfilePathHelpPrompt),
 					gomock.Any(),
 				).Return("Use an existing image instead", nil)
+				m.mockDockerEngine.EXPECT().CheckDockerEngineRunning().Return(nil)
 			},
-			mockDockerEngine: func(m *mocks.MockdockerEngine) {
-				m.EXPECT().CheckDockerEngineRunning().Return(nil)
-			},
-			mockFileSystem: func(mockFS afero.Fs) {},
 
 			wantedErr: fmt.Errorf("get image location: mock error"),
 		},
@@ -322,22 +333,18 @@ func TestJobInitOpts_Ask(t *testing.T) {
 			inJobSchedule:    wantedCronSchedule,
 			inDockerfilePath: "",
 
-			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().Get(wkldInitImagePrompt, wkldInitImagePromptHelp, nil, gomock.Any()).
+			setupMocks: func(m initJobMocks) {
+				m.mockMftReader.EXPECT().ReadWorkloadManifest(wantedJobName).Return(nil, &workspace.ErrFileNotExists{FileName: wantedJobName})
+				m.mockPrompt.EXPECT().Get(wkldInitImagePrompt, wkldInitImagePromptHelp, nil, gomock.Any()).
 					Return("mockImage", nil)
-			},
-			mockSel: func(m *mocks.MockinitJobSelector) {
-				m.EXPECT().Dockerfile(
+				m.mockSel.EXPECT().Dockerfile(
 					gomock.Eq(fmt.Sprintf(fmtWkldInitDockerfilePrompt, wantedJobName)),
 					gomock.Eq(fmt.Sprintf(fmtWkldInitDockerfilePathPrompt, wantedJobName)),
 					gomock.Eq(wkldInitDockerfileHelpPrompt),
 					gomock.Eq(wkldInitDockerfilePathHelpPrompt),
 					gomock.Any(),
 				).Return("Use an existing image instead", nil)
-			},
-			mockFileSystem: func(mockFS afero.Fs) {},
-			mockDockerEngine: func(m *mocks.MockdockerEngine) {
-				m.EXPECT().CheckDockerEngineRunning().Return(nil)
+				m.mockDockerEngine.EXPECT().CheckDockerEngineRunning().Return(nil)
 			},
 
 			wantedSchedule: wantedCronSchedule,
@@ -348,19 +355,16 @@ func TestJobInitOpts_Ask(t *testing.T) {
 			inDockerfilePath: "",
 			inJobSchedule:    wantedCronSchedule,
 
-			mockFileSystem: func(mockFS afero.Fs) {},
-			mockPrompt:     func(m *mocks.Mockprompter) {},
-			mockSel: func(m *mocks.MockinitJobSelector) {
-				m.EXPECT().Dockerfile(
+			setupMocks: func(m initJobMocks) {
+				m.mockMftReader.EXPECT().ReadWorkloadManifest(wantedJobName).Return(nil, &workspace.ErrFileNotExists{FileName: wantedJobName})
+				m.mockSel.EXPECT().Dockerfile(
 					gomock.Eq(fmt.Sprintf(fmtWkldInitDockerfilePrompt, color.HighlightUserInput(wantedJobName))),
 					gomock.Eq(fmt.Sprintf(fmtWkldInitDockerfilePathPrompt, color.HighlightUserInput(wantedJobName))),
 					gomock.Any(),
 					gomock.Any(),
 					gomock.Any(),
 				).Return("cuteness-aggregator/Dockerfile", nil)
-			},
-			mockDockerEngine: func(m *mocks.MockdockerEngine) {
-				m.EXPECT().CheckDockerEngineRunning().Return(nil)
+				m.mockDockerEngine.EXPECT().CheckDockerEngineRunning().Return(nil)
 			},
 
 			wantedSchedule: wantedCronSchedule,
@@ -371,19 +375,16 @@ func TestJobInitOpts_Ask(t *testing.T) {
 			inDockerfilePath: "",
 			inJobSchedule:    wantedCronSchedule,
 
-			mockFileSystem: func(mockFS afero.Fs) {},
-			mockPrompt:     func(m *mocks.Mockprompter) {},
-			mockSel: func(m *mocks.MockinitJobSelector) {
-				m.EXPECT().Dockerfile(
+			setupMocks: func(m initJobMocks) {
+				m.mockMftReader.EXPECT().ReadWorkloadManifest(wantedJobName).Return(nil, &workspace.ErrFileNotExists{FileName: wantedJobName})
+				m.mockSel.EXPECT().Dockerfile(
 					gomock.Eq(fmt.Sprintf(fmtWkldInitDockerfilePrompt, color.HighlightUserInput(wantedJobName))),
 					gomock.Eq(fmt.Sprintf(fmtWkldInitDockerfilePathPrompt, color.HighlightUserInput(wantedJobName))),
 					gomock.Any(),
 					gomock.Any(),
 					gomock.Any(),
 				).Return("", errors.New("some error"))
-			},
-			mockDockerEngine: func(m *mocks.MockdockerEngine) {
-				m.EXPECT().CheckDockerEngineRunning().Return(nil)
+				m.mockDockerEngine.EXPECT().CheckDockerEngineRunning().Return(nil)
 			},
 
 			wantedErr: fmt.Errorf("select Dockerfile: some error"),
@@ -394,17 +395,15 @@ func TestJobInitOpts_Ask(t *testing.T) {
 			inDockerfilePath: wantedDockerfilePath,
 			inJobSchedule:    "",
 
-			mockFileSystem: func(mockFS afero.Fs) {},
-			mockSel: func(m *mocks.MockinitJobSelector) {
-				m.EXPECT().Schedule(
+			setupMocks: func(m initJobMocks) {
+				m.mockMftReader.EXPECT().ReadWorkloadManifest(wantedJobName).Return(nil, &workspace.ErrFileNotExists{FileName: wantedJobName})
+				m.mockSel.EXPECT().Schedule(
 					gomock.Eq(jobInitSchedulePrompt),
 					gomock.Eq(jobInitScheduleHelp),
 					gomock.Any(),
 					gomock.Any(),
 				).Return(wantedCronSchedule, nil)
 			},
-			mockPrompt:       func(m *mocks.Mockprompter) {},
-			mockDockerEngine: func(m *mocks.MockdockerEngine) {},
 
 			wantedSchedule: wantedCronSchedule,
 		},
@@ -414,17 +413,15 @@ func TestJobInitOpts_Ask(t *testing.T) {
 			inDockerfilePath: wantedDockerfilePath,
 			inJobSchedule:    "",
 
-			mockPrompt:     func(m *mocks.Mockprompter) {},
-			mockFileSystem: func(mockFS afero.Fs) {},
-			mockSel: func(m *mocks.MockinitJobSelector) {
-				m.EXPECT().Schedule(
+			setupMocks: func(m initJobMocks) {
+				m.mockMftReader.EXPECT().ReadWorkloadManifest(wantedJobName).Return(nil, &workspace.ErrFileNotExists{FileName: wantedJobName})
+				m.mockSel.EXPECT().Schedule(
 					gomock.Any(),
 					gomock.Any(),
 					gomock.Any(),
 					gomock.Any(),
 				).Return("", fmt.Errorf("some error"))
 			},
-			mockDockerEngine: func(m *mocks.MockdockerEngine) {},
 
 			wantedErr: fmt.Errorf("get schedule: some error"),
 		},
@@ -438,6 +435,14 @@ func TestJobInitOpts_Ask(t *testing.T) {
 			mockPrompt := mocks.NewMockprompter(ctrl)
 			mockSel := mocks.NewMockinitJobSelector(ctrl)
 			mockDockerEngine := mocks.NewMockdockerEngine(ctrl)
+			mockManifestReader := mocks.NewMockmanifestReader(ctrl)
+			mocks := initJobMocks{
+				mockPrompt:       mockPrompt,
+				mockSel:          mockSel,
+				mockDockerEngine: mockDockerEngine,
+				mockMftReader:    mockManifestReader,
+			}
+			tc.setupMocks(mocks)
 			opts := &initJobOpts{
 				initJobVars: initJobVars{
 					initWkldVars: initWkldVars{
@@ -448,16 +453,11 @@ func TestJobInitOpts_Ask(t *testing.T) {
 					},
 					schedule: tc.inJobSchedule,
 				},
-				fs:           &afero.Afero{Fs: afero.NewMemMapFs()},
 				sel:          mockSel,
 				dockerEngine: mockDockerEngine,
+				mftReader:    mockManifestReader,
 				prompt:       mockPrompt,
 			}
-
-			tc.mockFileSystem(opts.fs)
-			tc.mockPrompt(mockPrompt)
-			tc.mockSel(mockSel)
-			tc.mockDockerEngine(mockDockerEngine)
 
 			// WHEN
 			err := opts.Ask()

--- a/internal/pkg/cli/job_init_test.go
+++ b/internal/pkg/cli/job_init_test.go
@@ -248,7 +248,8 @@ func TestJobInitOpts_Ask(t *testing.T) {
 			inJobSchedule:    wantedCronSchedule,
 
 			setupMocks: func(m initJobMocks) {
-				m.mockMftReader.EXPECT().ReadWorkloadManifest(wantedJobName).Return([]byte(""), nil)
+				m.mockMftReader.EXPECT().ReadWorkloadManifest(wantedJobName).Return([]byte(`name: cuteness-aggregator
+type: Scheduled Job`), nil)
 			},
 
 			wantedSchedule: wantedCronSchedule,

--- a/internal/pkg/cli/job_package.go
+++ b/internal/pkg/cli/job_package.go
@@ -128,7 +128,7 @@ func (o *packageJobOpts) Validate() error {
 		return errNoAppInWorkspace
 	}
 	if o.name != "" {
-		names, err := o.ws.JobNames()
+		names, err := o.ws.ListJobs()
 		if err != nil {
 			return fmt.Errorf("list jobs in the workspace: %w", err)
 		}

--- a/internal/pkg/cli/job_package_test.go
+++ b/internal/pkg/cli/job_package_test.go
@@ -30,7 +30,7 @@ func TestPackageJobOpts_Validate(t *testing.T) {
 	}{
 		"invalid workspace": {
 			setupMocks: func() {
-				mockWorkspace.EXPECT().JobNames().Times(0)
+				mockWorkspace.EXPECT().ListJobs().Times(0)
 				mockStore.EXPECT().GetEnvironment(gomock.Any(), gomock.Any()).Times(0)
 			},
 			wantedErrorS: "could not find an application attached to this workspace, please run `app init` first",
@@ -39,7 +39,7 @@ func TestPackageJobOpts_Validate(t *testing.T) {
 			inAppName: "phonetool",
 			inJobName: "resizer",
 			setupMocks: func() {
-				mockWorkspace.EXPECT().JobNames().Return(nil, errors.New("some error"))
+				mockWorkspace.EXPECT().ListJobs().Return(nil, errors.New("some error"))
 				mockStore.EXPECT().GetEnvironment(gomock.Any(), gomock.Any()).Times(0)
 			},
 
@@ -49,7 +49,7 @@ func TestPackageJobOpts_Validate(t *testing.T) {
 			inAppName: "phonetool",
 			inJobName: "resizer",
 			setupMocks: func() {
-				mockWorkspace.EXPECT().JobNames().Return([]string{"other-job"}, nil)
+				mockWorkspace.EXPECT().ListJobs().Return([]string{"other-job"}, nil)
 				mockStore.EXPECT().GetEnvironment(gomock.Any(), gomock.Any()).Times(0)
 			},
 
@@ -60,7 +60,7 @@ func TestPackageJobOpts_Validate(t *testing.T) {
 			inEnvName: "test",
 
 			setupMocks: func() {
-				mockWorkspace.EXPECT().JobNames().Times(0)
+				mockWorkspace.EXPECT().ListJobs().Times(0)
 				mockStore.EXPECT().GetEnvironment("phonetool", "test").Return(nil, &config.ErrNoSuchEnvironment{
 					ApplicationName: "phonetool",
 					EnvironmentName: "test",

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -2150,80 +2150,42 @@ func (mr *MockwsFileDeleterMockRecorder) DeleteWorkspaceFile() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteWorkspaceFile", reflect.TypeOf((*MockwsFileDeleter)(nil).DeleteWorkspaceFile))
 }
 
-// MocksvcManifestReader is a mock of svcManifestReader interface.
-type MocksvcManifestReader struct {
+// MockmanifestReader is a mock of manifestReader interface.
+type MockmanifestReader struct {
 	ctrl     *gomock.Controller
-	recorder *MocksvcManifestReaderMockRecorder
+	recorder *MockmanifestReaderMockRecorder
 }
 
-// MocksvcManifestReaderMockRecorder is the mock recorder for MocksvcManifestReader.
-type MocksvcManifestReaderMockRecorder struct {
-	mock *MocksvcManifestReader
+// MockmanifestReaderMockRecorder is the mock recorder for MockmanifestReader.
+type MockmanifestReaderMockRecorder struct {
+	mock *MockmanifestReader
 }
 
-// NewMocksvcManifestReader creates a new mock instance.
-func NewMocksvcManifestReader(ctrl *gomock.Controller) *MocksvcManifestReader {
-	mock := &MocksvcManifestReader{ctrl: ctrl}
-	mock.recorder = &MocksvcManifestReaderMockRecorder{mock}
+// NewMockmanifestReader creates a new mock instance.
+func NewMockmanifestReader(ctrl *gomock.Controller) *MockmanifestReader {
+	mock := &MockmanifestReader{ctrl: ctrl}
+	mock.recorder = &MockmanifestReaderMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MocksvcManifestReader) EXPECT() *MocksvcManifestReaderMockRecorder {
+func (m *MockmanifestReader) EXPECT() *MockmanifestReaderMockRecorder {
 	return m.recorder
 }
 
-// ReadServiceManifest mocks base method.
-func (m *MocksvcManifestReader) ReadServiceManifest(svcName string) ([]byte, error) {
+// ReadWorkloadManifest mocks base method.
+func (m *MockmanifestReader) ReadWorkloadManifest(name string) ([]byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadServiceManifest", svcName)
+	ret := m.ctrl.Call(m, "ReadWorkloadManifest", name)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ReadServiceManifest indicates an expected call of ReadServiceManifest.
-func (mr *MocksvcManifestReaderMockRecorder) ReadServiceManifest(svcName interface{}) *gomock.Call {
+// ReadWorkloadManifest indicates an expected call of ReadWorkloadManifest.
+func (mr *MockmanifestReaderMockRecorder) ReadWorkloadManifest(name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadServiceManifest", reflect.TypeOf((*MocksvcManifestReader)(nil).ReadServiceManifest), svcName)
-}
-
-// MockjobManifestReader is a mock of jobManifestReader interface.
-type MockjobManifestReader struct {
-	ctrl     *gomock.Controller
-	recorder *MockjobManifestReaderMockRecorder
-}
-
-// MockjobManifestReaderMockRecorder is the mock recorder for MockjobManifestReader.
-type MockjobManifestReaderMockRecorder struct {
-	mock *MockjobManifestReader
-}
-
-// NewMockjobManifestReader creates a new mock instance.
-func NewMockjobManifestReader(ctrl *gomock.Controller) *MockjobManifestReader {
-	mock := &MockjobManifestReader{ctrl: ctrl}
-	mock.recorder = &MockjobManifestReaderMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockjobManifestReader) EXPECT() *MockjobManifestReaderMockRecorder {
-	return m.recorder
-}
-
-// ReadJobManifest mocks base method.
-func (m *MockjobManifestReader) ReadJobManifest(jobName string) ([]byte, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadJobManifest", jobName)
-	ret0, _ := ret[0].([]byte)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ReadJobManifest indicates an expected call of ReadJobManifest.
-func (mr *MockjobManifestReaderMockRecorder) ReadJobManifest(jobName interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadJobManifest", reflect.TypeOf((*MockjobManifestReader)(nil).ReadJobManifest), jobName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadWorkloadManifest", reflect.TypeOf((*MockmanifestReader)(nil).ReadWorkloadManifest), name)
 }
 
 // MockcopilotDirGetter is a mock of copilotDirGetter interface.
@@ -2355,42 +2317,42 @@ func (mr *MockwsPipelineWriterMockRecorder) WritePipelineManifest(marshaler inte
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WritePipelineManifest", reflect.TypeOf((*MockwsPipelineWriter)(nil).WritePipelineManifest), marshaler)
 }
 
-// MockwsServiceLister is a mock of wsServiceLister interface.
-type MockwsServiceLister struct {
+// MockserviceLister is a mock of serviceLister interface.
+type MockserviceLister struct {
 	ctrl     *gomock.Controller
-	recorder *MockwsServiceListerMockRecorder
+	recorder *MockserviceListerMockRecorder
 }
 
-// MockwsServiceListerMockRecorder is the mock recorder for MockwsServiceLister.
-type MockwsServiceListerMockRecorder struct {
-	mock *MockwsServiceLister
+// MockserviceListerMockRecorder is the mock recorder for MockserviceLister.
+type MockserviceListerMockRecorder struct {
+	mock *MockserviceLister
 }
 
-// NewMockwsServiceLister creates a new mock instance.
-func NewMockwsServiceLister(ctrl *gomock.Controller) *MockwsServiceLister {
-	mock := &MockwsServiceLister{ctrl: ctrl}
-	mock.recorder = &MockwsServiceListerMockRecorder{mock}
+// NewMockserviceLister creates a new mock instance.
+func NewMockserviceLister(ctrl *gomock.Controller) *MockserviceLister {
+	mock := &MockserviceLister{ctrl: ctrl}
+	mock.recorder = &MockserviceListerMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockwsServiceLister) EXPECT() *MockwsServiceListerMockRecorder {
+func (m *MockserviceLister) EXPECT() *MockserviceListerMockRecorder {
 	return m.recorder
 }
 
-// ServiceNames mocks base method.
-func (m *MockwsServiceLister) ServiceNames() ([]string, error) {
+// ListServices mocks base method.
+func (m *MockserviceLister) ListServices() ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ServiceNames")
+	ret := m.ctrl.Call(m, "ListServices")
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ServiceNames indicates an expected call of ServiceNames.
-func (mr *MockwsServiceListerMockRecorder) ServiceNames() *gomock.Call {
+// ListServices indicates an expected call of ListServices.
+func (mr *MockserviceListerMockRecorder) ListServices() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceNames", reflect.TypeOf((*MockwsServiceLister)(nil).ServiceNames))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServices", reflect.TypeOf((*MockserviceLister)(nil).ListServices))
 }
 
 // MockwsSvcReader is a mock of wsSvcReader interface.
@@ -2416,34 +2378,34 @@ func (m *MockwsSvcReader) EXPECT() *MockwsSvcReaderMockRecorder {
 	return m.recorder
 }
 
-// ReadServiceManifest mocks base method.
-func (m *MockwsSvcReader) ReadServiceManifest(svcName string) ([]byte, error) {
+// ListServices mocks base method.
+func (m *MockwsSvcReader) ListServices() ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadServiceManifest", svcName)
-	ret0, _ := ret[0].([]byte)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ReadServiceManifest indicates an expected call of ReadServiceManifest.
-func (mr *MockwsSvcReaderMockRecorder) ReadServiceManifest(svcName interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadServiceManifest", reflect.TypeOf((*MockwsSvcReader)(nil).ReadServiceManifest), svcName)
-}
-
-// ServiceNames mocks base method.
-func (m *MockwsSvcReader) ServiceNames() ([]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ServiceNames")
+	ret := m.ctrl.Call(m, "ListServices")
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ServiceNames indicates an expected call of ServiceNames.
-func (mr *MockwsSvcReaderMockRecorder) ServiceNames() *gomock.Call {
+// ListServices indicates an expected call of ListServices.
+func (mr *MockwsSvcReaderMockRecorder) ListServices() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceNames", reflect.TypeOf((*MockwsSvcReader)(nil).ServiceNames))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServices", reflect.TypeOf((*MockwsSvcReader)(nil).ListServices))
+}
+
+// ReadWorkloadManifest mocks base method.
+func (m *MockwsSvcReader) ReadWorkloadManifest(name string) ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReadWorkloadManifest", name)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReadWorkloadManifest indicates an expected call of ReadWorkloadManifest.
+func (mr *MockwsSvcReaderMockRecorder) ReadWorkloadManifest(name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadWorkloadManifest", reflect.TypeOf((*MockwsSvcReader)(nil).ReadWorkloadManifest), name)
 }
 
 // MockwsSvcDirReader is a mock of wsSvcDirReader interface.
@@ -2484,72 +2446,72 @@ func (mr *MockwsSvcDirReaderMockRecorder) CopilotDirPath() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopilotDirPath", reflect.TypeOf((*MockwsSvcDirReader)(nil).CopilotDirPath))
 }
 
-// ReadServiceManifest mocks base method.
-func (m *MockwsSvcDirReader) ReadServiceManifest(svcName string) ([]byte, error) {
+// ListServices mocks base method.
+func (m *MockwsSvcDirReader) ListServices() ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadServiceManifest", svcName)
+	ret := m.ctrl.Call(m, "ListServices")
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListServices indicates an expected call of ListServices.
+func (mr *MockwsSvcDirReaderMockRecorder) ListServices() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServices", reflect.TypeOf((*MockwsSvcDirReader)(nil).ListServices))
+}
+
+// ReadWorkloadManifest mocks base method.
+func (m *MockwsSvcDirReader) ReadWorkloadManifest(name string) ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReadWorkloadManifest", name)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ReadServiceManifest indicates an expected call of ReadServiceManifest.
-func (mr *MockwsSvcDirReaderMockRecorder) ReadServiceManifest(svcName interface{}) *gomock.Call {
+// ReadWorkloadManifest indicates an expected call of ReadWorkloadManifest.
+func (mr *MockwsSvcDirReaderMockRecorder) ReadWorkloadManifest(name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadServiceManifest", reflect.TypeOf((*MockwsSvcDirReader)(nil).ReadServiceManifest), svcName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadWorkloadManifest", reflect.TypeOf((*MockwsSvcDirReader)(nil).ReadWorkloadManifest), name)
 }
 
-// ServiceNames mocks base method.
-func (m *MockwsSvcDirReader) ServiceNames() ([]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ServiceNames")
-	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ServiceNames indicates an expected call of ServiceNames.
-func (mr *MockwsSvcDirReaderMockRecorder) ServiceNames() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceNames", reflect.TypeOf((*MockwsSvcDirReader)(nil).ServiceNames))
-}
-
-// MockwsJobLister is a mock of wsJobLister interface.
-type MockwsJobLister struct {
+// MockjobLister is a mock of jobLister interface.
+type MockjobLister struct {
 	ctrl     *gomock.Controller
-	recorder *MockwsJobListerMockRecorder
+	recorder *MockjobListerMockRecorder
 }
 
-// MockwsJobListerMockRecorder is the mock recorder for MockwsJobLister.
-type MockwsJobListerMockRecorder struct {
-	mock *MockwsJobLister
+// MockjobListerMockRecorder is the mock recorder for MockjobLister.
+type MockjobListerMockRecorder struct {
+	mock *MockjobLister
 }
 
-// NewMockwsJobLister creates a new mock instance.
-func NewMockwsJobLister(ctrl *gomock.Controller) *MockwsJobLister {
-	mock := &MockwsJobLister{ctrl: ctrl}
-	mock.recorder = &MockwsJobListerMockRecorder{mock}
+// NewMockjobLister creates a new mock instance.
+func NewMockjobLister(ctrl *gomock.Controller) *MockjobLister {
+	mock := &MockjobLister{ctrl: ctrl}
+	mock.recorder = &MockjobListerMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockwsJobLister) EXPECT() *MockwsJobListerMockRecorder {
+func (m *MockjobLister) EXPECT() *MockjobListerMockRecorder {
 	return m.recorder
 }
 
-// JobNames mocks base method.
-func (m *MockwsJobLister) JobNames() ([]string, error) {
+// ListJobs mocks base method.
+func (m *MockjobLister) ListJobs() ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "JobNames")
+	ret := m.ctrl.Call(m, "ListJobs")
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// JobNames indicates an expected call of JobNames.
-func (mr *MockwsJobListerMockRecorder) JobNames() *gomock.Call {
+// ListJobs indicates an expected call of ListJobs.
+func (mr *MockjobListerMockRecorder) ListJobs() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JobNames", reflect.TypeOf((*MockwsJobLister)(nil).JobNames))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListJobs", reflect.TypeOf((*MockjobLister)(nil).ListJobs))
 }
 
 // MockwsJobReader is a mock of wsJobReader interface.
@@ -2575,72 +2537,72 @@ func (m *MockwsJobReader) EXPECT() *MockwsJobReaderMockRecorder {
 	return m.recorder
 }
 
-// JobNames mocks base method.
-func (m *MockwsJobReader) JobNames() ([]string, error) {
+// ListJobs mocks base method.
+func (m *MockwsJobReader) ListJobs() ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "JobNames")
+	ret := m.ctrl.Call(m, "ListJobs")
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// JobNames indicates an expected call of JobNames.
-func (mr *MockwsJobReaderMockRecorder) JobNames() *gomock.Call {
+// ListJobs indicates an expected call of ListJobs.
+func (mr *MockwsJobReaderMockRecorder) ListJobs() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JobNames", reflect.TypeOf((*MockwsJobReader)(nil).JobNames))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListJobs", reflect.TypeOf((*MockwsJobReader)(nil).ListJobs))
 }
 
-// ReadJobManifest mocks base method.
-func (m *MockwsJobReader) ReadJobManifest(jobName string) ([]byte, error) {
+// ReadWorkloadManifest mocks base method.
+func (m *MockwsJobReader) ReadWorkloadManifest(name string) ([]byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadJobManifest", jobName)
+	ret := m.ctrl.Call(m, "ReadWorkloadManifest", name)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ReadJobManifest indicates an expected call of ReadJobManifest.
-func (mr *MockwsJobReaderMockRecorder) ReadJobManifest(jobName interface{}) *gomock.Call {
+// ReadWorkloadManifest indicates an expected call of ReadWorkloadManifest.
+func (mr *MockwsJobReaderMockRecorder) ReadWorkloadManifest(name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadJobManifest", reflect.TypeOf((*MockwsJobReader)(nil).ReadJobManifest), jobName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadWorkloadManifest", reflect.TypeOf((*MockwsJobReader)(nil).ReadWorkloadManifest), name)
 }
 
-// MockwsWlReader is a mock of wsWlReader interface.
-type MockwsWlReader struct {
+// MockwlLister is a mock of wlLister interface.
+type MockwlLister struct {
 	ctrl     *gomock.Controller
-	recorder *MockwsWlReaderMockRecorder
+	recorder *MockwlListerMockRecorder
 }
 
-// MockwsWlReaderMockRecorder is the mock recorder for MockwsWlReader.
-type MockwsWlReaderMockRecorder struct {
-	mock *MockwsWlReader
+// MockwlListerMockRecorder is the mock recorder for MockwlLister.
+type MockwlListerMockRecorder struct {
+	mock *MockwlLister
 }
 
-// NewMockwsWlReader creates a new mock instance.
-func NewMockwsWlReader(ctrl *gomock.Controller) *MockwsWlReader {
-	mock := &MockwsWlReader{ctrl: ctrl}
-	mock.recorder = &MockwsWlReaderMockRecorder{mock}
+// NewMockwlLister creates a new mock instance.
+func NewMockwlLister(ctrl *gomock.Controller) *MockwlLister {
+	mock := &MockwlLister{ctrl: ctrl}
+	mock.recorder = &MockwlListerMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockwsWlReader) EXPECT() *MockwsWlReaderMockRecorder {
+func (m *MockwlLister) EXPECT() *MockwlListerMockRecorder {
 	return m.recorder
 }
 
-// WorkloadNames mocks base method.
-func (m *MockwsWlReader) WorkloadNames() ([]string, error) {
+// ListWorkloads mocks base method.
+func (m *MockwlLister) ListWorkloads() ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WorkloadNames")
+	ret := m.ctrl.Call(m, "ListWorkloads")
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// WorkloadNames indicates an expected call of WorkloadNames.
-func (mr *MockwsWlReaderMockRecorder) WorkloadNames() *gomock.Call {
+// ListWorkloads indicates an expected call of ListWorkloads.
+func (mr *MockwlListerMockRecorder) ListWorkloads() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadNames", reflect.TypeOf((*MockwsWlReader)(nil).WorkloadNames))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListWorkloads", reflect.TypeOf((*MockwlLister)(nil).ListWorkloads))
 }
 
 // MockwsJobDirReader is a mock of wsJobDirReader interface.
@@ -2681,34 +2643,34 @@ func (mr *MockwsJobDirReaderMockRecorder) CopilotDirPath() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopilotDirPath", reflect.TypeOf((*MockwsJobDirReader)(nil).CopilotDirPath))
 }
 
-// JobNames mocks base method.
-func (m *MockwsJobDirReader) JobNames() ([]string, error) {
+// ListJobs mocks base method.
+func (m *MockwsJobDirReader) ListJobs() ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "JobNames")
+	ret := m.ctrl.Call(m, "ListJobs")
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// JobNames indicates an expected call of JobNames.
-func (mr *MockwsJobDirReaderMockRecorder) JobNames() *gomock.Call {
+// ListJobs indicates an expected call of ListJobs.
+func (mr *MockwsJobDirReaderMockRecorder) ListJobs() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JobNames", reflect.TypeOf((*MockwsJobDirReader)(nil).JobNames))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListJobs", reflect.TypeOf((*MockwsJobDirReader)(nil).ListJobs))
 }
 
-// ReadJobManifest mocks base method.
-func (m *MockwsJobDirReader) ReadJobManifest(jobName string) ([]byte, error) {
+// ReadWorkloadManifest mocks base method.
+func (m *MockwsJobDirReader) ReadWorkloadManifest(name string) ([]byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadJobManifest", jobName)
+	ret := m.ctrl.Call(m, "ReadWorkloadManifest", name)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ReadJobManifest indicates an expected call of ReadJobManifest.
-func (mr *MockwsJobDirReaderMockRecorder) ReadJobManifest(jobName interface{}) *gomock.Call {
+// ReadWorkloadManifest indicates an expected call of ReadWorkloadManifest.
+func (mr *MockwsJobDirReaderMockRecorder) ReadWorkloadManifest(name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadJobManifest", reflect.TypeOf((*MockwsJobDirReader)(nil).ReadJobManifest), jobName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadWorkloadManifest", reflect.TypeOf((*MockwsJobDirReader)(nil).ReadWorkloadManifest), name)
 }
 
 // MockwsWlDirReader is a mock of wsWlDirReader interface.
@@ -2749,21 +2711,6 @@ func (mr *MockwsWlDirReaderMockRecorder) CopilotDirPath() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopilotDirPath", reflect.TypeOf((*MockwsWlDirReader)(nil).CopilotDirPath))
 }
 
-// JobNames mocks base method.
-func (m *MockwsWlDirReader) JobNames() ([]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "JobNames")
-	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// JobNames indicates an expected call of JobNames.
-func (mr *MockwsWlDirReaderMockRecorder) JobNames() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JobNames", reflect.TypeOf((*MockwsWlDirReader)(nil).JobNames))
-}
-
 // ListDockerfiles mocks base method.
 func (m *MockwsWlDirReader) ListDockerfiles() ([]string, error) {
 	m.ctrl.T.Helper()
@@ -2779,49 +2726,64 @@ func (mr *MockwsWlDirReaderMockRecorder) ListDockerfiles() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDockerfiles", reflect.TypeOf((*MockwsWlDirReader)(nil).ListDockerfiles))
 }
 
-// ReadJobManifest mocks base method.
-func (m *MockwsWlDirReader) ReadJobManifest(jobName string) ([]byte, error) {
+// ListJobs mocks base method.
+func (m *MockwsWlDirReader) ListJobs() ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadJobManifest", jobName)
-	ret0, _ := ret[0].([]byte)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ReadJobManifest indicates an expected call of ReadJobManifest.
-func (mr *MockwsWlDirReaderMockRecorder) ReadJobManifest(jobName interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadJobManifest", reflect.TypeOf((*MockwsWlDirReader)(nil).ReadJobManifest), jobName)
-}
-
-// ReadServiceManifest mocks base method.
-func (m *MockwsWlDirReader) ReadServiceManifest(svcName string) ([]byte, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadServiceManifest", svcName)
-	ret0, _ := ret[0].([]byte)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ReadServiceManifest indicates an expected call of ReadServiceManifest.
-func (mr *MockwsWlDirReaderMockRecorder) ReadServiceManifest(svcName interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadServiceManifest", reflect.TypeOf((*MockwsWlDirReader)(nil).ReadServiceManifest), svcName)
-}
-
-// ServiceNames mocks base method.
-func (m *MockwsWlDirReader) ServiceNames() ([]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ServiceNames")
+	ret := m.ctrl.Call(m, "ListJobs")
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ServiceNames indicates an expected call of ServiceNames.
-func (mr *MockwsWlDirReaderMockRecorder) ServiceNames() *gomock.Call {
+// ListJobs indicates an expected call of ListJobs.
+func (mr *MockwsWlDirReaderMockRecorder) ListJobs() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceNames", reflect.TypeOf((*MockwsWlDirReader)(nil).ServiceNames))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListJobs", reflect.TypeOf((*MockwsWlDirReader)(nil).ListJobs))
+}
+
+// ListServices mocks base method.
+func (m *MockwsWlDirReader) ListServices() ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListServices")
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListServices indicates an expected call of ListServices.
+func (mr *MockwsWlDirReaderMockRecorder) ListServices() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServices", reflect.TypeOf((*MockwsWlDirReader)(nil).ListServices))
+}
+
+// ListWorkloads mocks base method.
+func (m *MockwsWlDirReader) ListWorkloads() ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListWorkloads")
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListWorkloads indicates an expected call of ListWorkloads.
+func (mr *MockwsWlDirReaderMockRecorder) ListWorkloads() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListWorkloads", reflect.TypeOf((*MockwsWlDirReader)(nil).ListWorkloads))
+}
+
+// ReadWorkloadManifest mocks base method.
+func (m *MockwsWlDirReader) ReadWorkloadManifest(name string) ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReadWorkloadManifest", name)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReadWorkloadManifest indicates an expected call of ReadWorkloadManifest.
+func (mr *MockwsWlDirReaderMockRecorder) ReadWorkloadManifest(name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadWorkloadManifest", reflect.TypeOf((*MockwsWlDirReader)(nil).ReadWorkloadManifest), name)
 }
 
 // Summary mocks base method.
@@ -2837,21 +2799,6 @@ func (m *MockwsWlDirReader) Summary() (*workspace.Summary, error) {
 func (mr *MockwsWlDirReaderMockRecorder) Summary() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Summary", reflect.TypeOf((*MockwsWlDirReader)(nil).Summary))
-}
-
-// WorkloadNames mocks base method.
-func (m *MockwsWlDirReader) WorkloadNames() ([]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WorkloadNames")
-	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WorkloadNames indicates an expected call of WorkloadNames.
-func (mr *MockwsWlDirReaderMockRecorder) WorkloadNames() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadNames", reflect.TypeOf((*MockwsWlDirReader)(nil).WorkloadNames))
 }
 
 // MockwsPipelineReader is a mock of wsPipelineReader interface.
@@ -2877,6 +2824,21 @@ func (m *MockwsPipelineReader) EXPECT() *MockwsPipelineReaderMockRecorder {
 	return m.recorder
 }
 
+// ListWorkloads mocks base method.
+func (m *MockwsPipelineReader) ListWorkloads() ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListWorkloads")
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListWorkloads indicates an expected call of ListWorkloads.
+func (mr *MockwsPipelineReaderMockRecorder) ListWorkloads() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListWorkloads", reflect.TypeOf((*MockwsPipelineReader)(nil).ListWorkloads))
+}
+
 // ReadPipelineManifest mocks base method.
 func (m *MockwsPipelineReader) ReadPipelineManifest() ([]byte, error) {
 	m.ctrl.T.Helper()
@@ -2890,21 +2852,6 @@ func (m *MockwsPipelineReader) ReadPipelineManifest() ([]byte, error) {
 func (mr *MockwsPipelineReaderMockRecorder) ReadPipelineManifest() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadPipelineManifest", reflect.TypeOf((*MockwsPipelineReader)(nil).ReadPipelineManifest))
-}
-
-// WorkloadNames mocks base method.
-func (m *MockwsPipelineReader) WorkloadNames() ([]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WorkloadNames")
-	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WorkloadNames indicates an expected call of WorkloadNames.
-func (mr *MockwsPipelineReaderMockRecorder) WorkloadNames() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadNames", reflect.TypeOf((*MockwsPipelineReader)(nil).WorkloadNames))
 }
 
 // MockwsAppManager is a mock of wsAppManager interface.
@@ -2982,19 +2929,19 @@ func (m *MockwsAddonManager) EXPECT() *MockwsAddonManagerMockRecorder {
 	return m.recorder
 }
 
-// WorkloadNames mocks base method.
-func (m *MockwsAddonManager) WorkloadNames() ([]string, error) {
+// ListWorkloads mocks base method.
+func (m *MockwsAddonManager) ListWorkloads() ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WorkloadNames")
+	ret := m.ctrl.Call(m, "ListWorkloads")
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// WorkloadNames indicates an expected call of WorkloadNames.
-func (mr *MockwsAddonManagerMockRecorder) WorkloadNames() *gomock.Call {
+// ListWorkloads indicates an expected call of ListWorkloads.
+func (mr *MockwsAddonManagerMockRecorder) ListWorkloads() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadNames", reflect.TypeOf((*MockwsAddonManager)(nil).WorkloadNames))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListWorkloads", reflect.TypeOf((*MockwsAddonManager)(nil).ListWorkloads))
 }
 
 // WriteAddon mocks base method.

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -2174,10 +2174,10 @@ func (m *MockmanifestReader) EXPECT() *MockmanifestReaderMockRecorder {
 }
 
 // ReadWorkloadManifest mocks base method.
-func (m *MockmanifestReader) ReadWorkloadManifest(name string) ([]byte, error) {
+func (m *MockmanifestReader) ReadWorkloadManifest(name string) (workspace.WorkloadManifest, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReadWorkloadManifest", name)
-	ret0, _ := ret[0].([]byte)
+	ret0, _ := ret[0].(workspace.WorkloadManifest)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2394,10 +2394,10 @@ func (mr *MockwsSvcReaderMockRecorder) ListServices() *gomock.Call {
 }
 
 // ReadWorkloadManifest mocks base method.
-func (m *MockwsSvcReader) ReadWorkloadManifest(name string) ([]byte, error) {
+func (m *MockwsSvcReader) ReadWorkloadManifest(name string) (workspace.WorkloadManifest, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReadWorkloadManifest", name)
-	ret0, _ := ret[0].([]byte)
+	ret0, _ := ret[0].(workspace.WorkloadManifest)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2462,10 +2462,10 @@ func (mr *MockwsSvcDirReaderMockRecorder) ListServices() *gomock.Call {
 }
 
 // ReadWorkloadManifest mocks base method.
-func (m *MockwsSvcDirReader) ReadWorkloadManifest(name string) ([]byte, error) {
+func (m *MockwsSvcDirReader) ReadWorkloadManifest(name string) (workspace.WorkloadManifest, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReadWorkloadManifest", name)
-	ret0, _ := ret[0].([]byte)
+	ret0, _ := ret[0].(workspace.WorkloadManifest)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2553,10 +2553,10 @@ func (mr *MockwsJobReaderMockRecorder) ListJobs() *gomock.Call {
 }
 
 // ReadWorkloadManifest mocks base method.
-func (m *MockwsJobReader) ReadWorkloadManifest(name string) ([]byte, error) {
+func (m *MockwsJobReader) ReadWorkloadManifest(name string) (workspace.WorkloadManifest, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReadWorkloadManifest", name)
-	ret0, _ := ret[0].([]byte)
+	ret0, _ := ret[0].(workspace.WorkloadManifest)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2659,10 +2659,10 @@ func (mr *MockwsJobDirReaderMockRecorder) ListJobs() *gomock.Call {
 }
 
 // ReadWorkloadManifest mocks base method.
-func (m *MockwsJobDirReader) ReadWorkloadManifest(name string) ([]byte, error) {
+func (m *MockwsJobDirReader) ReadWorkloadManifest(name string) (workspace.WorkloadManifest, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReadWorkloadManifest", name)
-	ret0, _ := ret[0].([]byte)
+	ret0, _ := ret[0].(workspace.WorkloadManifest)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2772,10 +2772,10 @@ func (mr *MockwsWlDirReaderMockRecorder) ListWorkloads() *gomock.Call {
 }
 
 // ReadWorkloadManifest mocks base method.
-func (m *MockwsWlDirReader) ReadWorkloadManifest(name string) ([]byte, error) {
+func (m *MockwsWlDirReader) ReadWorkloadManifest(name string) (workspace.WorkloadManifest, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReadWorkloadManifest", name)
-	ret0, _ := ret[0].([]byte)
+	ret0, _ := ret[0].(workspace.WorkloadManifest)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/internal/pkg/cli/pipeline_update.go
+++ b/internal/pkg/cli/pipeline_update.go
@@ -175,7 +175,7 @@ func (o *updatePipelineOpts) Execute() error {
 
 func (o *updatePipelineOpts) convertStages(manifestStages []manifest.PipelineStage) ([]deploy.PipelineStage, error) {
 	var stages []deploy.PipelineStage
-	workloads, err := o.ws.WorkloadNames()
+	workloads, err := o.ws.ListWorkloads()
 	if err != nil {
 		return nil, fmt.Errorf("get workload names from workspace: %w", err)
 	}

--- a/internal/pkg/cli/pipeline_update_test.go
+++ b/internal/pkg/cli/pipeline_update_test.go
@@ -52,7 +52,7 @@ func TestUpdatePipelineOpts_convertStages(t *testing.T) {
 					Prod:      false,
 				}
 				gomock.InOrder(
-					m.ws.EXPECT().WorkloadNames().Return([]string{"frontend", "backend"}, nil).Times(1),
+					m.ws.EXPECT().ListWorkloads().Return([]string{"frontend", "backend"}, nil).Times(1),
 					m.envStore.EXPECT().GetEnvironment("badgoose", "test").Return(mockEnv, nil).Times(1),
 				)
 			},
@@ -87,7 +87,7 @@ func TestUpdatePipelineOpts_convertStages(t *testing.T) {
 					Prod:      false,
 				}
 				gomock.InOrder(
-					m.ws.EXPECT().WorkloadNames().Return([]string{"frontend", "backend"}, nil).Times(1),
+					m.ws.EXPECT().ListWorkloads().Return([]string{"frontend", "backend"}, nil).Times(1),
 					m.envStore.EXPECT().GetEnvironment("badgoose", "test").Return(mockEnv, nil).Times(1),
 				)
 			},
@@ -123,7 +123,7 @@ func TestUpdatePipelineOpts_convertStages(t *testing.T) {
 					Prod:      true,
 				}
 				gomock.InOrder(
-					m.ws.EXPECT().WorkloadNames().Return([]string{"frontend", "backend"}, nil).Times(1),
+					m.ws.EXPECT().ListWorkloads().Return([]string{"frontend", "backend"}, nil).Times(1),
 					m.envStore.EXPECT().GetEnvironment("badgoose", "test").Return(mockEnv, nil).Times(1),
 				)
 			},
@@ -309,7 +309,7 @@ stages:
 					m.prog.EXPECT().Stop(log.Ssuccessf(fmtPipelineUpdateResourcesComplete, appName)).Times(1),
 
 					m.ws.EXPECT().ReadPipelineManifest().Return([]byte(content), nil),
-					m.ws.EXPECT().WorkloadNames().Return([]string{"frontend", "backend"}, nil).Times(1),
+					m.ws.EXPECT().ListWorkloads().Return([]string{"frontend", "backend"}, nil).Times(1),
 
 					// convertStages
 					m.envStore.EXPECT().GetEnvironment(appName, "chicken").Return(mockEnv, nil).Times(1),
@@ -339,7 +339,7 @@ stages:
 					m.prog.EXPECT().Stop(log.Ssuccessf(fmtPipelineUpdateResourcesComplete, appName)).Times(1),
 
 					m.ws.EXPECT().ReadPipelineManifest().Return([]byte(content), nil),
-					m.ws.EXPECT().WorkloadNames().Return([]string{"frontend", "backend"}, nil).Times(1),
+					m.ws.EXPECT().ListWorkloads().Return([]string{"frontend", "backend"}, nil).Times(1),
 
 					// convertStages
 					m.envStore.EXPECT().GetEnvironment(appName, "chicken").Return(mockEnv, nil).Times(1),
@@ -370,7 +370,7 @@ stages:
 					m.prog.EXPECT().Stop(log.Ssuccessf(fmtPipelineUpdateResourcesComplete, appName)).Times(1),
 
 					m.ws.EXPECT().ReadPipelineManifest().Return([]byte(content), nil),
-					m.ws.EXPECT().WorkloadNames().Return([]string{"frontend", "backend"}, nil).Times(1),
+					m.ws.EXPECT().ListWorkloads().Return([]string{"frontend", "backend"}, nil).Times(1),
 
 					// convertStages
 					m.envStore.EXPECT().GetEnvironment(appName, "chicken").Return(mockEnv, nil).Times(1),
@@ -398,7 +398,7 @@ stages:
 					m.prog.EXPECT().Stop(log.Ssuccessf(fmtPipelineUpdateResourcesComplete, appName)).Times(1),
 
 					m.ws.EXPECT().ReadPipelineManifest().Return([]byte(content), nil),
-					m.ws.EXPECT().WorkloadNames().Return([]string{"frontend", "backend"}, nil).Times(1),
+					m.ws.EXPECT().ListWorkloads().Return([]string{"frontend", "backend"}, nil).Times(1),
 
 					// convertStages
 					m.envStore.EXPECT().GetEnvironment(appName, "chicken").Return(mockEnv, nil).Times(1),
@@ -513,7 +513,7 @@ source:
 					m.prog.EXPECT().Stop(log.Ssuccessf(fmtPipelineUpdateResourcesComplete, appName)).Times(1),
 
 					m.ws.EXPECT().ReadPipelineManifest().Return([]byte(content), nil),
-					m.ws.EXPECT().WorkloadNames().Return(nil, errors.New("some error")).Times(1),
+					m.ws.EXPECT().ListWorkloads().Return(nil, errors.New("some error")).Times(1),
 				)
 			},
 			expectedError: fmt.Errorf("convert environments to deployment stage: get workload names from workspace: some error"),
@@ -529,7 +529,7 @@ source:
 					m.prog.EXPECT().Stop(log.Ssuccessf(fmtPipelineUpdateResourcesComplete, appName)).Times(1),
 
 					m.ws.EXPECT().ReadPipelineManifest().Return([]byte(content), nil),
-					m.ws.EXPECT().WorkloadNames().Return([]string{"frontend", "backend"}, nil).Times(1),
+					m.ws.EXPECT().ListWorkloads().Return([]string{"frontend", "backend"}, nil).Times(1),
 
 					// convertStages
 					m.envStore.EXPECT().GetEnvironment(appName, "chicken").Return(mockEnv, nil).Times(1),
@@ -552,7 +552,7 @@ source:
 					m.prog.EXPECT().Stop(log.Ssuccessf(fmtPipelineUpdateResourcesComplete, appName)).Times(1),
 
 					m.ws.EXPECT().ReadPipelineManifest().Return([]byte(content), nil),
-					m.ws.EXPECT().WorkloadNames().Return([]string{"frontend", "backend"}, nil).Times(1),
+					m.ws.EXPECT().ListWorkloads().Return([]string{"frontend", "backend"}, nil).Times(1),
 
 					// convertStages
 					m.envStore.EXPECT().GetEnvironment(appName, "chicken").Return(mockEnv, nil).Times(1),
@@ -578,7 +578,7 @@ source:
 					m.prog.EXPECT().Stop(log.Ssuccessf(fmtPipelineUpdateResourcesComplete, appName)).Times(1),
 
 					m.ws.EXPECT().ReadPipelineManifest().Return([]byte(content), nil),
-					m.ws.EXPECT().WorkloadNames().Return([]string{"frontend", "backend"}, nil).Times(1),
+					m.ws.EXPECT().ListWorkloads().Return([]string{"frontend", "backend"}, nil).Times(1),
 
 					// convertStages
 					m.envStore.EXPECT().GetEnvironment(appName, "chicken").Return(mockEnv, nil).Times(1),
@@ -608,7 +608,7 @@ source:
 					m.prog.EXPECT().Stop(log.Ssuccessf(fmtPipelineUpdateResourcesComplete, appName)).Times(1),
 
 					m.ws.EXPECT().ReadPipelineManifest().Return([]byte(content), nil),
-					m.ws.EXPECT().WorkloadNames().Return([]string{"frontend", "backend"}, nil).Times(1),
+					m.ws.EXPECT().ListWorkloads().Return([]string{"frontend", "backend"}, nil).Times(1),
 
 					// convertStages
 					m.envStore.EXPECT().GetEnvironment(appName, "chicken").Return(mockEnv, nil).Times(1),
@@ -665,7 +665,7 @@ stages:
 					m.prog.EXPECT().Stop(log.Ssuccessf(fmtPipelineUpdateResourcesComplete, appName)).Times(1),
 
 					m.ws.EXPECT().ReadPipelineManifest().Return([]byte(content), nil),
-					m.ws.EXPECT().WorkloadNames().Return([]string{"frontend", "backend"}, nil).Times(1),
+					m.ws.EXPECT().ListWorkloads().Return([]string{"frontend", "backend"}, nil).Times(1),
 
 					// convertStages
 					m.envStore.EXPECT().GetEnvironment(appName, "chicken").Return(mockEnv, nil).Times(1),

--- a/internal/pkg/cli/storage_init.go
+++ b/internal/pkg/cli/storage_init.go
@@ -576,7 +576,7 @@ func (o *initStorageOpts) askAuroraInitialDBName() error {
 }
 
 func (o *initStorageOpts) validateWorkloadName() error {
-	names, err := o.ws.WorkloadNames()
+	names, err := o.ws.ListWorkloads()
 	if err != nil {
 		return fmt.Errorf("retrieve local workload names: %w", err)
 	}

--- a/internal/pkg/cli/storage_init_test.go
+++ b/internal/pkg/cli/storage_init_test.go
@@ -45,7 +45,7 @@ func TestStorageInitOpts_Validate(t *testing.T) {
 		},
 		"svc not in workspace": {
 			mockWs: func(m *mocks.MockwsAddonManager) {
-				m.EXPECT().WorkloadNames().Return([]string{"bad", "workspace"}, nil)
+				m.EXPECT().ListWorkloads().Return([]string{"bad", "workspace"}, nil)
 			},
 			mockStore: func(m *mocks.Mockstore) {},
 
@@ -57,7 +57,7 @@ func TestStorageInitOpts_Validate(t *testing.T) {
 		},
 		"workspace error": {
 			mockWs: func(m *mocks.MockwsAddonManager) {
-				m.EXPECT().WorkloadNames().Return(nil, errors.New("wanted err"))
+				m.EXPECT().ListWorkloads().Return(nil, errors.New("wanted err"))
 			},
 			mockStore: func(m *mocks.Mockstore) {},
 

--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -241,7 +241,7 @@ func (o *deploySvcOpts) RecommendActions() error {
 }
 
 func (o *deploySvcOpts) validateSvcName() error {
-	names, err := o.ws.ServiceNames()
+	names, err := o.ws.ListServices()
 	if err != nil {
 		return fmt.Errorf("list services in the workspace: %w", err)
 	}
@@ -449,7 +449,7 @@ func (o *deploySvcOpts) manifest() (interface{}, error) {
 		return o.appliedManifest, nil
 	}
 
-	raw, err := o.ws.ReadServiceManifest(o.name)
+	raw, err := o.ws.ReadWorkloadManifest(o.name)
 	if err != nil {
 		return nil, fmt.Errorf("read service %s manifest file: %w", o.name, err)
 	}

--- a/internal/pkg/cli/svc_deploy_test.go
+++ b/internal/pkg/cli/svc_deploy_test.go
@@ -64,7 +64,7 @@ func TestSvcDeployOpts_Validate(t *testing.T) {
 			inAppName: "phonetool",
 			inSvcName: "frontend",
 			mockWs: func(m *mocks.MockwsSvcDirReader) {
-				m.EXPECT().ServiceNames().Return(nil, errors.New("some error"))
+				m.EXPECT().ListServices().Return(nil, errors.New("some error"))
 			},
 			mockStore: func(m *mocks.Mockstore) {},
 
@@ -74,7 +74,7 @@ func TestSvcDeployOpts_Validate(t *testing.T) {
 			inAppName: "phonetool",
 			inSvcName: "frontend",
 			mockWs: func(m *mocks.MockwsSvcDirReader) {
-				m.EXPECT().ServiceNames().Return([]string{}, nil)
+				m.EXPECT().ListServices().Return([]string{}, nil)
 			},
 			mockStore: func(m *mocks.Mockstore) {},
 
@@ -96,7 +96,7 @@ func TestSvcDeployOpts_Validate(t *testing.T) {
 			inSvcName: "frontend",
 			inEnvName: "test",
 			mockWs: func(m *mocks.MockwsSvcDirReader) {
-				m.EXPECT().ServiceNames().Return([]string{"frontend"}, nil)
+				m.EXPECT().ListServices().Return([]string{"frontend"}, nil)
 			},
 			mockStore: func(m *mocks.Mockstore) {
 				m.EXPECT().GetEnvironment("phonetool", "test").
@@ -272,7 +272,7 @@ image:
 			inputSvc: "serviceA",
 			setupMocks: func(m deploySvcMocks) {
 				gomock.InOrder(
-					m.mockWs.EXPECT().ReadServiceManifest("serviceA").Return(nil, mockError),
+					m.mockWs.EXPECT().ReadWorkloadManifest("serviceA").Return(nil, mockError),
 				)
 			},
 			wantErr: fmt.Errorf("read service %s manifest file: %w", "serviceA", mockError),
@@ -281,7 +281,7 @@ image:
 			inputSvc: "serviceA",
 			setupMocks: func(m deploySvcMocks) {
 				gomock.InOrder(
-					m.mockWs.EXPECT().ReadServiceManifest(gomock.Any()).Return(mockManifest, nil),
+					m.mockWs.EXPECT().ReadWorkloadManifest(gomock.Any()).Return(mockManifest, nil),
 					m.mockInterpolator.EXPECT().Interpolate(string(mockManifest)).Return("", mockError),
 				)
 			},
@@ -291,7 +291,7 @@ image:
 			inputSvc: "serviceA",
 			setupMocks: func(m deploySvcMocks) {
 				gomock.InOrder(
-					m.mockWs.EXPECT().ReadServiceManifest(gomock.Any()).Return(mockManifest, nil),
+					m.mockWs.EXPECT().ReadWorkloadManifest(gomock.Any()).Return(mockManifest, nil),
 					m.mockInterpolator.EXPECT().Interpolate(string(mockManifest)).Return(string(mockManifest), nil),
 					m.mockWs.EXPECT().CopilotDirPath().Return("", mockError),
 				)
@@ -302,7 +302,7 @@ image:
 			inputSvc: "serviceA",
 			setupMocks: func(m deploySvcMocks) {
 				gomock.InOrder(
-					m.mockWs.EXPECT().ReadServiceManifest("serviceA").Return(mockManifestWithBadPlatform, nil),
+					m.mockWs.EXPECT().ReadWorkloadManifest("serviceA").Return(mockManifestWithBadPlatform, nil),
 					m.mockInterpolator.EXPECT().Interpolate(string(mockManifestWithBadPlatform)).Return(string(mockManifestWithBadPlatform), nil),
 				)
 			},
@@ -312,7 +312,7 @@ image:
 			inputSvc: "serviceA",
 			setupMocks: func(m deploySvcMocks) {
 				gomock.InOrder(
-					m.mockWs.EXPECT().ReadServiceManifest("serviceA").Return(mockManifestWithGoodPlatform, nil),
+					m.mockWs.EXPECT().ReadWorkloadManifest("serviceA").Return(mockManifestWithGoodPlatform, nil),
 					m.mockInterpolator.EXPECT().Interpolate(string(mockManifestWithGoodPlatform)).Return(string(mockManifestWithGoodPlatform), nil),
 					m.mockWs.EXPECT().CopilotDirPath().Return("/ws/root/copilot", nil),
 					m.mockimageBuilderPusher.EXPECT().BuildAndPush(gomock.Any(), &dockerengine.BuildArguments{
@@ -328,7 +328,7 @@ image:
 			inputSvc: "serviceA",
 			setupMocks: func(m deploySvcMocks) {
 				gomock.InOrder(
-					m.mockWs.EXPECT().ReadServiceManifest("serviceA").Return(mockMftNoBuild, nil),
+					m.mockWs.EXPECT().ReadWorkloadManifest("serviceA").Return(mockMftNoBuild, nil),
 					m.mockInterpolator.EXPECT().Interpolate(string(mockMftNoBuild)).Return(string(mockMftNoBuild), nil),
 					m.mockWs.EXPECT().CopilotDirPath().Times(0),
 					m.mockimageBuilderPusher.EXPECT().BuildAndPush(gomock.Any(), gomock.Any()).Times(0),
@@ -339,7 +339,7 @@ image:
 			inputSvc: "serviceA",
 			setupMocks: func(m deploySvcMocks) {
 				gomock.InOrder(
-					m.mockWs.EXPECT().ReadServiceManifest("serviceA").Return(mockManifest, nil),
+					m.mockWs.EXPECT().ReadWorkloadManifest("serviceA").Return(mockManifest, nil),
 					m.mockInterpolator.EXPECT().Interpolate(string(mockManifest)).Return(string(mockManifest), nil),
 					m.mockWs.EXPECT().CopilotDirPath().Return("/ws/root/copilot", nil),
 					m.mockimageBuilderPusher.EXPECT().BuildAndPush(gomock.Any(), gomock.Any()).Return("", mockError),
@@ -351,7 +351,7 @@ image:
 			inputSvc: "serviceA",
 			setupMocks: func(m deploySvcMocks) {
 				gomock.InOrder(
-					m.mockWs.EXPECT().ReadServiceManifest("serviceA").Return(mockManifest, nil),
+					m.mockWs.EXPECT().ReadWorkloadManifest("serviceA").Return(mockManifest, nil),
 					m.mockInterpolator.EXPECT().Interpolate(string(mockManifest)).Return(string(mockManifest), nil),
 					m.mockWs.EXPECT().CopilotDirPath().Return("/ws/root/copilot", nil),
 					m.mockimageBuilderPusher.EXPECT().BuildAndPush(gomock.Any(), &dockerengine.BuildArguments{
@@ -366,7 +366,7 @@ image:
 			inputSvc: "serviceA",
 			setupMocks: func(m deploySvcMocks) {
 				gomock.InOrder(
-					m.mockWs.EXPECT().ReadServiceManifest("serviceA").Return(mockMftBuildString, nil),
+					m.mockWs.EXPECT().ReadWorkloadManifest("serviceA").Return(mockMftBuildString, nil),
 					m.mockInterpolator.EXPECT().Interpolate(string(mockMftBuildString)).Return(string(mockMftBuildString), nil),
 					m.mockWs.EXPECT().CopilotDirPath().Return("/ws/root/copilot", nil),
 					m.mockimageBuilderPusher.EXPECT().BuildAndPush(gomock.Any(), &dockerengine.BuildArguments{
@@ -381,7 +381,7 @@ image:
 			inputSvc: "serviceA",
 			setupMocks: func(m deploySvcMocks) {
 				gomock.InOrder(
-					m.mockWs.EXPECT().ReadServiceManifest("serviceA").Return(mockMftNoContext, nil),
+					m.mockWs.EXPECT().ReadWorkloadManifest("serviceA").Return(mockMftNoContext, nil),
 					m.mockInterpolator.EXPECT().Interpolate(string(mockMftNoContext)).Return(string(mockMftNoContext), nil),
 					m.mockWs.EXPECT().CopilotDirPath().Return("/ws/root/copilot", nil),
 					m.mockimageBuilderPusher.EXPECT().BuildAndPush(gomock.Any(), &dockerengine.BuildArguments{
@@ -606,13 +606,13 @@ func TestSvcDeployOpts_deploySvc(t *testing.T) {
 	}{
 		"fail to read service manifest": {
 			mock: func(m *deploySvcMocks) {
-				m.mockWs.EXPECT().ReadServiceManifest(mockSvcName).Return(nil, mockError)
+				m.mockWs.EXPECT().ReadWorkloadManifest(mockSvcName).Return(nil, mockError)
 			},
 			wantErr: fmt.Errorf("read service %s manifest file: %w", mockSvcName, mockError),
 		},
 		"fail to interpolate manifest": {
 			mock: func(m *deploySvcMocks) {
-				m.mockWs.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
+				m.mockWs.EXPECT().ReadWorkloadManifest(mockSvcName).Return([]byte{}, nil)
 				m.mockInterpolator.EXPECT().Interpolate("").Return("", mockError)
 			},
 			wantErr: fmt.Errorf("interpolate environment variables for mockSvc manifest: %w", mockError),
@@ -627,7 +627,7 @@ func TestSvcDeployOpts_deploySvc(t *testing.T) {
 				Name: mockAppName,
 			},
 			mock: func(m *deploySvcMocks) {
-				m.mockWs.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
+				m.mockWs.EXPECT().ReadWorkloadManifest(mockSvcName).Return([]byte{}, nil)
 				m.mockInterpolator.EXPECT().Interpolate("").Return("", nil)
 				m.mockAppResourcesGetter.EXPECT().GetAppResourcesByRegion(&config.Application{
 					Name: mockAppName,
@@ -646,7 +646,7 @@ func TestSvcDeployOpts_deploySvc(t *testing.T) {
 				Name: mockAppName,
 			},
 			mock: func(m *deploySvcMocks) {
-				m.mockWs.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
+				m.mockWs.EXPECT().ReadWorkloadManifest(mockSvcName).Return([]byte{}, nil)
 				m.mockInterpolator.EXPECT().Interpolate("").Return("", nil)
 				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
 			},
@@ -663,7 +663,7 @@ func TestSvcDeployOpts_deploySvc(t *testing.T) {
 				AccountID: "1234567890",
 			},
 			mock: func(m *deploySvcMocks) {
-				m.mockWs.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
+				m.mockWs.EXPECT().ReadWorkloadManifest(mockSvcName).Return([]byte{}, nil)
 				m.mockInterpolator.EXPECT().Interpolate("").Return("", nil)
 				m.mockAppResourcesGetter.EXPECT().GetAppResourcesByRegion(&config.Application{
 					Name:      mockAppName,
@@ -686,7 +686,7 @@ func TestSvcDeployOpts_deploySvc(t *testing.T) {
 				Domain: "mockDomain",
 			},
 			mock: func(m *deploySvcMocks) {
-				m.mockWs.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
+				m.mockWs.EXPECT().ReadWorkloadManifest(mockSvcName).Return([]byte{}, nil)
 				m.mockInterpolator.EXPECT().Interpolate("").Return("", nil)
 				m.mockAppVersionGetter.EXPECT().Version().Return("", mockError)
 				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
@@ -704,7 +704,7 @@ func TestSvcDeployOpts_deploySvc(t *testing.T) {
 				Domain: "mockDomain",
 			},
 			mock: func(m *deploySvcMocks) {
-				m.mockWs.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
+				m.mockWs.EXPECT().ReadWorkloadManifest(mockSvcName).Return([]byte{}, nil)
 				m.mockInterpolator.EXPECT().Interpolate("").Return("", nil)
 				m.mockAppVersionGetter.EXPECT().Version().Return("v0.0.0", nil)
 				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
@@ -722,7 +722,7 @@ func TestSvcDeployOpts_deploySvc(t *testing.T) {
 				Domain: "mockDomain",
 			},
 			mock: func(m *deploySvcMocks) {
-				m.mockWs.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
+				m.mockWs.EXPECT().ReadWorkloadManifest(mockSvcName).Return([]byte{}, nil)
 				m.mockInterpolator.EXPECT().Interpolate("").Return("", nil)
 				m.mockAppVersionGetter.EXPECT().Version().Return("v1.0.0", nil)
 				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
@@ -740,7 +740,7 @@ func TestSvcDeployOpts_deploySvc(t *testing.T) {
 				Domain: "mockDomain",
 			},
 			mock: func(m *deploySvcMocks) {
-				m.mockWs.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
+				m.mockWs.EXPECT().ReadWorkloadManifest(mockSvcName).Return([]byte{}, nil)
 				m.mockInterpolator.EXPECT().Interpolate("").Return("", nil)
 				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
 				m.mockServiceDeployer.EXPECT().DeployService(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("some error"))
@@ -757,7 +757,7 @@ func TestSvcDeployOpts_deploySvc(t *testing.T) {
 				Domain: "mockDomain",
 			},
 			mock: func(m *deploySvcMocks) {
-				m.mockWs.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
+				m.mockWs.EXPECT().ReadWorkloadManifest(mockSvcName).Return([]byte{}, nil)
 				m.mockInterpolator.EXPECT().Interpolate("").Return("", nil)
 				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
 				m.mockServiceDeployer.EXPECT().DeployService(gomock.Any(), gomock.Any(), gomock.Any()).Return(cloudformation.NewMockErrChangeSetEmpty())
@@ -775,7 +775,7 @@ func TestSvcDeployOpts_deploySvc(t *testing.T) {
 				Domain: "mockDomain",
 			},
 			mock: func(m *deploySvcMocks) {
-				m.mockWs.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
+				m.mockWs.EXPECT().ReadWorkloadManifest(mockSvcName).Return([]byte{}, nil)
 				m.mockInterpolator.EXPECT().Interpolate("").Return("", nil)
 				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
 				m.mockServiceDeployer.EXPECT().DeployService(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -797,7 +797,7 @@ func TestSvcDeployOpts_deploySvc(t *testing.T) {
 				Domain: "mockDomain",
 			},
 			mock: func(m *deploySvcMocks) {
-				m.mockWs.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
+				m.mockWs.EXPECT().ReadWorkloadManifest(mockSvcName).Return([]byte{}, nil)
 				m.mockInterpolator.EXPECT().Interpolate("").Return("", nil)
 				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
 				m.mockServiceDeployer.EXPECT().DeployService(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -828,7 +828,7 @@ func TestSvcDeployOpts_deploySvc(t *testing.T) {
 				Domain: "mockDomain",
 			},
 			mock: func(m *deploySvcMocks) {
-				m.mockWs.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
+				m.mockWs.EXPECT().ReadWorkloadManifest(mockSvcName).Return([]byte{}, nil)
 				m.mockInterpolator.EXPECT().Interpolate("").Return("", nil)
 				m.mockAppVersionGetter.EXPECT().Version().Return("v1.0.0", nil)
 				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
@@ -846,7 +846,7 @@ func TestSvcDeployOpts_deploySvc(t *testing.T) {
 				Domain: "mockDomain",
 			},
 			mock: func(m *deploySvcMocks) {
-				m.mockWs.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
+				m.mockWs.EXPECT().ReadWorkloadManifest(mockSvcName).Return([]byte{}, nil)
 				m.mockInterpolator.EXPECT().Interpolate("").Return("", nil)
 				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
 				m.mockServiceDeployer.EXPECT().DeployService(gomock.Any(), gomock.Any(), gomock.Any()).Return(cloudformation.NewMockErrChangeSetEmpty())
@@ -968,7 +968,7 @@ func TestSvcDeployOpts_rdWebServiceStackConfiguration(t *testing.T) {
 				Name: mockAppName,
 			},
 			mock: func(m *deployRDSvcMocks) {
-				m.mockWorkspace.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
+				m.mockWorkspace.EXPECT().ReadWorkloadManifest(mockSvcName).Return([]byte{}, nil)
 				m.mockInterpolator.EXPECT().Interpolate("").Return("", nil)
 				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
 			},
@@ -986,7 +986,7 @@ func TestSvcDeployOpts_rdWebServiceStackConfiguration(t *testing.T) {
 				Domain: "mockDomain",
 			},
 			mock: func(m *deployRDSvcMocks) {
-				m.mockWorkspace.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
+				m.mockWorkspace.EXPECT().ReadWorkloadManifest(mockSvcName).Return([]byte{}, nil)
 				m.mockInterpolator.EXPECT().Interpolate("").Return("", nil)
 				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
 				m.mockIdentity.EXPECT().Get().Return(identity.Caller{}, errors.New("some error"))
@@ -1005,7 +1005,7 @@ func TestSvcDeployOpts_rdWebServiceStackConfiguration(t *testing.T) {
 				Domain: "mockDomain",
 			},
 			mock: func(m *deployRDSvcMocks) {
-				m.mockWorkspace.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
+				m.mockWorkspace.EXPECT().ReadWorkloadManifest(mockSvcName).Return([]byte{}, nil)
 				m.mockInterpolator.EXPECT().Interpolate("").Return("", nil)
 				m.mockAppVersionGetter.EXPECT().Version().Return("v1.0.0", nil)
 				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
@@ -1031,7 +1031,7 @@ func TestSvcDeployOpts_rdWebServiceStackConfiguration(t *testing.T) {
 				Domain: "mockDomain",
 			},
 			mock: func(m *deployRDSvcMocks) {
-				m.mockWorkspace.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
+				m.mockWorkspace.EXPECT().ReadWorkloadManifest(mockSvcName).Return([]byte{}, nil)
 				m.mockInterpolator.EXPECT().Interpolate("").Return("", nil)
 				m.mockAppVersionGetter.EXPECT().Version().Return("v1.0.0", nil)
 				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
@@ -1053,7 +1053,7 @@ func TestSvcDeployOpts_rdWebServiceStackConfiguration(t *testing.T) {
 				Domain: "mockDomain",
 			},
 			mock: func(m *deployRDSvcMocks) {
-				m.mockWorkspace.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
+				m.mockWorkspace.EXPECT().ReadWorkloadManifest(mockSvcName).Return([]byte{}, nil)
 				m.mockInterpolator.EXPECT().Interpolate("").Return("", nil)
 				m.mockAppVersionGetter.EXPECT().Version().Return("v1.0.0", nil)
 				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
@@ -1075,7 +1075,7 @@ func TestSvcDeployOpts_rdWebServiceStackConfiguration(t *testing.T) {
 				Domain: "mockDomain",
 			},
 			mock: func(m *deployRDSvcMocks) {
-				m.mockWorkspace.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
+				m.mockWorkspace.EXPECT().ReadWorkloadManifest(mockSvcName).Return([]byte{}, nil)
 				m.mockInterpolator.EXPECT().Interpolate("").Return("", nil)
 				m.mockAppVersionGetter.EXPECT().Version().Return("v1.0.0", nil)
 				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
@@ -1097,7 +1097,7 @@ func TestSvcDeployOpts_rdWebServiceStackConfiguration(t *testing.T) {
 				Domain: "mockDomain",
 			},
 			mock: func(m *deployRDSvcMocks) {
-				m.mockWorkspace.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
+				m.mockWorkspace.EXPECT().ReadWorkloadManifest(mockSvcName).Return([]byte{}, nil)
 				m.mockInterpolator.EXPECT().Interpolate("").Return("", nil)
 				m.mockAppVersionGetter.EXPECT().Version().Return("v1.0.0", nil)
 				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
@@ -1119,7 +1119,7 @@ func TestSvcDeployOpts_rdWebServiceStackConfiguration(t *testing.T) {
 				Domain: "mockDomain",
 			},
 			mock: func(m *deployRDSvcMocks) {
-				m.mockWorkspace.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
+				m.mockWorkspace.EXPECT().ReadWorkloadManifest(mockSvcName).Return([]byte{}, nil)
 				m.mockInterpolator.EXPECT().Interpolate("").Return("", nil)
 				m.mockAppVersionGetter.EXPECT().Version().Return("v1.0.0", nil)
 				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
@@ -1148,7 +1148,7 @@ func TestSvcDeployOpts_rdWebServiceStackConfiguration(t *testing.T) {
 				Domain: "mockDomain",
 			},
 			mock: func(m *deployRDSvcMocks) {
-				m.mockWorkspace.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
+				m.mockWorkspace.EXPECT().ReadWorkloadManifest(mockSvcName).Return([]byte{}, nil)
 				m.mockInterpolator.EXPECT().Interpolate("").Return("", nil)
 				m.mockAppVersionGetter.EXPECT().Version().Return("v1.0.0", nil)
 				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
@@ -1265,7 +1265,7 @@ func TestSvcDeployOpts_stackConfiguration_worker(t *testing.T) {
 	}{
 		"fail to read service manifest": {
 			mock: func(m *deploySvcMocks) {
-				m.mockWs.EXPECT().ReadServiceManifest(mockSvcName).Return(nil, mockError)
+				m.mockWs.EXPECT().ReadWorkloadManifest(mockSvcName).Return(nil, mockError)
 			},
 			wantErr: fmt.Errorf("read service %s manifest file: %w", mockSvcName, mockError),
 		},
@@ -1279,7 +1279,7 @@ func TestSvcDeployOpts_stackConfiguration_worker(t *testing.T) {
 				Domain: "mockDomain",
 			},
 			mock: func(m *deploySvcMocks) {
-				m.mockWs.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
+				m.mockWs.EXPECT().ReadWorkloadManifest(mockSvcName).Return([]byte{}, nil)
 				m.mockInterpolator.EXPECT().Interpolate("").Return("", nil)
 				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
 				m.mockDeployStore.EXPECT().ListSNSTopics(mockAppName, mockEnvName).Return(nil, mockError)
@@ -1296,7 +1296,7 @@ func TestSvcDeployOpts_stackConfiguration_worker(t *testing.T) {
 				Domain: "mockDomain",
 			},
 			mock: func(m *deploySvcMocks) {
-				m.mockWs.EXPECT().ReadServiceManifest(mockSvcName).Return([]byte{}, nil)
+				m.mockWs.EXPECT().ReadWorkloadManifest(mockSvcName).Return([]byte{}, nil)
 				m.mockInterpolator.EXPECT().Interpolate("").Return("", nil)
 				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockEnv.mockApp.local", nil)
 				m.mockDeployStore.EXPECT().ListSNSTopics(mockAppName, mockEnvName).Return([]deploy.Topic{

--- a/internal/pkg/cli/svc_init.go
+++ b/internal/pkg/cli/svc_init.go
@@ -229,7 +229,7 @@ func (o *initSvcOpts) Ask() error {
 			return fmt.Errorf(`read "type" field for service %s from local manifest: %w`, o.name, err)
 		}
 		o.wkldType = svcType
-		log.Infof("Local manifest file for service %s is found; Copilot will create from the existing manifest.", o.name)
+		log.Infof("Manifest file for job %s already exists. Skipping configuration.\n", o.name)
 		return nil
 	}
 	var errNotFound *workspace.ErrFileNotExists

--- a/internal/pkg/cli/svc_init.go
+++ b/internal/pkg/cli/svc_init.go
@@ -226,14 +226,15 @@ func (o *initSvcOpts) Ask() error {
 	if err == nil {
 		svcType, err := localMft.WorkloadType()
 		if err != nil {
-			return fmt.Errorf("read type for service %s from local manifest: %w", o.name, err)
+			return fmt.Errorf(`read "type" field for service %s from local manifest: %w`, o.name, err)
 		}
 		o.wkldType = svcType
+		log.Infof("Local manifest file for service %s is found; Copilot will create from the existing manifest.", o.name)
 		return nil
 	}
-	_, ok := err.(*workspace.ErrFileNotExists)
-	if !ok {
-		return fmt.Errorf("check if local manifest for service %s exists: %w", o.name, err)
+	var errNotFound *workspace.ErrFileNotExists
+	if !errors.As(err, &errNotFound) {
+		return fmt.Errorf("read manifest file for service %s: %w", o.name, err)
 	}
 	if err := o.askSvcType(); err != nil {
 		return err

--- a/internal/pkg/cli/svc_init_test.go
+++ b/internal/pkg/cli/svc_init_test.go
@@ -228,7 +228,7 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 				m.mockMftReader.EXPECT().ReadWorkloadManifest(wantedSvcName).Return(nil, mockError)
 			},
 
-			wantedErr: fmt.Errorf("check if local manifest for service frontend exists: mock error"),
+			wantedErr: fmt.Errorf("read manifest file for service frontend: mock error"),
 		},
 		"return an error if fail to get service type": {
 			inSvcType:        "",

--- a/internal/pkg/cli/svc_package.go
+++ b/internal/pkg/cli/svc_package.go
@@ -239,7 +239,7 @@ func (o *packageSvcOpts) Validate() error {
 		return errNoAppInWorkspace
 	}
 	if o.name != "" {
-		names, err := o.ws.ServiceNames()
+		names, err := o.ws.ListServices()
 		if err != nil {
 			return fmt.Errorf("list services in the workspace: %w", err)
 		}
@@ -352,7 +352,7 @@ type svcCfnTemplates struct {
 
 // getSvcTemplates returns the CloudFormation stack's template and its parameters for the service.
 func (o *packageSvcOpts) getSvcTemplates(env *config.Environment) (*svcCfnTemplates, error) {
-	raw, err := o.ws.ReadServiceManifest(o.name)
+	raw, err := o.ws.ReadWorkloadManifest(o.name)
 	if err != nil {
 		return nil, fmt.Errorf("read service manifest: %w", err)
 	}

--- a/internal/pkg/cli/svc_package_test.go
+++ b/internal/pkg/cli/svc_package_test.go
@@ -34,7 +34,7 @@ func TestPackageSvcOpts_Validate(t *testing.T) {
 	}{
 		"invalid workspace": {
 			setupMocks: func() {
-				mockWorkspace.EXPECT().ServiceNames().Times(0)
+				mockWorkspace.EXPECT().ListServices().Times(0)
 				mockStore.EXPECT().GetEnvironment(gomock.Any(), gomock.Any()).Times(0)
 			},
 			wantedErrorS: "could not find an application attached to this workspace, please run `app init` first",
@@ -43,7 +43,7 @@ func TestPackageSvcOpts_Validate(t *testing.T) {
 			inAppName: "phonetool",
 			inSvcName: "frontend",
 			setupMocks: func() {
-				mockWorkspace.EXPECT().ServiceNames().Return(nil, errors.New("some error"))
+				mockWorkspace.EXPECT().ListServices().Return(nil, errors.New("some error"))
 				mockStore.EXPECT().GetEnvironment(gomock.Any(), gomock.Any()).Times(0)
 			},
 
@@ -53,7 +53,7 @@ func TestPackageSvcOpts_Validate(t *testing.T) {
 			inAppName: "phonetool",
 			inSvcName: "frontend",
 			setupMocks: func() {
-				mockWorkspace.EXPECT().ServiceNames().Return([]string{"backend"}, nil)
+				mockWorkspace.EXPECT().ListServices().Return([]string{"backend"}, nil)
 				mockStore.EXPECT().GetEnvironment(gomock.Any(), gomock.Any()).Times(0)
 			},
 
@@ -64,7 +64,7 @@ func TestPackageSvcOpts_Validate(t *testing.T) {
 			inEnvName: "test",
 
 			setupMocks: func() {
-				mockWorkspace.EXPECT().ServiceNames().Times(0)
+				mockWorkspace.EXPECT().ListServices().Times(0)
 				mockStore.EXPECT().GetEnvironment("phonetool", "test").Return(nil, &config.ErrNoSuchEnvironment{
 					ApplicationName: "phonetool",
 					EnvironmentName: "test",
@@ -271,7 +271,7 @@ count: 1`
 
 				mockWs := mocks.NewMockwsSvcReader(ctrl)
 				mockWs.EXPECT().
-					ReadServiceManifest("api").
+					ReadWorkloadManifest("api").
 					Return([]byte(lbwsMft), nil)
 
 				mockItpl := mocks.NewMockinterpolator(ctrl)
@@ -348,7 +348,7 @@ count: 1`
 
 				mockWs := mocks.NewMockwsSvcReader(ctrl)
 				mockWs.EXPECT().
-					ReadServiceManifest("api").
+					ReadWorkloadManifest("api").
 					Return([]byte(rdwsMft), nil)
 
 				mockItpl := mocks.NewMockinterpolator(ctrl)

--- a/internal/pkg/list/list.go
+++ b/internal/pkg/list/list.go
@@ -35,8 +35,8 @@ type Store interface {
 
 // Workspace wraps the methods required to interact with a local workspace.
 type Workspace interface {
-	JobNames() ([]string, error)
-	ServiceNames() ([]string, error)
+	ListJobs() ([]string, error)
+	ListServices() ([]string, error)
 }
 
 // JobListWriter holds all the metadata and clients needed to list all jobs in a given
@@ -72,7 +72,7 @@ func (l *JobListWriter) Write(appName string) error {
 		return fmt.Errorf("get %s names: %w", jobWorkloadType, err)
 	}
 	if l.ShowLocalJobs {
-		localWklds, err := l.Ws.JobNames()
+		localWklds, err := l.Ws.ListJobs()
 		if err != nil {
 			return fmt.Errorf("get local %s names: %w", jobWorkloadType, err)
 		}
@@ -100,7 +100,7 @@ func (l *SvcListWriter) Write(appName string) error {
 		return fmt.Errorf("get %s names: %w", svcWorkloadType, err)
 	}
 	if l.ShowLocalSvcs {
-		localWklds, err := l.Ws.ServiceNames()
+		localWklds, err := l.Ws.ListServices()
 		if err != nil {
 			return fmt.Errorf("get local %s names: %w", svcWorkloadType, err)
 		}

--- a/internal/pkg/list/list_test.go
+++ b/internal/pkg/list/list_test.go
@@ -102,7 +102,7 @@ farmer              Scheduled Job
 						{Name: "badgoose", Type: "Scheduled Job"},
 						{Name: "farmer", Type: "Scheduled Job"},
 					}, nil)
-				mockWs.EXPECT().JobNames().Return([]string{"badgoose"}, nil)
+				mockWs.EXPECT().ListJobs().Return([]string{"badgoose"}, nil)
 			},
 		},
 		"with failed call to ListJobs": {
@@ -131,7 +131,7 @@ farmer              Scheduled Job
 						{Name: "badgoose", Type: "Scheduled Job"},
 						{Name: "farmer", Type: "Scheduled Job"},
 					}, nil)
-				mockWs.EXPECT().JobNames().Return([]string{}, nil)
+				mockWs.EXPECT().ListJobs().Return([]string{}, nil)
 			},
 		},
 		"with no local jobs json": {
@@ -149,7 +149,7 @@ farmer              Scheduled Job
 						{Name: "badgoose", Type: "Scheduled Job"},
 						{Name: "farmer", Type: "Scheduled Job"},
 					}, nil)
-				mockWs.EXPECT().JobNames().Return([]string{""}, nil)
+				mockWs.EXPECT().ListJobs().Return([]string{""}, nil)
 			},
 		},
 	}
@@ -263,7 +263,7 @@ func TestList_SvcListWriter(t *testing.T) {
 						{Name: "trough", Type: "Backend Service"},
 						{Name: "gaggle", Type: "Load Balanced Web Service"},
 					}, nil)
-				mockWs.EXPECT().ServiceNames().Return([]string{"trough"}, nil)
+				mockWs.EXPECT().ListServices().Return([]string{"trough"}, nil)
 			},
 		},
 		"with failed call to ListJobs": {
@@ -292,7 +292,7 @@ func TestList_SvcListWriter(t *testing.T) {
 						{Name: "trough", Type: "Backend Service"},
 						{Name: "gaggle", Type: "Load Balanced Web Service"},
 					}, nil)
-				mockWs.EXPECT().ServiceNames().Return([]string{}, nil)
+				mockWs.EXPECT().ListServices().Return([]string{}, nil)
 			},
 		},
 		"with no local services json": {
@@ -310,7 +310,7 @@ func TestList_SvcListWriter(t *testing.T) {
 						{Name: "trough", Type: "Backend Service"},
 						{Name: "gaggle", Type: "Load Balanced Web Service"},
 					}, nil)
-				mockWs.EXPECT().ServiceNames().Return([]string{}, nil)
+				mockWs.EXPECT().ListServices().Return([]string{}, nil)
 			},
 		},
 	}

--- a/internal/pkg/list/mocks/mock_list.go
+++ b/internal/pkg/list/mocks/mock_list.go
@@ -102,32 +102,32 @@ func (m *MockWorkspace) EXPECT() *MockWorkspaceMockRecorder {
 	return m.recorder
 }
 
-// JobNames mocks base method.
-func (m *MockWorkspace) JobNames() ([]string, error) {
+// ListJobs mocks base method.
+func (m *MockWorkspace) ListJobs() ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "JobNames")
+	ret := m.ctrl.Call(m, "ListJobs")
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// JobNames indicates an expected call of JobNames.
-func (mr *MockWorkspaceMockRecorder) JobNames() *gomock.Call {
+// ListJobs indicates an expected call of ListJobs.
+func (mr *MockWorkspaceMockRecorder) ListJobs() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JobNames", reflect.TypeOf((*MockWorkspace)(nil).JobNames))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListJobs", reflect.TypeOf((*MockWorkspace)(nil).ListJobs))
 }
 
-// ServiceNames mocks base method.
-func (m *MockWorkspace) ServiceNames() ([]string, error) {
+// ListServices mocks base method.
+func (m *MockWorkspace) ListServices() ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ServiceNames")
+	ret := m.ctrl.Call(m, "ListServices")
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ServiceNames indicates an expected call of ServiceNames.
-func (mr *MockWorkspaceMockRecorder) ServiceNames() *gomock.Call {
+// ListServices indicates an expected call of ListServices.
+func (mr *MockWorkspaceMockRecorder) ListServices() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceNames", reflect.TypeOf((*MockWorkspace)(nil).ServiceNames))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServices", reflect.TypeOf((*MockWorkspace)(nil).ListServices))
 }

--- a/internal/pkg/term/selector/mocks/mock_selector.go
+++ b/internal/pkg/term/selector/mocks/mock_selector.go
@@ -361,49 +361,49 @@ func (m *MockWsWorkloadLister) EXPECT() *MockWsWorkloadListerMockRecorder {
 	return m.recorder
 }
 
-// JobNames mocks base method.
-func (m *MockWsWorkloadLister) JobNames() ([]string, error) {
+// ListJobs mocks base method.
+func (m *MockWsWorkloadLister) ListJobs() ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "JobNames")
+	ret := m.ctrl.Call(m, "ListJobs")
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// JobNames indicates an expected call of JobNames.
-func (mr *MockWsWorkloadListerMockRecorder) JobNames() *gomock.Call {
+// ListJobs indicates an expected call of ListJobs.
+func (mr *MockWsWorkloadListerMockRecorder) ListJobs() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JobNames", reflect.TypeOf((*MockWsWorkloadLister)(nil).JobNames))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListJobs", reflect.TypeOf((*MockWsWorkloadLister)(nil).ListJobs))
 }
 
-// ServiceNames mocks base method.
-func (m *MockWsWorkloadLister) ServiceNames() ([]string, error) {
+// ListServices mocks base method.
+func (m *MockWsWorkloadLister) ListServices() ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ServiceNames")
+	ret := m.ctrl.Call(m, "ListServices")
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ServiceNames indicates an expected call of ServiceNames.
-func (mr *MockWsWorkloadListerMockRecorder) ServiceNames() *gomock.Call {
+// ListServices indicates an expected call of ListServices.
+func (mr *MockWsWorkloadListerMockRecorder) ListServices() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceNames", reflect.TypeOf((*MockWsWorkloadLister)(nil).ServiceNames))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServices", reflect.TypeOf((*MockWsWorkloadLister)(nil).ListServices))
 }
 
-// WorkloadNames mocks base method.
-func (m *MockWsWorkloadLister) WorkloadNames() ([]string, error) {
+// ListWorkloads mocks base method.
+func (m *MockWsWorkloadLister) ListWorkloads() ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WorkloadNames")
+	ret := m.ctrl.Call(m, "ListWorkloads")
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// WorkloadNames indicates an expected call of WorkloadNames.
-func (mr *MockWsWorkloadListerMockRecorder) WorkloadNames() *gomock.Call {
+// ListWorkloads indicates an expected call of ListWorkloads.
+func (mr *MockWsWorkloadListerMockRecorder) ListWorkloads() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadNames", reflect.TypeOf((*MockWsWorkloadLister)(nil).WorkloadNames))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListWorkloads", reflect.TypeOf((*MockWsWorkloadLister)(nil).ListWorkloads))
 }
 
 // MockWorkspaceRetriever is a mock of WorkspaceRetriever interface.
@@ -429,21 +429,6 @@ func (m *MockWorkspaceRetriever) EXPECT() *MockWorkspaceRetrieverMockRecorder {
 	return m.recorder
 }
 
-// JobNames mocks base method.
-func (m *MockWorkspaceRetriever) JobNames() ([]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "JobNames")
-	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// JobNames indicates an expected call of JobNames.
-func (mr *MockWorkspaceRetrieverMockRecorder) JobNames() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JobNames", reflect.TypeOf((*MockWorkspaceRetriever)(nil).JobNames))
-}
-
 // ListDockerfiles mocks base method.
 func (m *MockWorkspaceRetriever) ListDockerfiles() ([]string, error) {
 	m.ctrl.T.Helper()
@@ -459,19 +444,49 @@ func (mr *MockWorkspaceRetrieverMockRecorder) ListDockerfiles() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDockerfiles", reflect.TypeOf((*MockWorkspaceRetriever)(nil).ListDockerfiles))
 }
 
-// ServiceNames mocks base method.
-func (m *MockWorkspaceRetriever) ServiceNames() ([]string, error) {
+// ListJobs mocks base method.
+func (m *MockWorkspaceRetriever) ListJobs() ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ServiceNames")
+	ret := m.ctrl.Call(m, "ListJobs")
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ServiceNames indicates an expected call of ServiceNames.
-func (mr *MockWorkspaceRetrieverMockRecorder) ServiceNames() *gomock.Call {
+// ListJobs indicates an expected call of ListJobs.
+func (mr *MockWorkspaceRetrieverMockRecorder) ListJobs() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceNames", reflect.TypeOf((*MockWorkspaceRetriever)(nil).ServiceNames))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListJobs", reflect.TypeOf((*MockWorkspaceRetriever)(nil).ListJobs))
+}
+
+// ListServices mocks base method.
+func (m *MockWorkspaceRetriever) ListServices() ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListServices")
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListServices indicates an expected call of ListServices.
+func (mr *MockWorkspaceRetrieverMockRecorder) ListServices() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServices", reflect.TypeOf((*MockWorkspaceRetriever)(nil).ListServices))
+}
+
+// ListWorkloads mocks base method.
+func (m *MockWorkspaceRetriever) ListWorkloads() ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListWorkloads")
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListWorkloads indicates an expected call of ListWorkloads.
+func (mr *MockWorkspaceRetrieverMockRecorder) ListWorkloads() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListWorkloads", reflect.TypeOf((*MockWorkspaceRetriever)(nil).ListWorkloads))
 }
 
 // Summary mocks base method.
@@ -487,21 +502,6 @@ func (m *MockWorkspaceRetriever) Summary() (*workspace.Summary, error) {
 func (mr *MockWorkspaceRetrieverMockRecorder) Summary() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Summary", reflect.TypeOf((*MockWorkspaceRetriever)(nil).Summary))
-}
-
-// WorkloadNames mocks base method.
-func (m *MockWorkspaceRetriever) WorkloadNames() ([]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WorkloadNames")
-	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WorkloadNames indicates an expected call of WorkloadNames.
-func (mr *MockWorkspaceRetrieverMockRecorder) WorkloadNames() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkloadNames", reflect.TypeOf((*MockWorkspaceRetriever)(nil).WorkloadNames))
 }
 
 // MockDeployStoreClient is a mock of DeployStoreClient interface.

--- a/internal/pkg/term/selector/selector.go
+++ b/internal/pkg/term/selector/selector.go
@@ -117,9 +117,9 @@ type ConfigLister interface {
 
 // WsWorkloadLister wraps the method to get workloads in current workspace.
 type WsWorkloadLister interface {
-	ServiceNames() ([]string, error)
-	JobNames() ([]string, error)
-	WorkloadNames() ([]string, error)
+	ListServices() ([]string, error)
+	ListJobs() ([]string, error)
+	ListWorkloads() ([]string, error)
 }
 
 // WorkspaceRetriever wraps methods to get workload names, app names, and Dockerfiles from the workspace.
@@ -860,7 +860,7 @@ func (s *ConfigSelect) retrieveJobs(app string) ([]string, error) {
 }
 
 func (s *WorkspaceSelect) retrieveWorkspaceServices() ([]string, error) {
-	localServiceNames, err := s.ws.ServiceNames()
+	localServiceNames, err := s.ws.ListServices()
 	if err != nil {
 		return nil, err
 	}
@@ -868,7 +868,7 @@ func (s *WorkspaceSelect) retrieveWorkspaceServices() ([]string, error) {
 }
 
 func (s *WorkspaceSelect) retrieveWorkspaceJobs() ([]string, error) {
-	localJobNames, err := s.ws.JobNames()
+	localJobNames, err := s.ws.ListJobs()
 	if err != nil {
 		return nil, err
 	}
@@ -876,7 +876,7 @@ func (s *WorkspaceSelect) retrieveWorkspaceJobs() ([]string, error) {
 }
 
 func (s *WorkspaceSelect) retrieveWorkspaceWorkloads() ([]string, error) {
-	localWlNames, err := s.ws.WorkloadNames()
+	localWlNames, err := s.ws.ListWorkloads()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/term/selector/selector_test.go
+++ b/internal/pkg/term/selector/selector_test.go
@@ -497,7 +497,7 @@ func TestWorkspaceSelect_Service(t *testing.T) {
 	}{
 		"with no workspace services and no store services": {
 			setupMocks: func(m workspaceSelectMocks) {
-				m.workloadLister.EXPECT().ServiceNames().Return(
+				m.workloadLister.EXPECT().ListServices().Return(
 					[]string{}, nil).Times(1)
 				m.workloadLister.EXPECT().Summary().Return(
 					&workspace.Summary{
@@ -512,7 +512,7 @@ func TestWorkspaceSelect_Service(t *testing.T) {
 		},
 		"with one workspace service but no store services": {
 			setupMocks: func(m workspaceSelectMocks) {
-				m.workloadLister.EXPECT().ServiceNames().Return(
+				m.workloadLister.EXPECT().ListServices().Return(
 					[]string{
 						"service1",
 					}, nil).
@@ -528,7 +528,7 @@ func TestWorkspaceSelect_Service(t *testing.T) {
 		},
 		"with one store service but no workspace services": {
 			setupMocks: func(m workspaceSelectMocks) {
-				m.workloadLister.EXPECT().ServiceNames().Return(
+				m.workloadLister.EXPECT().ListServices().Return(
 					[]string{}, nil).
 					Times(1)
 				m.workloadLister.EXPECT().Summary().Return(
@@ -548,7 +548,7 @@ func TestWorkspaceSelect_Service(t *testing.T) {
 		},
 		"with only one service in both workspace and store (skips prompting)": {
 			setupMocks: func(m workspaceSelectMocks) {
-				m.workloadLister.EXPECT().ServiceNames().Return(
+				m.workloadLister.EXPECT().ListServices().Return(
 					[]string{
 						"service1",
 					}, nil).Times(1)
@@ -572,7 +572,7 @@ func TestWorkspaceSelect_Service(t *testing.T) {
 		},
 		"with multiple workspace services but only one store service (skips prompting)": {
 			setupMocks: func(m workspaceSelectMocks) {
-				m.workloadLister.EXPECT().ServiceNames().Return(
+				m.workloadLister.EXPECT().ListServices().Return(
 					[]string{
 						"service1",
 						"service2",
@@ -598,7 +598,7 @@ func TestWorkspaceSelect_Service(t *testing.T) {
 		},
 		"with multiple store services but only one workspace service (skips prompting)": {
 			setupMocks: func(m workspaceSelectMocks) {
-				m.workloadLister.EXPECT().ServiceNames().Return(
+				m.workloadLister.EXPECT().ListServices().Return(
 					[]string{
 						"service3",
 					}, nil).Times(1)
@@ -633,7 +633,7 @@ func TestWorkspaceSelect_Service(t *testing.T) {
 		"with multiple workspace services and multiple store services, of which multiple overlap": {
 			setupMocks: func(m workspaceSelectMocks) {
 				m.workloadLister.
-					EXPECT().ServiceNames().Return(
+					EXPECT().ListServices().Return(
 					[]string{
 						"service1",
 						"service2",
@@ -675,7 +675,7 @@ func TestWorkspaceSelect_Service(t *testing.T) {
 		"with error retrieving services from workspace": {
 			setupMocks: func(m workspaceSelectMocks) {
 				m.workloadLister.
-					EXPECT().ServiceNames().Return(
+					EXPECT().ListServices().Return(
 					[]string{""}, errors.New("some error"))
 				m.workloadLister.EXPECT().Summary().Return(
 					&workspace.Summary{
@@ -686,7 +686,7 @@ func TestWorkspaceSelect_Service(t *testing.T) {
 		},
 		"with error retrieving services from store": {
 			setupMocks: func(m workspaceSelectMocks) {
-				m.workloadLister.EXPECT().ServiceNames().Return(
+				m.workloadLister.EXPECT().ListServices().Return(
 					[]string{
 						"service1",
 						"service2",
@@ -704,7 +704,7 @@ func TestWorkspaceSelect_Service(t *testing.T) {
 		"with error selecting services": {
 			setupMocks: func(m workspaceSelectMocks) {
 				m.workloadLister.
-					EXPECT().ServiceNames().Return(
+					EXPECT().ListServices().Return(
 					[]string{
 						"service1",
 						"service2",
@@ -778,7 +778,7 @@ func TestWorkspaceSelect_Job(t *testing.T) {
 		"with no workspace jobs and no store jobs": {
 			setupMocks: func(m workspaceSelectMocks) {
 				m.workloadLister.
-					EXPECT().JobNames().Return(
+					EXPECT().ListJobs().Return(
 					[]string{}, nil).Times(1)
 				m.workloadLister.EXPECT().Summary().Return(
 					&workspace.Summary{
@@ -796,7 +796,7 @@ func TestWorkspaceSelect_Job(t *testing.T) {
 		"with one workspace job but no store jobs": {
 			setupMocks: func(m workspaceSelectMocks) {
 				m.workloadLister.
-					EXPECT().JobNames().Return(
+					EXPECT().ListJobs().Return(
 					[]string{
 						"job1",
 					}, nil).Times(1)
@@ -816,7 +816,7 @@ func TestWorkspaceSelect_Job(t *testing.T) {
 		"with one store job but no workspace jobs": {
 			setupMocks: func(m workspaceSelectMocks) {
 				m.workloadLister.
-					EXPECT().JobNames().Return(
+					EXPECT().ListJobs().Return(
 					[]string{}, nil).Times(1)
 				m.workloadLister.EXPECT().Summary().Return(
 					&workspace.Summary{
@@ -841,7 +841,7 @@ func TestWorkspaceSelect_Job(t *testing.T) {
 			setupMocks: func(m workspaceSelectMocks) {
 
 				m.workloadLister.
-					EXPECT().JobNames().Return(
+					EXPECT().ListJobs().Return(
 					[]string{
 						"resizer",
 					}, nil).Times(1)
@@ -866,7 +866,7 @@ func TestWorkspaceSelect_Job(t *testing.T) {
 		},
 		"with multiple workspace jobs but only one store job (skips prompting)": {
 			setupMocks: func(m workspaceSelectMocks) {
-				m.workloadLister.EXPECT().JobNames().Return(
+				m.workloadLister.EXPECT().ListJobs().Return(
 					[]string{
 						"job1",
 						"job2",
@@ -892,7 +892,7 @@ func TestWorkspaceSelect_Job(t *testing.T) {
 		},
 		"with multiple store jobs but only one workspace job (skips prompting)": {
 			setupMocks: func(m workspaceSelectMocks) {
-				m.workloadLister.EXPECT().JobNames().Return(
+				m.workloadLister.EXPECT().ListJobs().Return(
 					[]string{
 						"job3",
 					}, nil).Times(1)
@@ -926,7 +926,7 @@ func TestWorkspaceSelect_Job(t *testing.T) {
 		},
 		"with multiple workspace jobs and multiple store jobs, of which multiple overlap": {
 			setupMocks: func(m workspaceSelectMocks) {
-				m.workloadLister.EXPECT().JobNames().Return(
+				m.workloadLister.EXPECT().ListJobs().Return(
 					[]string{
 						"job1",
 						"job2",
@@ -972,7 +972,7 @@ func TestWorkspaceSelect_Job(t *testing.T) {
 		"with error retrieving jobs from workspace": {
 			setupMocks: func(m workspaceSelectMocks) {
 				m.workloadLister.
-					EXPECT().JobNames().Return(
+					EXPECT().ListJobs().Return(
 					[]string{""}, errors.New("some error"))
 				m.workloadLister.EXPECT().Summary().Return(
 					&workspace.Summary{
@@ -983,7 +983,7 @@ func TestWorkspaceSelect_Job(t *testing.T) {
 		},
 		"with error retrieving jobs from store": {
 			setupMocks: func(m workspaceSelectMocks) {
-				m.workloadLister.EXPECT().JobNames().Return(
+				m.workloadLister.EXPECT().ListJobs().Return(
 					[]string{
 						"service1",
 						"service2",
@@ -1000,7 +1000,7 @@ func TestWorkspaceSelect_Job(t *testing.T) {
 		},
 		"with error selecting jobs": {
 			setupMocks: func(m workspaceSelectMocks) {
-				m.workloadLister.EXPECT().JobNames().Return(
+				m.workloadLister.EXPECT().ListJobs().Return(
 					[]string{
 						"resizer1",
 						"resizer2",

--- a/internal/pkg/workspace/errors.go
+++ b/internal/pkg/workspace/errors.go
@@ -20,6 +20,15 @@ func (e *ErrFileExists) Error() string {
 	return fmt.Sprintf("file %s already exists", e.FileName)
 }
 
+// ErrFileNotExists means we tried to read a non-existing file.
+type ErrFileNotExists struct {
+	FileName string
+}
+
+func (e *ErrFileNotExists) Error() string {
+	return fmt.Sprintf("file %s does not exists", e.FileName)
+}
+
 // errWorkspaceNotFound means we couldn't locate a workspace root.
 type errWorkspaceNotFound struct {
 	CurrentDirectory      string

--- a/internal/pkg/workspace/workspace.go
+++ b/internal/pkg/workspace/workspace.go
@@ -197,7 +197,7 @@ func (ws *Workspace) ReadWorkloadManifest(mftDirName string) (WorkloadManifest, 
 		return nil, err
 	}
 	if mftName != mftDirName {
-		return nil, fmt.Errorf("name of the manifest and directory do not match")
+		return nil, fmt.Errorf(`name of the manifest "%s" and directory "%s" do not match`, mftName, mftDirName)
 	}
 	return mft, nil
 }
@@ -491,7 +491,7 @@ func (w WorkloadManifest) workloadName() (string, error) {
 		Name string `yaml:"name"`
 	}{}
 	if err := yaml.Unmarshal(w, &wl); err != nil {
-		return "", err
+		return "", fmt.Errorf(`unmarshal manifest file to retrieve "name": %w`, err)
 	}
 	return wl.Name, nil
 }
@@ -502,7 +502,7 @@ func (w WorkloadManifest) WorkloadType() (string, error) {
 		Type string `yaml:"type"`
 	}{}
 	if err := yaml.Unmarshal(w, &wl); err != nil {
-		return "", err
+		return "", fmt.Errorf(`unmarshal manifest file to retrieve "type": %w`, err)
 	}
 	return wl.Type, nil
 }

--- a/internal/pkg/workspace/workspace_test.go
+++ b/internal/pkg/workspace/workspace_test.go
@@ -275,7 +275,7 @@ type: Load Balanced Web Service`))
 				return fs
 			},
 
-			wantedErr: fmt.Errorf("read manifest for workload users: name of the manifest and directory do not match"),
+			wantedErr: fmt.Errorf(`read manifest for workload users: name of the manifest "payment" and directory "users" do not match`),
 		},
 		"retrieve only directories with manifest files": {
 			copilotDir: "/copilot",

--- a/internal/pkg/workspace/workspace_test.go
+++ b/internal/pkg/workspace/workspace_test.go
@@ -241,7 +241,7 @@ func TestWorkspace_Create(t *testing.T) {
 	}
 }
 
-func TestWorkspace_ServiceNames(t *testing.T) {
+func TestWorkspace_ListServices(t *testing.T) {
 	testCases := map[string]struct {
 		copilotDir string
 		fs         func() afero.Fs
@@ -257,6 +257,26 @@ func TestWorkspace_ServiceNames(t *testing.T) {
 			},
 			wantedErr: errors.New("read directory /copilot: open /copilot: file does not exist"),
 		},
+		"return error if directory name and manifest name do not match": {
+			copilotDir: "/copilot",
+			fs: func() afero.Fs {
+				fs := afero.NewMemMapFs()
+				fs.Mkdir("/copilot", 0755)
+				fs.Create("/copilot/buildspec.yml")
+
+				fs.Mkdir("/copilot/users", 0755)
+				manifest, _ := fs.Create("/copilot/users/manifest.yml")
+				defer manifest.Close()
+				manifest.Write([]byte(`name: payment
+type: Load Balanced Web Service`))
+
+				// Missing manifest.yml.
+				fs.Mkdir("/copilot/inventory", 0755)
+				return fs
+			},
+
+			wantedErr: fmt.Errorf("read manifest for workload users: name of the manifest and directory do not match"),
+		},
 		"retrieve only directories with manifest files": {
 			copilotDir: "/copilot",
 			fs: func() afero.Fs {
@@ -268,13 +288,15 @@ func TestWorkspace_ServiceNames(t *testing.T) {
 				fs.Mkdir("/copilot/users", 0755)
 				manifest, _ := fs.Create("/copilot/users/manifest.yml")
 				defer manifest.Close()
-				manifest.Write([]byte("type: Load Balanced Web Service"))
+				manifest.Write([]byte(`name: users
+type: Load Balanced Web Service`))
 
 				// Valid service directory structure.
 				fs.MkdirAll("/copilot/payments/addons", 0755)
 				manifest2, _ := fs.Create("/copilot/payments/manifest.yml")
 				defer manifest2.Close()
-				manifest2.Write([]byte("type: Load Balanced Web Service"))
+				manifest2.Write([]byte(`name: payments
+type: Load Balanced Web Service`))
 
 				// Missing manifest.yml.
 				fs.Mkdir("/copilot/inventory", 0755)
@@ -294,13 +316,15 @@ func TestWorkspace_ServiceNames(t *testing.T) {
 				fs.Mkdir("/copilot/users", 0755)
 				manifest, _ := fs.Create("/copilot/users/manifest.yml")
 				defer manifest.Close()
-				manifest.Write([]byte("type: Scheduled Job"))
+				manifest.Write([]byte(`name: users
+type: Scheduled Job`))
 
 				// Valid service directory structure.
 				fs.MkdirAll("/copilot/payments/addons", 0755)
 				manifest2, _ := fs.Create("/copilot/payments/manifest.yml")
 				defer manifest2.Close()
-				manifest2.Write([]byte("type: Load Balanced Web Service"))
+				manifest2.Write([]byte(`name: payments
+type: Load Balanced Web Service`))
 
 				// Missing manifest.yml.
 				fs.Mkdir("/copilot/inventory", 0755)
@@ -320,17 +344,18 @@ func TestWorkspace_ServiceNames(t *testing.T) {
 				},
 			}
 
-			names, err := ws.ServiceNames()
+			names, err := ws.ListServices()
 			if tc.wantedErr != nil {
 				require.EqualError(t, err, tc.wantedErr.Error())
 			} else {
+				require.NoError(t, err)
 				require.ElementsMatch(t, tc.wantedNames, names)
 			}
 		})
 	}
 }
 
-func TestWorkspace_JobNames(t *testing.T) {
+func TestWorkspace_ListJobs(t *testing.T) {
 	testCases := map[string]struct {
 		copilotDir string
 		fs         func() afero.Fs
@@ -357,13 +382,15 @@ func TestWorkspace_JobNames(t *testing.T) {
 				fs.Mkdir("/copilot/users", 0755)
 				manifest, _ := fs.Create("/copilot/users/manifest.yml")
 				defer manifest.Close()
-				manifest.Write([]byte("type: Scheduled Job"))
+				manifest.Write([]byte(`name: users
+type: Scheduled Job`))
 
 				// Valid service directory structure.
 				fs.MkdirAll("/copilot/payments/addons", 0755)
 				manifest2, _ := fs.Create("/copilot/payments/manifest.yml")
 				defer manifest2.Close()
-				manifest2.Write([]byte("type: Scheduled Job"))
+				manifest2.Write([]byte(`name: payments
+type: Scheduled Job`))
 
 				// Missing manifest.yml.
 				fs.Mkdir("/copilot/inventory", 0755)
@@ -383,13 +410,15 @@ func TestWorkspace_JobNames(t *testing.T) {
 				fs.Mkdir("/copilot/users", 0755)
 				manifest, _ := fs.Create("/copilot/users/manifest.yml")
 				defer manifest.Close()
-				manifest.Write([]byte("type: Scheduled Job"))
+				manifest.Write([]byte(`name: users
+type: Scheduled Job`))
 
 				// Valid service directory structure.
 				fs.MkdirAll("/copilot/payments/addons", 0755)
 				manifest2, _ := fs.Create("/copilot/payments/manifest.yml")
 				defer manifest2.Close()
-				manifest2.Write([]byte("type: Load Balanced Web Service"))
+				manifest2.Write([]byte(`name: payments
+type: Load Balanced Web Service`))
 
 				// Missing manifest.yml.
 				fs.Mkdir("/copilot/inventory", 0755)
@@ -409,7 +438,7 @@ func TestWorkspace_JobNames(t *testing.T) {
 				},
 			}
 
-			names, err := ws.JobNames()
+			names, err := ws.ListJobs()
 			if tc.wantedErr != nil {
 				require.EqualError(t, err, tc.wantedErr.Error())
 			} else {
@@ -419,7 +448,7 @@ func TestWorkspace_JobNames(t *testing.T) {
 	}
 }
 
-func TestWorkspace_WorkspaceNames(t *testing.T) {
+func TestWorkspace_ListWorkspaces(t *testing.T) {
 	testCases := map[string]struct {
 		copilotDir string
 		fs         func() afero.Fs
@@ -438,17 +467,20 @@ func TestWorkspace_WorkspaceNames(t *testing.T) {
 				fs.Mkdir("/copilot/frontend", 0755)
 				frontendManifest, _ := fs.Create("/copilot/frontend/manifest.yml")
 				defer frontendManifest.Close()
-				frontendManifest.Write([]byte("type: Load Balanced Web Service"))
+				frontendManifest.Write([]byte(`name: frontend
+type: Load Balanced Web Service`))
 
 				fs.Mkdir("/copilot/users", 0755)
 				userManifest, _ := fs.Create("/copilot/users/manifest.yml")
 				defer userManifest.Close()
-				userManifest.Write([]byte("type: Backend Service"))
+				userManifest.Write([]byte(`name: users
+type: Backend Service`))
 
 				fs.MkdirAll("/copilot/report/addons", 0755)
 				reportManifest, _ := fs.Create("/copilot/report/manifest.yml")
 				defer reportManifest.Close()
-				reportManifest.Write([]byte("type: Scheduled Job"))
+				reportManifest.Write([]byte(`name: report
+type: Scheduled Job`))
 
 				// Missing manifest.yml.
 				fs.Mkdir("/copilot/inventory", 0755)
@@ -468,7 +500,7 @@ func TestWorkspace_WorkspaceNames(t *testing.T) {
 				},
 			}
 
-			names, err := ws.WorkloadNames()
+			names, err := ws.ListWorkloads()
 			if tc.wantedErr != nil {
 				require.EqualError(t, err, tc.wantedErr.Error())
 			} else {
@@ -519,7 +551,19 @@ func TestWorkspace_read(t *testing.T) {
 		fs         func() afero.Fs
 
 		wantedData []byte
+		wantedErr  error
 	}{
+		"return error if file does not exist": {
+			elems: []string{"webhook", "manifest.yml"},
+
+			copilotDir: "/copilot",
+			fs: func() afero.Fs {
+				fs := afero.NewMemMapFs()
+				return fs
+			},
+
+			wantedErr: fmt.Errorf("file /copilot/webhook/manifest.yml does not exists"),
+		},
 		"read existing file": {
 			elems: []string{"webhook", "manifest.yml"},
 
@@ -548,8 +592,12 @@ func TestWorkspace_read(t *testing.T) {
 
 			data, err := ws.read(tc.elems...)
 
-			require.NoError(t, err)
-			require.Equal(t, tc.wantedData, data)
+			if tc.wantedErr == nil {
+				require.NoError(t, err)
+				require.Equal(t, tc.wantedData, data)
+			} else {
+				require.EqualError(t, err, tc.wantedErr.Error())
+			}
 		})
 	}
 }


### PR DESCRIPTION
<!-- Provide summary of changes -->
Part of #2960

Note that this PR changes the order of questions for `svc/job init`: we'll ask the name before the type so that if we find the local manifest already exists, we won't ask any repetitive questions.

However, `init` experience hasn't changed yet as we won't know if they want to init a service or a job, unless we ask them first.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
