### PR TITLE
chore: quick follow-up to revert partial changes to buildspec

### DIFF
--- a/internal/pkg/template/templates/cicd/buildspec.yml
+++ b/internal/pkg/template/templates/cicd/buildspec.yml
@@ -51,9 +51,9 @@ phases:
       # The tag is the build ID but we replaced the colon ':' with a dash '-'.
       # We truncate the tag (from the front) to 128 characters, the limit for Docker tags
       # (https://docs.docker.com/engine/reference/commandline/tag/)
+      - tag=$(sed 's/:/-/g' <<<"${CODEBUILD_BUILD_ID##*:}" | rev | cut -c 1-128 | rev)
       - >
         for env in $pl_envs; do
-          tag=$(sed 's/:/-/g' <<<"${CODEBUILD_BUILD_ID##*:}" | rev | cut -c 1-128 | rev)
           for svc in $svcs; do
           ./copilot-linux svc package -n $svc -e $env --output-dir './infrastructure' --tag $tag;
           done;
@@ -86,7 +86,6 @@ phases:
         for workload in $WORKLOADS; do
           manifest=$(cat $CODEBUILD_SRC_DIR/copilot/$workload/manifest.yml | ruby -ryaml -rjson -e 'puts JSON.pretty_generate(YAML.load(ARGF))')
           for env in $pl_envs; do
-            tag=$(sed 's/:/-/g' <<<"${CODEBUILD_BUILD_ID##*:}" | rev | cut -c 1-128 | rev)
             images=$(echo $manifest | jq "{base_image: .image, env_image: (.environments?.$env?.image? // {}) }")
             image=$(echo $images | jq 'if (.env_image | length == 0) then .base_image else (.base_image | del(.location)) * .env_image end')
             image_location=$(echo $image | jq '.location')

--- a/internal/pkg/template/templates/cicd/buildspec.yml
+++ b/internal/pkg/template/templates/cicd/buildspec.yml
@@ -53,7 +53,7 @@ phases:
       # (https://docs.docker.com/engine/reference/commandline/tag/)
       - >
         for env in $pl_envs; do
-          tag=$(sed 's/:/-/g' <<<"${CODEBUILD_BUILD_ID}-${env}" | rev | cut -c 1-128 | rev)
+          tag=$(sed 's/:/-/g' <<<"${CODEBUILD_BUILD_ID##*:}" | rev | cut -c 1-128 | rev)
           for svc in $svcs; do
           ./copilot-linux svc package -n $svc -e $env --output-dir './infrastructure' --tag $tag;
           done;
@@ -86,7 +86,7 @@ phases:
         for workload in $WORKLOADS; do
           manifest=$(cat $CODEBUILD_SRC_DIR/copilot/$workload/manifest.yml | ruby -ryaml -rjson -e 'puts JSON.pretty_generate(YAML.load(ARGF))')
           for env in $pl_envs; do
-            tag=$(sed 's/:/-/g' <<<"${CODEBUILD_BUILD_ID##*:}-${env}" | rev | cut -c 1-128 | rev)
+            tag=$(sed 's/:/-/g' <<<"${CODEBUILD_BUILD_ID##*:}" | rev | cut -c 1-128 | rev)
             images=$(echo $manifest | jq "{base_image: .image, env_image: (.environments?.$env?.image? // {}) }")
             image=$(echo $images | jq 'if (.env_image | length == 0) then .base_image else (.base_image | del(.location)) * .env_image end')
             image_location=$(echo $image | jq '.location')


### PR DESCRIPTION
This PR is a quick follow up to #2970, reverting some changes. 

The previous PR assigns different tags to each environment image. However, if the images are the same across all environments, the tags shouldn't be different.

We will send out a follow-up PR to update the `buildspec` such that we assign the same tag / environment-specific tags to images depending on whether the images are the same across environments / environment-specific.

For now, we temporarily revert the change so that it maintains existing behavior until we send out an update.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
