### PR TITLE
feat: add `--build-context` flag to task run

### DIFF
--- a/internal/pkg/cli/flag.go
+++ b/internal/pkg/cli/flag.go
@@ -142,7 +142,7 @@ var (
 Mutually exclusive with -%s, --%s.`, dockerFileFlagShort, dockerFileFlag)
 	dockerFileFlagDescription = fmt.Sprintf(`Path to the Dockerfile.
 Mutually exclusive with -%s, --%s.`, imageFlagShort, imageFlag)
-	dockerFileContextFlagDescription = fmt.Sprintf(`Path to the Docker context.
+	dockerFileContextFlagDescription = fmt.Sprintf(`Path to the Docker build context.
 Mutually exclusive with -%s, --%s.`, imageFlagShort, imageFlag)
 	storageTypeFlagDescription = fmt.Sprintf(`Type of storage to add. Must be one of:
 %s.`, strings.Join(template.QuoteSliceFunc(storageTypes), ", "))

--- a/internal/pkg/cli/flag.go
+++ b/internal/pkg/cli/flag.go
@@ -29,6 +29,7 @@ const (
 
 	// Command specific flags.
 	dockerFileFlag        = "dockerfile"
+	dockerFileContextFlag = "context"
 	imageTagFlag          = "tag"
 	resourceTagsFlag      = "resource-tags"
 	stackOutputDirFlag    = "output-dir"
@@ -140,6 +141,8 @@ var (
 	imageFlagDescription = fmt.Sprintf(`The location of an existing Docker image.
 Mutually exclusive with -%s, --%s.`, dockerFileFlagShort, dockerFileFlag)
 	dockerFileFlagDescription = fmt.Sprintf(`Path to the Dockerfile.
+Mutually exclusive with -%s, --%s.`, imageFlagShort, imageFlag)
+	dockerFileContextFlagDescription = fmt.Sprintf(`Path to the Docker context.
 Mutually exclusive with -%s, --%s.`, imageFlagShort, imageFlag)
 	storageTypeFlagDescription = fmt.Sprintf(`Type of storage to add. Must be one of:
 %s.`, strings.Join(template.QuoteSliceFunc(storageTypes), ", "))

--- a/internal/pkg/cli/flag.go
+++ b/internal/pkg/cli/flag.go
@@ -29,7 +29,7 @@ const (
 
 	// Command specific flags.
 	dockerFileFlag        = "dockerfile"
-	dockerFileContextFlag = "context"
+	dockerFileContextFlag = "build-context"
 	imageTagFlag          = "tag"
 	resourceTagsFlag      = "resource-tags"
 	stackOutputDirFlag    = "output-dir"

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -313,7 +313,7 @@ func (o *runTaskOpts) Validate() error {
 	}
 
 	if o.image != "" && o.isDockerfileContextSet {
-		return errors.New("cannot specify both `--image` and `--context`")
+		return errors.New("cannot specify both `--image` and `--build-context`")
 	}
 
 	if o.isDockerfileSet {

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -319,13 +319,13 @@ func (o *runTaskOpts) Validate() error {
 
 	if o.isDockerfileSet {
 		if _, err := o.fs.Stat(o.dockerfilePath); err != nil {
-			return err
+			return fmt.Errorf("invalid `--dockerfile` path: %w", err)
 		}
 	}
 
 	if o.dockerfileContextPath != "" {
 		if _, err := o.fs.Stat(o.dockerfileContextPath); err != nil {
-			return err
+			return fmt.Errorf("invalid `--build-context` path: %w", err)
 		}
 	}
 

--- a/internal/pkg/cli/task_run_test.go
+++ b/internal/pkg/cli/task_run_test.go
@@ -72,6 +72,7 @@ func TestTaskRunOpts_Validate(t *testing.T) {
 
 		appName         string
 		isDockerfileSet bool
+		isDockerfileContextSet bool
 
 		mockStore      func(m *mocks.Mockstore)
 		mockFileSystem func(mockFS afero.Fs)
@@ -208,6 +209,14 @@ func TestTaskRunOpts_Validate(t *testing.T) {
 			inOS:        "WINDOWS_SERVER_2019_CORE",
 			inArch:      "X86_64",
 			wantedError: errors.New("memory is 2000, but it must be at least 2048 for a Windows-based task"),
+		},
+		"both dockerfileContext and image name specified": {
+			basicOpts: defaultOpts,
+
+			inImage:         "113459295.dkr.ecr.ap-northeast-1.amazonaws.com/my-app",
+			isDockerfileContextSet: true,
+
+			wantedError: errors.New("cannot specify both `--image` and `--context`"),
 		},
 		"both dockerfile and image name specified": {
 			basicOpts: defaultOpts,
@@ -396,6 +405,7 @@ func TestTaskRunOpts_Validate(t *testing.T) {
 					arch:                        tc.inArch,
 				},
 				isDockerfileSet: tc.isDockerfileSet,
+				isDockerfileContextSet: tc.isDockerfileContextSet,
 				nFlag:           2,
 
 				fs:    &afero.Afero{Fs: afero.NewMemMapFs()},

--- a/internal/pkg/cli/task_run_test.go
+++ b/internal/pkg/cli/task_run_test.go
@@ -216,7 +216,7 @@ func TestTaskRunOpts_Validate(t *testing.T) {
 			inImage:         "113459295.dkr.ecr.ap-northeast-1.amazonaws.com/my-app",
 			isDockerfileContextSet: true,
 
-			wantedError: errors.New("cannot specify both `--image` and `--context`"),
+			wantedError: errors.New("cannot specify both `--image` and `--build-context`"),
 		},
 		"both dockerfile and image name specified": {
 			basicOpts: defaultOpts,

--- a/internal/pkg/cli/task_run_test.go
+++ b/internal/pkg/cli/task_run_test.go
@@ -232,7 +232,14 @@ func TestTaskRunOpts_Validate(t *testing.T) {
 			inDockerfilePath: "world/hello/Dockerfile",
 			isDockerfileSet:  true,
 
-			wantedError: errors.New("open world/hello/Dockerfile: file does not exist"),
+			wantedError: errors.New("invalid `--dockerfile` path: open world/hello/Dockerfile: file does not exist"),
+		},
+		"invalid build context path": {
+			basicOpts: defaultOpts,
+
+			inDockerfileContextPath: "world/hello/Dockerfile",
+
+			wantedError: errors.New("invalid `--build-context` path: open world/hello/Dockerfile: file does not exist"),
 		},
 		"specified app exists": {
 			basicOpts: defaultOpts,


### PR DESCRIPTION
this optional flag allows the user to provide the docker context path

if not provided, it fallbacks to the previous behaveior so this change
is transparently retro compatible, it takes the context from the
Dockerfile directory.

Addresses #3044

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
