### PR TITLE
chore: do not error out if TLD isn't supported by Route53

### DIFF
--- a/internal/pkg/aws/route53/domain.go
+++ b/internal/pkg/aws/route53/domain.go
@@ -30,8 +30,8 @@ func NewRoute53Domains(s *session.Session) *Route53Domains {
 	}
 }
 
-// IsDomainRegisteredInRoute53 checks if the domain is owned by the account.
-func (r *Route53Domains) IsDomainRegisteredInRoute53(domainName string) error {
+// IsRegisteredDomain checks if the domain is owned by the account.
+func (r *Route53Domains) IsRegisteredDomain(domainName string) error {
 	_, err := r.client.GetDomainDetail(&route53domains.GetDomainDetailInput{
 		DomainName: aws.String(domainName),
 	})
@@ -41,13 +41,13 @@ func (r *Route53Domains) IsDomainRegisteredInRoute53(domainName string) error {
 	var errUnsupportedTLD *route53domains.UnsupportedTLD
 	if errors.As(err, &errUnsupportedTLD) {
 		// The TLD isn't supported by Route53, hence it can't have been registered witH Route53.
-		return &ErrDomainNotFoundInRoute53{
+		return &ErrDomainNotFound{
 			domainName: domainName,
 		}
 	}
 	var errInvalidInput *route53domains.InvalidInput
 	if errors.As(err, &errInvalidInput) && strings.Contains(err.Error(), fmt.Sprintf("Domain %s not found", domainName)) {
-		return &ErrDomainNotFoundInRoute53{
+		return &ErrDomainNotFound{
 			domainName: domainName,
 		}
 	}

--- a/internal/pkg/aws/route53/domain.go
+++ b/internal/pkg/aws/route53/domain.go
@@ -40,7 +40,7 @@ func (r *Route53Domains) IsRegisteredDomain(domainName string) error {
 	}
 	var errUnsupportedTLD *route53domains.UnsupportedTLD
 	if errors.As(err, &errUnsupportedTLD) {
-		// The TLD isn't supported by Route53, hence it can't have been registered witH Route53.
+		// The TLD isn't supported by Route53, hence it can't have been registered with Route53.
 		return &ErrDomainNotFound{
 			domainName: domainName,
 		}

--- a/internal/pkg/aws/route53/domain.go
+++ b/internal/pkg/aws/route53/domain.go
@@ -30,22 +30,26 @@ func NewRoute53Domains(s *session.Session) *Route53Domains {
 	}
 }
 
-// IsDomainOwned checks if the domain is owned by the account.
-func (r *Route53Domains) IsDomainOwned(domainName string) error {
+// IsDomainRegisteredInRoute53 checks if the domain is owned by the account.
+func (r *Route53Domains) IsDomainRegisteredInRoute53(domainName string) error {
 	_, err := r.client.GetDomainDetail(&route53domains.GetDomainDetailInput{
 		DomainName: aws.String(domainName),
 	})
 	if err == nil {
 		return nil
 	}
+	var errUnsupportedTLD *route53domains.UnsupportedTLD
+	if errors.As(err, &errUnsupportedTLD) {
+		// The TLD isn't supported by Route53, hence it can't have been registered witH Route53.
+		return &ErrDomainNotFoundInRoute53{
+			domainName: domainName,
+		}
+	}
 	var errInvalidInput *route53domains.InvalidInput
-	if !errors.As(err, &errInvalidInput) {
-		return fmt.Errorf("get domain detail: %w", err)
+	if errors.As(err, &errInvalidInput) && strings.Contains(err.Error(), fmt.Sprintf("Domain %s not found", domainName)) {
+		return &ErrDomainNotFoundInRoute53{
+			domainName: domainName,
+		}
 	}
-	if !strings.Contains(err.Error(), fmt.Sprintf("Domain %s not found", domainName)) {
-		return fmt.Errorf("get domain detail: %w", err)
-	}
-	return &ErrDomainNotFound{
-		domainName: domainName,
-	}
+	return fmt.Errorf("get domain detail: %w", err)
 }

--- a/internal/pkg/aws/route53/domain_test.go
+++ b/internal/pkg/aws/route53/domain_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/aws/route53/mocks"
 )
 
-func TestRoute53_IsDomainRegisteredInRoute53(t *testing.T) {
+func TestRoute53_IsRegisteredDomain(t *testing.T) {
 
 	testCases := map[string]struct {
 		domainName        string
@@ -84,7 +84,7 @@ func TestRoute53_IsDomainRegisteredInRoute53(t *testing.T) {
 			client := Route53Domains{
 				client: mockRoute53Client,
 			}
-			gotErr := client.IsDomainRegisteredInRoute53(tc.domainName)
+			gotErr := client.IsRegisteredDomain(tc.domainName)
 
 			if tc.wantErr != nil {
 				require.NotNil(t, gotErr)

--- a/internal/pkg/aws/route53/errors.go
+++ b/internal/pkg/aws/route53/errors.go
@@ -16,11 +16,11 @@ func (e *ErrDomainHostedZoneNotFound) Error() string {
 	return fmt.Sprintf("hosted zone is not found for domain %s", e.domainName)
 }
 
-// ErrDomainNotFoundInRoute53 occurs when the domain is not found in the account.
-type ErrDomainNotFoundInRoute53 struct {
+// ErrDomainNotFound occurs when the domain is not found in the account.
+type ErrDomainNotFound struct {
 	domainName string
 }
 
-func (e *ErrDomainNotFoundInRoute53) Error() string {
+func (e *ErrDomainNotFound) Error() string {
 	return fmt.Sprintf("domain %s is not found in the account", e.domainName)
 }

--- a/internal/pkg/aws/route53/errors.go
+++ b/internal/pkg/aws/route53/errors.go
@@ -16,11 +16,11 @@ func (e *ErrDomainHostedZoneNotFound) Error() string {
 	return fmt.Sprintf("hosted zone is not found for domain %s", e.domainName)
 }
 
-// ErrDomainNotFound occurs when the domain is not found in the account.
-type ErrDomainNotFound struct {
+// ErrDomainNotFoundInRoute53 occurs when the domain is not found in the account.
+type ErrDomainNotFoundInRoute53 struct {
 	domainName string
 }
 
-func (e *ErrDomainNotFound) Error() string {
+func (e *ErrDomainNotFoundInRoute53) Error() string {
 	return fmt.Sprintf("domain %s is not found in the account", e.domainName)
 }

--- a/internal/pkg/cli/app_init.go
+++ b/internal/pkg/cli/app_init.go
@@ -233,11 +233,11 @@ func (o *initAppOpts) validateAppName(name string) error {
 }
 
 func (o *initAppOpts) isDomainOwned() error {
-	err := o.domainInfoGetter.IsDomainOwned(o.domainName)
+	err := o.domainInfoGetter.IsDomainRegisteredInRoute53(o.domainName)
 	if err == nil {
 		return nil
 	}
-	var errDomainNotFound *route53.ErrDomainNotFound
+	var errDomainNotFound *route53.ErrDomainNotFoundInRoute53
 	if errors.As(err, &errDomainNotFound) {
 		log.Warningf(`The account does not seem to own the domain that you entered.
 Please make sure that %s is registered with Route53 in your account, or that your hosted zone has the appropriate NS records.

--- a/internal/pkg/cli/app_init.go
+++ b/internal/pkg/cli/app_init.go
@@ -233,11 +233,11 @@ func (o *initAppOpts) validateAppName(name string) error {
 }
 
 func (o *initAppOpts) isDomainOwned() error {
-	err := o.domainInfoGetter.IsDomainRegisteredInRoute53(o.domainName)
+	err := o.domainInfoGetter.IsRegisteredDomain(o.domainName)
 	if err == nil {
 		return nil
 	}
-	var errDomainNotFound *route53.ErrDomainNotFoundInRoute53
+	var errDomainNotFound *route53.ErrDomainNotFound
 	if errors.As(err, &errDomainNotFound) {
 		log.Warningf(`The account does not seem to own the domain that you entered.
 Please make sure that %s is registered with Route53 in your account, or that your hosted zone has the appropriate NS records.

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -406,7 +406,7 @@ type domainHostedZoneGetter interface {
 }
 
 type domainInfoGetter interface {
-	IsDomainOwned(domainName string) error
+	IsDomainRegisteredInRoute53(domainName string) error
 }
 
 type dockerfileParser interface {

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -406,7 +406,7 @@ type domainHostedZoneGetter interface {
 }
 
 type domainInfoGetter interface {
-	IsDomainRegisteredInRoute53(domainName string) error
+	IsRegisteredDomain(domainName string) error
 }
 
 type dockerfileParser interface {

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -4273,9 +4273,9 @@ func (m *MockdomainInfoGetter) EXPECT() *MockdomainInfoGetterMockRecorder {
 }
 
 // IsDomainOwned mocks base method.
-func (m *MockdomainInfoGetter) IsDomainRegisteredInRoute53(domainName string) error {
+func (m *MockdomainInfoGetter) IsRegisteredDomain(domainName string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsDomainRegisteredInRoute53", domainName)
+	ret := m.ctrl.Call(m, "IsRegisteredDomain", domainName)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
@@ -4283,7 +4283,7 @@ func (m *MockdomainInfoGetter) IsDomainRegisteredInRoute53(domainName string) er
 // IsDomainOwned indicates an expected call of IsDomainOwned.
 func (mr *MockdomainInfoGetterMockRecorder) IsDomainOwned(domainName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsDomainRegisteredInRoute53", reflect.TypeOf((*MockdomainInfoGetter)(nil).IsDomainRegisteredInRoute53), domainName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsRegisteredDomain", reflect.TypeOf((*MockdomainInfoGetter)(nil).IsRegisteredDomain), domainName)
 }
 
 // MockdockerfileParser is a mock of dockerfileParser interface.

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -4273,9 +4273,9 @@ func (m *MockdomainInfoGetter) EXPECT() *MockdomainInfoGetterMockRecorder {
 }
 
 // IsDomainOwned mocks base method.
-func (m *MockdomainInfoGetter) IsDomainOwned(domainName string) error {
+func (m *MockdomainInfoGetter) IsDomainRegisteredInRoute53(domainName string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsDomainOwned", domainName)
+	ret := m.ctrl.Call(m, "IsDomainRegisteredInRoute53", domainName)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
@@ -4283,7 +4283,7 @@ func (m *MockdomainInfoGetter) IsDomainOwned(domainName string) error {
 // IsDomainOwned indicates an expected call of IsDomainOwned.
 func (mr *MockdomainInfoGetterMockRecorder) IsDomainOwned(domainName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsDomainOwned", reflect.TypeOf((*MockdomainInfoGetter)(nil).IsDomainOwned), domainName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsDomainRegisteredInRoute53", reflect.TypeOf((*MockdomainInfoGetter)(nil).IsDomainRegisteredInRoute53), domainName)
 }
 
 // MockdockerfileParser is a mock of dockerfileParser interface.


### PR DESCRIPTION
Since customer can bring their domain purchased outside of Route53, the TLD isn't necessarily supported by Route53. This skips the error.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
