### PR TITLE
fix: Implement reverted feature again in #2994

### DIFF
--- a/internal/pkg/template/templates/cicd/buildspec.yml
+++ b/internal/pkg/template/templates/cicd/buildspec.yml
@@ -51,9 +51,9 @@ phases:
       # The tag is the build ID but we replaced the colon ':' with a dash '-'.
       # We truncate the tag (from the front) to 128 characters, the limit for Docker tags
       # (https://docs.docker.com/engine/reference/commandline/tag/)
-      - tag=$(sed 's/:/-/g' <<<"${CODEBUILD_BUILD_ID##*:}" | rev | cut -c 1-128 | rev)
       - >
         for env in $pl_envs; do
+          tag=$(sed 's/:/-/g' <<<"${CODEBUILD_BUILD_ID##*:}-${env}" | rev | cut -c 1-128 | rev)
           for svc in $svcs; do
           ./copilot-linux svc package -n $svc -e $env --output-dir './infrastructure' --tag $tag;
           done;
@@ -86,6 +86,7 @@ phases:
         for workload in $WORKLOADS; do
           manifest=$(cat $CODEBUILD_SRC_DIR/copilot/$workload/manifest.yml | ruby -ryaml -rjson -e 'puts JSON.pretty_generate(YAML.load(ARGF))')
           for env in $pl_envs; do
+            tag=$(sed 's/:/-/g' <<<"${CODEBUILD_BUILD_ID##*:}-${env}" | rev | cut -c 1-128 | rev)
             images=$(echo $manifest | jq "{base_image: .image, env_image: (.environments?.$env?.image? // {}) }")
             image=$(echo $images | jq 'if (.env_image | length == 0) then .base_image else (.base_image | del(.location)) * .env_image end')
             image_location=$(echo $image | jq '.location')


### PR DESCRIPTION
<!-- Provide summary of changes -->
- Generate docker image tags for each environments, and workloads.

In #2994,

> For now, we temporarily revert the change so that it maintains existing behavior until we send out an update.

My PR (#2970) is not a feature update, but bugfix.
It does not affect the existing behavior as long as the digests match, just add tags for same digests and push image once (will be skipped for existing digest).
![スクリーンショット 2021-11-06 22 04 36](https://user-images.githubusercontent.com/611276/140653468-704bbf02-3cef-497d-af08-040653488308.png)

The problem arises because using the same tag when the digest does not match changes the image that the tag represents.
![スクリーンショット 2021-11-08 1 41 07](https://user-images.githubusercontent.com/611276/140654040-439eec3d-68c8-4e5e-9741-1de967e0fd8a.png)

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->
Fixes #2927 
Addresses #2970, #2994 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
