### PR TITLE
chore: fix e2e test by skipping `WorkspaceNotFound` error in `svc init` and `job init`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,31 +30,3 @@ require (
 	gopkg.in/ini.v1 v1.63.2
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )
-
-require (
-	github.com/agext/levenshtein v1.2.3 // indirect
-	github.com/containerd/typeurl v1.0.2 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/docker/docker v20.10.7+incompatible // indirect
-	github.com/docker/go-connections v0.4.0 // indirect
-	github.com/docker/go-units v0.4.0 // indirect
-	github.com/fsnotify/fsnotify v1.4.9 // indirect
-	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/inconshreveable/mousetrap v1.0.0 // indirect
-	github.com/jmespath/go-jmespath v0.4.0 // indirect
-	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
-	github.com/mattn/go-colorable v0.1.9 // indirect
-	github.com/mattn/go-isatty v0.0.14 // indirect
-	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
-	github.com/nxadm/tail v1.4.8 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/net v0.0.0-20210614182718-04defd469f4e // indirect
-	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
-	golang.org/x/term v0.0.0-20210503060354-a79de5458b56 // indirect
-	golang.org/x/text v0.3.6 // indirect
-	google.golang.org/protobuf v1.26.0 // indirect
-	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
-)

--- a/go.mod
+++ b/go.mod
@@ -30,3 +30,31 @@ require (
 	gopkg.in/ini.v1 v1.63.2
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )
+
+require (
+	github.com/agext/levenshtein v1.2.3 // indirect
+	github.com/containerd/typeurl v1.0.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/docker/docker v20.10.7+incompatible // indirect
+	github.com/docker/go-connections v0.4.0 // indirect
+	github.com/docker/go-units v0.4.0 // indirect
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
+	github.com/mattn/go-colorable v0.1.9 // indirect
+	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
+	github.com/nxadm/tail v1.4.8 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/net v0.0.0-20210614182718-04defd469f4e // indirect
+	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
+	golang.org/x/term v0.0.0-20210503060354-a79de5458b56 // indirect
+	golang.org/x/text v0.3.6 // indirect
+	google.golang.org/protobuf v1.26.0 // indirect
+	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+)

