### PR TITLE
build(e2e): remove `env GOPROXY direct` from e2e Dockerfile

### DIFF
--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -5,7 +5,6 @@ ARG GOLANG_VERSION=1.17.1
 # Docker needs somewhere to put creds from docker login.
 RUN wget https://github.com/docker/docker-credential-helpers/releases/download/v0.6.0/docker-credential-pass-v0.6.0-amd64.tar.gz && tar -xf docker-credential-pass-v0.6.0-amd64.tar.gz && chmod +x docker-credential-pass &&  mv docker-credential-pass /bin
 ENV DOCKER_HOST=tcp://127.0.0.1:2375
-ENV GOPROXY direct
 ENV GOBIN /go/bin
 
 # Install Go, Git and other dependencies so we can run ginkgo


### PR DESCRIPTION
While running our e2e tests, we observe intermittent errors while
dowloading modules:
```
Cannot obtain refs from GitHub: cannot talk to GitHub:
Get https://github.com/go-yaml/yaml.git/info/refs?service=git-upload-pack:
net/http: request canceled (Client.Timeout exceeded while awaiting headers)
```

I wonder if it's more reliable to first hit 'https://proxy.golang.org' and
then 'direct'.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
