### PR TITLE
docs: add details about scheduled jobs' pre-defined rates

### DIFF
--- a/site/content/docs/manifest/scheduled-job.en.md
+++ b/site/content/docs/manifest/scheduled-job.en.md
@@ -47,11 +47,14 @@ The configuration for the event that triggers your job.
 <span class="parent-field">on.</span><a id="on-schedule" href="#on-schedule" class="field">`schedule`</a> <span class="type">String</span>  
 You can specify a rate to periodically trigger your job. Supported rates:
 
-* `"@yearly"`
-* `"@monthly"`
-* `"@weekly"`
-* `"@daily"`
-* `"@hourly"`
+| Rate         | Identical to          | In human-readable text and `UTC`, it runs ... |
+| ------------ | --------------------- | --------------------------------------------- |
+| `"@yearly"`  | `"cron(0 * * * ? *)"` | at midnight on January 1st                    |
+| `"@monthly"` | `"cron(0 0 1 * ? *)"` | at midnight on the first day of the month     |
+| `"@weekly"`  | `"cron(0 0 ? * 1 *)"` | at midnight on Sunday                         |
+| `"@daily"`   | `"cron(0 0 * * ? *)"` | at midnight                                   |
+| `"@hourly"`  | `"cron(0 * * * ? *)"` | at minute 0                                   |
+
 * `"@every {duration}"` (For example, "1m", "5m")
 * `"rate({duration})"` based on CloudWatch's [rate expressions](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html#RateExpressions)
 


### PR DESCRIPTION
<!-- Provide summary of changes -->

This PR adds more details about the pre-defined rates on the [`Scheduled Jobs` manifest doc](https://aws.github.io/copilot-cli/docs/manifest/scheduled-job/#on-schedule) like the attached pic, to make it easy for users to know how it actually works. The original feedback is [here on Twitter](https://twitter.com/77web/status/1460517905620078594).

![image](https://user-images.githubusercontent.com/3761357/142101480-5549b35d-3604-4803-a8fc-2d73a90759fa.png)

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
