### PR TITLE
feat: Show tasks exit codes when all tasks are stopped

### DIFF
--- a/internal/pkg/logging/task.go
+++ b/internal/pkg/logging/task.go
@@ -117,6 +117,14 @@ func (t *TaskClient) allTasksStopped() (bool, error) {
 		}
 	}
 	t.tasks = runningTasks
+
+	if stopped {
+		// Show all stopped tasks exit codes when all tasks are stopped
+		for _, tresp := range tasksResp {
+			// not sure why, but I 'm assuming there's a single container
+			log.Infoln(fmt.Sprintf("Task %s exitCode: %d", *tresp.TaskArn, *tresp.Containers[0].ExitCode))
+		}
+	}
 	return stopped, nil
 }
 


### PR DESCRIPTION
When running `task run --follow` it will now print out the `taskArn` along with the container's `exitCode`.

This maybe useful to get the `exitCode` as requested on #2525. One could `tee` the `task run --follow` command then `grep`/`awk` it to get the exit codes and make decisions with that info.

If it's too verbose for the regular case maybe we could add an option flag for this.

Maybe is not the best implementation but I thought it would be clearer to propose a change instead of trying to explain the change with comments on the issue. I 'm not pushing for you to merge it at all... I 'm kind of checking wether you think is a good enough workaround to be able to get the exit codes from copilot or not.

Please feel free to discard the PR if it's not aligned with what you envision for the tool.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
