### PR TITLE
chore: enable NLB, TLS termination, and NLB aliases

### DIFF
--- a/cf-custom-resources/lib/nlb-cert-manager.js
+++ b/cf-custom-resources/lib/nlb-cert-manager.js
@@ -652,7 +652,7 @@ async function inUseByOtherServices(loadBalancerDNS, domainName, route53Client) 
         ({hostedZoneID} = await domainResources(domainName));
     } catch (err) {
         if (err instanceof UnrecognizedDomainTypeError) {
-            console.log("Found ${domainName} in subject alternative names. " +
+            console.log(`Found ${domainName} in subject alternative names. ` +
 "It does not match any of these patterns: '.<env>.<app>.<domain>'， '.<app>.<domain>' or '.<domain>'. " +
 "This is unexpected. We don't error out as it may not cause any issue.");
             return true; // This option has unrecognized pattern, we can't check if it is in use, so we assume it is in use.

--- a/cf-custom-resources/lib/nlb-cert-validator-updater.js
+++ b/cf-custom-resources/lib/nlb-cert-validator-updater.js
@@ -652,9 +652,9 @@ async function inUseByOtherServices(loadBalancerDNS, domainName, route53Client) 
         ({hostedZoneID} = await domainResources(domainName));
     } catch (err) {
         if (err instanceof UnrecognizedDomainTypeError) {
-            console.log(`Found ${domainName} in subject alternative names. 
-It does not match any of these patterns: ".<env>.<app>.<domain>"， ".<app>.<domain>" or ".<domain>". 
-This is unexpected. We don't error out as it may not cause any issue.`);
+            console.log("Found ${domainName} in subject alternative names. " +
+"It does not match any of these patterns: '.<env>.<app>.<domain>'， '.<app>.<domain>' or '.<domain>'. " +
+"This is unexpected. We don't error out as it may not cause any issue.");
             return true; // This option has unrecognized pattern, we can't check if it is in use, so we assume it is in use.
         }
         throw err;

--- a/cf-custom-resources/test/nlb-cert-manager-test.js
+++ b/cf-custom-resources/test/nlb-cert-manager-test.js
@@ -8,7 +8,7 @@ const sinon = require("sinon");
 const nock = require("nock");
 let origLog = console.log;
 
-const { attemptsValidationOptionsReady } = require("../lib/nlb-cert-validator-updater");
+const { attemptsValidationOptionsReady } = require("../lib/nlb-cert-manager");
 
 describe("DNS Certificate Validation And Custom Domains for NLB", () => {
     // Mock requests.
@@ -44,7 +44,7 @@ describe("DNS Certificate Validation And Custom Domains for NLB", () => {
         // This workaround follows the comment here: https://github.com/dwyl/aws-sdk-mock/issues/206#issuecomment-640418772.
         jest.resetModules();
         AWS.setSDKInstance(require('aws-sdk'));
-        const imported = require("../lib/nlb-cert-validator-updater");
+        const imported = require("../lib/nlb-cert-manager");
         handler = imported.handler;
         reset = imported.reset;
         withDeadlineExpired = imported.withDeadlineExpired;

--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -626,7 +626,17 @@ func (o *deploySvcOpts) stackConfiguration() (cloudformation.StackConfiguration,
 				return nil, err
 			}
 			opts = append(opts, stack.WithHTTPS())
-			opts = append(opts, stack.WithDNSDelegation())
+
+			var caller identity.Caller
+			caller, err = o.identity.Get()
+			if err != nil {
+				return nil, fmt.Errorf("get identity: %w", err)
+			}
+			opts = append(opts, stack.WithDNSDelegation(deploy.AppInformation{
+				Name:                o.targetEnvironment.App,
+				DNSName:             o.targetApp.Domain,
+				AccountPrincipalARN: caller.RootUserARN,
+			}))
 		}
 		if !t.NLBConfig.IsEmpty() {
 			cidrBlocks, err := o.publicCIDRBlocks()

--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -606,7 +606,7 @@ func (o *deploySvcOpts) stackConfiguration() (cloudformation.StackConfiguration,
 	var conf cloudformation.StackConfiguration
 	switch t := mft.(type) {
 	case *manifest.LoadBalancedWebService:
-		if o.targetApp.Domain == "" && (!t.Alias.IsEmpty() || !t.NLBConfig.Aliases.IsEmpty()) {
+		if o.targetApp.Domain == "" && t.HasAliases() {
 			log.Errorf(aliasUsedWithoutDomainFriendlyText)
 			return nil, errors.New("alias specified when application is not associated with a domain")
 		}

--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -614,7 +614,7 @@ func (o *deploySvcOpts) stackConfiguration() (cloudformation.StackConfiguration,
 		var opts []stack.LoadBalancedWebServiceOption
 
 		// TODO: https://github.com/aws/copilot-cli/issues/2918
-		// 3. ALB block should not be executed if http is disabled
+		// 1. ALB block should not be executed if http is disabled
 		if o.targetApp.RequiresDNSDelegation() {
 			var appVersionGetter versionGetter
 			if appVersionGetter, err = o.newAppVersionGetter(o.appName); err != nil {

--- a/internal/pkg/cli/svc_deploy_test.go
+++ b/internal/pkg/cli/svc_deploy_test.go
@@ -47,6 +47,7 @@ type deploySvcMocks struct {
 	mockSubnetLister       *mocks.MockvpcSubnetLister
 	mockS3Svc              *mocks.Mockuploader
 	mockAddons             *mocks.Mocktemplater
+	mockIdentity           *mocks.MockidentityService
 }
 
 type mockWorkloadMft struct {
@@ -797,6 +798,9 @@ func TestSvcDeployOpts_deploySvc(t *testing.T) {
 				m.mockWs.EXPECT().ReadWorkloadManifest(mockSvcName).Return([]byte{}, nil)
 				m.mockInterpolator.EXPECT().Interpolate("").Return("", nil)
 				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
+				m.mockIdentity.EXPECT().Get().Return(identity.Caller{
+					RootUserARN: "1234",
+				}, nil)
 				m.mockServiceDeployer.EXPECT().DeployService(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("some error"))
 			},
 			wantErr: fmt.Errorf("deploy service: some error"),
@@ -814,6 +818,9 @@ func TestSvcDeployOpts_deploySvc(t *testing.T) {
 				m.mockWs.EXPECT().ReadWorkloadManifest(mockSvcName).Return([]byte{}, nil)
 				m.mockInterpolator.EXPECT().Interpolate("").Return("", nil)
 				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
+				m.mockIdentity.EXPECT().Get().Return(identity.Caller{
+					RootUserARN: "1234",
+				}, nil)
 				m.mockServiceDeployer.EXPECT().DeployService(gomock.Any(), gomock.Any(), gomock.Any()).Return(cloudformation.NewMockErrChangeSetEmpty())
 			},
 			wantErr: fmt.Errorf("deploy service: change set with name mockChangeSet for stack mockStack has no changes"),
@@ -832,6 +839,9 @@ func TestSvcDeployOpts_deploySvc(t *testing.T) {
 				m.mockWs.EXPECT().ReadWorkloadManifest(mockSvcName).Return([]byte{}, nil)
 				m.mockInterpolator.EXPECT().Interpolate("").Return("", nil)
 				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
+				m.mockIdentity.EXPECT().Get().Return(identity.Caller{
+					RootUserARN: "1234",
+				}, nil)
 				m.mockServiceDeployer.EXPECT().DeployService(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil)
 				m.mockServiceUpdater.EXPECT().LastUpdatedAt(mockAppName, mockEnvName, mockSvcName).
@@ -853,6 +863,9 @@ func TestSvcDeployOpts_deploySvc(t *testing.T) {
 				m.mockWs.EXPECT().ReadWorkloadManifest(mockSvcName).Return([]byte{}, nil)
 				m.mockInterpolator.EXPECT().Interpolate("").Return("", nil)
 				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
+				m.mockIdentity.EXPECT().Get().Return(identity.Caller{
+					RootUserARN: "1234",
+				}, nil)
 				m.mockServiceDeployer.EXPECT().DeployService(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil)
 				m.mockServiceUpdater.EXPECT().LastUpdatedAt(mockAppName, mockEnvName, mockSvcName).
@@ -877,6 +890,9 @@ func TestSvcDeployOpts_deploySvc(t *testing.T) {
 					Return(cloudformation.NewMockErrChangeSetEmpty())
 				m.mockServiceUpdater.EXPECT().LastUpdatedAt(mockAppName, mockEnvName, mockSvcName).
 					Return(mockBeforeTime, nil)
+				m.mockIdentity.EXPECT().Get().Return(identity.Caller{
+					RootUserARN: "1234",
+				}, nil)
 				m.mockSpinner.EXPECT().Start(fmt.Sprintf(fmtForceUpdateSvcStart, mockSvcName, mockEnvName))
 				m.mockServiceUpdater.EXPECT().ForceUpdateService(mockAppName, mockEnvName, mockSvcName).Return(mockError)
 				m.mockSpinner.EXPECT().Stop(log.Serrorf(fmtForceUpdateSvcFailed, mockSvcName, mockEnvName, mockError))
@@ -897,6 +913,9 @@ func TestSvcDeployOpts_deploySvc(t *testing.T) {
 				m.mockWs.EXPECT().ReadWorkloadManifest(mockSvcName).Return([]byte{}, nil)
 				m.mockInterpolator.EXPECT().Interpolate("").Return("", nil)
 				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
+				m.mockIdentity.EXPECT().Get().Return(identity.Caller{
+					RootUserARN: "1234",
+				}, nil)
 				m.mockServiceDeployer.EXPECT().DeployService(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(cloudformation.NewMockErrChangeSetEmpty())
 				m.mockServiceUpdater.EXPECT().LastUpdatedAt(mockAppName, mockEnvName, mockSvcName).
@@ -931,8 +950,10 @@ func TestSvcDeployOpts_deploySvc(t *testing.T) {
 				m.mockInterpolator.EXPECT().Interpolate("").Return("", nil)
 				m.mockAppVersionGetter.EXPECT().Version().Return("v1.0.0", nil)
 				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
+				m.mockIdentity.EXPECT().Get().Return(identity.Caller{
+					RootUserARN: "1234",
+				}, nil)
 				m.mockServiceDeployer.EXPECT().DeployService(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-
 			},
 		},
 		"success with force update": {
@@ -949,6 +970,9 @@ func TestSvcDeployOpts_deploySvc(t *testing.T) {
 				m.mockWs.EXPECT().ReadWorkloadManifest(mockSvcName).Return([]byte{}, nil)
 				m.mockInterpolator.EXPECT().Interpolate("").Return("", nil)
 				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
+				m.mockIdentity.EXPECT().Get().Return(identity.Caller{
+					RootUserARN: "1234",
+				}, nil)
 				m.mockServiceDeployer.EXPECT().DeployService(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(cloudformation.NewMockErrChangeSetEmpty())
 				m.mockServiceUpdater.EXPECT().LastUpdatedAt(mockAppName, mockEnvName, mockSvcName).
@@ -976,6 +1000,7 @@ func TestSvcDeployOpts_deploySvc(t *testing.T) {
 				mockInterpolator:       mocks.NewMockinterpolator(ctrl),
 				mockEnvDescriber:       mocks.NewMockenvDescriber(ctrl),
 				mockSubnetLister:       mocks.NewMockvpcSubnetLister(ctrl),
+				mockIdentity:           mocks.NewMockidentityService(ctrl),
 			}
 			tc.mock(m)
 
@@ -993,6 +1018,7 @@ func TestSvcDeployOpts_deploySvc(t *testing.T) {
 					return m.mockAppVersionGetter, nil
 				},
 				endpointGetter:    m.mockEndpointGetter,
+				identity:          m.mockIdentity,
 				targetApp:         tc.inApp,
 				targetEnvironment: tc.inEnvironment,
 				newInterpolator: func(app, env string) interpolator {

--- a/internal/pkg/deploy/cloudformation/stack/lb_web_svc.go
+++ b/internal/pkg/deploy/cloudformation/stack/lb_web_svc.go
@@ -20,6 +20,7 @@ const (
 	lbWebSvcRulePriorityGeneratorPath = "custom-resources/alb-rule-priority-generator.js"
 	desiredCountGeneratorPath         = "custom-resources/desired-count-delegation.js"
 	envControllerPath                 = "custom-resources/env-controller.js"
+	nlbCertManagerPath                = "custom-resources/nlb-cert-validator-updater.js"
 )
 
 // Parameter logical IDs for a load balanced web service.
@@ -128,6 +129,10 @@ func (s *LoadBalancedWebService) Template() (string, error) {
 	envControllerLambda, err := s.parser.Read(envControllerPath)
 	if err != nil {
 		return "", fmt.Errorf("read env controller lambda: %w", err)
+	}
+	nlbLambda, err := s.parser.Read(nlbCertManagerPath)
+	if err != nil {
+		return "", fmt.Errorf("read network load balancer certificate manager lambda: %w", err)
 	}
 	addonsParams, err := s.addonsParameters()
 	if err != nil {

--- a/internal/pkg/deploy/cloudformation/stack/lb_web_svc.go
+++ b/internal/pkg/deploy/cloudformation/stack/lb_web_svc.go
@@ -259,6 +259,10 @@ func (s *LoadBalancedWebService) httpLoadBalancerTarget() (targetContainer *stri
 	return
 }
 
+func (s *LoadBalancedWebService) containerPort() string {
+	return strconv.FormatUint(uint64(aws.Uint16Value(s.manifest.ImageConfig.Port)), 10)
+}
+
 // Parameters returns the list of CloudFormation parameters used by the template.
 func (s *LoadBalancedWebService) Parameters() ([]*cloudformation.Parameter, error) {
 	wkldParams, err := s.ecsWkld.Parameters()
@@ -269,7 +273,7 @@ func (s *LoadBalancedWebService) Parameters() ([]*cloudformation.Parameter, erro
 	return append(wkldParams, []*cloudformation.Parameter{
 		{
 			ParameterKey:   aws.String(LBWebServiceContainerPortParamKey),
-			ParameterValue: aws.String(strconv.FormatUint(uint64(aws.Uint16Value(s.manifest.ImageConfig.Port)), 10)),
+			ParameterValue: aws.String(s.containerPort()),
 		},
 		{
 			ParameterKey:   aws.String(LBWebServiceRulePathParamKey),

--- a/internal/pkg/deploy/cloudformation/stack/transformers.go
+++ b/internal/pkg/deploy/cloudformation/stack/transformers.go
@@ -6,6 +6,7 @@ package stack
 import (
 	"fmt"
 	"hash/crc32"
+	"strconv"
 	"strings"
 	"time"
 
@@ -32,6 +33,7 @@ const (
 	defaultIAM             = disabled
 	defaultReadOnly        = true
 	defaultWritePermission = false
+	defaultNLBProtocol     = "TCP_UDP"
 )
 
 // Supported capacityproviders for Fargate services
@@ -254,6 +256,57 @@ func convertHTTPHealthCheck(hc *manifest.HealthCheckArgsOrString) template.HTTPH
 		opts.GracePeriod = aws.Int64(int64(hc.HealthCheckArgs.GracePeriod.Seconds()))
 	}
 	return opts
+}
+
+func (s *LoadBalancedWebService) convertNetworkLoadBalancer() (*template.NetworkLoadBalancer, error) {
+	nlbConfig := s.manifest.NLBConfig
+	if nlbConfig.IsEmpty() {
+		return nil, nil
+	}
+
+	// Parse listener port and protocol.
+	port, protocol, err := parsePortMapping(nlbConfig.Port)
+	if err != nil {
+		return nil, err
+	}
+	if protocol == nil {
+		protocol = aws.String(defaultNLBProtocol)
+	}
+
+	// Configure target container and port.
+	targetContainer := s.name
+	if nlbConfig.TargetContainer != nil {
+		targetContainer = aws.StringValue(nlbConfig.TargetContainer)
+	}
+
+	// By default, the target port is the same as listener port.
+	targetPort := aws.StringValue(port)
+	if targetContainer != s.name {
+		// If the target container is a sidecar container, the target port is the exposed sidecar port.
+		sideCarPort := s.manifest.Sidecars[targetContainer].Port // We validated that a sidecar container exposes a port if it is a target container.
+		port, _, err := parsePortMapping(sideCarPort)
+		if err != nil {
+			return nil, err
+		}
+		targetPort = aws.StringValue(port)
+	}
+	// Finally, if a target port is explicitly specified, use that value.
+	if nlbConfig.TargetPort != nil {
+		targetPort = strconv.Itoa(aws.IntValue(nlbConfig.TargetPort))
+	}
+
+	return &template.NetworkLoadBalancer{
+		PublicSubnetCIDRs: s.publicSubnetCIDRBlocks,
+		Listener: template.NetworkLoadBalancerListener{
+			Port:            aws.StringValue(port),
+			Protocol:        strings.ToUpper(aws.StringValue(protocol)),
+			TargetContainer: targetContainer,
+			TargetPort:      targetPort,
+			SSLPolicy:       nlbConfig.SSLPolicy,
+			Aliases:         nil,
+		},
+		MainContainerPort: strconv.FormatUint(uint64(aws.Uint16Value(s.manifest.ImageConfig.Port)), 10),
+	}, nil
 }
 
 func convertExecuteCommand(e *manifest.ExecuteCommand) *template.ExecuteCommandOpts {

--- a/internal/pkg/deploy/cloudformation/stack/transformers.go
+++ b/internal/pkg/deploy/cloudformation/stack/transformers.go
@@ -295,6 +295,10 @@ func (s *LoadBalancedWebService) convertNetworkLoadBalancer() (*template.Network
 		targetPort = strconv.Itoa(aws.IntValue(nlbConfig.TargetPort))
 	}
 
+	aliases, err := convertAlias(nlbConfig.Aliases)
+	if err != nil {
+		return nil, fmt.Errorf(`convert "nlb.alias" to string slice: %w`, err)
+	}
 	return &template.NetworkLoadBalancer{
 		PublicSubnetCIDRs: s.publicSubnetCIDRBlocks,
 		Listener: template.NetworkLoadBalancerListener{
@@ -303,7 +307,7 @@ func (s *LoadBalancedWebService) convertNetworkLoadBalancer() (*template.Network
 			TargetContainer: targetContainer,
 			TargetPort:      targetPort,
 			SSLPolicy:       nlbConfig.SSLPolicy,
-			Aliases:         nil,
+			Aliases:         aliases,
 		},
 		MainContainerPort: strconv.FormatUint(uint64(aws.Uint16Value(s.manifest.ImageConfig.Port)), 10),
 	}, nil

--- a/internal/pkg/deploy/cloudformation/stack/transformers.go
+++ b/internal/pkg/deploy/cloudformation/stack/transformers.go
@@ -320,7 +320,7 @@ func (s *LoadBalancedWebService) convertNetworkLoadBalancer() (networkLoadBalanc
 				SSLPolicy:       nlbConfig.SSLPolicy,
 				Aliases:         aliases,
 			},
-			MainContainerPort: strconv.FormatUint(uint64(aws.Uint16Value(s.manifest.ImageConfig.Port)), 10),
+			MainContainerPort: s.containerPort(),
 		},
 	}
 

--- a/internal/pkg/manifest/lb_web_svc.go
+++ b/internal/pkg/manifest/lb_web_svc.go
@@ -220,10 +220,11 @@ type NetworkLoadBalancerConfiguration struct {
 	TargetContainer *string                 `yaml:"target_container"`
 	TargetPort      *int                    `yaml:"target_port"`
 	SSLPolicy       *string                 `yaml:"ssl_policy"`
+	Aliases         Alias                   `yaml:"alias"`
 }
 
 func (c *NetworkLoadBalancerConfiguration) IsEmpty() bool {
-	return c.Port == nil && c.HealthCheck.IsEmpty() && c.TargetContainer == nil && c.TargetPort == nil && c.SSLPolicy == nil
+	return c.Port == nil && c.HealthCheck.IsEmpty() && c.TargetContainer == nil && c.TargetPort == nil && c.SSLPolicy == nil && c.Aliases.IsEmpty()
 }
 
 // IPNet represents an IP network string. For example: 10.1.0.0/16

--- a/internal/pkg/manifest/lb_web_svc.go
+++ b/internal/pkg/manifest/lb_web_svc.go
@@ -162,6 +162,11 @@ func (s *LoadBalancedWebService) BuildArgs(wsRoot string) *DockerBuildArgs {
 	return s.ImageConfig.Image.BuildConfig(wsRoot)
 }
 
+// HasAliases returns true if the Load-Balanced Web Service uses aliases, either for ALB or NLB.
+func (s *LoadBalancedWebService) HasAliases() bool {
+	return !s.RoutingRule.Alias.IsEmpty() || !s.NLBConfig.Aliases.IsEmpty()
+}
+
 // ApplyEnv returns the service manifest with environment overrides.
 // If the environment passed in does not have any overrides then it returns itself.
 func (s LoadBalancedWebService) ApplyEnv(envName string) (WorkloadManifest, error) {

--- a/internal/pkg/manifest/lb_web_svc_test.go
+++ b/internal/pkg/manifest/lb_web_svc_test.go
@@ -1368,6 +1368,68 @@ func TestLoadBalancedWebService_BuildRequired(t *testing.T) {
 	}
 }
 
+func TestLoadBalancedWebService_HasAliases(t *testing.T) {
+	testCases := map[string]struct {
+		config LoadBalancedWebServiceConfig
+		want   bool
+	}{
+		"use http aliases": {
+			config: LoadBalancedWebServiceConfig{
+				RoutingRule: RoutingRule{
+					Alias: Alias{
+						String: aws.String("mockAlias"),
+					},
+				},
+			},
+			want: true,
+		},
+		"use nlb aliases": {
+			config: LoadBalancedWebServiceConfig{
+				NLBConfig: NetworkLoadBalancerConfiguration{
+					Aliases: Alias{
+						StringSlice: []string{"mockAlias", "mockAnotherAlias"},
+					},
+				},
+			},
+			want: true,
+		},
+		"both http and nlb use aliases": {
+			config: LoadBalancedWebServiceConfig{
+				RoutingRule: RoutingRule{
+					Alias: Alias{
+						StringSlice: []string{"mockAlias", "mockAnotherAlias"},
+					},
+				},
+				NLBConfig: NetworkLoadBalancerConfiguration{
+					Aliases: Alias{
+						String: aws.String("mockAlias"),
+					},
+				},
+			},
+			want: true,
+		},
+		"not using aliases": {
+			config: LoadBalancedWebServiceConfig{},
+			want:   false,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// GIVEN
+			manifest := &LoadBalancedWebService{
+				LoadBalancedWebServiceConfig: tc.config,
+			}
+
+			// WHEN
+			got := manifest.HasAliases()
+
+			// THEN
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
 func TestAlias_IsEmpty(t *testing.T) {
 	testCases := map[string]struct {
 		in     Alias

--- a/internal/pkg/manifest/validate.go
+++ b/internal/pkg/manifest/validate.go
@@ -599,6 +599,9 @@ func (c NetworkLoadBalancerConfiguration) Validate() error {
 	if err := c.HealthCheck.Validate(); err != nil {
 		return fmt.Errorf(`validate "healthcheck": %w`, err)
 	}
+	if err := c.Aliases.Validate(); err != nil {
+		return fmt.Errorf(`validate "alias": %w`, err)
+	}
 	return nil
 }
 

--- a/internal/pkg/template/templates/workloads/partials/cf/nlb.yml
+++ b/internal/pkg/template/templates/workloads/partials/cf/nlb.yml
@@ -22,8 +22,7 @@ NLBListener:
     Protocol: {{ .NLB.Listener.Protocol }}
 {{- if eq .NLB.Listener.Protocol "TLS" }}
     Certificates:
-      - CertificateArn:
-          !GetAtt EnvControllerAction.HTTPSCert
+      - CertificateArn: !Ref NLBCertManagerAction
     SslPolicy: {{ if .NLB.Listener.SSLPolicy }}{{ .NLB.Listener.SSLPolicy }}{{ else }} ELBSecurityPolicy-TLS13-1-2-2021-06 {{ end }}
 {{- end}}
 
@@ -78,7 +77,7 @@ NLBSecurityGroup:
       - CidrIp: {{$cidr}}
         Description: Ingress to allow access from Network Load Balancer subnet
         FromPort: {{ $.NLB.Listener.Port }}
-        IpProtocol: {{ $.NLB.Listener.Protocol }}
+        IpProtocol: {{- if eq $.NLB.Listener.Protocol "TLS" }} TCP {{- else }} {{ $.NLB.Listener.Protocol }} {{- end}}
         ToPort: {{ $.NLB.Listener.Port }}
 {{end}}
     Tags:
@@ -118,7 +117,7 @@ NLBCertManagerAction:
   Type: Custom::NLBCertManagerFunction
   Condition: HasAssociatedDomain
   Properties:
-    ServiceToken: !Ref NLBCertManagerFunction
+    ServiceToken: !GetAtt NLBCertManagerFunction.Arn
     LoadBalancerDNS: !GetAtt PublicNetworkLoadBalancer.DNSName
     LoadBalancerHostedZoneID: !GetAtt PublicNetworkLoadBalancer.CanonicalHostedZoneID
     EnvHostedZoneId:
@@ -159,18 +158,14 @@ NLBCertManagerRole:
             - sts:AssumeRole
     Path: /
     Policies:
-      - PolicyName: "NLBCertManagerPolicyWrite"
+      - PolicyName: "NLBCertManagerPolicy"
         PolicyDocument:
           Version: '2012-10-17'
           Statement:
             - Sid: EnvHostedZoneUpdateAndWait
               Effect: Allow
               Action: route53:ChangeResourceRecordSets
-              Resource:
-                !Sub
-                  - arn:${AWS::Partition}:route53:::hostedzone/${EnvHostedZone}
-                  - EnvHostedZone: Fn::ImportValue
-                        !Sub "${AppName}-${EnvName}-HostedZone"
+              Resource: "*"
             - Sid: EnvHostedZoneRead
               Effect: Allow
               Action:
@@ -203,8 +198,7 @@ NLBCertManagerRole:
                   'aws:ResourceTag/copilot-service': !Sub '${WorkloadName}'
             - Sid: CertificateRead
               Effect: Allow
-              Action:
-                - acm:DescribeCertificate
+              Action: acm:DescribeCertificate
               Resource: "*"
     ManagedPolicyArns:
       - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole

--- a/internal/pkg/template/templates/workloads/partials/cf/nlb.yml
+++ b/internal/pkg/template/templates/workloads/partials/cf/nlb.yml
@@ -165,7 +165,11 @@ NLBCertManagerRole:
             - Sid: EnvHostedZoneUpdateAndWait
               Effect: Allow
               Action: route53:ChangeResourceRecordSets
-              Resource: "*"
+              Resource:
+                !Sub
+                  - arn:${AWS::Partition}:route53:::hostedzone/${EnvHostedZone}
+                  - EnvHostedZone: Fn::ImportValue
+                      !Sub "${AppName}-${EnvName}-HostedZone"
             - Sid: EnvHostedZoneRead
               Effect: Allow
               Action:

--- a/internal/pkg/template/templates/workloads/partials/cf/workload-container.yml
+++ b/internal/pkg/template/templates/workloads/partials/cf/workload-container.yml
@@ -29,6 +29,16 @@
 {{- if eq .WorkloadType "Load Balanced Web Service"}}
   PortMappings:
     - ContainerPort: !Ref ContainerPort
+{{- if .NLB}}
+  {{if ne .NLB.Listener.TargetPort .NLB.MainContainerPort}} {{/*No need to add additional port if the target port is the same as image port*/}}
+    - ContainerPort: {{.NLB.Listener.TargetPort}}
+      {{- if eq .NLB.Listener.Protocol "UDP" }}
+      Protocol: udp
+      {{- else }}
+      Protocol: tcp
+      {{- end }}
+  {{- end}}
+{{- end}}
 {{- end}}
 {{- if eq .WorkloadType "Backend Service"}}
   PortMappings: !If [ExposePort, [{ContainerPort: !Ref ContainerPort}], !Ref "AWS::NoValue"]

--- a/internal/pkg/template/workload.go
+++ b/internal/pkg/template/workload.go
@@ -220,6 +220,7 @@ type NetworkLoadBalancerListener struct {
 type NetworkLoadBalancer struct {
 	PublicSubnetCIDRs []string
 	Listener          NetworkLoadBalancerListener
+	MainContainerPort string
 }
 
 // AdvancedCount holds configuration for autoscaling and capacity provider


### PR DESCRIPTION
This PR:
1. Enable rendering NLB template if `nlb` is specified in manifest
2. Enable TLS termination, using a certificate managed by Copilot custom resource that is dedicated to the service
3. Enable alias for NLB

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