--- a/internal/pkg/cli/job_init.go
+++ b/internal/pkg/cli/job_init.go
@@ -178,7 +178,7 @@ func (o *initJobOpts) Ask() error {
 		errWorkspaceNotFound *workspace.ErrWorkspaceNotFound
 	)
 	if !errors.As(err, &errNotFound) && !errors.As(err, &errWorkspaceNotFound){
-		return fmt.Errorf("read manifest file for service %s: %w", o.name, err)
+		return fmt.Errorf("read manifest file for job %s: %w", o.name, err)
 	}
 	if err := o.askJobType(); err != nil {
 		return err

--- a/internal/pkg/cli/job_init.go
+++ b/internal/pkg/cli/job_init.go
@@ -173,9 +173,12 @@ func (o *initJobOpts) Ask() error {
 		log.Infof("Manifest file for job %s already exists. Skipping configuration.\n", o.name)
 		return nil
 	}
-	var errNotFound *workspace.ErrFileNotExists
-	if !errors.As(err, &errNotFound) {
-		return fmt.Errorf("read manifest file for job %s: %w", o.name, err)
+	var (
+		errNotFound *workspace.ErrFileNotExists
+		errWorkspaceNotFound *workspace.ErrWorkspaceNotFound
+	)
+	if !errors.As(err, &errNotFound) && !errors.As(err, &errWorkspaceNotFound){
+		return fmt.Errorf("read manifest file for service %s: %w", o.name, err)
 	}
 	if err := o.askJobType(); err != nil {
 		return err

--- a/internal/pkg/cli/job_init_test.go
+++ b/internal/pkg/cli/job_init_test.go
@@ -397,7 +397,7 @@ type: Scheduled Job`), nil)
 			inJobSchedule:    "",
 
 			setupMocks: func(m initJobMocks) {
-				m.mockMftReader.EXPECT().ReadWorkloadManifest(wantedJobName).Return(nil, &workspace.ErrFileNotExists{FileName: wantedJobName})
+				m.mockMftReader.EXPECT().ReadWorkloadManifest(wantedJobName).Return(nil, &workspace.ErrWorkspaceNotFound{})
 				m.mockSel.EXPECT().Schedule(
 					gomock.Eq(jobInitSchedulePrompt),
 					gomock.Eq(jobInitScheduleHelp),

--- a/internal/pkg/cli/svc_init.go
+++ b/internal/pkg/cli/svc_init.go
@@ -232,8 +232,11 @@ func (o *initSvcOpts) Ask() error {
 		log.Infof("Manifest file for job %s already exists. Skipping configuration.\n", o.name)
 		return nil
 	}
-	var errNotFound *workspace.ErrFileNotExists
-	if !errors.As(err, &errNotFound) {
+	var (
+		errNotFound *workspace.ErrFileNotExists
+		errWorkspaceNotFound *workspace.ErrWorkspaceNotFound
+	)
+	if !errors.As(err, &errNotFound) && !errors.As(err, &errWorkspaceNotFound){
 		return fmt.Errorf("read manifest file for service %s: %w", o.name, err)
 	}
 	if err := o.askSvcType(); err != nil {

--- a/internal/pkg/cli/svc_init_test.go
+++ b/internal/pkg/cli/svc_init_test.go
@@ -474,7 +474,7 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 			inDockerfilePath: "",
 
 			setupMocks: func(m initSvcMocks) {
-				m.mockMftReader.EXPECT().ReadWorkloadManifest(wantedSvcName).Return(nil, &workspace.ErrWorkspaceNotFound{})
+				m.mockMftReader.EXPECT().ReadWorkloadManifest(wantedSvcName).Return(nil, &workspace.ErrFileNotExists{FileName: wantedSvcName})
 				m.mocktopicSel.EXPECT().Topics(
 					gomock.Eq(svcInitPublisherPrompt),
 					gomock.Eq(svcInitPublisherHelpPrompt),

--- a/internal/pkg/cli/svc_init_test.go
+++ b/internal/pkg/cli/svc_init_test.go
@@ -474,7 +474,7 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 			inDockerfilePath: "",
 
 			setupMocks: func(m initSvcMocks) {
-				m.mockMftReader.EXPECT().ReadWorkloadManifest(wantedSvcName).Return(nil, &workspace.ErrFileNotExists{FileName: wantedSvcName})
+				m.mockMftReader.EXPECT().ReadWorkloadManifest(wantedSvcName).Return(nil, &workspace.ErrWorkspaceNotFound{})
 				m.mocktopicSel.EXPECT().Topics(
 					gomock.Eq(svcInitPublisherPrompt),
 					gomock.Eq(svcInitPublisherHelpPrompt),

--- a/internal/pkg/workspace/errors.go
+++ b/internal/pkg/workspace/errors.go
@@ -29,14 +29,14 @@ func (e *ErrFileNotExists) Error() string {
 	return fmt.Sprintf("file %s does not exists", e.FileName)
 }
 
-// errWorkspaceNotFound means we couldn't locate a workspace root.
-type errWorkspaceNotFound struct {
+// ErrWorkspaceNotFound means we couldn't locate a workspace root.
+type ErrWorkspaceNotFound struct {
 	CurrentDirectory      string
 	ManifestDirectoryName string
 	NumberOfLevelsChecked int
 }
 
-func (e *errWorkspaceNotFound) Error() string {
+func (e *ErrWorkspaceNotFound) Error() string {
 	return fmt.Sprintf("couldn't find a directory called %s up to %d levels up from %s",
 		e.ManifestDirectoryName,
 		e.NumberOfLevelsChecked,

--- a/internal/pkg/workspace/workspace.go
+++ b/internal/pkg/workspace/workspace.go
@@ -378,7 +378,7 @@ func (ws *Workspace) CopilotDirPath() (string, error) {
 		}
 		searchingDir = filepath.Dir(searchingDir)
 	}
-	return "", &errWorkspaceNotFound{
+	return "", &ErrWorkspaceNotFound{
 		CurrentDirectory:      ws.workingDir,
 		ManifestDirectoryName: CopilotDirName,
 		NumberOfLevelsChecked: maximumParentDirsToSearch,


### PR DESCRIPTION
The e2e test failed because of #2966. When `copilot` commands is run for the first time in a directory, the workspace, indicated by the existence of `copilot/` folder,  may not exist. This error should be skipped, not surfaced, as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
