### PR TITLE
docs: missing "profile" in ~/.aws/config profile

### DIFF
--- a/site/content/docs/credentials.en.md
+++ b/site/content/docs/credentials.en.md
@@ -24,7 +24,7 @@ Alternatively, you can set the `AWS_PROFILE` environment variable to point to a 
 
 ```ini
 # ~/.aws/config
-[my-app]
+[profile my-app]
 credential_process = /opt/bin/awscreds-custom --username helen
 region=us-west-2
 

--- a/site/content/docs/credentials.ja.md
+++ b/site/content/docs/credentials.ja.md
@@ -28,7 +28,7 @@ region=us-west-2
 
 ```ini
 # ~/.aws/config
-[my-app]
+[profile my-app]
 credential_process = /opt/bin/awscreds-custom --username helen
 region=us-west-2
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
To define a profile in the `~/.aws/config` file, it need to be `[profile <profile name>]`.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
