### PR TITLE
chore(custom-resources): retrieve validation options that need to be deleted

### DIFF
--- a/cf-custom-resources/lib/nlb-cert-validator-updater.js
+++ b/cf-custom-resources/lib/nlb-cert-validator-updater.js
@@ -459,7 +459,7 @@ async function serviceCertificates() {
  * @param {Set<String>} aliases is the subject alternative names of the certificate(s) pending deletion.
  * @returns {Set<Object>} The options that will be unused by the service.
  */
-async function optionsUnusedByService(aliases) {
+async function unusedOptionsByService(aliases) {
     // NOTE: `Set` uses object reference to identify elements. That is, two options with the same value will not be
     // identify as the same option. Therefore, we use map with object string as keys to identify object with actual
     // values instead of object reference.

--- a/cf-custom-resources/lib/nlb-cert-validator-updater.js
+++ b/cf-custom-resources/lib/nlb-cert-validator-updater.js
@@ -468,7 +468,7 @@ async function optionsUnusedByService(aliases) {
 
     let certificates = await serviceCertificates();
     for (const {DomainName: domainName, SubjectAlternativeNames: sans, DomainValidationOptions: validationOptions} of certificates) {
-        if (domainName === certificateDomain && setEqual(aliases.add(certificateDomain), new Set(sans))) {
+        if (domainName === certificateDomain && setEqual(new Set(aliases).add(certificateDomain), new Set(sans))) {
             // This is a certificate pending deletion. It is:
             // 1. Copilot-tagged, 2. use the default certificate domain name, and 3. uses the SANs that need to be deleted.
             for (let option of validationOptions) {

--- a/cf-custom-resources/lib/nlb-cert-validator-updater.js
+++ b/cf-custom-resources/lib/nlb-cert-validator-updater.js
@@ -219,6 +219,8 @@ exports.handler = async function (event, context) {
             case "Update":
             case "Delete":
                 let unusedOptions = await unusedValidationOptions(aliases, loadBalancerDNS);
+                // await deleteCertificate(aliases);
+                // await deactivate(unusedOptions, loadBalancerDNS, loadBalancerHostedZoneID);
                 throw new Error(`The number of options to be deleted is: ${unusedOptions.size}`);
             default:
                 throw new Error(`Unsupported request type ${event.RequestType}`);

--- a/cf-custom-resources/lib/nlb-cert-validator-updater.js
+++ b/cf-custom-resources/lib/nlb-cert-validator-updater.js
@@ -499,12 +499,16 @@ async function unusedOptionsByService(certsPendingDeletion, certsInUse) {
     let optionsPendingDeletion = new Map();
     for (const { DomainValidationOptions: validationOptions } of certsPendingDeletion) {
         for (const option of validationOptions) {
-            optionsPendingDeletion.set(JSON.stringify(option), option);
+            if (option["ResourceRecord"]) {
+                optionsPendingDeletion.set(JSON.stringify(option["ResourceRecord"]), option);
+            }
         }
     }
     for (const { DomainValidationOptions: validationOptions } of certsInUse) {
         for (const option of validationOptions) {
-            optionsPendingDeletion.delete(JSON.stringify(option));
+            if (option["ResourceRecord"]) {
+                optionsPendingDeletion.delete(JSON.stringify(option["ResourceRecord"]));
+            }
         }
     }
     let options = new Set();

--- a/cf-custom-resources/lib/nlb-cert-validator-updater.js
+++ b/cf-custom-resources/lib/nlb-cert-validator-updater.js
@@ -443,7 +443,7 @@ async function serviceCertificates() {
     for (let {ResourceARN: arn} of ResourceTagMappingList) {
         let promise = clients.acm().describeCertificate({
             CertificateArn: arn
-        }).promise().then(( { Certificate} ) => {
+        }).promise().then(( { Certificate } ) => {
             cachedServiceCertificates.push(Certificate);
         });
         promises.push(promise);
@@ -499,7 +499,7 @@ async function unusedOptionsByService(aliases) {
  * @returns {Promise<Set<any>>}
  */
 async function unusedValidationOptions(aliases, loadBalancerDNS) {
-    let optionsPendingUnused = await optionsUnusedByService(aliases);
+    let optionsPendingUnused = await unusedOptionsByService(aliases);
     let promises = [];
     for (let option of optionsPendingUnused) {
         let domainName = option["DomainName"];

--- a/cf-custom-resources/lib/nlb-cert-validator-updater.js
+++ b/cf-custom-resources/lib/nlb-cert-validator-updater.js
@@ -293,7 +293,7 @@ async function requestCertificate({ aliases, idempotencyToken }) {
                 Value: serviceName,
             }
         ],
-        ValidationMethod: "DNS",
+        ValidationMethod: "DNS"
     }).promise();
     return CertificateArn;
 }

--- a/cf-custom-resources/lib/nlb-cert-validator-updater.js
+++ b/cf-custom-resources/lib/nlb-cert-validator-updater.js
@@ -218,8 +218,8 @@ exports.handler = async function (event, context) {
                 break;
             case "Update":
             case "Delete":
-                await unusedValidationOptions(aliases, loadBalancerDNS);
-                break;
+                let unusedOptions = await unusedValidationOptions(aliases, loadBalancerDNS);
+                throw new Error(`The number of options to be deleted is: ${unusedOptions.size}`);
             default:
                 throw new Error(`Unsupported request type ${event.RequestType}`);
         }

--- a/cf-custom-resources/test/nlb-cert-validator-updater-test.js
+++ b/cf-custom-resources/test/nlb-cert-validator-updater-test.js
@@ -479,15 +479,35 @@ describe("DNS Certificate Validation And Custom Domains for NLB", () => {
                     DomainName: `${mockServiceName}-nlb.${mockEnvName}.${mockAppName}.${mockDomainName}`,
                     SubjectAlternativeNames: ["usedByOtherService.mockEnv.mockApp.mockDomain.com", "usedByOtherCert.mockApp.mockDomain.com", "unused.mockDomain.com", "usedByNewCert.mockApp.mockDomain.com", `${mockServiceName}-nlb.${mockEnvName}.${mockAppName}.${mockDomainName}`],
                     DomainValidationOptions: [{
-                        DomainName: "unused.mockDomain.com"
+                        DomainName: "unused.mockDomain.com",
+                        ResourceRecord: {
+                            Name: "validate.unused.mockDomain.com",
+                            Type: "CNAME",
+                            Value: "validate.unused.mockDomain.com.v"
+                        },
                     },{
-                        DomainName: "usedByNewCert.mockApp.mockDomain.com"
+                        DomainName: "usedByNewCert.mockApp.mockDomain.com",
+                        ResourceRecord: {
+                            Name: "validate.usedByNewCert.mockApp.mockDomain.com",
+                            Type: "CNAME",
+                            Value: "validate.usedByNewCert.mockApp.mockDomain.com.v"
+                        },
                     },{
-                        DomainName: "usedByOtherService.mockEnv.mockApp.mockDomain.com"
+                        DomainName: "usedByOtherService.mockEnv.mockApp.mockDomain.com",
+                        ResourceRecord: {
+                            Name: "validate.usedByOtherService.mockEnv.mockApp.mockDomain.com",
+                            Type: "CNAME",
+                            Value: "validate.usedByOtherService.mockEnv.mockApp.mockDomain.com.v"
+                        }
                     },{
-                        DomainName: "usedByOtherCert.mockApp.mockDomain.com"
+                        DomainName: "usedByOtherCert.mockApp.mockDomain.com",
+                        ResourceRecord: {
+                            Name: "validate.usedByOtherCert.mockApp.mockDomain.com",
+                            Type: "CNAME",
+                            Value: "validate.usedByOtherCert.mockApp.mockDomain.com.v"
+                        }
                     },{
-                        DomainName: `${mockServiceName}-nlb.${mockEnvName}.${mockAppName}.${mockDomainName}`
+                        DomainName: `${mockServiceName}-nlb.${mockEnvName}.${mockAppName}.${mockDomainName}`,
                     }],
                 }
             });
@@ -496,11 +516,26 @@ describe("DNS Certificate Validation And Custom Domains for NLB", () => {
                     DomainName: `${mockServiceName}-nlb.${mockEnvName}.${mockAppName}.${mockDomainName}`,
                     SubjectAlternativeNames: ["usedByNewCert.mockApp.mockDomain.com", "other.mockDomain.com", `${mockServiceName}-nlb.${mockEnvName}.${mockAppName}.${mockDomainName}`],
                     DomainValidationOptions: [{
-                        DomainName: "usedByNewCert.mockApp.mockDomain.com"
+                        DomainName: "usedByNewCert.mockApp.mockDomain.com",
+                        ResourceRecord: {
+                            Name: "validate.usedByNewCert.mockApp.mockDomain.com",
+                            Type: "CNAME",
+                            Value: "validate.usedByNewCert.mockApp.mockDomain.com.v"
+                        },
                     },{
-                        DomainName: "other.mockDomain.com"
+                        DomainName: "other.mockDomain.com",
+                        ResourceRecord: {
+                            Name: "validate.other.mockDomain.com",
+                            Type: "CNAME",
+                            Value: "validate.other.mockDomain.com.v"
+                        },
                     },{
-                        DomainName: `${mockServiceName}-nlb.${mockEnvName}.${mockAppName}.${mockDomainName}`
+                        DomainName: `${mockServiceName}-nlb.${mockEnvName}.${mockAppName}.${mockDomainName}`,
+                        ResourceRecord: {
+                            Name: "validate.canonical.default.cert.domain",
+                            Type: "CNAME",
+                            Value: "validate.canonical.default.cert.domain.v"
+                        }
                     }],
                 }
             });
@@ -509,11 +544,26 @@ describe("DNS Certificate Validation And Custom Domains for NLB", () => {
                     DomainName: `some.domain.name.that.is.not.default.hence.not.created.by.copilot`,
                     SubjectAlternativeNames: ["usedByOtherCert.mockApp.mockDomain.com", "other.mockDomain.com", `some.domain.name.that.is.not.default.hence.not.created.by.copilot`],
                     DomainValidationOptions: [{
-                        DomainName: "usedByOtherCert.mockApp.mockDomain.com"
+                        DomainName: "usedByOtherCert.mockApp.mockDomain.com",
+                        ResourceRecord: {
+                            Name: "validate.usedByOtherCert.mockApp.mockDomain.com",
+                            Type: "CNAME",
+                            Value: "validate.usedByOtherCert.mockApp.mockDomain.com.v"
+                        }
                     },{
-                        DomainName: "other.mockDomain.com"
+                        DomainName: "other.mockDomain.com",
+                        ResourceRecord: {
+                            Name: "validate.other.mockDomain.com",
+                            Type: "CNAME",
+                            Value: "validate.other.mockDomain.com.v"
+                        },
                     },{
-                        DomainName: `${mockServiceName}-nlb.${mockEnvName}.${mockAppName}.${mockDomainName}`
+                        DomainName: "some.domain.name.that.is.not.default.hence.not.created.by.copilot",
+                        ResourceRecord: {
+                            Name: "validate.some.domain.name.that.is.not.default.hence.not.created.by.copilot",
+                            Type: "CNAME",
+                            Value: "validate.some.domain.name.that.is.not.default.hence.not.created.by.copilot.v"
+                        },
                     }],
                 }
             });

--- a/cf-custom-resources/test/nlb-cert-validator-updater-test.js
+++ b/cf-custom-resources/test/nlb-cert-validator-updater-test.js
@@ -477,7 +477,7 @@ describe("DNS Certificate Validation And Custom Domains for NLB", () => {
             mockDescribeCertificate.withArgs(sinon.match({ CertificateArn: "mockARNToDelete" })).resolves({
                 Certificate: {
                     DomainName: `${mockServiceName}-nlb.${mockEnvName}.${mockAppName}.${mockDomainName}`,
-                    SubjectAlternativeNames: ["usedByOtherService.mockEnv.mockApp.mockDomain.com", "usedByOtherCert.mockApp.mockDomain.com", "unused.mockDomain.com", "usedByNewCert.mockApp.mockDomain.com"],
+                    SubjectAlternativeNames: ["usedByOtherService.mockEnv.mockApp.mockDomain.com", "usedByOtherCert.mockApp.mockDomain.com", "unused.mockDomain.com", "usedByNewCert.mockApp.mockDomain.com", `${mockServiceName}-nlb.${mockEnvName}.${mockAppName}.${mockDomainName}`],
                     DomainValidationOptions: [{
                         DomainName: "unused.mockDomain.com"
                     },{
@@ -494,7 +494,7 @@ describe("DNS Certificate Validation And Custom Domains for NLB", () => {
             mockDescribeCertificate.withArgs(sinon.match({ CertificateArn: "mockARNInUse" })).resolves({
                 Certificate: {
                     DomainName: `${mockServiceName}-nlb.${mockEnvName}.${mockAppName}.${mockDomainName}`,
-                    SubjectAlternativeNames: ["usedByNewCert.mockApp.mockDomain.com", "other.mockDomain.com"],
+                    SubjectAlternativeNames: ["usedByNewCert.mockApp.mockDomain.com", "other.mockDomain.com", `${mockServiceName}-nlb.${mockEnvName}.${mockAppName}.${mockDomainName}`],
                     DomainValidationOptions: [{
                         DomainName: "usedByNewCert.mockApp.mockDomain.com"
                     },{
@@ -507,7 +507,7 @@ describe("DNS Certificate Validation And Custom Domains for NLB", () => {
             mockDescribeCertificate.withArgs(sinon.match({ CertificateArn: "mockARNInUse2" })).resolves({
                 Certificate: {
                     DomainName: `some.domain.name.that.is.not.default.hence.not.created.by.copilot`,
-                    SubjectAlternativeNames: ["usedByOtherCert.mockApp.mockDomain.com", "other.mockDomain.com"],
+                    SubjectAlternativeNames: ["usedByOtherCert.mockApp.mockDomain.com", "other.mockDomain.com", `some.domain.name.that.is.not.default.hence.not.created.by.copilot`],
                     DomainValidationOptions: [{
                         DomainName: "usedByOtherCert.mockApp.mockDomain.com"
                     },{


### PR DESCRIPTION
This PR:
1. Add skeleton for "Delete" action that deletes unused certificate and records 
2. Implement functions to determine which validation options need to be deleted

### What resources are being managed
The custom resource manages the certificate, the validation options, and the aliases. Upon "Delete" event, it needs to delete:
1. The certificate that is used by the service with the specified set of aliases;
2. The validation records that will be unused after deleting the certificate;
3. The A records.

Note that 1.[The certificate that is used by the service with the specified set of aliases] is determined by:
1. The canonical certificate domain name. Copilot only creates certificate using the name "svc-nlb.env.app.domain", so it also only deletes certificate with such name.
2. The tags. Copilot should only be able to delete certificate that's Copilot-tagged.
3. The SANs. If a "Delete" event is sent with a list of alias, that means the service doesn't need this specific combination of aliases anymore. The certificate used to validate this combination is no longer needed.

A certificate satisfying all three of these conditions should be safely deleted.

### Validation Options
After deleting the certificate, the validation options used to validate the certificate need to be cleaned up. However, we should make sure that the option being deleted is not used by other certificate, other service.

A validation option can be deleted only if:
1. The option's domain is one of the three Copilot recognized pattern: a.env.app.domain, a.app.domain, or a.domain. The hosted zones associated with these three patterns are Copilot-managed; by ensuring the domain follows one of these patterns, Copilot is only touching the records in the authorized hosted zones. 
2. Among all Copilot-tagged service certificate, it is used to validate only the certificate that is pending deletion. 
3. It is not currently in use by any other service.

Note that 1. and 2. are virtually the same requirement as indicated by the current ALB implementation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
