### PR TITLE
chore: addons should not depend on env ctrler when it doesn't exist

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/rd_web_svc_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/rd_web_svc_test.go
@@ -219,6 +219,10 @@ func TestRequestDrivenWebService_Template(t *testing.T) {
 		wantedError          error
 	}{
 		"should throw an error if env controller cannot be parsed": {
+			inManifest: func(mft manifest.RequestDrivenWebService) manifest.RequestDrivenWebService {
+				mft.Network.VPC.Placement = (*manifest.RequestDrivenWebServicePlacement)(&manifest.PrivateSubnetPlacement)
+				return mft
+			},
 			mockDependencies: func(t *testing.T, ctrl *gomock.Controller, c *RequestDrivenWebService) {
 				mockParser := mocks.NewMockrequestDrivenWebSvcReadParser(ctrl)
 				mockParser.EXPECT().Read(envControllerPath).Return(nil, errors.New("some error"))
@@ -229,7 +233,6 @@ func TestRequestDrivenWebService_Template(t *testing.T) {
 		"should throw an error if addons template cannot be parsed": {
 			mockDependencies: func(t *testing.T, ctrl *gomock.Controller, c *RequestDrivenWebService) {
 				mockParser := mocks.NewMockrequestDrivenWebSvcReadParser(ctrl)
-				mockParser.EXPECT().Read(envControllerPath).Return(&template.Content{Buffer: bytes.NewBufferString("something")}, nil)
 				addons := mockAddons{tplErr: errors.New("some error")}
 				c.parser = mockParser
 				c.wkld.addons = addons
@@ -272,13 +275,11 @@ func TestRequestDrivenWebService_Template(t *testing.T) {
 		"should parse template without addons/ directory": {
 			mockDependencies: func(t *testing.T, ctrl *gomock.Controller, c *RequestDrivenWebService) {
 				mockParser := mocks.NewMockrequestDrivenWebSvcReadParser(ctrl)
-				mockParser.EXPECT().Read(envControllerPath).Return(&template.Content{Buffer: bytes.NewBufferString("something")}, nil)
 				addons := mockAddons{tplErr: &addon.ErrAddonsNotFound{}, paramsErr: &addon.ErrAddonsNotFound{}}
 				mockParser.EXPECT().ParseRequestDrivenWebService(template.WorkloadOpts{
-					Variables:           c.manifest.Variables,
-					Tags:                c.manifest.Tags,
-					EnvControllerLambda: "something",
-					EnableHealthCheck:   true,
+					Variables:         c.manifest.Variables,
+					Tags:              c.manifest.Tags,
+					EnableHealthCheck: true,
 				}).Return(&template.Content{Buffer: bytes.NewBufferString("template")}, nil)
 				c.parser = mockParser
 				c.addons = addons
@@ -288,7 +289,6 @@ func TestRequestDrivenWebService_Template(t *testing.T) {
 		"should parse template with addons": {
 			mockDependencies: func(t *testing.T, ctrl *gomock.Controller, c *RequestDrivenWebService) {
 				mockParser := mocks.NewMockrequestDrivenWebSvcReadParser(ctrl)
-				mockParser.EXPECT().Read(envControllerPath).Return(&template.Content{Buffer: bytes.NewBufferString("something")}, nil)
 				addons := mockAddons{
 					tpl: `Resources:
   AdditionalResourcesPolicy:
@@ -319,8 +319,7 @@ Outputs:
 						VariableOutputs: []string{"DDBTableName", "Hello"},
 						PolicyOutputs:   []string{"AdditionalResourcesPolicyArn"},
 					},
-					EnableHealthCheck:   true,
-					EnvControllerLambda: "something",
+					EnableHealthCheck: true,
 				}).Return(&template.Content{Buffer: bytes.NewBufferString("template")}, nil)
 				c.parser = mockParser
 				c.addons = addons
@@ -330,13 +329,11 @@ Outputs:
 		"should return parsing error": {
 			mockDependencies: func(t *testing.T, ctrl *gomock.Controller, c *RequestDrivenWebService) {
 				mockParser := mocks.NewMockrequestDrivenWebSvcReadParser(ctrl)
-				mockParser.EXPECT().Read(envControllerPath).Return(&template.Content{Buffer: bytes.NewBufferString("something")}, nil)
 				addons := mockAddons{tplErr: &addon.ErrAddonsNotFound{}}
 				mockParser.EXPECT().ParseRequestDrivenWebService(template.WorkloadOpts{
-					Variables:           c.manifest.Variables,
-					Tags:                c.manifest.Tags,
-					EnableHealthCheck:   true,
-					EnvControllerLambda: "something",
+					Variables:         c.manifest.Variables,
+					Tags:              c.manifest.Tags,
+					EnableHealthCheck: true,
 				}).Return(nil, errors.New("parsing error"))
 				c.parser = mockParser
 				c.addons = addons
@@ -353,7 +350,6 @@ Outputs:
 			},
 			mockDependencies: func(t *testing.T, ctrl *gomock.Controller, c *RequestDrivenWebService) {
 				mockParser := mocks.NewMockrequestDrivenWebSvcReadParser(ctrl)
-				mockParser.EXPECT().Read(envControllerPath).Return(&template.Content{Buffer: bytes.NewBufferString("something")}, nil)
 				addons := mockAddons{tplErr: &addon.ErrAddonsNotFound{}}
 				c.parser = mockParser
 				c.wkld.addons = addons

--- a/internal/pkg/template/templates/workloads/services/rd-web/cf.yml
+++ b/internal/pkg/template/templates/workloads/services/rd-web/cf.yml
@@ -191,6 +191,6 @@ Resources:
 {{- end }}
 {{include "publish" . | indent 2}}
 
-{{- if eq .Network.SubnetsType "PrivateSubnets"}}
+{{- if ne .EnvControllerLambda ""}}
 {{include "env-controller" . | indent 2}}
 {{- end}}


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
