### PR TITLE
docs: add `http.version` to lbws manifest

### DIFF
--- a/internal/pkg/manifest/lb_web_svc.go
+++ b/internal/pkg/manifest/lb_web_svc.go
@@ -23,6 +23,10 @@ const (
 	DefaultHealthCheckGracePeriod = 60
 )
 
+const (
+	GRPCProtocol = "gRPC" // GRPCProtocol is the HTTP protocol version for gRPC.
+)
+
 var (
 	errUnmarshalHealthCheckArgs = errors.New("can't unmarshal healthcheck field into string or compose-style map")
 )
@@ -61,8 +65,10 @@ type LoadBalancedWebServiceConfig struct {
 // LoadBalancedWebServiceProps contains properties for creating a new load balanced fargate service manifest.
 type LoadBalancedWebServiceProps struct {
 	*WorkloadProps
-	Path        string
-	Port        uint16
+	Path string
+	Port uint16
+
+	HTTPVersion string               // Optional http protocol version such as gRPC, HTTP2.
 	HealthCheck ContainerHealthCheck // Optional healthcheck configuration.
 	Platform    PlatformArgsOrString // Optional platform configuration.
 }
@@ -81,6 +87,9 @@ func NewLoadBalancedWebService(props *LoadBalancedWebServiceProps) *LoadBalanced
 	if isWindowsPlatform(props.Platform) {
 		svc.LoadBalancedWebServiceConfig.TaskConfig.CPU = aws.Int(MinWindowsTaskCPU)
 		svc.LoadBalancedWebServiceConfig.TaskConfig.Memory = aws.Int(MinWindowsTaskMemory)
+	}
+	if props.HTTPVersion != "" {
+		svc.RoutingRule.ProtocolVersion = &props.HTTPVersion
 	}
 	svc.RoutingRule.Path = aws.String(props.Path)
 	svc.parser = template.New()

--- a/internal/pkg/manifest/lb_web_svc_test.go
+++ b/internal/pkg/manifest/lb_web_svc_test.go
@@ -21,16 +21,13 @@ func TestNewLoadBalancedWebService(t *testing.T) {
 
 		wanted *LoadBalancedWebService
 	}{
-		"translates to load balanced web service": {
+		"initializes with default settings when only required configuration is provided": {
 			props: LoadBalancedWebServiceProps{
 				WorkloadProps: &WorkloadProps{
 					Name:       "frontend",
 					Dockerfile: "./Dockerfile",
 				},
 				Path: "/",
-				HealthCheck: ContainerHealthCheck{
-					Command: []string{"CMD", "curl -f http://localhost:8080 || exit 1"},
-				},
 				Port: 80,
 			},
 
@@ -50,9 +47,6 @@ func TestNewLoadBalancedWebService(t *testing.T) {
 								},
 							},
 							Port: aws.Uint16(80),
-						},
-						HealthCheck: ContainerHealthCheck{
-							Command: []string{"CMD", "curl -f http://localhost:8080 || exit 1"},
 						},
 					},
 					RoutingRule: RoutingRule{
@@ -82,19 +76,20 @@ func TestNewLoadBalancedWebService(t *testing.T) {
 				},
 			},
 		},
-		"with windows platform": {
+		"overrides default settings when optional configuration is provided": {
 			props: LoadBalancedWebServiceProps{
 				WorkloadProps: &WorkloadProps{
 					Name:       "subscribers",
 					Dockerfile: "./subscribers/Dockerfile",
 				},
 				Path: "/",
+				Port: 80,
+
+				HTTPVersion: "gRPC",
 				HealthCheck: ContainerHealthCheck{
 					Command: []string{"CMD", "curl -f http://localhost:8080 || exit 1"},
 				},
 				Platform: PlatformArgsOrString{PlatformString: (*PlatformString)(aws.String("windows/amd64"))},
-
-				Port: 80,
 			},
 
 			wanted: &LoadBalancedWebService{
@@ -119,7 +114,8 @@ func TestNewLoadBalancedWebService(t *testing.T) {
 						},
 					},
 					RoutingRule: RoutingRule{
-						Path: stringP("/"),
+						Path:            stringP("/"),
+						ProtocolVersion: aws.String("gRPC"),
 						HealthCheck: HealthCheckArgsOrString{
 							HealthCheckPath: stringP("/"),
 						},

--- a/internal/pkg/template/templates/workloads/services/lb-web/manifest.yml
+++ b/internal/pkg/template/templates/workloads/services/lb-web/manifest.yml
@@ -8,6 +8,9 @@ type: {{.Type}}
 
 # Distribute traffic to your service.
 http:
+  {{- if .ProtocolVersion }}
+  version: {{.ProtocolVersion}}
+  {{- end }}
   # Requests to this path will be forwarded to your service.
   # To match all requests you can use the "/" path.
   path: '{{.Path}}'

--- a/site/content/docs/include/http-config.en.md
+++ b/site/content/docs/include/http-config.en.md
@@ -72,3 +72,7 @@ http:
 http:
   alias: ["example.com", "v1.example.com"]
 ```
+
+<span class="parent-field">http.</span><a id="http-version" href="#http-version" class="field">`version`</a> <span class="type">String</span>  
+The HTTP(S) protocol version. Must be one of `'grpc'`, `'http1'`, or `'http2'`. If omitted, then `'http1'` is assumed.    
+If using gRPC, please note that a domain must be associated with your application.


### PR DESCRIPTION
Also parse the Dockerfile for port `50051` that's commonly used for gRPC and set in the manifest file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
