### PR TITLE
chore(pipeline): exit build stage if manifest validation failed

### DIFF
--- a/internal/pkg/template/templates/cicd/buildspec.yml
+++ b/internal/pkg/template/templates/cicd/buildspec.yml
@@ -51,23 +51,21 @@ phases:
       # The tag is the build ID but we replaced the colon ':' with a dash '-'.
       # We truncate the tag (from the front) to 128 characters, the limit for Docker tags
       # (https://docs.docker.com/engine/reference/commandline/tag/)
-      # Check if the params file is empty. If so, echo error msg and exit.
+      # Check if the `svc package` commanded exited with a non-zero status. If so, echo error msg and exit.
       - >
         for env in $pl_envs; do
           tag=$(sed 's/:/-/g' <<<"${CODEBUILD_BUILD_ID##*:}-${env}" | rev | cut -c 1-128 | rev)
           for svc in $svcs; do
           ./copilot-linux svc package -n $svc -e $env --output-dir './infrastructure' --tag $tag;
-          [ -s ./infrastructure/$svc-$env.params.json ]
           if [ $? -ne 0 ]; then
-            echo "Cloudformation stack and config files were not generated. Please check build logs for a manifest validation error message." 1>&2;
+            echo "Cloudformation stack and config files were not generated. Please check build logs to see if there was a manifest validation error." 1>&2;
             exit 1;
           fi
           done;
           for job in $jobs; do
           ./copilot-linux job package -n $job -e $env --output-dir './infrastructure' --tag $tag;
-          [ -s ./infrastructure/$job-$env.params.json ]
           if [ $? -ne 0 ]; then
-            echo "Cloudformation stack and config files were not generated. Please check build logs for a manifest validation error message." 1>&2;
+            echo "Cloudformation stack and config files were not generated. Please check build logs to see if there was a manifest validation error." 1>&2;
             exit 1;
           fi
           done;

--- a/internal/pkg/template/templates/cicd/buildspec.yml
+++ b/internal/pkg/template/templates/cicd/buildspec.yml
@@ -56,9 +56,21 @@ phases:
           tag=$(sed 's/:/-/g' <<<"${CODEBUILD_BUILD_ID##*:}-${env}" | rev | cut -c 1-128 | rev)
           for svc in $svcs; do
           ./copilot-linux svc package -n $svc -e $env --output-dir './infrastructure' --tag $tag;
+      # Check if the params file is empty. If so, echo error msg and exit.
+          [ -s ./infrastructure/$svc-$env.params.json ]
+          if [ $? -ne 0 ]; then
+            echo "Cloudformation stack and config files were not generated. Please check build logs for a manifest validation error message." 1>&2;
+            exit 1;
+          fi
           done;
           for job in $jobs; do
           ./copilot-linux job package -n $job -e $env --output-dir './infrastructure' --tag $tag;
+        # Check if the params file is empty. If so, echo error msg and exit.
+          [ -s ./infrastructure/$job-$env.params.json ]
+          if [ $? -ne 0 ]; then
+            echo "Cloudformation stack and config files were not generated. Please check build logs for a manifest validation error message." 1>&2;
+            exit 1;
+          fi
           done;
         done;
       - ls -lah ./infrastructure

--- a/internal/pkg/template/templates/cicd/buildspec.yml
+++ b/internal/pkg/template/templates/cicd/buildspec.yml
@@ -51,12 +51,12 @@ phases:
       # The tag is the build ID but we replaced the colon ':' with a dash '-'.
       # We truncate the tag (from the front) to 128 characters, the limit for Docker tags
       # (https://docs.docker.com/engine/reference/commandline/tag/)
+      # Check if the params file is empty. If so, echo error msg and exit.
       - >
         for env in $pl_envs; do
           tag=$(sed 's/:/-/g' <<<"${CODEBUILD_BUILD_ID##*:}-${env}" | rev | cut -c 1-128 | rev)
           for svc in $svcs; do
           ./copilot-linux svc package -n $svc -e $env --output-dir './infrastructure' --tag $tag;
-      # Check if the params file is empty. If so, echo error msg and exit.
           [ -s ./infrastructure/$svc-$env.params.json ]
           if [ $? -ne 0 ]; then
             echo "Cloudformation stack and config files were not generated. Please check build logs for a manifest validation error message." 1>&2;
@@ -65,7 +65,6 @@ phases:
           done;
           for job in $jobs; do
           ./copilot-linux job package -n $job -e $env --output-dir './infrastructure' --tag $tag;
-        # Check if the params file is empty. If so, echo error msg and exit.
           [ -s ./infrastructure/$job-$env.params.json ]
           if [ $? -ne 0 ]; then
             echo "Cloudformation stack and config files were not generated. Please check build logs for a manifest validation error message." 1>&2;


### PR DESCRIPTION
Fixes #3072.

If a workload manifest fails, the pipeline build stage will fail, too, but only after many more steps, logs, and time. The validation error gets buried, and it isn't obvious that it's the cause of the failure.

This change checks if the `params.json` file that would be generated upon successful manifest validation is empty; if it is, the build exits with a suggestion to look for a manifest validation error message. There are, of course, still logs to wade through, but this should make the point of failure easier to pinpoint.

Manually tested with invalid service manifest (ARM + Spot), valid service manifest, invalid job manifest (bad platform), valid job manifest.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
