### PR TITLE
chore: allow disabling "http" from manifest

### DIFF
--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -606,28 +606,24 @@ func (o *deploySvcOpts) stackConfiguration() (cloudformation.StackConfiguration,
 	var conf cloudformation.StackConfiguration
 	switch t := mft.(type) {
 	case *manifest.LoadBalancedWebService:
-		if o.targetApp.Domain == "" && t.HasAliases() {
-			log.Errorf(aliasUsedWithoutDomainFriendlyText)
-			return nil, errors.New("alias specified when application is not associated with a domain")
+		appVersionGetter, err := o.newAppVersionGetter(o.appName)
+		if err != nil {
+			return nil, fmt.Errorf("new app describer for application %s: %w", o.appName, err)
+		}
+		if err := validateLBWSRuntime(o.targetApp, o.envName, t, appVersionGetter); err != nil {
+			return nil, err
 		}
 
 		var opts []stack.LoadBalancedWebServiceOption
+		if !t.NLBConfig.IsEmpty() {
+			cidrBlocks, err := o.publicCIDRBlocks()
+			if err != nil {
+				return nil, err
+			}
+			opts = append(opts, stack.WithNLB(cidrBlocks))
+		}
 
-		// TODO: https://github.com/aws/copilot-cli/issues/2918
-		// 1. ALB block should not be executed if http is disabled
 		if o.targetApp.RequiresDNSDelegation() {
-			var appVersionGetter versionGetter
-			if appVersionGetter, err = o.newAppVersionGetter(o.appName); err != nil {
-				return nil, err
-			}
-			if err = validateLBSvcAliasAndAppVersion(aws.StringValue(t.Name), t.RoutingRule.Alias, o.targetApp, o.envName, appVersionGetter); err != nil {
-				return nil, err
-			}
-			if err = validateLBSvcAliasAndAppVersion(aws.StringValue(t.Name), t.NLBConfig.Aliases, o.targetApp, o.envName, appVersionGetter); err != nil {
-				return nil, err
-			}
-			opts = append(opts, stack.WithHTTPS())
-
 			var caller identity.Caller
 			caller, err = o.identity.Get()
 			if err != nil {
@@ -638,13 +634,10 @@ func (o *deploySvcOpts) stackConfiguration() (cloudformation.StackConfiguration,
 				DNSName:             o.targetApp.Domain,
 				AccountPrincipalARN: caller.RootUserARN,
 			}))
-		}
-		if !t.NLBConfig.IsEmpty() {
-			cidrBlocks, err := o.publicCIDRBlocks()
-			if err != nil {
-				return nil, err
+
+			if !t.RoutingRule.Disabled() {
+				opts = append(opts, stack.WithHTTPS())
 			}
-			opts = append(opts, stack.WithNLB(cidrBlocks))
 		}
 		conf, err = stack.NewLoadBalancedWebService(t, o.targetEnvironment.Name, o.targetEnvironment.App, *rc, opts...)
 	case *manifest.RequestDrivenWebService:
@@ -811,17 +804,13 @@ func envFile(unmarshaledManifest interface{}) string {
 	return ""
 }
 
-func validateLBSvcAliasAndAppVersion(svcName string, aliases manifest.Alias, app *config.Application, envName string, appVersionGetter versionGetter) error {
+func validateLBSvcAlias(aliases manifest.Alias, app *config.Application, envName string) error {
 	if aliases.IsEmpty() {
 		return nil
 	}
 	aliasList, err := aliases.ToStringSlice()
 	if err != nil {
 		return fmt.Errorf(`convert 'http.alias' to string slice: %w`, err)
-	}
-	if err := validateAppVersion(app.Name, appVersionGetter); err != nil {
-		logAppVersionOutdatedError(svcName)
-		return err
 	}
 	for _, alias := range aliasList {
 		// Alias should be within either env, app, or root hosted zone.
@@ -928,6 +917,28 @@ func validateAppVersion(appName string, appVersionGetter versionGetter) error {
 	diff := semver.Compare(appVersion, deploy.AliasLeastAppTemplateVersion)
 	if diff < 0 {
 		return fmt.Errorf(`alias is not compatible with application versions below %s`, deploy.AliasLeastAppTemplateVersion)
+	}
+	return nil
+}
+
+func validateLBWSRuntime(app *config.Application, envName string, t *manifest.LoadBalancedWebService, appVersionGetter versionGetter) error {
+	if app.Domain == "" && t.HasAliases() {
+		log.Errorf(aliasUsedWithoutDomainFriendlyText)
+		return errors.New("alias specified when application is not associated with a domain")
+	}
+
+	if app.RequiresDNSDelegation() {
+		if err := validateAppVersion(app.Name, appVersionGetter); err != nil {
+			logAppVersionOutdatedError(aws.StringValue(t.Name))
+			return err
+		}
+	}
+
+	if err := validateLBSvcAlias(t.RoutingRule.Alias, app, envName); err != nil {
+		return err
+	}
+	if err := validateLBSvcAlias(t.NLBConfig.Aliases, app, envName); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -403,6 +403,23 @@ func (o *deploySvcOpts) publicCIDRBlocks() ([]string, error) {
 	return cidrBlocks, nil
 }
 
+func publicCIDRBlocks(envDescriber envDescriber, subnetLister vpcSubnetLister, envName string) ([]string, error) {
+	envDescription, err := envDescriber.Describe()
+	if err != nil {
+		return nil, fmt.Errorf("describe environment %s: %w", envName, err)
+	}
+	vpcID := envDescription.EnvironmentVPC.ID
+	subnets, err := subnetLister.ListVPCSubnets(vpcID)
+	if err != nil {
+		return nil, fmt.Errorf("list subnets of vpc %s in environment %s: %w", vpcID, envName, err)
+	}
+	var cidrBlocks []string
+	for _, subnet := range subnets.Public {
+		cidrBlocks = append(cidrBlocks, subnet.CIDRBlock)
+	}
+	return cidrBlocks, nil
+}
+
 func (o *deploySvcOpts) configureContainerImage() error {
 	svc, err := o.manifest()
 	if err != nil {

--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -623,7 +623,8 @@ func (o *deploySvcOpts) stackConfiguration() (cloudformation.StackConfiguration,
 	var conf cloudformation.StackConfiguration
 	switch t := mft.(type) {
 	case *manifest.LoadBalancedWebService:
-		appVersionGetter, err := o.newAppVersionGetter(o.appName)
+		var appVersionGetter versionGetter
+		appVersionGetter, err = o.newAppVersionGetter(o.appName)
 		if err != nil {
 			return nil, fmt.Errorf("new app describer for application %s: %w", o.appName, err)
 		}

--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -620,7 +620,7 @@ func (o *deploySvcOpts) stackConfiguration() (cloudformation.StackConfiguration,
 			if appVersionGetter, err = o.newAppVersionGetter(o.appName); err != nil {
 				return nil, err
 			}
-			if err = validateLBSvcAliasAndAppVersion(aws.StringValue(t.Name), t.Alias, o.targetApp, o.envName, appVersionGetter); err != nil {
+			if err = validateLBSvcAliasAndAppVersion(aws.StringValue(t.Name), t.RoutingRule.Alias, o.targetApp, o.envName, appVersionGetter); err != nil {
 				return nil, err
 			}
 			if err = validateLBSvcAliasAndAppVersion(aws.StringValue(t.Name), t.NLBConfig.Aliases, o.targetApp, o.envName, appVersionGetter); err != nil {

--- a/internal/pkg/cli/svc_deploy_test.go
+++ b/internal/pkg/cli/svc_deploy_test.go
@@ -1080,8 +1080,10 @@ func TestSvcDeployOpts_deploySvc(t *testing.T) {
 									Port: aws.Uint16(80),
 								},
 							},
-							RoutingRule: manifest.RoutingRule{
-								Alias: tc.inAliases,
+							RoutingRule: manifest.RoutingRuleConfigOrBool{
+								RoutingRuleConfiguration: manifest.RoutingRuleConfiguration{
+									Alias: tc.inAliases,
+								},
 							},
 							NLBConfig: tc.inNLB,
 						},

--- a/internal/pkg/cli/svc_deploy_test.go
+++ b/internal/pkg/cli/svc_deploy_test.go
@@ -833,16 +833,12 @@ func TestSvcDeployOpts_deploySvc(t *testing.T) {
 				Region: "us-west-2",
 			},
 			inApp: &config.Application{
-				Name:   mockAppName,
-				Domain: "mockDomain",
+				Name: mockAppName,
 			},
 			mock: func(m *deploySvcMocks) {
 				m.mockWs.EXPECT().ReadWorkloadManifest(mockSvcName).Return([]byte{}, nil)
 				m.mockInterpolator.EXPECT().Interpolate("").Return("", nil)
 				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
-				m.mockIdentity.EXPECT().Get().Return(identity.Caller{
-					RootUserARN: "1234",
-				}, nil)
 				m.mockServiceDeployer.EXPECT().DeployService(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("some error"))
 			},
 			wantErr: fmt.Errorf("deploy service: some error"),
@@ -853,16 +849,12 @@ func TestSvcDeployOpts_deploySvc(t *testing.T) {
 				Region: "us-west-2",
 			},
 			inApp: &config.Application{
-				Name:   mockAppName,
-				Domain: "mockDomain",
+				Name: mockAppName,
 			},
 			mock: func(m *deploySvcMocks) {
 				m.mockWs.EXPECT().ReadWorkloadManifest(mockSvcName).Return([]byte{}, nil)
 				m.mockInterpolator.EXPECT().Interpolate("").Return("", nil)
 				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
-				m.mockIdentity.EXPECT().Get().Return(identity.Caller{
-					RootUserARN: "1234",
-				}, nil)
 				m.mockServiceDeployer.EXPECT().DeployService(gomock.Any(), gomock.Any(), gomock.Any()).Return(cloudformation.NewMockErrChangeSetEmpty())
 			},
 			wantErr: fmt.Errorf("deploy service: change set with name mockChangeSet for stack mockStack has no changes"),
@@ -874,16 +866,12 @@ func TestSvcDeployOpts_deploySvc(t *testing.T) {
 				Region: "us-west-2",
 			},
 			inApp: &config.Application{
-				Name:   mockAppName,
-				Domain: "mockDomain",
+				Name: mockAppName,
 			},
 			mock: func(m *deploySvcMocks) {
 				m.mockWs.EXPECT().ReadWorkloadManifest(mockSvcName).Return([]byte{}, nil)
 				m.mockInterpolator.EXPECT().Interpolate("").Return("", nil)
 				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
-				m.mockIdentity.EXPECT().Get().Return(identity.Caller{
-					RootUserARN: "1234",
-				}, nil)
 				m.mockServiceDeployer.EXPECT().DeployService(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil)
 				m.mockServiceUpdater.EXPECT().LastUpdatedAt(mockAppName, mockEnvName, mockSvcName).
@@ -898,16 +886,12 @@ func TestSvcDeployOpts_deploySvc(t *testing.T) {
 				Region: "us-west-2",
 			},
 			inApp: &config.Application{
-				Name:   mockAppName,
-				Domain: "mockDomain",
+				Name: mockAppName,
 			},
 			mock: func(m *deploySvcMocks) {
 				m.mockWs.EXPECT().ReadWorkloadManifest(mockSvcName).Return([]byte{}, nil)
 				m.mockInterpolator.EXPECT().Interpolate("").Return("", nil)
 				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
-				m.mockIdentity.EXPECT().Get().Return(identity.Caller{
-					RootUserARN: "1234",
-				}, nil)
 				m.mockServiceDeployer.EXPECT().DeployService(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil)
 				m.mockServiceUpdater.EXPECT().LastUpdatedAt(mockAppName, mockEnvName, mockSvcName).
@@ -921,8 +905,7 @@ func TestSvcDeployOpts_deploySvc(t *testing.T) {
 				Region: "us-west-2",
 			},
 			inApp: &config.Application{
-				Name:   mockAppName,
-				Domain: "mockDomain",
+				Name: mockAppName,
 			},
 			mock: func(m *deploySvcMocks) {
 				m.mockWs.EXPECT().ReadWorkloadManifest(mockSvcName).Return([]byte{}, nil)
@@ -932,9 +915,6 @@ func TestSvcDeployOpts_deploySvc(t *testing.T) {
 					Return(cloudformation.NewMockErrChangeSetEmpty())
 				m.mockServiceUpdater.EXPECT().LastUpdatedAt(mockAppName, mockEnvName, mockSvcName).
 					Return(mockBeforeTime, nil)
-				m.mockIdentity.EXPECT().Get().Return(identity.Caller{
-					RootUserARN: "1234",
-				}, nil)
 				m.mockSpinner.EXPECT().Start(fmt.Sprintf(fmtForceUpdateSvcStart, mockSvcName, mockEnvName))
 				m.mockServiceUpdater.EXPECT().ForceUpdateService(mockAppName, mockEnvName, mockSvcName).Return(mockError)
 				m.mockSpinner.EXPECT().Stop(log.Serrorf(fmtForceUpdateSvcFailed, mockSvcName, mockEnvName, mockError))
@@ -948,16 +928,12 @@ func TestSvcDeployOpts_deploySvc(t *testing.T) {
 				Region: "us-west-2",
 			},
 			inApp: &config.Application{
-				Name:   mockAppName,
-				Domain: "mockDomain",
+				Name: mockAppName,
 			},
 			mock: func(m *deploySvcMocks) {
 				m.mockWs.EXPECT().ReadWorkloadManifest(mockSvcName).Return([]byte{}, nil)
 				m.mockInterpolator.EXPECT().Interpolate("").Return("", nil)
 				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
-				m.mockIdentity.EXPECT().Get().Return(identity.Caller{
-					RootUserARN: "1234",
-				}, nil)
 				m.mockServiceDeployer.EXPECT().DeployService(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(cloudformation.NewMockErrChangeSetEmpty())
 				m.mockServiceUpdater.EXPECT().LastUpdatedAt(mockAppName, mockEnvName, mockSvcName).
@@ -1005,16 +981,12 @@ func TestSvcDeployOpts_deploySvc(t *testing.T) {
 				Region: "us-west-2",
 			},
 			inApp: &config.Application{
-				Name:   mockAppName,
-				Domain: "mockDomain",
+				Name: mockAppName,
 			},
 			mock: func(m *deploySvcMocks) {
 				m.mockWs.EXPECT().ReadWorkloadManifest(mockSvcName).Return([]byte{}, nil)
 				m.mockInterpolator.EXPECT().Interpolate("").Return("", nil)
 				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
-				m.mockIdentity.EXPECT().Get().Return(identity.Caller{
-					RootUserARN: "1234",
-				}, nil)
 				m.mockServiceDeployer.EXPECT().DeployService(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(cloudformation.NewMockErrChangeSetEmpty())
 				m.mockServiceUpdater.EXPECT().LastUpdatedAt(mockAppName, mockEnvName, mockSvcName).

--- a/internal/pkg/cli/svc_package.go
+++ b/internal/pkg/cli/svc_package.go
@@ -130,13 +130,13 @@ func newPackageSvcOpts(vars packageSvcVars) (*packageSvcOpts, error) {
 			var options []stack.LoadBalancedWebServiceOption
 			if !t.NLBConfig.IsEmpty() {
 				envDescriber, err := describe.NewEnvDescriber(describe.NewEnvDescriberConfig{
-					App:         vars.appName,
-					Env:         vars.envName,
+					App:         app.Name,
+					Env:         env.Name,
 					ConfigStore: store,
 					DeployStore: deployStore,
 				})
 				if err != nil {
-					return nil, fmt.Errorf("create describer for environment %s in application %s: %w", vars.envName, vars.appName, err)
+					return nil, fmt.Errorf("create describer for environment %s in application %s: %w", env.Name, app.Name, err)
 				}
 				envSession, err := p.FromRole(env.ManagerRoleARN, env.Region)
 				if err != nil {

--- a/internal/pkg/cli/svc_package.go
+++ b/internal/pkg/cli/svc_package.go
@@ -124,10 +124,13 @@ func newPackageSvcOpts(vars packageSvcVars) (*packageSvcOpts, error) {
 		switch t := mft.(type) {
 		case *manifest.LoadBalancedWebService:
 			var opts []stack.LoadBalancedWebServiceOption
+			if err := validateLBWSRuntime(app, env.Name, t, appVersionGetter); err != nil {
+				return nil, err
+			}
 			if app.RequiresDNSDelegation() {
-				if err := validateLBSvcAliasAndAppVersion(aws.StringValue(t.Name), t.RoutingRule.Alias, app, env.Name, appVersionGetter); err != nil {
-					return nil, err
-				}
+				// if err := validateLBSvcAlias(aws.StringValue(t.Name), t.RoutingRule.Alias, app, env.Name, appVersionGetter); err != nil {
+				// 	return nil, err
+				// }
 				opts = append(opts, stack.WithHTTPS())
 			}
 			serializer, err = stack.NewLoadBalancedWebService(t, env.Name, app.Name, rc, opts...)

--- a/internal/pkg/cli/svc_package.go
+++ b/internal/pkg/cli/svc_package.go
@@ -125,7 +125,7 @@ func newPackageSvcOpts(vars packageSvcVars) (*packageSvcOpts, error) {
 		case *manifest.LoadBalancedWebService:
 			var opts []stack.LoadBalancedWebServiceOption
 			if app.RequiresDNSDelegation() {
-				if err := validateLBSvcAliasAndAppVersion(aws.StringValue(t.Name), t.Alias, app, env.Name, appVersionGetter); err != nil {
+				if err := validateLBSvcAliasAndAppVersion(aws.StringValue(t.Name), t.RoutingRule.Alias, app, env.Name, appVersionGetter); err != nil {
 					return nil, err
 				}
 				opts = append(opts, stack.WithHTTPS())

--- a/internal/pkg/deploy/cloudformation/stack/lb_web_svc.go
+++ b/internal/pkg/deploy/cloudformation/stack/lb_web_svc.go
@@ -230,6 +230,7 @@ func (s *LoadBalancedWebService) Template() (string, error) {
 		NLB:                          nlbConfig.settings,
 		AppDNSName:                   nlbConfig.appDNSName,
 		AppDNSDelegationRole:         nlbConfig.appDNSDelegationRole,
+		HTTPDisabled:                 s.manifest.RoutingRule.Disabled(),
 	})
 	if err != nil {
 		return "", err

--- a/internal/pkg/deploy/cloudformation/stack/lb_web_svc.go
+++ b/internal/pkg/deploy/cloudformation/stack/lb_web_svc.go
@@ -21,7 +21,7 @@ const (
 	lbWebSvcRulePriorityGeneratorPath = "custom-resources/alb-rule-priority-generator.js"
 	desiredCountGeneratorPath         = "custom-resources/desired-count-delegation.js"
 	envControllerPath                 = "custom-resources/env-controller.js"
-	nlbCertManagerPath                = "custom-resources/nlb-cert-validator-updater.js"
+	nlbCertManagerPath                = "custom-resources/nlb-cert-manager.js"
 )
 
 // Parameter logical IDs for a load balanced web service.

--- a/internal/pkg/deploy/cloudformation/stack/lb_web_svc_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/lb_web_svc_test.go
@@ -119,7 +119,7 @@ func TestLoadBalancedWebService_Template(t *testing.T) {
 	testLBWebServiceManifest.ImageConfig.HealthCheck = manifest.ContainerHealthCheck{
 		Retries: aws.Int(5),
 	}
-	testLBWebServiceManifest.Alias = manifest.Alias{String: aws.String("mockAlias")}
+	testLBWebServiceManifest.RoutingRule.Alias = manifest.Alias{String: aws.String("mockAlias")}
 	testLBWebServiceManifest.EntryPoint = manifest.EntryPointOverride{
 		String:      nil,
 		StringSlice: []string{"/bin/echo", "hello"},
@@ -378,14 +378,14 @@ func TestLoadBalancedWebService_Parameters(t *testing.T) {
 		},
 	}
 	testLBWebServiceManifestWithSidecar := manifest.NewLoadBalancedWebService(baseProps)
-	testLBWebServiceManifestWithSidecar.TargetContainer = aws.String("xray")
+	testLBWebServiceManifestWithSidecar.RoutingRule.TargetContainer = aws.String("xray")
 	testLBWebServiceManifestWithSidecar.Sidecars = map[string]*manifest.SidecarConfig{
 		"xray": {
 			Port: aws.String("5000"),
 		},
 	}
 	testLBWebServiceManifestWithStickiness := manifest.NewLoadBalancedWebService(baseProps)
-	testLBWebServiceManifestWithStickiness.Stickiness = aws.Bool(true)
+	testLBWebServiceManifestWithStickiness.RoutingRule.Stickiness = aws.Bool(true)
 	testLBWebServiceManifestWithExecEnabled := manifest.NewLoadBalancedWebService(baseProps)
 	testLBWebServiceManifestWithExecEnabled.ExecuteCommand = manifest.ExecuteCommand{
 		Enable: aws.Bool(false),

--- a/internal/pkg/deploy/cloudformation/stack/transformers.go
+++ b/internal/pkg/deploy/cloudformation/stack/transformers.go
@@ -309,6 +309,18 @@ func (s *LoadBalancedWebService) convertNetworkLoadBalancer() (networkLoadBalanc
 		return networkLoadBalancerConfig{}, fmt.Errorf(`convert "nlb.alias" to string slice: %w`, err)
 	}
 
+	healthCheckOpts := template.NetworkLoadBalancerHealthCheckOpts{
+		HealthyThreshold:   nlbConfig.HealthCheck.HealthyThreshold,
+		UnhealthyThreshold: nlbConfig.HealthCheck.UnhealthyThreshold,
+	}
+
+	if nlbConfig.HealthCheck.Interval != nil {
+		healthCheckOpts.Interval = aws.Int64(int64(nlbConfig.HealthCheck.Interval.Seconds()))
+	}
+	if nlbConfig.HealthCheck.Timeout != nil {
+		healthCheckOpts.Timeout = aws.Int64(int64(nlbConfig.HealthCheck.Timeout.Seconds()))
+	}
+
 	config := networkLoadBalancerConfig{
 		settings: &template.NetworkLoadBalancer{
 			PublicSubnetCIDRs: s.publicSubnetCIDRBlocks,
@@ -319,6 +331,7 @@ func (s *LoadBalancedWebService) convertNetworkLoadBalancer() (networkLoadBalanc
 				TargetPort:      targetPort,
 				SSLPolicy:       nlbConfig.SSLPolicy,
 				Aliases:         aliases,
+				HealthCheck:     healthCheckOpts,
 			},
 			MainContainerPort: s.containerPort(),
 		},

--- a/internal/pkg/initialize/workload_test.go
+++ b/internal/pkg/initialize/workload_test.go
@@ -366,7 +366,7 @@ func TestAppInitOpts_createLoadBalancedAppManifest(t *testing.T) {
 				require.Equal(t, tc.inSvcName, aws.StringValue(manifest.Workload.Name))
 				require.Equal(t, tc.inSvcPort, aws.Uint16Value(manifest.ImageConfig.Port))
 				require.Contains(t, tc.inDockerfilePath, aws.StringValue(manifest.ImageConfig.Image.Build.BuildArgs.Dockerfile))
-				require.Equal(t, tc.wantedPath, aws.StringValue(manifest.Path))
+				require.Equal(t, tc.wantedPath, aws.StringValue(manifest.RoutingRule.Path))
 			} else {
 				require.EqualError(t, err, tc.wantedErr.Error())
 			}

--- a/internal/pkg/manifest/lb_web_svc.go
+++ b/internal/pkg/manifest/lb_web_svc.go
@@ -203,11 +203,7 @@ type RoutingRuleConfigOrBool struct {
 }
 
 func (r *RoutingRuleConfigOrBool) Disabled() bool {
-	return r.Enabled != nil && aws.BoolValue(r.Enabled) == false
-}
-
-func (r *RoutingRuleConfigOrBool) isEmpty() bool {
-	return r.RoutingRuleConfiguration.isEmpty() && r.Enabled == nil
+	return r.Enabled != nil && !aws.BoolValue(r.Enabled)
 }
 
 // UnmarshalYAML implements the yaml(v3) interface. It allows https routing rule to be specified as a

--- a/internal/pkg/manifest/lb_web_svc.go
+++ b/internal/pkg/manifest/lb_web_svc.go
@@ -8,9 +8,10 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/copilot-cli/internal/pkg/template"
 	"github.com/imdario/mergo"
 	"gopkg.in/yaml.v3"
+
+	"github.com/aws/copilot-cli/internal/pkg/template"
 )
 
 const (
@@ -133,6 +134,36 @@ func newDefaultLoadBalancedWebService() *LoadBalancedWebService {
 	}
 }
 
+// newDefaultEmptyLoadBalancedWebService returns an empty LoadBalancedWebService with only the default values set, without any load balancer configured.
+func newDefaultEmptyLoadBalancedWebService() *LoadBalancedWebService {
+	return &LoadBalancedWebService{
+		Workload: Workload{
+			Type: aws.String(LoadBalancedWebServiceType),
+		},
+		LoadBalancedWebServiceConfig: LoadBalancedWebServiceConfig{
+			ImageConfig: ImageWithPortAndHealthcheck{},
+			TaskConfig: TaskConfig{
+				CPU:    aws.Int(256),
+				Memory: aws.Int(512),
+				Count: Count{
+					Value: aws.Int(1),
+					AdvancedCount: AdvancedCount{ // Leave advanced count empty while passing down the type of the workload.
+						workloadType: LoadBalancedWebServiceType,
+					},
+				},
+				ExecuteCommand: ExecuteCommand{
+					Enable: aws.Bool(false),
+				},
+			},
+			Network: NetworkConfig{
+				VPC: vpcConfig{
+					Placement: &PublicSubnetPlacement,
+				},
+			},
+		},
+	}
+}
+
 // MarshalBinary serializes the manifest object into a binary YAML document.
 // Implements the encoding.BinaryMarshaler interface.
 func (s *LoadBalancedWebService) MarshalBinary() ([]byte, error) {
@@ -219,7 +250,7 @@ func (r *RoutingRuleConfigOrBool) UnmarshalYAML(value *yaml.Node) error {
 	}
 
 	if !r.RoutingRuleConfiguration.isEmpty() {
-		// Unmarshalled successfully to r.Advanced, unset r.Enabled, and return.
+		// Unmarshalled successfully to r.RoutingRuleConfiguration, unset r.Enabled, and return.
 		r.Enabled = nil
 		return nil
 	}
@@ -255,8 +286,8 @@ func (r *RoutingRuleConfiguration) targetContainer() *string {
 }
 
 func (r *RoutingRuleConfiguration) isEmpty() bool {
-	return r.Path == nil && r.ProtocolVersion == nil && r.HealthCheck.IsEmpty() && r.Stickiness == nil && r.Alias.IsEmpty() && r.TargetContainer == nil &&
-		r.TargetContainerCamelCase == nil && r.AllowedSourceIps == nil
+	return r.Path == nil && r.ProtocolVersion == nil && r.HealthCheck.IsEmpty() && r.Stickiness == nil && r.Alias.IsEmpty() &&
+		r.DeregistrationDelay == nil && r.TargetContainer == nil && r.TargetContainerCamelCase == nil && r.AllowedSourceIps == nil
 }
 
 // NetworkLoadBalancerConfiguration holds options for a network load balancer

--- a/internal/pkg/manifest/lb_web_svc.go
+++ b/internal/pkg/manifest/lb_web_svc.go
@@ -52,7 +52,7 @@ type LoadBalancedWebService struct {
 type LoadBalancedWebServiceConfig struct {
 	ImageConfig      ImageWithPortAndHealthcheck `yaml:"image,flow"`
 	ImageOverride    `yaml:",inline"`
-	RoutingRule      `yaml:"http,flow"`
+	RoutingRule      RoutingRuleConfigOrBool `yaml:"http,flow"`
 	TaskConfig       `yaml:",inline"`
 	Logging          `yaml:"logging,flow"`
 	Sidecars         map[string]*SidecarConfig        `yaml:"sidecars"` // NOTE: keep the pointers because `mergo` doesn't automatically deep merge map's value unless it's a pointer type.
@@ -104,9 +104,11 @@ func newDefaultLoadBalancedWebService() *LoadBalancedWebService {
 		},
 		LoadBalancedWebServiceConfig: LoadBalancedWebServiceConfig{
 			ImageConfig: ImageWithPortAndHealthcheck{},
-			RoutingRule: RoutingRule{
-				HealthCheck: HealthCheckArgsOrString{
-					HealthCheckPath: aws.String(DefaultHealthCheckPath),
+			RoutingRule: RoutingRuleConfigOrBool{
+				RoutingRuleConfiguration: RoutingRuleConfiguration{
+					HealthCheck: HealthCheckArgsOrString{
+						HealthCheckPath: aws.String(DefaultHealthCheckPath),
+					},
 				},
 			},
 			TaskConfig: TaskConfig{
@@ -194,8 +196,42 @@ func (s LoadBalancedWebService) ApplyEnv(envName string) (WorkloadManifest, erro
 	return &s, nil
 }
 
-// RoutingRule holds the path to route requests to the service.
-type RoutingRule struct {
+// RoutingRuleConfigOrBool holds advanced configuration for routing rule or a boolean switch.
+type RoutingRuleConfigOrBool struct {
+	RoutingRuleConfiguration
+	Enabled *bool
+}
+
+func (r *RoutingRuleConfigOrBool) isEmpty() bool {
+	return r.RoutingRuleConfiguration.isEmpty() && r.Enabled == nil
+}
+
+// UnmarshalYAML implements the yaml(v3) interface. It allows https routing rule to be specified as a
+// bool or a struct alternately.
+func (r *RoutingRuleConfigOrBool) UnmarshalYAML(value *yaml.Node) error {
+	if err := value.Decode(&r.RoutingRuleConfiguration); err != nil {
+		switch err.(type) {
+		case *yaml.TypeError:
+			break
+		default:
+			return err
+		}
+	}
+
+	if !r.RoutingRuleConfiguration.isEmpty() {
+		// Unmarshalled successfully to r.Advanced, unset r.Enabled, and return.
+		r.Enabled = nil
+		return nil
+	}
+
+	if err := value.Decode(&r.Enabled); err != nil {
+		return errors.New(`cannot marshal "http" field into bool or map`)
+	}
+	return nil
+}
+
+// RoutingRuleConfiguration holds the path to route requests to the service.
+type RoutingRuleConfiguration struct {
 	Path                *string                 `yaml:"path"`
 	ProtocolVersion     *string                 `yaml:"version"`
 	HealthCheck         HealthCheckArgsOrString `yaml:"healthcheck"`
@@ -208,7 +244,7 @@ type RoutingRule struct {
 	AllowedSourceIps         []IPNet `yaml:"allowed_source_ips"`
 }
 
-func (r *RoutingRule) targetContainer() *string {
+func (r *RoutingRuleConfiguration) targetContainer() *string {
 	if r.TargetContainer == nil && r.TargetContainerCamelCase == nil {
 		return nil
 	}
@@ -216,6 +252,11 @@ func (r *RoutingRule) targetContainer() *string {
 		return r.TargetContainer
 	}
 	return r.TargetContainerCamelCase
+}
+
+func (r *RoutingRuleConfiguration) isEmpty() bool {
+	return r.Path == nil && r.ProtocolVersion == nil && r.HealthCheck.IsEmpty() && r.Stickiness == nil && r.Alias.IsEmpty() && r.TargetContainer == nil &&
+		r.TargetContainerCamelCase == nil && r.AllowedSourceIps == nil
 }
 
 // NetworkLoadBalancerConfiguration holds options for a network load balancer

--- a/internal/pkg/manifest/lb_web_svc.go
+++ b/internal/pkg/manifest/lb_web_svc.go
@@ -202,6 +202,10 @@ type RoutingRuleConfigOrBool struct {
 	Enabled *bool
 }
 
+func (r *RoutingRuleConfigOrBool) Disabled() bool {
+	return r.Enabled != nil && aws.BoolValue(r.Enabled) == false
+}
+
 func (r *RoutingRuleConfigOrBool) isEmpty() bool {
 	return r.RoutingRuleConfiguration.isEmpty() && r.Enabled == nil
 }

--- a/internal/pkg/manifest/lb_web_svc.go
+++ b/internal/pkg/manifest/lb_web_svc.go
@@ -292,16 +292,16 @@ func (r *RoutingRuleConfiguration) isEmpty() bool {
 
 // NetworkLoadBalancerConfiguration holds options for a network load balancer
 type NetworkLoadBalancerConfiguration struct {
-	Port            *string                 `yaml:"port"`
-	HealthCheck     HealthCheckArgsOrString `yaml:"healthcheck"`
-	TargetContainer *string                 `yaml:"target_container"`
-	TargetPort      *int                    `yaml:"target_port"`
-	SSLPolicy       *string                 `yaml:"ssl_policy"`
-	Aliases         Alias                   `yaml:"alias"`
+	Port            *string            `yaml:"port"`
+	HealthCheck     NLBHealthCheckArgs `yaml:"healthcheck"`
+	TargetContainer *string            `yaml:"target_container"`
+	TargetPort      *int               `yaml:"target_port"`
+	SSLPolicy       *string            `yaml:"ssl_policy"`
+	Aliases         Alias              `yaml:"alias"`
 }
 
 func (c *NetworkLoadBalancerConfiguration) IsEmpty() bool {
-	return c.Port == nil && c.HealthCheck.IsEmpty() && c.TargetContainer == nil && c.TargetPort == nil && c.SSLPolicy == nil && c.Aliases.IsEmpty()
+	return c.Port == nil && c.HealthCheck.isEmpty() && c.TargetContainer == nil && c.TargetPort == nil && c.SSLPolicy == nil && c.Aliases.IsEmpty()
 }
 
 // IPNet represents an IP network string. For example: 10.1.0.0/16

--- a/internal/pkg/manifest/lb_web_svc_test.go
+++ b/internal/pkg/manifest/lb_web_svc_test.go
@@ -49,10 +49,12 @@ func TestNewLoadBalancedWebService(t *testing.T) {
 							Port: aws.Uint16(80),
 						},
 					},
-					RoutingRule: RoutingRule{
-						Path: stringP("/"),
-						HealthCheck: HealthCheckArgsOrString{
-							HealthCheckPath: stringP("/"),
+					RoutingRule: RoutingRuleConfigOrBool{
+						RoutingRuleConfiguration: RoutingRuleConfiguration{
+							Path: stringP("/"),
+							HealthCheck: HealthCheckArgsOrString{
+								HealthCheckPath: stringP("/"),
+							},
 						},
 					},
 					TaskConfig: TaskConfig{
@@ -113,11 +115,13 @@ func TestNewLoadBalancedWebService(t *testing.T) {
 							Command: []string{"CMD", "curl -f http://localhost:8080 || exit 1"},
 						},
 					},
-					RoutingRule: RoutingRule{
-						Path:            stringP("/"),
-						ProtocolVersion: aws.String("gRPC"),
-						HealthCheck: HealthCheckArgsOrString{
-							HealthCheckPath: stringP("/"),
+					RoutingRule: RoutingRuleConfigOrBool{
+						RoutingRuleConfiguration: RoutingRuleConfiguration{
+							Path:            stringP("/"),
+							ProtocolVersion: aws.String("gRPC"),
+							HealthCheck: HealthCheckArgsOrString{
+								HealthCheckPath: stringP("/"),
+							},
 						},
 					},
 					TaskConfig: TaskConfig{
@@ -292,10 +296,12 @@ func TestLoadBalancedWebService_ApplyEnv(t *testing.T) {
 							Port: aws.Uint16(80),
 						},
 					},
-					RoutingRule: RoutingRule{
-						Path: aws.String("/awards/*"),
-						HealthCheck: HealthCheckArgsOrString{
-							HealthCheckPath: aws.String("/"),
+					RoutingRule: RoutingRuleConfigOrBool{
+						RoutingRuleConfiguration: RoutingRuleConfiguration{
+							Path: aws.String("/awards/*"),
+							HealthCheck: HealthCheckArgsOrString{
+								HealthCheckPath: aws.String("/"),
+							},
 						},
 					},
 					TaskConfig: TaskConfig{
@@ -342,10 +348,12 @@ func TestLoadBalancedWebService_ApplyEnv(t *testing.T) {
 							Port: aws.Uint16(80),
 						},
 					},
-					RoutingRule: RoutingRule{
-						Path: aws.String("/awards/*"),
-						HealthCheck: HealthCheckArgsOrString{
-							HealthCheckPath: aws.String("/"),
+					RoutingRule: RoutingRuleConfigOrBool{
+						RoutingRuleConfiguration: RoutingRuleConfiguration{
+							Path: aws.String("/awards/*"),
+							HealthCheck: HealthCheckArgsOrString{
+								HealthCheckPath: aws.String("/"),
+							},
 						},
 					},
 					TaskConfig: TaskConfig{
@@ -392,10 +400,12 @@ func TestLoadBalancedWebService_ApplyEnv(t *testing.T) {
 							Port: aws.Uint16(80),
 						},
 					},
-					RoutingRule: RoutingRule{
-						Path: aws.String("/awards/*"),
-						HealthCheck: HealthCheckArgsOrString{
-							HealthCheckPath: aws.String("/"),
+					RoutingRule: RoutingRuleConfigOrBool{
+						RoutingRuleConfiguration: RoutingRuleConfiguration{
+							Path: aws.String("/awards/*"),
+							HealthCheck: HealthCheckArgsOrString{
+								HealthCheckPath: aws.String("/"),
+							},
 						},
 					},
 					TaskConfig: TaskConfig{
@@ -463,8 +473,10 @@ func TestLoadBalancedWebService_ApplyEnv(t *testing.T) {
 								Port: aws.Uint16(5000),
 							},
 						},
-						RoutingRule: RoutingRule{
-							TargetContainer: aws.String("xray"),
+						RoutingRule: RoutingRuleConfigOrBool{
+							RoutingRuleConfiguration: RoutingRuleConfiguration{
+								TargetContainer: aws.String("xray"),
+							},
 						},
 						TaskConfig: TaskConfig{
 							CPU: aws.Int(2046),
@@ -536,12 +548,14 @@ func TestLoadBalancedWebService_ApplyEnv(t *testing.T) {
 							Port: aws.Uint16(5000),
 						},
 					},
-					RoutingRule: RoutingRule{
-						Path: aws.String("/awards/*"),
-						HealthCheck: HealthCheckArgsOrString{
-							HealthCheckPath: aws.String("/"),
+					RoutingRule: RoutingRuleConfigOrBool{
+						RoutingRuleConfiguration: RoutingRuleConfiguration{
+							Path: aws.String("/awards/*"),
+							HealthCheck: HealthCheckArgsOrString{
+								HealthCheckPath: aws.String("/"),
+							},
+							TargetContainer: aws.String("xray"),
 						},
-						TargetContainer: aws.String("xray"),
 					},
 					TaskConfig: TaskConfig{
 						CPU:    aws.Int(2046),
@@ -1122,17 +1136,21 @@ func TestLoadBalancedWebService_ApplyEnv(t *testing.T) {
 					Type: aws.String(LoadBalancedWebServiceType),
 				},
 				LoadBalancedWebServiceConfig: LoadBalancedWebServiceConfig{
-					RoutingRule: RoutingRule{
-						HealthCheck: HealthCheckArgsOrString{
-							HealthCheckPath: aws.String("path"),
+					RoutingRule: RoutingRuleConfigOrBool{
+						RoutingRuleConfiguration: RoutingRuleConfiguration{
+							HealthCheck: HealthCheckArgsOrString{
+								HealthCheckPath: aws.String("path"),
+							},
+							AllowedSourceIps: []IPNet{mockIPNet1},
 						},
-						AllowedSourceIps: []IPNet{mockIPNet1},
 					},
 				},
 				Environments: map[string]*LoadBalancedWebServiceConfig{
 					"prod-iad": {
-						RoutingRule: RoutingRule{
-							AllowedSourceIps: []IPNet{mockIPNet2},
+						RoutingRule: RoutingRuleConfigOrBool{
+							RoutingRuleConfiguration: RoutingRuleConfiguration{
+								AllowedSourceIps: []IPNet{mockIPNet2},
+							},
 						},
 					},
 				},
@@ -1145,11 +1163,13 @@ func TestLoadBalancedWebService_ApplyEnv(t *testing.T) {
 					Type: aws.String(LoadBalancedWebServiceType),
 				},
 				LoadBalancedWebServiceConfig: LoadBalancedWebServiceConfig{
-					RoutingRule: RoutingRule{
-						HealthCheck: HealthCheckArgsOrString{
-							HealthCheckPath: aws.String("path"),
+					RoutingRule: RoutingRuleConfigOrBool{
+						RoutingRuleConfiguration: RoutingRuleConfiguration{
+							HealthCheck: HealthCheckArgsOrString{
+								HealthCheckPath: aws.String("path"),
+							},
+							AllowedSourceIps: []IPNet{mockIPNet2},
 						},
-						AllowedSourceIps: []IPNet{mockIPNet2},
 					},
 				},
 			},
@@ -1161,18 +1181,22 @@ func TestLoadBalancedWebService_ApplyEnv(t *testing.T) {
 					Type: aws.String(LoadBalancedWebServiceType),
 				},
 				LoadBalancedWebServiceConfig: LoadBalancedWebServiceConfig{
-					RoutingRule: RoutingRule{
-						HealthCheck: HealthCheckArgsOrString{
-							HealthCheckPath: aws.String("path"),
+					RoutingRule: RoutingRuleConfigOrBool{
+						RoutingRuleConfiguration: RoutingRuleConfiguration{
+							HealthCheck: HealthCheckArgsOrString{
+								HealthCheckPath: aws.String("path"),
+							},
+							AllowedSourceIps: []IPNet{mockIPNet1, mockIPNet2},
 						},
-						AllowedSourceIps: []IPNet{mockIPNet1, mockIPNet2},
 					},
 				},
 				Environments: map[string]*LoadBalancedWebServiceConfig{
 					"prod-iad": {
-						RoutingRule: RoutingRule{
-							HealthCheck: HealthCheckArgsOrString{
-								HealthCheckPath: aws.String("another-path"),
+						RoutingRule: RoutingRuleConfigOrBool{
+							RoutingRuleConfiguration: RoutingRuleConfiguration{
+								HealthCheck: HealthCheckArgsOrString{
+									HealthCheckPath: aws.String("another-path"),
+								},
 							},
 						},
 					},
@@ -1186,11 +1210,13 @@ func TestLoadBalancedWebService_ApplyEnv(t *testing.T) {
 					Type: aws.String(LoadBalancedWebServiceType),
 				},
 				LoadBalancedWebServiceConfig: LoadBalancedWebServiceConfig{
-					RoutingRule: RoutingRule{
-						HealthCheck: HealthCheckArgsOrString{
-							HealthCheckPath: aws.String("another-path"),
+					RoutingRule: RoutingRuleConfigOrBool{
+						RoutingRuleConfiguration: RoutingRuleConfiguration{
+							HealthCheck: HealthCheckArgsOrString{
+								HealthCheckPath: aws.String("another-path"),
+							},
+							AllowedSourceIps: []IPNet{mockIPNet1, mockIPNet2},
 						},
-						AllowedSourceIps: []IPNet{mockIPNet1, mockIPNet2},
 					},
 				},
 			},
@@ -1202,20 +1228,24 @@ func TestLoadBalancedWebService_ApplyEnv(t *testing.T) {
 					Type: aws.String(LoadBalancedWebServiceType),
 				},
 				LoadBalancedWebServiceConfig: LoadBalancedWebServiceConfig{
-					RoutingRule: RoutingRule{
-						HealthCheck: HealthCheckArgsOrString{
-							HealthCheckPath: aws.String("path"),
+					RoutingRule: RoutingRuleConfigOrBool{
+						RoutingRuleConfiguration: RoutingRuleConfiguration{
+							HealthCheck: HealthCheckArgsOrString{
+								HealthCheckPath: aws.String("path"),
+							},
+							AllowedSourceIps: []IPNet{mockIPNet1, mockIPNet2},
 						},
-						AllowedSourceIps: []IPNet{mockIPNet1, mockIPNet2},
 					},
 				},
 				Environments: map[string]*LoadBalancedWebServiceConfig{
 					"prod-iad": {
-						RoutingRule: RoutingRule{
-							HealthCheck: HealthCheckArgsOrString{
-								HealthCheckPath: aws.String("another-path"),
+						RoutingRule: RoutingRuleConfigOrBool{
+							RoutingRuleConfiguration: RoutingRuleConfiguration{
+								HealthCheck: HealthCheckArgsOrString{
+									HealthCheckPath: aws.String("another-path"),
+								},
+								AllowedSourceIps: []IPNet{},
 							},
-							AllowedSourceIps: []IPNet{},
 						},
 					},
 				},
@@ -1228,11 +1258,13 @@ func TestLoadBalancedWebService_ApplyEnv(t *testing.T) {
 					Type: aws.String(LoadBalancedWebServiceType),
 				},
 				LoadBalancedWebServiceConfig: LoadBalancedWebServiceConfig{
-					RoutingRule: RoutingRule{
-						HealthCheck: HealthCheckArgsOrString{
-							HealthCheckPath: aws.String("another-path"),
+					RoutingRule: RoutingRuleConfigOrBool{
+						RoutingRuleConfiguration: RoutingRuleConfiguration{
+							HealthCheck: HealthCheckArgsOrString{
+								HealthCheckPath: aws.String("another-path"),
+							},
+							AllowedSourceIps: []IPNet{},
 						},
-						AllowedSourceIps: []IPNet{},
 					},
 				},
 			},
@@ -1375,9 +1407,11 @@ func TestLoadBalancedWebService_HasAliases(t *testing.T) {
 	}{
 		"use http aliases": {
 			config: LoadBalancedWebServiceConfig{
-				RoutingRule: RoutingRule{
-					Alias: Alias{
-						String: aws.String("mockAlias"),
+				RoutingRule: RoutingRuleConfigOrBool{
+					RoutingRuleConfiguration: RoutingRuleConfiguration{
+						Alias: Alias{
+							String: aws.String("mockAlias"),
+						},
 					},
 				},
 			},
@@ -1395,9 +1429,11 @@ func TestLoadBalancedWebService_HasAliases(t *testing.T) {
 		},
 		"both http and nlb use aliases": {
 			config: LoadBalancedWebServiceConfig{
-				RoutingRule: RoutingRule{
-					Alias: Alias{
-						StringSlice: []string{"mockAlias", "mockAnotherAlias"},
+				RoutingRule: RoutingRuleConfigOrBool{
+					RoutingRuleConfiguration: RoutingRuleConfiguration{
+						Alias: Alias{
+							StringSlice: []string{"mockAlias", "mockAnotherAlias"},
+						},
 					},
 				},
 				NLBConfig: NetworkLoadBalancerConfiguration{

--- a/internal/pkg/manifest/lb_web_svc_test.go
+++ b/internal/pkg/manifest/lb_web_svc_test.go
@@ -1493,6 +1493,45 @@ func TestAlias_IsEmpty(t *testing.T) {
 	}
 }
 
+func TestRoutingRuleConfigOrBool_Disabled(t *testing.T) {
+	testCases := map[string]struct {
+		in     RoutingRuleConfigOrBool
+		wanted bool
+	}{
+		"disabled": {
+			in: RoutingRuleConfigOrBool{
+				Enabled: aws.Bool(false),
+			},
+			wanted: true,
+		},
+		"enabled implicitly": {
+			in: RoutingRuleConfigOrBool{},
+		},
+		"enabled explicitly": {
+			in: RoutingRuleConfigOrBool{
+				Enabled: aws.Bool(true),
+			},
+		},
+		"enabled explicitly by advanced configuration": {
+			in: RoutingRuleConfigOrBool{
+				RoutingRuleConfiguration: RoutingRuleConfiguration{
+					Path: aws.String("mockPath"),
+				},
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// WHEN
+			got := tc.in.Disabled()
+
+			// THEN
+			require.Equal(t, tc.wanted, got)
+		})
+	}
+}
+
 func TestNetworkLoadBalancerConfiguration_IsEmpty(t *testing.T) {
 	testCases := map[string]struct {
 		in     NetworkLoadBalancerConfiguration

--- a/internal/pkg/manifest/svc.go
+++ b/internal/pkg/manifest/svc.go
@@ -278,6 +278,20 @@ func IsTypeAService(t string) bool {
 	return false
 }
 
+// NLBHealthCheckArgs holds the configuration to determine if the load balanced web service is healthy.
+// These options are specifiable under the "healthcheck" field.
+// See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html.
+type NLBHealthCheckArgs struct {
+	HealthyThreshold   *int64         `yaml:"healthy_threshold"`
+	UnhealthyThreshold *int64         `yaml:"unhealthy_threshold"`
+	Timeout            *time.Duration `yaml:"timeout"`
+	Interval           *time.Duration `yaml:"interval"`
+}
+
+func (h *NLBHealthCheckArgs) isEmpty() bool {
+	return h.HealthyThreshold == nil && h.UnhealthyThreshold == nil && h.Interval == nil && h.Timeout == nil
+}
+
 // HTTPHealthCheckArgs holds the configuration to determine if the load balanced web service is healthy.
 // These options are specifiable under the "healthcheck" field.
 // See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html.

--- a/internal/pkg/manifest/svc.go
+++ b/internal/pkg/manifest/svc.go
@@ -292,7 +292,7 @@ type HTTPHealthCheckArgs struct {
 }
 
 func (h *HTTPHealthCheckArgs) isEmpty() bool {
-	return h.Path == nil && h.HealthyThreshold == nil && h.UnhealthyThreshold == nil &&
+	return h.Path == nil && h.SuccessCodes == nil && h.HealthyThreshold == nil && h.UnhealthyThreshold == nil &&
 		h.Interval == nil && h.Timeout == nil && h.GracePeriod == nil
 }
 

--- a/internal/pkg/manifest/svc_test.go
+++ b/internal/pkg/manifest/svc_test.go
@@ -95,19 +95,21 @@ environments:
 								Credentials: aws.String("some arn"),
 							}, Port: aws.Uint16(80)},
 						},
-						RoutingRule: RoutingRule{
-							Alias: Alias{
-								StringSlice: []string{
-									"foobar.com",
-									"v1.foobar.com",
+						RoutingRule: RoutingRuleConfigOrBool{
+							RoutingRuleConfiguration: RoutingRuleConfiguration{
+								Alias: Alias{
+									StringSlice: []string{
+										"foobar.com",
+										"v1.foobar.com",
+									},
 								},
+								Path:            aws.String("svc"),
+								TargetContainer: aws.String("frontend"),
+								HealthCheck: HealthCheckArgsOrString{
+									HealthCheckPath: aws.String("/"),
+								},
+								AllowedSourceIps: []IPNet{IPNet("10.1.0.0/24"), IPNet("10.1.1.0/24")},
 							},
-							Path:            aws.String("svc"),
-							TargetContainer: aws.String("frontend"),
-							HealthCheck: HealthCheckArgsOrString{
-								HealthCheckPath: aws.String("/"),
-							},
-							AllowedSourceIps: []IPNet{IPNet("10.1.0.0/24"), IPNet("10.1.1.0/24")},
 						},
 						TaskConfig: TaskConfig{
 							CPU:    aws.Int(512),

--- a/internal/pkg/manifest/transform.go
+++ b/internal/pkg/manifest/transform.go
@@ -27,6 +27,7 @@ var defaultTransformers = []mergo.Transformers{
 	efsConfigOrBoolTransformer{},
 	efsVolumeConfigurationTransformer{},
 	sqsQueueOrBoolTransformer{},
+	routingRuleConfigOrBoolTransformer{},
 }
 
 // See a complete list of `reflect.Kind` here: https://pkg.go.dev/reflect#Kind.
@@ -317,6 +318,31 @@ func (q sqsQueueOrBoolTransformer) Transformer(typ reflect.Type) func(dst, src r
 
 		if srcStruct.Enabled != nil {
 			dstStruct.Advanced = SQSQueue{}
+		}
+
+		if dst.CanSet() { // For extra safety to prevent panicking.
+			dst.Set(reflect.ValueOf(dstStruct))
+		}
+		return nil
+	}
+}
+
+type routingRuleConfigOrBoolTransformer struct{}
+
+// Transformer returns custom merge logic for RoutingRuleConfigOrBool's fields.
+func (t routingRuleConfigOrBoolTransformer) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
+	if typ != reflect.TypeOf(RoutingRuleConfigOrBool{}) {
+		return nil
+	}
+	return func(dst, src reflect.Value) error {
+		dstStruct, srcStruct := dst.Interface().(RoutingRuleConfigOrBool), src.Interface().(RoutingRuleConfigOrBool)
+
+		if !srcStruct.RoutingRuleConfiguration.isEmpty() {
+			dstStruct.Enabled = nil
+		}
+
+		if srcStruct.Enabled != nil {
+			dstStruct.RoutingRuleConfiguration = RoutingRuleConfiguration{}
 		}
 
 		if dst.CanSet() { // For extra safety to prevent panicking.

--- a/internal/pkg/manifest/transform_test.go
+++ b/internal/pkg/manifest/transform_test.go
@@ -208,7 +208,7 @@ func TestImageTransformer_Transformer(t *testing.T) {
 			err := mergo.Merge(&dst, override, mergo.WithOverride)
 			require.NoError(t, err)
 
-			// Use imageTransformer.
+			// Use custom transformer.
 			err = mergo.Merge(&dst, override, mergo.WithOverride, mergo.WithTransformers(imageTransformer{}))
 			require.NoError(t, err)
 
@@ -271,7 +271,7 @@ func TestBuildArgsOrStringTransformer_Transformer(t *testing.T) {
 			err := mergo.Merge(&dst, override, mergo.WithOverride)
 			require.NoError(t, err)
 
-			// Use imageTransformer.
+			// Use custom transformer.
 			err = mergo.Merge(&dst, override, mergo.WithOverride, mergo.WithTransformers(buildArgsOrStringTransformer{}))
 			require.NoError(t, err)
 
@@ -323,7 +323,7 @@ func TestStringSliceOrStringTransformer_Transformer(t *testing.T) {
 			err := mergo.Merge(&dst, override, mergo.WithOverride)
 			require.NoError(t, err)
 
-			// Use imageTransformer.
+			// Use custom transformer.
 			err = mergo.Merge(&dst, override, mergo.WithOverride, mergo.WithTransformers(stringSliceOrStringTransformer{}))
 			require.NoError(t, err)
 
@@ -385,7 +385,7 @@ func TestPlatformArgsOrStringTransformer_Transformer(t *testing.T) {
 			err := mergo.Merge(&dst, override, mergo.WithOverride)
 			require.NoError(t, err)
 
-			// Use imageTransformer.
+			// Use custom transformer.
 			err = mergo.Merge(&dst, override, mergo.WithOverride, mergo.WithTransformers(platformArgsOrStringTransformer{}))
 			require.NoError(t, err)
 
@@ -446,7 +446,7 @@ func TestHealthCheckArgsOrStringTransformer_Transformer(t *testing.T) {
 			err := mergo.Merge(&dst, override, mergo.WithOverride)
 			require.NoError(t, err)
 
-			// Use imageTransformer.
+			// Use custom transformer.
 			err = mergo.Merge(&dst, override, mergo.WithOverride, mergo.WithTransformers(healthCheckArgsOrStringTransformer{}))
 			require.NoError(t, err)
 
@@ -504,7 +504,7 @@ func TestCountTransformer_Transformer(t *testing.T) {
 			err := mergo.Merge(&dst, override, mergo.WithOverride)
 			require.NoError(t, err)
 
-			// Use imageTransformer.
+			// Use custom transformer.
 			err = mergo.Merge(&dst, override, mergo.WithOverride, mergo.WithTransformers(countTransformer{}))
 			require.NoError(t, err)
 
@@ -569,7 +569,7 @@ func TestAdvancedCountTransformer_Transformer(t *testing.T) {
 			err := mergo.Merge(&dst, override, mergo.WithOverride)
 			require.NoError(t, err)
 
-			// Use imageTransformer.
+			// Use custom transformer.
 			err = mergo.Merge(&dst, override, mergo.WithOverride, mergo.WithTransformers(advancedCountTransformer{}))
 			require.NoError(t, err)
 
@@ -633,7 +633,7 @@ func TestRangeTransformer_Transformer(t *testing.T) {
 			err := mergo.Merge(&dst, override, mergo.WithOverride)
 			require.NoError(t, err)
 
-			// Use imageTransformer.
+			// Use custom transformer.
 			err = mergo.Merge(&dst, override, mergo.WithOverride, mergo.WithTransformers(rangeTransformer{}))
 			require.NoError(t, err)
 
@@ -694,7 +694,7 @@ func TestEfsConfigOrBoolTransformer_Transformer(t *testing.T) {
 			err := mergo.Merge(&dst, override, mergo.WithOverride)
 			require.NoError(t, err)
 
-			// Use imageTransformer.
+			// Use custom transformer.
 			err = mergo.Merge(&dst, override, mergo.WithOverride, mergo.WithTransformers(efsConfigOrBoolTransformer{}))
 			require.NoError(t, err)
 
@@ -752,7 +752,7 @@ func TestEfsVolumeConfigurationTransformer_Transformer(t *testing.T) {
 			err := mergo.Merge(&dst, override, mergo.WithOverride)
 			require.NoError(t, err)
 
-			// Use imageTransformer.
+			// Use custom transformer.
 			err = mergo.Merge(&dst, override, mergo.WithOverride, mergo.WithTransformers(efsVolumeConfigurationTransformer{}))
 			require.NoError(t, err)
 
@@ -810,8 +810,66 @@ func TestSQSQueueOrBoolTransformer_Transformer(t *testing.T) {
 			err := mergo.Merge(&dst, override, mergo.WithOverride)
 			require.NoError(t, err)
 
-			// Use imageTransformer.
+			// Use custom transformer.
 			err = mergo.Merge(&dst, override, mergo.WithOverride, mergo.WithTransformers(sqsQueueOrBoolTransformer{}))
+			require.NoError(t, err)
+
+			require.NoError(t, err)
+			require.Equal(t, wanted, dst)
+		})
+	}
+}
+
+func TestRoutingRuleConfigOrBoolTransformer_Transformer(t *testing.T) {
+	testCases := map[string]struct {
+		original func(r *RoutingRuleConfigOrBool)
+		override func(r *RoutingRuleConfigOrBool)
+		wanted   func(r *RoutingRuleConfigOrBool)
+	}{
+		"bool set to empty if config is not nil": {
+			original: func(r *RoutingRuleConfigOrBool) {
+				r.Enabled = aws.Bool(true)
+			},
+			override: func(r *RoutingRuleConfigOrBool) {
+				r.RoutingRuleConfiguration = RoutingRuleConfiguration{
+					Path: aws.String("mockPath"),
+				}
+			},
+			wanted: func(r *RoutingRuleConfigOrBool) {
+				r.RoutingRuleConfiguration = RoutingRuleConfiguration{
+					Path: aws.String("mockPath"),
+				}
+			},
+		},
+		"config set to empty if bool is not nil": {
+			original: func(r *RoutingRuleConfigOrBool) {
+				r.RoutingRuleConfiguration = RoutingRuleConfiguration{
+					Path: aws.String("mockPath"),
+				}
+			},
+			override: func(r *RoutingRuleConfigOrBool) {
+				r.Enabled = aws.Bool(false)
+			},
+			wanted: func(r *RoutingRuleConfigOrBool) {
+				r.Enabled = aws.Bool(false)
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			var dst, override, wanted RoutingRuleConfigOrBool
+
+			tc.original(&dst)
+			tc.override(&override)
+			tc.wanted(&wanted)
+
+			// Perform default merge.
+			err := mergo.Merge(&dst, override, mergo.WithOverride)
+			require.NoError(t, err)
+
+			// Use custom transformer.
+			err = mergo.Merge(&dst, override, mergo.WithOverride, mergo.WithTransformers(routingRuleConfigOrBoolTransformer{}))
 			require.NoError(t, err)
 
 			require.NoError(t, err)

--- a/internal/pkg/manifest/validate.go
+++ b/internal/pkg/manifest/validate.go
@@ -529,8 +529,8 @@ func (CommandOverride) Validate() error {
 	return nil
 }
 
-// Validate returns nil if RoutingRule is configured correctly.
-func (r RoutingRule) Validate() error {
+// Validate returns nil if RoutingRuleConfiguration is configured correctly.
+func (r RoutingRuleConfiguration) Validate() error {
 	var err error
 	if err = r.HealthCheck.Validate(); err != nil {
 		return fmt.Errorf(`validate "healthcheck": %w`, err)

--- a/internal/pkg/manifest/validate.go
+++ b/internal/pkg/manifest/validate.go
@@ -611,6 +611,10 @@ func (c NetworkLoadBalancerConfiguration) Validate() error {
 	return nil
 }
 
+func (h NLBHealthCheckArgs) Validate() error {
+	return nil
+}
+
 // Validate returns nil if TaskConfig is configured correctly.
 func (t TaskConfig) Validate() error {
 	var err error

--- a/internal/pkg/manifest/validate.go
+++ b/internal/pkg/manifest/validate.go
@@ -85,6 +85,9 @@ func (l LoadBalancedWebServiceConfig) Validate() error {
 	if l.RoutingRule.Disabled() && l.NLBConfig.IsEmpty() {
 		return errors.New(`must have one of "http" or "nlb" enabled`)
 	}
+	if l.RoutingRule.Disabled() && (l.Count.AdvancedCount.Requests != nil || l.Count.AdvancedCount.ResponseTime != nil) {
+		return errors.New(`scaling based on "nlb" requests is not supported yet`)
+	}
 	if err = l.ImageConfig.Validate(); err != nil {
 		return fmt.Errorf(`validate "image": %w`, err)
 	}

--- a/internal/pkg/manifest/validate.go
+++ b/internal/pkg/manifest/validate.go
@@ -82,6 +82,9 @@ func (l LoadBalancedWebService) Validate() error {
 // Validate returns nil if LoadBalancedWebServiceConfig is configured correctly.
 func (l LoadBalancedWebServiceConfig) Validate() error {
 	var err error
+	if l.RoutingRule.Disabled() && l.NLBConfig.IsEmpty() {
+		return errors.New(`must have one of "http" or "nlb" enabled`)
+	}
 	if err = l.ImageConfig.Validate(); err != nil {
 		return fmt.Errorf(`validate "image": %w`, err)
 	}

--- a/internal/pkg/manifest/validate_test.go
+++ b/internal/pkg/manifest/validate_test.go
@@ -47,9 +47,11 @@ func TestLoadBalancedWebService_Validate(t *testing.T) {
 			lbConfig: LoadBalancedWebService{
 				LoadBalancedWebServiceConfig: LoadBalancedWebServiceConfig{
 					ImageConfig: testImageConfig,
-					RoutingRule: RoutingRule{
-						TargetContainer:          aws.String("mockTargetContainer"),
-						TargetContainerCamelCase: aws.String("mockTargetContainer"),
+					RoutingRule: RoutingRuleConfigOrBool{
+						RoutingRuleConfiguration: RoutingRuleConfiguration{
+							TargetContainer:          aws.String("mockTargetContainer"),
+							TargetContainerCamelCase: aws.String("mockTargetContainer"),
+						},
 					},
 				},
 			},
@@ -122,8 +124,10 @@ func TestLoadBalancedWebService_Validate(t *testing.T) {
 				Workload: Workload{Name: aws.String("mockName")},
 				LoadBalancedWebServiceConfig: LoadBalancedWebServiceConfig{
 					ImageConfig: testImageConfig,
-					RoutingRule: RoutingRule{
-						TargetContainer: aws.String("foo"),
+					RoutingRule: RoutingRuleConfigOrBool{
+						RoutingRuleConfiguration: RoutingRuleConfiguration{
+							TargetContainer: aws.String("foo"),
+						},
 					},
 				},
 			},
@@ -134,8 +138,10 @@ func TestLoadBalancedWebService_Validate(t *testing.T) {
 				Workload: Workload{Name: aws.String("mockName")},
 				LoadBalancedWebServiceConfig: LoadBalancedWebServiceConfig{
 					ImageConfig: testImageConfig,
-					RoutingRule: RoutingRule{
-						TargetContainer: aws.String("mockName"),
+					RoutingRule: RoutingRuleConfigOrBool{
+						RoutingRuleConfiguration: RoutingRuleConfiguration{
+							TargetContainer: aws.String("mockName"),
+						},
 					},
 					NLBConfig: NetworkLoadBalancerConfiguration{
 						Port:            aws.String("443"),
@@ -908,20 +914,20 @@ func TestDependsOn_Validate(t *testing.T) {
 
 func TestRoutingRule_Validate(t *testing.T) {
 	testCases := map[string]struct {
-		RoutingRule RoutingRule
+		RoutingRule RoutingRuleConfiguration
 
 		wantedErrorMsgPrefix string
 		wantedError          error
 	}{
 		"error if both target_container and targetContainer are specified": {
-			RoutingRule: RoutingRule{
+			RoutingRule: RoutingRuleConfiguration{
 				TargetContainer:          aws.String("mockContainer"),
 				TargetContainerCamelCase: aws.String("mockContainer"),
 			},
 			wantedError: fmt.Errorf(`must specify one, not both, of "target_container" and "targetContainer"`),
 		},
 		"error if one of allowed_source_ips is not valid": {
-			RoutingRule: RoutingRule{
+			RoutingRule: RoutingRuleConfiguration{
 				AllowedSourceIps: []IPNet{
 					IPNet("10.1.0.0/24"),
 					IPNet("badIP"),
@@ -931,13 +937,13 @@ func TestRoutingRule_Validate(t *testing.T) {
 			wantedErrorMsgPrefix: `validate "allowed_source_ips[1]": `,
 		},
 		"error if protocol version is not valid": {
-			RoutingRule: RoutingRule{
+			RoutingRule: RoutingRuleConfiguration{
 				ProtocolVersion: aws.String("quic"),
 			},
 			wantedErrorMsgPrefix: `"version" field value 'quic' must be one of GRPC, HTTP1 or HTTP2`,
 		},
 		"should not error if protocol version is not uppercase": {
-			RoutingRule: RoutingRule{
+			RoutingRule: RoutingRuleConfiguration{
 				ProtocolVersion: aws.String("gRPC"),
 			},
 		},

--- a/internal/pkg/manifest/validate_test.go
+++ b/internal/pkg/manifest/validate_test.go
@@ -217,6 +217,52 @@ func TestLoadBalancedWebService_Validate(t *testing.T) {
 			},
 			wantedError: errors.New(`must have one of "http" or "nlb" enabled`),
 		},
+		"error if scaling based on nlb requests": {
+			lbConfig: LoadBalancedWebService{
+				Workload: Workload{
+					Name: aws.String("mockName"),
+				},
+				LoadBalancedWebServiceConfig: LoadBalancedWebServiceConfig{
+					TaskConfig: TaskConfig{
+						Count: Count{
+							AdvancedCount: AdvancedCount{
+								Requests: aws.Int(3),
+							},
+						},
+					},
+					RoutingRule: RoutingRuleConfigOrBool{
+						Enabled: aws.Bool(false),
+					},
+					NLBConfig: NetworkLoadBalancerConfiguration{
+						Port: aws.String("80"),
+					},
+				},
+			},
+			wantedError: errors.New(`scaling based on "nlb" requests is not supported yet`),
+		},
+		"error if scaling based on nlb response time": {
+			lbConfig: LoadBalancedWebService{
+				Workload: Workload{
+					Name: aws.String("mockName"),
+				},
+				LoadBalancedWebServiceConfig: LoadBalancedWebServiceConfig{
+					TaskConfig: TaskConfig{
+						Count: Count{
+							AdvancedCount: AdvancedCount{
+								ResponseTime: durationp(10 * time.Second),
+							},
+						},
+					},
+					RoutingRule: RoutingRuleConfigOrBool{
+						Enabled: aws.Bool(false),
+					},
+					NLBConfig: NetworkLoadBalancerConfiguration{
+						Port: aws.String("80"),
+					},
+				},
+			},
+			wantedError: errors.New(`scaling based on "nlb" requests is not supported yet`),
+		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {

--- a/internal/pkg/manifest/validate_test.go
+++ b/internal/pkg/manifest/validate_test.go
@@ -203,6 +203,20 @@ func TestLoadBalancedWebService_Validate(t *testing.T) {
 			},
 			wantedErrorMsgPrefix: `validate ARM: `,
 		},
+		"error if neither of http or nlb is enabled": {
+			lbConfig: LoadBalancedWebService{
+				Workload: Workload{
+					Name: aws.String("mockName"),
+				},
+				LoadBalancedWebServiceConfig: LoadBalancedWebServiceConfig{
+					ImageConfig: testImageConfig,
+					RoutingRule: RoutingRuleConfigOrBool{
+						Enabled: aws.Bool(false),
+					},
+				},
+			},
+			wantedError: errors.New(`must have one of "http" or "nlb" enabled`),
+		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {

--- a/internal/pkg/manifest/workload.go
+++ b/internal/pkg/manifest/workload.go
@@ -603,7 +603,7 @@ func UnmarshalWorkload(in []byte) (WorkloadManifest, error) {
 	var m manifest
 	switch typeVal {
 	case LoadBalancedWebServiceType:
-		m = newDefaultLoadBalancedWebService()
+		m = newDefaultEmptyLoadBalancedWebService()
 
 	case RequestDrivenWebServiceType:
 		m = newDefaultRequestDrivenWebService()

--- a/internal/pkg/template/templates/workloads/partials/cf/nlb.yml
+++ b/internal/pkg/template/templates/workloads/partials/cf/nlb.yml
@@ -31,6 +31,18 @@ NLBTargetGroup:
     'aws:copilot:description': 'A target group to connect the network load balancer to your service'
   Type: AWS::ElasticLoadBalancingV2::TargetGroup
   Properties:
+    {{- if .NLB.Listener.HealthCheck.HealthyThreshold }}
+    HealthyThresholdCount: {{.NLB.Listener.HealthCheck.HealthyThreshold}}
+    {{- end }}
+    {{- if .NLB.Listener.HealthCheck.UnhealthyThreshold }}
+    UnhealthyThresholdCount: {{.NLB.Listener.HealthCheck.UnhealthyThreshold}}
+    {{- end }}
+    {{- if .NLB.Listener.HealthCheck.Interval }}
+    HealthCheckIntervalSeconds: {{.NLB.Listener.HealthCheck.Interval}}
+    {{- end }}
+    {{- if .NLB.Listener.HealthCheck.Timeout }}
+    HealthCheckTimeoutSeconds: {{.NLB.Listener.HealthCheck.Timeout}}
+    {{- end }}
     Port: !Ref ContainerPort
 {{- if eq .NLB.Listener.Protocol "TLS"}}
     Protocol: TCP
@@ -39,16 +51,12 @@ NLBTargetGroup:
 {{- end}}
     TargetGroupAttributes:
       - Key: deregistration_delay.timeout_seconds
-        Value: {{.DeregistrationDelay}}  # ECS Default is 300; Copilot default is 60.
+        Value: 60  # ECS Default is 300; Copilot default is 60.
 {{- if ne .NLB.Listener.Protocol "TLS"}}
 {{/*Sticky sessions are not supported with TLS listeners and TLS target groups.*/}}
       - Key: stickiness.enabled
         Value: !Ref Stickiness
 {{- end}}
-      - Key: deregistration_delay.connection_termination.enabled
-        Value: false # NOTE: Default is false  TODO: remove this comment and investigate if we should surface this or not.
-      - Key: proxy_protocol_v2.enabled
-        Value: false # NOTE: Default is false  TODO: remove this comment and investigate if we should surface this or not.
     TargetType: ip
     VpcId:
       Fn::ImportValue:

--- a/internal/pkg/template/templates/workloads/partials/cf/nlb.yml
+++ b/internal/pkg/template/templates/workloads/partials/cf/nlb.yml
@@ -31,18 +31,6 @@ NLBTargetGroup:
     'aws:copilot:description': 'A target group to connect the network load balancer to your service'
   Type: AWS::ElasticLoadBalancingV2::TargetGroup
   Properties:
-    {{- if .HTTPHealthCheck.HealthyThreshold }}
-    HealthyThresholdCount: {{.HTTPHealthCheck.HealthyThreshold}}
-    {{- end }}
-    {{- if .HTTPHealthCheck.UnhealthyThreshold }}
-    UnhealthyThresholdCount: {{.HTTPHealthCheck.UnhealthyThreshold}}
-    {{- end }}
-    {{- if .HTTPHealthCheck.Interval }}
-    HealthCheckIntervalSeconds: {{.HTTPHealthCheck.Interval}}
-    {{- end }}
-    {{- if .HTTPHealthCheck.Timeout }}
-    HealthCheckTimeoutSeconds: {{.HTTPHealthCheck.Timeout}}
-    {{- end }}
     Port: !Ref ContainerPort
 {{- if eq .NLB.Listener.Protocol "TLS"}}
     Protocol: TCP

--- a/internal/pkg/template/templates/workloads/partials/cf/nlb.yml
+++ b/internal/pkg/template/templates/workloads/partials/cf/nlb.yml
@@ -172,8 +172,9 @@ NLBCertManagerRole:
               Resource:
                 !Sub
                   - arn:${AWS::Partition}:route53:::hostedzone/${EnvHostedZone}
-                  - EnvHostedZone: Fn::ImportValue
-                      !Sub "${AppName}-${EnvName}-HostedZone"
+                  - EnvHostedZone:
+                      Fn::ImportValue:
+                        !Sub "${AppName}-${EnvName}-HostedZone"
             - Sid: EnvHostedZoneRead
               Effect: Allow
               Action:

--- a/internal/pkg/template/templates/workloads/partials/cf/nlb.yml
+++ b/internal/pkg/template/templates/workloads/partials/cf/nlb.yml
@@ -82,7 +82,7 @@ NLBSecurityGroup:
     VpcId:
       Fn::ImportValue:
         !Sub "${AppName}-${EnvName}-VpcId"
-{{- if not .Aliases}}
+{{- if not .NLB.Listener.Aliases}}
 NLBDNSAlias:
   Metadata:
     'aws:copilot:description': 'The default alias record for the network load balancer'

--- a/internal/pkg/template/templates/workloads/partials/cf/nlb.yml
+++ b/internal/pkg/template/templates/workloads/partials/cf/nlb.yml
@@ -162,6 +162,10 @@ NLBCertManagerRole:
         PolicyDocument:
           Version: '2012-10-17'
           Statement:
+            - Sid: AllowAssumeRole
+              Effect: Allow
+              Action: sts:AssumeRole
+              Resource: "*"
             - Sid: EnvHostedZoneUpdateAndWait
               Effect: Allow
               Action: route53:ChangeResourceRecordSets

--- a/internal/pkg/template/templates/workloads/services/lb-web/cf.yml
+++ b/internal/pkg/template/templates/workloads/services/lb-web/cf.yml
@@ -13,17 +13,12 @@ Parameters:
     Type: String
   ContainerPort:
     Type: Number
-  RulePath:
-    Type: String
   TaskCPU:
     Type: String
   TaskMemory:
     Type: String
   TaskCount:
     Type: Number
-  HTTPSEnabled:
-    Type: String
-    AllowedValues: [true, false]
   DNSDelegated:
     Type: String
     AllowedValues: [true, false]
@@ -41,23 +36,32 @@ Parameters:
     Type: String
   TargetPort:
     Type: Number
+{{- if not .HTTPDisabled}}
+  HTTPSEnabled:
+    Type: String
+    AllowedValues: [true, false]
+  RulePath:
+    Type: String
   Stickiness:
     Type: String
     Default: false
+{{- end}}
 Conditions:
+{{- if not .HTTPDisabled}}
   HTTPLoadBalancer:
     !Not
       - !Condition HTTPSLoadBalancer
   HTTPSLoadBalancer:
     !Equals [!Ref HTTPSEnabled, true]
+  IsDefaultRootPath:
+    !Equals [!Ref RulePath, "/"]
+{{- end}}
   HasAssociatedDomain:
     !Equals [!Ref DNSDelegated, true]
   HasAddons: # If a bucket URL is specified, that means the template exists.
     !Not [!Equals [!Ref AddonsTemplateURL, ""]]
   HasEnvFile:
     !Not [!Equals [!Ref EnvFileARN, ""]]
-  IsDefaultRootPath:
-    !Equals [!Ref RulePath, "/"]
 Resources:
 {{include "loggroup" . | indent 2}}
 

--- a/internal/pkg/template/templates/workloads/services/lb-web/cf.yml
+++ b/internal/pkg/template/templates/workloads/services/lb-web/cf.yml
@@ -131,7 +131,9 @@ Resources:
       'aws:copilot:description': 'An ECS service to run and maintain your tasks in the environment cluster'
     Type: AWS::ECS::Service
     DependsOn:
+    {{- if not .HTTPDisabled}}
      - WaitUntilListenerRuleIsCreated
+    {{- end}}
     {{- if .NLB}}
      - NLBListener
     {{- end}}
@@ -140,9 +142,11 @@ Resources:
       # This may need to be adjusted if the container takes a while to start up
       HealthCheckGracePeriodSeconds: {{.HTTPHealthCheck.GracePeriod}}
       LoadBalancers:
+  {{- if not .HTTPDisabled}}
         - ContainerName: !Ref TargetContainer
           ContainerPort: !Ref TargetPort
           TargetGroupArn: !Ref TargetGroup
+  {{- end}}
   {{- if .NLB}}
         - ContainerName: {{.NLB.Listener.TargetContainer}}
           ContainerPort:  {{.NLB.Listener.TargetPort}}
@@ -152,6 +156,7 @@ Resources:
         - RegistryArn: !GetAtt DiscoveryService.Arn
           Port: !Ref ContainerPort
 
+{{- if not .HTTPDisabled}}
   TargetGroup:
     Metadata:
       'aws:copilot:description': 'A target group to connect the load balancer to your service'
@@ -438,6 +443,7 @@ Resources:
       Timeout: "1"
       Count: 0
 
+{{- end}} {{/*end if not .HTTPDisabled */}}
 {{- if .NLB}}
 {{include "nlb" . | indent 2}}
 {{- end}}

--- a/internal/pkg/template/templates/workloads/services/lb-web/manifest.yml
+++ b/internal/pkg/template/templates/workloads/services/lb-web/manifest.yml
@@ -8,14 +8,14 @@ type: {{.Type}}
 
 # Distribute traffic to your service.
 http:
-  {{- if .ProtocolVersion }}
-  version: {{.ProtocolVersion}}
+  {{- if .RoutingRule.ProtocolVersion }}
+  version: {{.RoutingRule.ProtocolVersion}}
   {{- end }}
   # Requests to this path will be forwarded to your service.
   # To match all requests you can use the "/" path.
-  path: '{{.Path}}'
+  path: '{{.RoutingRule.Path}}'
   # You can specify a custom health check path. The default is "/".
-  # healthcheck: '{{.HealthCheck.HealthCheckPath}}'
+  # healthcheck: '{{.RoutingRule.HealthCheck.HealthCheckPath}}'
 
 # Configuration for your containers and service.
 image:

--- a/internal/pkg/template/workload.go
+++ b/internal/pkg/template/workload.go
@@ -390,6 +390,7 @@ type WorkloadOpts struct {
 	Publish                  *PublishOpts
 	ServiceDiscoveryEndpoint string
 	HTTPVersion              *string
+	HTTPDisabled             bool
 
 	// Additional options for service templates.
 	WorkloadType        string

--- a/internal/pkg/template/workload.go
+++ b/internal/pkg/template/workload.go
@@ -206,14 +206,24 @@ type HTTPHealthCheckOpts struct {
 	GracePeriod         *int64
 }
 
+// NetworkLoadBalancerHealthCheckOpts holds configuration that's needed for NLB Health Check.
+type NetworkLoadBalancerHealthCheckOpts struct {
+	HealthyThreshold   *int64
+	UnhealthyThreshold *int64
+	Interval           *int64
+	Timeout            *int64
+}
+
 // NetworkLoadBalancerListener holds configuration that's need for a Network Load Balancer listener.
 type NetworkLoadBalancerListener struct {
-	Port            string
-	Protocol        string
-	TargetContainer string
-	TargetPort      string
-	SSLPolicy       *string
-	Aliases         []string
+	Port                string
+	Protocol            string
+	TargetContainer     string
+	TargetPort          string
+	SSLPolicy           *string
+	DeregistrationDelay *int64
+	Aliases             []string
+	HealthCheck         NetworkLoadBalancerHealthCheckOpts
 }
 
 // NetworkLoadBalancer holds configuration that's needed for a Network Load Balancer.


### PR DESCRIPTION
This PR:
1. Allow disabling "http" (i.e. ALB) from manifest
2. Tiny refactor on how LBWS's runtime validation is done

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
