### PR TITLE
chore: add time description for fixed schedules on `job init`

### DIFF
--- a/internal/pkg/term/selector/mocks/mock_selector.go
+++ b/internal/pkg/term/selector/mocks/mock_selector.go
@@ -119,6 +119,26 @@ func (mr *MockPrompterMockRecorder) SelectOne(message, help, options interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelectOne", reflect.TypeOf((*MockPrompter)(nil).SelectOne), varargs...)
 }
 
+// SelectOption mocks base method.
+func (m *MockPrompter) SelectOption(message, help string, opts []prompt.Option, promptCfgs ...prompt.PromptConfig) (string, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{message, help, opts}
+	for _, a := range promptCfgs {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "SelectOption", varargs...)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SelectOption indicates an expected call of SelectOption.
+func (mr *MockPrompterMockRecorder) SelectOption(message, help, opts interface{}, promptCfgs ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{message, help, opts}, promptCfgs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelectOption", reflect.TypeOf((*MockPrompter)(nil).SelectOption), varargs...)
+}
+
 // MockAppEnvLister is a mock of AppEnvLister interface.
 type MockAppEnvLister struct {
 	ctrl     *gomock.Controller

--- a/internal/pkg/term/selector/selector.go
+++ b/internal/pkg/term/selector/selector.go
@@ -80,12 +80,12 @@ var scheduleTypes = []string{
 }
 
 var presetSchedules = []prompt.Option{
-	{custom, ""},
-	{hourly, "At minute 0"},
-	{daily, "At midnight UTC"},
-	{weekly, "At midnight on Sunday UTC"},
-	{monthly, "At midnight, first day of month UTC"},
-	{yearly, "At midnight, Jan 1st UTC"},
+	{Value: custom, Hint: ""},
+	{Value: hourly, Hint: "At minute 0"},
+	{Value: daily, Hint: "At midnight UTC"},
+	{Value: weekly, Hint: "At midnight on Sunday UTC"},
+	{Value: monthly, Hint: "At midnight, first day of month UTC"},
+	{Value: yearly, Hint: "At midnight, Jan 1st UTC"},
 }
 
 // Prompter wraps the methods to ask for inputs from the terminal.

--- a/internal/pkg/term/selector/selector.go
+++ b/internal/pkg/term/selector/selector.go
@@ -79,19 +79,20 @@ var scheduleTypes = []string{
 	fixedSchedule,
 }
 
-var presetSchedules = []string{
-	custom,
-	hourly,
-	daily,
-	weekly,
-	monthly,
-	yearly,
+var presetSchedules = []prompt.Option{
+	{custom, ""},
+	{hourly, "At minute 0"},
+	{daily, "At midnight UTC"},
+	{weekly, "At midnight on Sunday UTC"},
+	{monthly, "At midnight, first day of month UTC"},
+	{yearly, "At midnight, Jan 1st UTC"},
 }
 
 // Prompter wraps the methods to ask for inputs from the terminal.
 type Prompter interface {
 	Get(message, help string, validator prompt.ValidatorFunc, promptOpts ...prompt.PromptConfig) (string, error)
 	SelectOne(message, help string, options []string, promptOpts ...prompt.PromptConfig) (string, error)
+	SelectOption(message, help string, opts []prompt.Option, promptCfgs ...prompt.PromptConfig) (value string, err error)
 	MultiSelect(message, help string, options []string, promptOpts ...prompt.PromptConfig) ([]string, error)
 	Confirm(message, help string, promptOpts ...prompt.PromptConfig) (bool, error)
 }
@@ -951,7 +952,7 @@ func (s *WorkspaceSelect) askRate(rateValidator prompt.ValidatorFunc) (string, e
 }
 
 func (s *WorkspaceSelect) askCron(scheduleValidator prompt.ValidatorFunc) (string, error) {
-	cronInput, err := s.prompt.SelectOne(
+	cronInput, err := s.prompt.SelectOption(
 		schedulePrompt,
 		scheduleHelp,
 		presetSchedules,

--- a/internal/pkg/term/selector/selector_test.go
+++ b/internal/pkg/term/selector/selector_test.go
@@ -2009,7 +2009,7 @@ func TestWorkspaceSelect_Schedule(t *testing.T) {
 			mockPrompt: func(m *mocks.MockPrompter) {
 				gomock.InOrder(
 					m.EXPECT().SelectOne(scheduleTypePrompt, scheduleTypeHelp, scheduleTypes, gomock.Any()).Return(fixedSchedule, nil),
-					m.EXPECT().SelectOne(schedulePrompt, scheduleHelp, presetSchedules, gomock.Any()).Return("Daily", nil),
+					m.EXPECT().SelectOption(schedulePrompt, scheduleHelp, presetSchedules, gomock.Any()).Return("Daily", nil),
 				)
 			},
 			wantedSchedule: "@daily",
@@ -2018,7 +2018,7 @@ func TestWorkspaceSelect_Schedule(t *testing.T) {
 			mockPrompt: func(m *mocks.MockPrompter) {
 				gomock.InOrder(
 					m.EXPECT().SelectOne(scheduleTypePrompt, scheduleTypeHelp, scheduleTypes, gomock.Any()).Return(fixedSchedule, nil),
-					m.EXPECT().SelectOne(schedulePrompt, scheduleHelp, presetSchedules, gomock.Any()).Return("", errors.New("some error")),
+					m.EXPECT().SelectOption(schedulePrompt, scheduleHelp, presetSchedules, gomock.Any()).Return("", errors.New("some error")),
 				)
 			},
 			wantedErr: errors.New("get preset schedule: some error"),
@@ -2027,7 +2027,7 @@ func TestWorkspaceSelect_Schedule(t *testing.T) {
 			mockPrompt: func(m *mocks.MockPrompter) {
 				gomock.InOrder(
 					m.EXPECT().SelectOne(scheduleTypePrompt, scheduleTypeHelp, scheduleTypes, gomock.Any()).Return(fixedSchedule, nil),
-					m.EXPECT().SelectOne(schedulePrompt, scheduleHelp, presetSchedules, gomock.Any()).Return("Custom", nil),
+					m.EXPECT().SelectOption(schedulePrompt, scheduleHelp, presetSchedules, gomock.Any()).Return("Custom", nil),
 					m.EXPECT().Get(customSchedulePrompt, customScheduleHelp, gomock.Any(), gomock.Any()).Return("0 * * * *", nil),
 					m.EXPECT().Confirm(humanReadableCronConfirmPrompt, humanReadableCronConfirmHelp).Return(true, nil),
 				)
@@ -2038,7 +2038,7 @@ func TestWorkspaceSelect_Schedule(t *testing.T) {
 			mockPrompt: func(m *mocks.MockPrompter) {
 				gomock.InOrder(
 					m.EXPECT().SelectOne(scheduleTypePrompt, scheduleTypeHelp, scheduleTypes, gomock.Any()).Return(fixedSchedule, nil),
-					m.EXPECT().SelectOne(schedulePrompt, scheduleHelp, presetSchedules, gomock.Any()).Return("Custom", nil),
+					m.EXPECT().SelectOption(schedulePrompt, scheduleHelp, presetSchedules, gomock.Any()).Return("Custom", nil),
 					m.EXPECT().Get(customSchedulePrompt, customScheduleHelp, gomock.Any(), gomock.Any()).Return("", errors.New("some error")),
 				)
 			},
@@ -2048,7 +2048,7 @@ func TestWorkspaceSelect_Schedule(t *testing.T) {
 			mockPrompt: func(m *mocks.MockPrompter) {
 				gomock.InOrder(
 					m.EXPECT().SelectOne(scheduleTypePrompt, scheduleTypeHelp, scheduleTypes, gomock.Any()).Return(fixedSchedule, nil),
-					m.EXPECT().SelectOne(schedulePrompt, scheduleHelp, presetSchedules, gomock.Any()).Return("Custom", nil),
+					m.EXPECT().SelectOption(schedulePrompt, scheduleHelp, presetSchedules, gomock.Any()).Return("Custom", nil),
 					m.EXPECT().Get(customSchedulePrompt, customScheduleHelp, gomock.Any(), gomock.Any()).Return("0 * * * *", nil),
 					m.EXPECT().Confirm(humanReadableCronConfirmPrompt, humanReadableCronConfirmHelp).Return(false, errors.New("some error")),
 				)
@@ -2059,7 +2059,7 @@ func TestWorkspaceSelect_Schedule(t *testing.T) {
 			mockPrompt: func(m *mocks.MockPrompter) {
 				gomock.InOrder(
 					m.EXPECT().SelectOne(scheduleTypePrompt, scheduleTypeHelp, scheduleTypes, gomock.Any()).Return(fixedSchedule, nil),
-					m.EXPECT().SelectOne(schedulePrompt, scheduleHelp, presetSchedules, gomock.Any()).Return("Custom", nil),
+					m.EXPECT().SelectOption(schedulePrompt, scheduleHelp, presetSchedules, gomock.Any()).Return("Custom", nil),
 					m.EXPECT().Get(customSchedulePrompt, customScheduleHelp, gomock.Any(), gomock.Any()).Return("@hourly", nil),
 				)
 			},


### PR DESCRIPTION
Related #3042

![job-init-schedules](https://user-images.githubusercontent.com/879348/142322212-811fb360-8863-43f2-9040-9665a89212ec.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
