### PR TITLE
chore: replace error with a friendly warning if domain is not explicitly owned

### DIFF
--- a/internal/pkg/cli/app_init.go
+++ b/internal/pkg/cli/app_init.go
@@ -239,12 +239,14 @@ func (o *initAppOpts) isDomainOwned() error {
 	}
 	var errDomainNotFound *route53.ErrDomainNotFound
 	if errors.As(err, &errDomainNotFound) {
-		log.Errorf(`The account does not seem to own the domain that you entered.
-Please make sure that %s is registered with Route53 in your account.
+		log.Warningf(`The account does not seem to own the domain that you entered.
+Please make sure that %s is registered with Route53 in your account, or that your hosted zone has the appropriate NS records.
 To transfer domain registration in Route53, see:
 https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/domain-transfer-to-route-53.html
-`, color.HighlightUserInput(o.domainName))
-		return errDomainNotFound
+To update the NS records in your hosted zone, see:
+https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/SOA-NSrecords.html#NSrecords
+`, o.domainName)
+		return nil
 	}
 	return fmt.Errorf("check if domain is owned by the account: %w", err)
 }

--- a/internal/pkg/cli/app_init_test.go
+++ b/internal/pkg/cli/app_init_test.go
@@ -114,13 +114,6 @@ func TestInitAppOpts_Validate(t *testing.T) {
 				m.mockDomainInfoGetter.EXPECT().IsDomainOwned("mockDomain.com").Return(nil)
 			},
 		},
-		"invalid domain that is not found in the account": {
-			inDomainName: "badMockDomain.com",
-			mock: func(m *initAppMocks) {
-				m.mockDomainInfoGetter.EXPECT().IsDomainOwned("badMockDomain.com").Return(&route53.ErrDomainNotFound{})
-			},
-			wantedError: &route53.ErrDomainNotFound{},
-		},
 		"valid domain name containing multiple dots": {
 			inDomainName: "hello.dog.com",
 			mock: func(m *initAppMocks) {


### PR DESCRIPTION
Instead of error-ing out, Copilot displays a friendly warning with purposed solution if the domain is not explicitly owned.

Sometimes the user put a subdomain for `--domain` flag, and they does own the top-level domain. In this case, the domain may not be explicitly owned by the account, but things should work as long as there is an appropriate NS record delegating the subdomain to the current account.

When the domain is indeed registered outside of Route53, they do need to transfer the domain to Route53 - otherwise later operations would require some manual intervention for the domain to work.

Either way, it's okay if they fix the problem after the application is created and registered with the domain. This way they don't have to tear down the app, fix the problem, and create the app again.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
