### PR TITLE
build(e2e): use --password-stdin flag for docker login

### DIFF
--- a/.release/buildspec_e2e.yml
+++ b/.release/buildspec_e2e.yml
@@ -140,7 +140,7 @@ phases:
       - 'goenv global 1.17.1'
   pre_build:
     commands:
-       - docker login -u ${DOCKERHUB_USERNAME} -p ${DOCKERHUB_TOKEN}
+       - printenv DOCKERHUB_TOKEN | docker login --username ${DOCKERHUB_USERNAME} --password-stdin
   build:
     commands:
        - cd $CODEBUILD_SRC_DIR


### PR DESCRIPTION


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
