### PR TITLE
chore: add `nlb` to manifest

### DIFF
--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -602,7 +602,7 @@ func (o *deploySvcOpts) stackConfiguration(addonsURL string) (cloudformation.Sta
 			opts = append(opts, stack.WithHTTPS())
 			opts = append(opts, stack.WithDNSDelegation())
 		}
-		if t.NLBConfig {
+		if t.NLBConfig.Enabled() {
 			cidrBlocks, err := o.publicCIDRBlocks()
 			if err != nil {
 				return nil, err

--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -602,7 +602,7 @@ func (o *deploySvcOpts) stackConfiguration(addonsURL string) (cloudformation.Sta
 			opts = append(opts, stack.WithHTTPS())
 			opts = append(opts, stack.WithDNSDelegation())
 		}
-		if t.NLBConfig.Enabled() {
+		if !t.NLBConfig.IsEmpty() {
 			cidrBlocks, err := o.publicCIDRBlocks()
 			if err != nil {
 				return nil, err

--- a/internal/pkg/cli/svc_deploy_test.go
+++ b/internal/pkg/cli/svc_deploy_test.go
@@ -599,11 +599,11 @@ func TestSvcDeployOpts_deploySvc(t *testing.T) {
 	)
 	tests := map[string]struct {
 		inAliases      manifest.Alias
+		inNLB          manifest.NetworkLoadBalancerConfiguration
 		inApp          *config.Application
 		inEnvironment  *config.Environment
 		inBuildRequire bool
 		inForceDeploy  bool
-		useNLB         bool
 
 		mock func(m *deploySvcMocks)
 
@@ -624,7 +624,9 @@ func TestSvcDeployOpts_deploySvc(t *testing.T) {
 		},
 		"fail to describe environment": {
 			inBuildRequire: false,
-			useNLB:         true,
+			inNLB: manifest.NetworkLoadBalancerConfiguration{
+				Port: aws.String("443/udp"),
+			},
 			inEnvironment: &config.Environment{
 				Name:   mockEnvName,
 				Region: "us-west-2",
@@ -642,7 +644,9 @@ func TestSvcDeployOpts_deploySvc(t *testing.T) {
 		},
 		"fail to list subnets": {
 			inBuildRequire: false,
-			useNLB:         true,
+			inNLB: manifest.NetworkLoadBalancerConfiguration{
+				Port: aws.String("443/udp"),
+			},
 			inEnvironment: &config.Environment{
 				Name:   mockEnvName,
 				Region: "us-west-2",
@@ -958,7 +962,7 @@ func TestSvcDeployOpts_deploySvc(t *testing.T) {
 							RoutingRule: manifest.RoutingRule{
 								Alias: tc.inAliases,
 							},
-							NLBConfig: tc.useNLB,
+							NLBConfig: tc.inNLB,
 						},
 					}, nil
 				},

--- a/internal/pkg/deploy/cloudformation/stack/lb_web_svc.go
+++ b/internal/pkg/deploy/cloudformation/stack/lb_web_svc.go
@@ -190,8 +190,8 @@ func (s *LoadBalancedWebService) Template() (string, error) {
 		return "", err
 	}
 	content, err := s.parser.ParseLoadBalancedWebService(template.WorkloadOpts{
-		Variables:                s.manifest.Variables,
-		Secrets:                  s.manifest.Secrets,
+		Variables:                s.manifest.TaskConfig.Variables,
+		Secrets:                  s.manifest.TaskConfig.Secrets,
 		Aliases:                  aliases,
 		NestedStack:              addonsOutputs,
 		AddonsExtraParams:        addonsParams,

--- a/internal/pkg/manifest/applyenv_test.go
+++ b/internal/pkg/manifest/applyenv_test.go
@@ -651,17 +651,17 @@ func TestApplyEnv_MapToString(t *testing.T) {
 	}{
 		"map upserted": {
 			inSvc: func(svc *LoadBalancedWebService) {
-				svc.Secrets = map[string]string{
+				svc.TaskConfig.Secrets = map[string]string{
 					"secret1": "the secret sauce is mole",
 					"secret2": "the secret agent is johnny rivers",
 				}
-				svc.Environments["test"].Secrets = map[string]string{
+				svc.Environments["test"].TaskConfig.Secrets = map[string]string{
 					"secret1": "the secret sauce is blue cheese which has mold in it",
 					"secret3": "the secret route is through egypt",
 				}
 			},
 			wanted: func(svc *LoadBalancedWebService) {
-				svc.Secrets = map[string]string{
+				svc.TaskConfig.Secrets = map[string]string{
 					"secret1": "the secret sauce is blue cheese which has mold in it", // Overridden.
 					"secret2": "the secret agent is johnny rivers",                    // Kept.
 					"secret3": "the secret route is through egypt",                    // Appended
@@ -670,14 +670,14 @@ func TestApplyEnv_MapToString(t *testing.T) {
 		},
 		"map not overridden by zero map": {
 			inSvc: func(svc *LoadBalancedWebService) {
-				svc.Secrets = map[string]string{
+				svc.TaskConfig.Secrets = map[string]string{
 					"secret1": "the secret sauce is mole",
 					"secret2": "the secret agent man is johnny rivers",
 				}
-				svc.Environments["test"].Secrets = map[string]string{}
+				svc.Environments["test"].TaskConfig.Secrets = map[string]string{}
 			},
 			wanted: func(svc *LoadBalancedWebService) {
-				svc.Secrets = map[string]string{
+				svc.TaskConfig.Secrets = map[string]string{
 					"secret1": "the secret sauce is mole",
 					"secret2": "the secret agent man is johnny rivers",
 				}
@@ -685,13 +685,13 @@ func TestApplyEnv_MapToString(t *testing.T) {
 		},
 		"map not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
-				svc.Secrets = map[string]string{
+				svc.TaskConfig.Secrets = map[string]string{
 					"secret1": "the secret sauce is mole",
 					"secret2": "the secret agent man is johnny rivers",
 				}
 			},
 			wanted: func(svc *LoadBalancedWebService) {
-				svc.Secrets = map[string]string{
+				svc.TaskConfig.Secrets = map[string]string{
 					"secret1": "the secret sauce is mole",
 					"secret2": "the secret agent man is johnny rivers",
 				}

--- a/internal/pkg/manifest/lb_web_svc.go
+++ b/internal/pkg/manifest/lb_web_svc.go
@@ -216,11 +216,6 @@ func (c *NetworkLoadBalancerConfiguration) IsEmpty() bool {
 	return c.Port == nil && c.HealthCheck.IsEmpty() && c.TargetContainer == nil && c.TargetPort == nil && c.SSLPolicy == nil
 }
 
-// Enabled returns true if network load balancer is enabled.
-func (c *NetworkLoadBalancerConfiguration) Enabled() bool {
-	return c.isEmpty()
-}
-
 // IPNet represents an IP network string. For example: 10.1.0.0/16
 type IPNet string
 

--- a/internal/pkg/manifest/lb_web_svc.go
+++ b/internal/pkg/manifest/lb_web_svc.go
@@ -205,16 +205,15 @@ func (r *RoutingRule) targetContainer() *string {
 
 // NetworkLoadBalancerConfiguration holds options for a network load balancer
 type NetworkLoadBalancerConfiguration struct {
-	Alias           Alias                   `yaml:"alias"`
-	Port            *string                 `yaml:"port"` // TODO: Needs to be a "port" to accept port/protocol
+	Port            *string                 `yaml:"port"`
 	HealthCheck     HealthCheckArgsOrString `yaml:"healthcheck"`
 	TargetContainer *string                 `yaml:"target_container"`
 	TargetPort      *int                    `yaml:"target_port"`
 	SSLPolicy       *string                 `yaml:"ssl_policy"`
 }
 
-func (c *NetworkLoadBalancerConfiguration) isEmpty() bool {
-	return c.Alias.IsEmpty() && c.Port == nil && c.HealthCheck.IsEmpty() && c.TargetContainer == nil && c.TargetPort == nil && c.SSLPolicy == nil
+func (c *NetworkLoadBalancerConfiguration) IsEmpty() bool {
+	return c.Port == nil && c.HealthCheck.IsEmpty() && c.TargetContainer == nil && c.TargetPort == nil && c.SSLPolicy == nil
 }
 
 // Enabled returns true if network load balancer is enabled.

--- a/internal/pkg/manifest/lb_web_svc_test.go
+++ b/internal/pkg/manifest/lb_web_svc_test.go
@@ -1399,6 +1399,29 @@ func TestAlias_IsEmpty(t *testing.T) {
 	}
 }
 
-func TestNetworkLoadBalancerConfiguration_Enabled(t *testing.T) {
-	// TODO: add this
+func TestNetworkLoadBalancerConfiguration_IsEmpty(t *testing.T) {
+	testCases := map[string]struct {
+		in     NetworkLoadBalancerConfiguration
+		wanted bool
+	}{
+		"empty": {
+			in:     NetworkLoadBalancerConfiguration{},
+			wanted: true,
+		},
+		"non empty": {
+			in: NetworkLoadBalancerConfiguration{
+				Port: aws.String("443"),
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// WHEN
+			got := tc.in.IsEmpty()
+
+			// THEN
+			require.Equal(t, tc.wanted, got)
+		})
+	}
 }

--- a/internal/pkg/manifest/lb_web_svc_test.go
+++ b/internal/pkg/manifest/lb_web_svc_test.go
@@ -1314,77 +1314,6 @@ func TestLoadBalancedWebService_Publish(t *testing.T) {
 	}
 }
 
-func Test_Temp(t *testing.T) {
-	wamtedImageConfig := ImageWithPortAndHealthcheck{
-		ImageWithPort: ImageWithPort{
-			Image: Image{
-				Location: aws.String("env-override location"),
-				DockerLabels: map[string]string{
-					"label1": "value1",
-					"label2": "value2",
-				},
-				DependsOn: map[string]string{
-					"depends1": "on1",
-					"depends2": "on2",
-				},
-			},
-			Port: aws.Uint16(5000),
-		},
-		HealthCheck: *NewDefaultContainerHealthCheck(),
-	}
-	t.Run("temporary", func(t *testing.T) {
-		// WHEN
-		in := &LoadBalancedWebService{
-			Workload: Workload{
-				Name: aws.String("phonetool"),
-				Type: aws.String(LoadBalancedWebServiceType),
-			},
-			LoadBalancedWebServiceConfig: LoadBalancedWebServiceConfig{
-				ImageConfig: ImageWithPortAndHealthcheck{
-					ImageWithPort: ImageWithPort{
-						Image: Image{
-							Build: BuildArgsOrString{
-								BuildArgs: DockerBuildArgs{
-									Dockerfile: aws.String("./Dockerfile"),
-								},
-							},
-							DockerLabels: map[string]string{
-								"label1": "value1",
-							},
-							DependsOn: map[string]string{
-								"depends1": "on1",
-							},
-						},
-						Port: aws.Uint16(80),
-					},
-				},
-			},
-			Environments: map[string]*LoadBalancedWebServiceConfig{
-				"prod-iad": {
-					ImageConfig: ImageWithPortAndHealthcheck{
-						ImageWithPort: ImageWithPort{
-							Image: Image{
-								Location: aws.String("env-override location"),
-								DockerLabels: map[string]string{
-									"label2": "value2",
-								},
-								DependsOn: map[string]string{
-									"depends2": "on2",
-								},
-							},
-							Port: aws.Uint16(5000),
-						},
-						HealthCheck: *NewDefaultContainerHealthCheck(),
-					},
-				},
-			},
-		}
-		envToApply := "prod-iad"
-		conf, _ := in.ApplyEnv(envToApply)
-		require.Equal(t, wamtedImageConfig, conf.(*LoadBalancedWebService).ImageConfig)
-	})
-}
-
 func TestLoadBalancedWebService_BuildRequired(t *testing.T) {
 	testCases := map[string]struct {
 		image   Image
@@ -1468,4 +1397,8 @@ func TestAlias_IsEmpty(t *testing.T) {
 			require.Equal(t, tc.wanted, got)
 		})
 	}
+}
+
+func TestNetworkLoadBalancerConfiguration_Enabled(t *testing.T) {
+	// TODO: add this
 }

--- a/internal/pkg/manifest/validate.go
+++ b/internal/pkg/manifest/validate.go
@@ -52,12 +52,19 @@ func (l LoadBalancedWebService) Validate() error {
 	if err = l.Workload.Validate(); err != nil {
 		return err
 	}
-	if err = validateLoadBalancerTarget(validateLoadBalancerTargetOpts{
+	if err = validateTargetContainer(validateTargetContainerOpts{
 		mainContainerName: aws.StringValue(l.Name),
-		routingRule:       l.RoutingRule,
+		targetContainer:   l.RoutingRule.targetContainer(),
 		sidecarConfig:     l.Sidecars,
 	}); err != nil {
-		return fmt.Errorf("validate load balancer target: %w", err)
+		return fmt.Errorf("validate HTTP load balancer target: %w", err)
+	}
+	if err = validateTargetContainer(validateTargetContainerOpts{
+		mainContainerName: aws.StringValue(l.Name),
+		targetContainer:   l.NLBConfig.TargetContainer,
+		sidecarConfig:     l.Sidecars,
+	}); err != nil {
+		return fmt.Errorf("validate network load balancer target: %w", err)
 	}
 	if err = validateContainerDeps(validateDependenciesOpts{
 		sidecarConfig:     l.Sidecars,
@@ -110,6 +117,9 @@ func (l LoadBalancedWebServiceConfig) Validate() error {
 		}); err != nil {
 			return fmt.Errorf("validate Windows: %w", err)
 		}
+	}
+	if err = l.NLBConfig.Validate(); err != nil {
+		return fmt.Errorf(`validate "nlb": %w`, err)
 	}
 	return nil
 }
@@ -530,6 +540,22 @@ func (Alias) Validate() error {
 func (ip IPNet) Validate() error {
 	if _, _, err := net.ParseCIDR(string(ip)); err != nil {
 		return fmt.Errorf("parse IPNet %s: %w", string(ip), err)
+	}
+	return nil
+}
+
+// Validate returns nil if NetworkLoadBalancerConfiguration is configured correctly.
+func (c NetworkLoadBalancerConfiguration) Validate() error {
+	if c.isEmpty() {
+		return nil
+	}
+	if aws.StringValue(c.Port) == ""{
+		return &errFieldMustBeSpecified{
+			missingField: "port",
+		}
+	}
+	if err := c.HealthCheck.Validate(); err != nil {
+		return fmt.Errorf(`validate "healthcheck": %w`, err)
 	}
 	return nil
 }
@@ -1108,12 +1134,6 @@ type validateDependenciesOpts struct {
 	imageConfig       Image
 }
 
-type validateLoadBalancerTargetOpts struct {
-	mainContainerName string
-	routingRule       RoutingRule
-	sidecarConfig     map[string]*SidecarConfig
-}
-
 type containerDependency struct {
 	dependsOn   DependsOn
 	isEssential bool
@@ -1124,14 +1144,18 @@ type validateWindowsOpts struct {
 	efsVolumes  map[string]*Volume
 }
 
-func validateLoadBalancerTarget(opts validateLoadBalancerTargetOpts) error {
-	if opts.routingRule.TargetContainer == nil && opts.routingRule.TargetContainerCamelCase == nil {
+
+type validateTargetContainerOpts struct {
+	mainContainerName string
+	targetContainer   *string
+	sidecarConfig     map[string]*SidecarConfig
+}
+
+func validateTargetContainer(opts validateTargetContainerOpts) error {
+	if opts.targetContainer == nil {
 		return nil
 	}
-	targetContainer := aws.StringValue(opts.routingRule.TargetContainerCamelCase)
-	if opts.routingRule.TargetContainer != nil {
-		targetContainer = aws.StringValue(opts.routingRule.TargetContainer)
-	}
+	targetContainer := aws.StringValue(opts.targetContainer)
 	if targetContainer == opts.mainContainerName {
 		return nil
 	}

--- a/internal/pkg/manifest/validate.go
+++ b/internal/pkg/manifest/validate.go
@@ -546,7 +546,7 @@ func (ip IPNet) Validate() error {
 
 // Validate returns nil if NetworkLoadBalancerConfiguration is configured correctly.
 func (c NetworkLoadBalancerConfiguration) Validate() error {
-	if c.isEmpty() {
+	if c.IsEmpty() {
 		return nil
 	}
 	if aws.StringValue(c.Port) == ""{

--- a/internal/pkg/template/workload.go
+++ b/internal/pkg/template/workload.go
@@ -206,7 +206,7 @@ type HTTPHealthCheckOpts struct {
 
 // NetworkLoadBalancerListener holds configuration that's need for a Network Load Balancer listener.
 type NetworkLoadBalancerListener struct {
-	Port            int
+	Port            string
 	Protocol        string
 	TargetContainer string
 	TargetPort      string


### PR DESCRIPTION
This PR enables `nlb` in manifest.

This PR allows:
1. Using NLB and access the service through NLB default URL
2. Using NLB and access the service through NLB default alias -  formatted as <service-name>-nlb.env.app.domain.com - provided that the app is registered with a domain

Next:
- [ ] Enable TLS termination from manifest
- [ ] Enable `nlb.alias`
- [ ] Allow disabling `http` by `http:false`, also update env controller parameter
- [ ] Update `svc deploy` output to provide NLB URL

Previous PR: #3008 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
