### PR TITLE
chore(custom-resource): extend alias to app-level and domain-level for NLB

### DIFF
--- a/cf-custom-resources/lib/nlb-cert-validator-updater.js
+++ b/cf-custom-resources/lib/nlb-cert-validator-updater.js
@@ -85,7 +85,7 @@ const rootHostedZoneIDContext = () => {
     };
 }
 
-let hostecZoneID = {
+let hostedZoneID = {
     app: appHostedZoneIDContext(),
     root: rootHostedZoneIDContext(),
 }
@@ -239,11 +239,13 @@ async function validateAliases(aliases, loadBalancerDNS) {
             if (!recordSet || recordSet.length === 0) {
                 return;
             }
+            if (recordSet[0].Name !== alias) {
+                return;
+            }
             let aliasTarget = recordSet[0].AliasTarget;
             if (aliasTarget && aliasTarget.DNSName === `${loadBalancerDNS}.`) {
                 return; // The record is an alias record and is in use by myself, hence valid.
             }
-
             if (aliasTarget) {
                 throw new Error(`Alias ${alias} is already in use by ${aliasTarget.DNSName}. This could be another load balancer of a different service.`);
             }
@@ -432,14 +434,14 @@ async function domainResources (alias) {
         return {
             domain: domainTypes.AppDomainZone.domain,
             route53Client: clients.app.route53(),
-            hostedZoneID: await hostecZoneID.app(),
+            hostedZoneID: await hostedZoneID.app(),
         };
     }
     if (domainTypes.RootDomainZone.regex.test(alias)) {
         return {
             domain: domainTypes.RootDomainZone.domain,
             route53Client: clients.root.route53(),
-            hostedZoneID: await hostecZoneID.root(),
+            hostedZoneID: await hostedZoneID.root(),
         };
     }
     throw new Error(`unrecognized domain type for ${alias}`);

--- a/cf-custom-resources/lib/nlb-cert-validator-updater.js
+++ b/cf-custom-resources/lib/nlb-cert-validator-updater.js
@@ -83,7 +83,6 @@ exports.handler = async function (event, context) {
     const props = event.ResourceProperties;
     let {LoadBalancerDNS: loadBalancerDNS,
         LoadBalancerHostedZoneID: loadBalancerHostedZoneID,
-        DomainName: domainName,
     } = props;
     const aliases = new Set(props.Aliases);
 
@@ -91,7 +90,6 @@ exports.handler = async function (event, context) {
     envHostedZoneID = props.EnvHostedZoneId;
     envName = props.EnvName;
     appName = props.AppName;
-
     serviceName = props.ServiceName;
     domainName = props.DomainName;
     rootDNSRole = props.RootDNSRole;
@@ -338,23 +336,22 @@ function loadResources() {
         envRoute53 = new AWS.Route53();
     }
 
-    if (!domainTypes) {
-        domainTypes = {
-            EnvDomainZone: {
-                regex: new RegExp(`^([^\.]+\.)?${envName}.${appName}.${domainName}`),
-                domain: `${envName}.${appName}.${domainName}`,
-            },
-            AppDomainZone: {
-                regex: new RegExp(`^([^\.]+\.)?${appName}.${domainName}`),
-                domain: `${appName}.${domainName}`,
-            },
-            RootDomainZone: {
-                regex: new RegExp(`^([^\.]+\.)?${domainName}`),
-                domain: `${domainName}`,
-            },
-            OtherDomainZone: {},
-        };
-    }
+    domainTypes = {
+        EnvDomainZone: {
+            regex: new RegExp(`^([^\.]+\.)?${envName}.${appName}.${domainName}`),
+            domain: `${envName}.${appName}.${domainName}`,
+        },
+        AppDomainZone: {
+            regex: new RegExp(`^([^\.]+\.)?${appName}.${domainName}`),
+            domain: `${appName}.${domainName}`,
+        },
+        RootDomainZone: {
+            regex: new RegExp(`^([^\.]+\.)?${domainName}`),
+            domain: `${domainName}`,
+        },
+        OtherDomainZone: {},
+    };
+
 }
 
 /**
@@ -394,8 +391,7 @@ async function hostedZoneID(domain) {
         .listHostedZonesByName({
             DNSName: domain,
             MaxItems: "1",
-        })
-        .promise();
+        }).promise();
     if (!HostedZones || HostedZones.length === 0) {
         throw new Error( `Couldn't find any Hosted Zone with DNS name ${domainName}.`);
     }

--- a/cf-custom-resources/lib/nlb-cert-validator-updater.js
+++ b/cf-custom-resources/lib/nlb-cert-validator-updater.js
@@ -349,7 +349,6 @@ function loadResources() {
             regex: new RegExp(`^([^\.]+\.)?${domainName}`),
             domain: `${domainName}`,
         },
-        OtherDomainZone: {},
     };
 
 }

--- a/cf-custom-resources/test/nlb-cert-validator-updater-test.js
+++ b/cf-custom-resources/test/nlb-cert-validator-updater-test.js
@@ -248,7 +248,8 @@ describe("DNS Certificate Validation And Custom Domains for NLB", () => {
                 "ResourceRecordSets": [{
                     "AliasTarget": {
                         "DNSName": "other-lb-DNS",
-                    }
+                    },
+                    Name: "dash-test.mockDomain.com",
                 }]
             });
             AWS.mock("Route53", "listHostedZonesByName", mockListHostedZonesByName);


### PR DESCRIPTION
The previous PR #3057 takes into consideration only the case where the aliases are environment-level (e.g. `a.env.app.domain.com`); however, they could also be app-level (e.g. `a.app.domain.com`) or root-level (e.g. `a.domain.com`). This PR extends the cases considered as such.

In addition, the PR adds lazy-loading into the script.

Previous PR: #3057 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
