### PR TITLE
chore: UI update for NLB support

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/lb_web_svc.go
+++ b/internal/pkg/deploy/cloudformation/stack/lb_web_svc.go
@@ -34,6 +34,8 @@ const (
 	LBWebServiceTargetPortParamKey      = "TargetPort"
 	LBWebServiceStickinessParamKey      = "Stickiness"
 	LBWebServiceDNSDelegatedParamKey    = "DNSDelegated"
+	LBWebServiceNLBAliasesParamKey      = "NLBAliases"
+	LBWebServiceNLBPortParamKey         = "NLBPort"
 )
 
 type loadBalancedWebSvcReadParser interface {
@@ -309,6 +311,22 @@ func (s *LoadBalancedWebService) Parameters() ([]*cloudformation.Parameter, erro
 			{
 				ParameterKey:   aws.String(LBWebServiceStickinessParamKey),
 				ParameterValue: aws.String(strconv.FormatBool(aws.BoolValue(s.manifest.RoutingRule.Stickiness))),
+			},
+		}...)
+	}
+	if !s.manifest.NLBConfig.IsEmpty() {
+		port, _, err := parsePortMapping(s.manifest.NLBConfig.Port)
+		if err != nil {
+			return nil, err
+		}
+		wkldParams = append(wkldParams, []*cloudformation.Parameter{
+			{
+				ParameterKey:   aws.String(LBWebServiceNLBAliasesParamKey),
+				ParameterValue: aws.String(s.manifest.NLBConfig.Aliases.ToString()),
+			},
+			{
+				ParameterKey:   aws.String(LBWebServiceNLBPortParamKey),
+				ParameterValue: port,
 			},
 		}...)
 	}

--- a/internal/pkg/deploy/cloudformation/stack/lb_web_svc.go
+++ b/internal/pkg/deploy/cloudformation/stack/lb_web_svc.go
@@ -315,7 +315,7 @@ func (s *LoadBalancedWebService) Parameters() ([]*cloudformation.Parameter, erro
 		}...)
 	}
 	if !s.manifest.NLBConfig.IsEmpty() {
-		port, _, err := parsePortMapping(s.manifest.NLBConfig.Port)
+		port, _, err := manifest.ParsePortMapping(s.manifest.NLBConfig.Port)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/pkg/deploy/cloudformation/stack/lb_web_svc_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/lb_web_svc_test.go
@@ -382,10 +382,6 @@ func TestLoadBalancedWebService_Parameters(t *testing.T) {
 			ParameterValue: aws.String("80"),
 		},
 		{
-			ParameterKey:   aws.String(LBWebServiceRulePathParamKey),
-			ParameterValue: aws.String("frontend"),
-		},
-		{
 			ParameterKey:   aws.String(WorkloadTaskCPUParamKey),
 			ParameterValue: aws.String("256"),
 		},
@@ -446,6 +442,10 @@ func TestLoadBalancedWebService_Parameters(t *testing.T) {
 					ParameterValue: aws.String("2"),
 				},
 				{
+					ParameterKey:   aws.String(LBWebServiceRulePathParamKey),
+					ParameterValue: aws.String("frontend"),
+				},
+				{
 					ParameterKey:   aws.String(LBWebServiceStickinessParamKey),
 					ParameterValue: aws.String("false"),
 				},
@@ -469,6 +469,10 @@ func TestLoadBalancedWebService_Parameters(t *testing.T) {
 				}
 			},
 			expectedParams: append(expectedParams, []*cloudformation.Parameter{
+				{
+					ParameterKey:   aws.String(LBWebServiceRulePathParamKey),
+					ParameterValue: aws.String("frontend"),
+				},
 				{
 					ParameterKey:   aws.String(LBWebServiceHTTPSParamKey),
 					ParameterValue: aws.String("false"),
@@ -507,6 +511,10 @@ func TestLoadBalancedWebService_Parameters(t *testing.T) {
 			},
 			expectedParams: append(expectedParams, []*cloudformation.Parameter{
 				{
+					ParameterKey:   aws.String(LBWebServiceRulePathParamKey),
+					ParameterValue: aws.String("frontend"),
+				},
+				{
 					ParameterKey:   aws.String(LBWebServiceHTTPSParamKey),
 					ParameterValue: aws.String("true"),
 				},
@@ -538,6 +546,10 @@ func TestLoadBalancedWebService_Parameters(t *testing.T) {
 				service.RoutingRule.Stickiness = aws.Bool(true)
 			},
 			expectedParams: append(expectedParams, []*cloudformation.Parameter{
+				{
+					ParameterKey:   aws.String(LBWebServiceRulePathParamKey),
+					ParameterValue: aws.String("frontend"),
+				},
 				{
 					ParameterKey:   aws.String(LBWebServiceHTTPSParamKey),
 					ParameterValue: aws.String("false"),
@@ -575,6 +587,10 @@ func TestLoadBalancedWebService_Parameters(t *testing.T) {
 				}
 			},
 			expectedParams: append(expectedParams, []*cloudformation.Parameter{
+				{
+					ParameterKey:   aws.String(LBWebServiceRulePathParamKey),
+					ParameterValue: aws.String("frontend"),
+				},
 				{
 					ParameterKey:   aws.String(LBWebServiceHTTPSParamKey),
 					ParameterValue: aws.String("false"),
@@ -615,6 +631,10 @@ func TestLoadBalancedWebService_Parameters(t *testing.T) {
 			},
 			expectedParams: append(expectedParams, []*cloudformation.Parameter{
 				{
+					ParameterKey:   aws.String(LBWebServiceRulePathParamKey),
+					ParameterValue: aws.String("frontend"),
+				},
+				{
 					ParameterKey:   aws.String(LBWebServiceHTTPSParamKey),
 					ParameterValue: aws.String("false"),
 				},
@@ -637,6 +657,124 @@ func TestLoadBalancedWebService_Parameters(t *testing.T) {
 				{
 					ParameterKey:   aws.String(LBWebServiceDNSDelegatedParamKey),
 					ParameterValue: aws.String("true"),
+				},
+			}...),
+		},
+		"nlb enabled": {
+			setupManifest: func(service *manifest.LoadBalancedWebService) {
+				service.NLBConfig = manifest.NetworkLoadBalancerConfiguration{
+					Port: aws.String("443/tcp"),
+				}
+			},
+			expectedParams: append(expectedParams, []*cloudformation.Parameter{
+				{
+					ParameterKey:   aws.String(LBWebServiceRulePathParamKey),
+					ParameterValue: aws.String("frontend"),
+				},
+				{
+					ParameterKey:   aws.String(LBWebServiceHTTPSParamKey),
+					ParameterValue: aws.String("false"),
+				},
+				{
+					ParameterKey:   aws.String(LBWebServiceTargetContainerParamKey),
+					ParameterValue: aws.String("frontend"),
+				},
+				{
+					ParameterKey:   aws.String(LBWebServiceTargetPortParamKey),
+					ParameterValue: aws.String("80"),
+				},
+				{
+					ParameterKey:   aws.String(WorkloadTaskCountParamKey),
+					ParameterValue: aws.String("1"),
+				},
+				{
+					ParameterKey:   aws.String(LBWebServiceStickinessParamKey),
+					ParameterValue: aws.String("false"),
+				},
+				{
+					ParameterKey:   aws.String(LBWebServiceDNSDelegatedParamKey),
+					ParameterValue: aws.String("false"),
+				},
+				{
+					ParameterKey:   aws.String(LBWebServiceNLBPortParamKey),
+					ParameterValue: aws.String("443"),
+				},
+				{
+					ParameterKey:   aws.String(LBWebServiceNLBAliasesParamKey),
+					ParameterValue: aws.String(""),
+				},
+			}...),
+		},
+		"nlb alias enabled": {
+			setupManifest: func(service *manifest.LoadBalancedWebService) {
+				service.NLBConfig = manifest.NetworkLoadBalancerConfiguration{
+					Aliases: manifest.Alias{
+						StringSlice: []string{"example.com", "v1.example.com"},
+					},
+					Port: aws.String("443/tcp"),
+				}
+			},
+			expectedParams: append(expectedParams, []*cloudformation.Parameter{
+				{
+					ParameterKey:   aws.String(LBWebServiceRulePathParamKey),
+					ParameterValue: aws.String("frontend"),
+				},
+				{
+					ParameterKey:   aws.String(LBWebServiceHTTPSParamKey),
+					ParameterValue: aws.String("false"),
+				},
+				{
+					ParameterKey:   aws.String(LBWebServiceTargetContainerParamKey),
+					ParameterValue: aws.String("frontend"),
+				},
+				{
+					ParameterKey:   aws.String(LBWebServiceTargetPortParamKey),
+					ParameterValue: aws.String("80"),
+				},
+				{
+					ParameterKey:   aws.String(WorkloadTaskCountParamKey),
+					ParameterValue: aws.String("1"),
+				},
+				{
+					ParameterKey:   aws.String(LBWebServiceStickinessParamKey),
+					ParameterValue: aws.String("false"),
+				},
+				{
+					ParameterKey:   aws.String(LBWebServiceDNSDelegatedParamKey),
+					ParameterValue: aws.String("false"),
+				},
+				{
+					ParameterKey:   aws.String(LBWebServiceNLBPortParamKey),
+					ParameterValue: aws.String("443"),
+				},
+				{
+					ParameterKey:   aws.String(LBWebServiceNLBAliasesParamKey),
+					ParameterValue: aws.String("example.com,v1.example.com"),
+				},
+			}...),
+		},
+		"do not render http params when disabled": {
+			setupManifest: func(service *manifest.LoadBalancedWebService) {
+				service.RoutingRule = manifest.RoutingRuleConfigOrBool{
+					Enabled: aws.Bool(false),
+				}
+			},
+			expectedParams: append(expectedParams, []*cloudformation.Parameter{
+				{
+					ParameterKey:   aws.String(LBWebServiceTargetContainerParamKey),
+					ParameterValue: aws.String("frontend"),
+				},
+				{
+					ParameterKey:   aws.String(LBWebServiceTargetPortParamKey),
+					ParameterValue: aws.String("80"),
+				},
+				{
+					ParameterKey:   aws.String(WorkloadTaskCountParamKey),
+					ParameterValue: aws.String("1"),
+				},
+				{
+					ParameterKey:   aws.String(LBWebServiceDNSDelegatedParamKey),
+					ParameterValue: aws.String("false"),
 				},
 			}...),
 		},

--- a/internal/pkg/deploy/cloudformation/stack/transformers.go
+++ b/internal/pkg/deploy/cloudformation/stack/transformers.go
@@ -54,7 +54,7 @@ func convertSidecar(s map[string]*manifest.SidecarConfig) ([]*template.SidecarOp
 	}
 	var sidecars []*template.SidecarOpts
 	for name, config := range s {
-		port, protocol, err := parsePortMapping(config.Port)
+		port, protocol, err := manifest.ParsePortMapping(config.Port)
 		if err != nil {
 			return nil, err
 		}
@@ -114,22 +114,6 @@ func convertDependsOn(d manifest.DependsOn) map[string]string {
 		dependsOn[name] = strings.ToUpper(status)
 	}
 	return dependsOn
-}
-
-// Valid sidecar portMapping example: 2000/udp, or 2000 (default to be tcp).
-func parsePortMapping(s *string) (port *string, protocol *string, err error) {
-	if s == nil {
-		return nil, nil, nil
-	}
-	portProtocol := strings.Split(*s, "/")
-	switch len(portProtocol) {
-	case 1:
-		return aws.String(portProtocol[0]), nil, nil
-	case 2:
-		return aws.String(portProtocol[0]), aws.String(portProtocol[1]), nil
-	default:
-		return nil, nil, fmt.Errorf("cannot parse port mapping from %s", *s)
-	}
 }
 
 func convertAdvancedCount(a manifest.AdvancedCount) (*template.AdvancedCount, error) {
@@ -276,7 +260,7 @@ func (s *LoadBalancedWebService) convertNetworkLoadBalancer() (networkLoadBalanc
 	}
 
 	// Parse listener port and protocol.
-	port, protocol, err := parsePortMapping(nlbConfig.Port)
+	port, protocol, err := manifest.ParsePortMapping(nlbConfig.Port)
 	if err != nil {
 		return networkLoadBalancerConfig{}, err
 	}
@@ -295,7 +279,7 @@ func (s *LoadBalancedWebService) convertNetworkLoadBalancer() (networkLoadBalanc
 	if targetContainer != s.name {
 		// If the target container is a sidecar container, the target port is the exposed sidecar port.
 		sideCarPort := s.manifest.Sidecars[targetContainer].Port // We validated that a sidecar container exposes a port if it is a target container.
-		port, _, err := parsePortMapping(sideCarPort)
+		port, _, err := manifest.ParsePortMapping(sideCarPort)
 		if err != nil {
 			return networkLoadBalancerConfig{}, err
 		}

--- a/internal/pkg/deploy/cloudformation/stack/transformers.go
+++ b/internal/pkg/deploy/cloudformation/stack/transformers.go
@@ -34,7 +34,7 @@ const (
 	defaultIAM             = disabled
 	defaultReadOnly        = true
 	defaultWritePermission = false
-	defaultNLBProtocol     = "TCP_UDP"
+	defaultNLBProtocol     = manifest.TCPUDP
 )
 
 // Supported capacityproviders for Fargate services

--- a/internal/pkg/deploy/cloudformation/stack/transformers.go
+++ b/internal/pkg/deploy/cloudformation/stack/transformers.go
@@ -315,7 +315,6 @@ func (s *LoadBalancedWebService) convertNetworkLoadBalancer() (networkLoadBalanc
 		settings: &template.NetworkLoadBalancer{
 			PublicSubnetCIDRs: s.publicSubnetCIDRBlocks,
 			Listener: template.NetworkLoadBalancerListener{
-				Port:            aws.StringValue(port),
 				Protocol:        strings.ToUpper(aws.StringValue(protocol)),
 				TargetContainer: targetContainer,
 				TargetPort:      targetPort,

--- a/internal/pkg/describe/backend_service_test.go
+++ b/internal/pkg/describe/backend_service_test.go
@@ -529,8 +529,6 @@ Resources
 				environments:     []string{"test", "prod"},
 			}
 			human := backendSvc.HumanString()
-			fmt.Println(human)
-			fmt.Println(tc.wantedHumanString)
 			json, _ := backendSvc.JSONString()
 
 			require.Equal(t, tc.wantedHumanString, human)

--- a/internal/pkg/describe/backend_service_test.go
+++ b/internal/pkg/describe/backend_service_test.go
@@ -529,6 +529,8 @@ Resources
 				environments:     []string{"test", "prod"},
 			}
 			human := backendSvc.HumanString()
+			fmt.Println(human)
+			fmt.Println(tc.wantedHumanString)
 			json, _ := backendSvc.JSONString()
 
 			require.Equal(t, tc.wantedHumanString, human)

--- a/internal/pkg/describe/lb_web_service.go
+++ b/internal/pkg/describe/lb_web_service.go
@@ -8,12 +8,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/aws/copilot-cli/internal/pkg/docker/dockerengine"
 	"io"
 	"sort"
 	"strconv"
 	"strings"
 	"text/tabwriter"
+
+	"github.com/aws/copilot-cli/internal/pkg/docker/dockerengine"
 
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -26,6 +27,11 @@ import (
 const (
 	envOutputPublicLoadBalancerDNSName = "PublicLoadBalancerDNSName"
 	envOutputSubdomain                 = "EnvironmentSubdomain"
+	svcParamHTTPSEnabled               = "HTTPSEnabled"
+
+	svcStackResourceALBTargetGroupLogicalID = "TargetGroup"
+	svcStackResourceNLBTargetGroupLogicalID = "NLBTargetGroup"
+	svcOutputPublicNLBDNSName               = "PublicNetworkLoadBalancerDNSName"
 )
 
 type envDescriber interface {

--- a/internal/pkg/describe/lb_web_service_test.go
+++ b/internal/pkg/describe/lb_web_service_test.go
@@ -50,10 +50,15 @@ func TestLBWebServiceDescriber_Describe(t *testing.T) {
 			},
 			wantedError: fmt.Errorf("list deployed environments for application phonetool: some error"),
 		},
-		"return error if fail to retrieve URI": {
+		"return error if fail to retrieve URI for ALB service": {
 			setupMocks: func(m lbWebSvcDescriberMocks) {
 				gomock.InOrder(
 					m.storeSvc.EXPECT().ListEnvironmentsDeployedTo(testApp, testSvc).Return([]string{testEnv}, nil),
+					m.ecsDescriber.EXPECT().ServiceStackResources().Return([]*stack.Resource{
+						{
+							LogicalID: svcStackResourceALBTargetGroupLogicalID,
+						},
+					}, nil),
 					m.envDescriber.EXPECT().Params().Return(nil, mockErr),
 				)
 			},
@@ -63,6 +68,11 @@ func TestLBWebServiceDescriber_Describe(t *testing.T) {
 			setupMocks: func(m lbWebSvcDescriberMocks) {
 				gomock.InOrder(
 					m.storeSvc.EXPECT().ListEnvironmentsDeployedTo(testApp, testSvc).Return([]string{testEnv}, nil),
+					m.ecsDescriber.EXPECT().ServiceStackResources().Return([]*stack.Resource{
+						{
+							LogicalID: svcStackResourceALBTargetGroupLogicalID,
+						},
+					}, nil),
 					m.envDescriber.EXPECT().Params().Return(map[string]string{}, nil),
 					m.envDescriber.EXPECT().Outputs().Return(map[string]string{
 						envOutputPublicLoadBalancerDNSName: testEnvLBDNSName,
@@ -94,6 +104,11 @@ func TestLBWebServiceDescriber_Describe(t *testing.T) {
 			setupMocks: func(m lbWebSvcDescriberMocks) {
 				gomock.InOrder(
 					m.storeSvc.EXPECT().ListEnvironmentsDeployedTo(testApp, testSvc).Return([]string{testEnv}, nil),
+					m.ecsDescriber.EXPECT().ServiceStackResources().Return([]*stack.Resource{
+						{
+							LogicalID: svcStackResourceALBTargetGroupLogicalID,
+						},
+					}, nil),
 					m.envDescriber.EXPECT().Params().Return(map[string]string{}, nil),
 					m.envDescriber.EXPECT().Outputs().Return(map[string]string{
 						envOutputPublicLoadBalancerDNSName: testEnvLBDNSName,
@@ -114,6 +129,11 @@ func TestLBWebServiceDescriber_Describe(t *testing.T) {
 			setupMocks: func(m lbWebSvcDescriberMocks) {
 				gomock.InOrder(
 					m.storeSvc.EXPECT().ListEnvironmentsDeployedTo(testApp, testSvc).Return([]string{testEnv}, nil),
+					m.ecsDescriber.EXPECT().ServiceStackResources().Return([]*stack.Resource{
+						{
+							LogicalID: svcStackResourceALBTargetGroupLogicalID,
+						},
+					}, nil),
 					m.envDescriber.EXPECT().Params().Return(map[string]string{}, nil),
 					m.envDescriber.EXPECT().Outputs().Return(map[string]string{
 						envOutputPublicLoadBalancerDNSName: testEnvLBDNSName,
@@ -138,6 +158,11 @@ func TestLBWebServiceDescriber_Describe(t *testing.T) {
 			setupMocks: func(m lbWebSvcDescriberMocks) {
 				gomock.InOrder(
 					m.storeSvc.EXPECT().ListEnvironmentsDeployedTo(testApp, testSvc).Return([]string{testEnv}, nil),
+					m.ecsDescriber.EXPECT().ServiceStackResources().Return([]*stack.Resource{
+						{
+							LogicalID: svcStackResourceALBTargetGroupLogicalID,
+						},
+					}, nil),
 					m.envDescriber.EXPECT().Params().Return(map[string]string{}, nil),
 					m.envDescriber.EXPECT().Outputs().Return(map[string]string{
 						envOutputPublicLoadBalancerDNSName: testEnvLBDNSName,
@@ -166,11 +191,16 @@ func TestLBWebServiceDescriber_Describe(t *testing.T) {
 			},
 			wantedError: fmt.Errorf("retrieve secrets: some error"),
 		},
-		"return error if fail to retrieve service resources": {
+		"return error if fail to retrieve service resources for ALB service": {
 			shouldOutputResources: true,
 			setupMocks: func(m lbWebSvcDescriberMocks) {
 				gomock.InOrder(
 					m.storeSvc.EXPECT().ListEnvironmentsDeployedTo(testApp, testSvc).Return([]string{testEnv}, nil),
+					m.ecsDescriber.EXPECT().ServiceStackResources().Return([]*stack.Resource{
+						{
+							LogicalID: svcStackResourceALBTargetGroupLogicalID,
+						},
+					}, nil),
 					m.envDescriber.EXPECT().Params().Return(map[string]string{}, nil),
 					m.envDescriber.EXPECT().Outputs().Return(map[string]string{
 						envOutputPublicLoadBalancerDNSName: testEnvLBDNSName,
@@ -211,12 +241,16 @@ func TestLBWebServiceDescriber_Describe(t *testing.T) {
 			},
 			wantedError: fmt.Errorf("retrieve service resources: some error"),
 		},
-		"success": {
+		"success for ALB service": {
 			shouldOutputResources: true,
 			setupMocks: func(m lbWebSvcDescriberMocks) {
 				gomock.InOrder(
 					m.storeSvc.EXPECT().ListEnvironmentsDeployedTo(testApp, testSvc).Return([]string{testEnv, prodEnv}, nil),
-
+					m.ecsDescriber.EXPECT().ServiceStackResources().Return([]*stack.Resource{
+						{
+							LogicalID: svcStackResourceALBTargetGroupLogicalID,
+						},
+					}, nil),
 					m.envDescriber.EXPECT().Params().Return(map[string]string{}, nil),
 					m.envDescriber.EXPECT().Outputs().Return(map[string]string{
 						envOutputPublicLoadBalancerDNSName: testEnvLBDNSName,
@@ -245,6 +279,11 @@ func TestLBWebServiceDescriber_Describe(t *testing.T) {
 							Name:      "GITHUB_WEBHOOK_SECRET",
 							Container: "container",
 							ValueFrom: "GH_WEBHOOK_SECRET",
+						},
+					}, nil),
+					m.ecsDescriber.EXPECT().ServiceStackResources().Return([]*stack.Resource{
+						{
+							LogicalID: svcStackResourceALBTargetGroupLogicalID,
 						},
 					}, nil),
 					m.envDescriber.EXPECT().Params().Return(map[string]string{}, nil),

--- a/internal/pkg/describe/stack/stack.go
+++ b/internal/pkg/describe/stack/stack.go
@@ -28,6 +28,7 @@ type StackDescription struct {
 type Resource struct {
 	Type       string `json:"type"`
 	PhysicalID string `json:"physicalID"`
+	LogicalID  string `json:"logicalID,omitempty"`
 }
 
 // HumanString returns the stringified Resource struct with human readable format.
@@ -107,6 +108,7 @@ func flattenResources(stackResources []*cloudformation.StackResource) []*Resourc
 		resources = append(resources, &Resource{
 			Type:       aws.StringValue(stackResource.ResourceType),
 			PhysicalID: aws.StringValue(stackResource.PhysicalResourceId),
+			LogicalID:  aws.StringValue(stackResource.LogicalResourceId),
 		})
 	}
 	return resources

--- a/internal/pkg/describe/stack/stack_test.go
+++ b/internal/pkg/describe/stack/stack_test.go
@@ -125,6 +125,7 @@ func TestStackDescriber_Resources(t *testing.T) {
 						{
 							ResourceType:       aws.String("mockResourceType"),
 							PhysicalResourceId: aws.String("mockPhysicalID"),
+							LogicalResourceId:  aws.String("mockLogicalID"),
 						},
 					}, nil),
 				)
@@ -133,6 +134,7 @@ func TestStackDescriber_Resources(t *testing.T) {
 				{
 					Type:       "mockResourceType",
 					PhysicalID: "mockPhysicalID",
+					LogicalID:  "mockLogicalID",
 				},
 			},
 		},

--- a/internal/pkg/describe/uri.go
+++ b/internal/pkg/describe/uri.go
@@ -132,12 +132,15 @@ func (d *LBWebServiceDescriber) nlbURI(envName string) (nlbURI, error) {
 	if err != nil {
 		return nlbURI{}, fmt.Errorf("get stack parameters for service %s: %w", d.svc, err)
 	}
-	port, _ := svcParams[stack.LBWebServiceNLBPortParamKey]
+	port, ok := svcParams[stack.LBWebServiceNLBPortParamKey]
+	if !ok {
+		return nlbURI{}, nil
+	}
 	uri := nlbURI{
 		Port: port,
 	}
-	dnsDelegated, _ := svcParams[stack.LBWebServiceDNSDelegatedParamKey]
-	if dnsDelegated != "true" {
+	dnsDelegated, ok := svcParams[stack.LBWebServiceDNSDelegatedParamKey]
+	if !ok || dnsDelegated != "true" {
 		svcOutputs, err := d.ecsServiceDescribers[envName].Outputs()
 		if err != nil {
 			return nlbURI{}, fmt.Errorf("get stack outputs for service %s: %w", d.svc, err)
@@ -146,8 +149,8 @@ func (d *LBWebServiceDescriber) nlbURI(envName string) (nlbURI, error) {
 		return uri, nil
 	}
 
-	aliases, _ := svcParams[stack.LBWebServiceNLBAliasesParamKey]
-	if aliases != "" {
+	aliases, ok := svcParams[stack.LBWebServiceNLBAliasesParamKey]
+	if ok && aliases != "" {
 		uri.DNSNames = strings.Split(aliases, ",")
 		return uri, nil
 	}

--- a/internal/pkg/describe/uri_test.go
+++ b/internal/pkg/describe/uri_test.go
@@ -170,7 +170,10 @@ func TestLBWebServiceDescriber_URI(t *testing.T) {
 						LogicalID: svcStackResourceNLBTargetGroupLogicalID,
 					},
 				}, nil)
-				m.ecsDescriber.EXPECT().Params().Return(map[string]string{}, nil)
+				m.ecsDescriber.EXPECT().Params().Return(map[string]string{
+					stack.LBWebServiceNLBPortParamKey:      "443",
+					stack.LBWebServiceDNSDelegatedParamKey: "false",
+				}, nil)
 				m.ecsDescriber.EXPECT().Outputs().Return(nil, mockErr)
 			},
 			wantedError: fmt.Errorf("get stack outputs for service jobs: some error"),
@@ -183,6 +186,7 @@ func TestLBWebServiceDescriber_URI(t *testing.T) {
 					},
 				}, nil)
 				m.ecsDescriber.EXPECT().Params().Return(map[string]string{
+					stack.LBWebServiceNLBPortParamKey:      "443",
 					stack.LBWebServiceDNSDelegatedParamKey: "true",
 				}, nil)
 				m.envDescriber.EXPECT().Outputs().Return(nil, mockErr)

--- a/internal/pkg/manifest/lb_web_svc.go
+++ b/internal/pkg/manifest/lb_web_svc.go
@@ -318,6 +318,7 @@ func (e *Alias) ToStringSlice() ([]string, error) {
 	return out, nil
 }
 
+// ToString converts an Alias to a string.
 func (e *Alias) ToString() string {
 	if e.String != nil {
 		return aws.StringValue(e.String)

--- a/internal/pkg/manifest/lb_web_svc.go
+++ b/internal/pkg/manifest/lb_web_svc.go
@@ -5,6 +5,7 @@ package manifest
 
 import (
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -315,4 +316,11 @@ func (e *Alias) ToStringSlice() ([]string, error) {
 		return nil, err
 	}
 	return out, nil
+}
+
+func (e *Alias) ToString() string {
+	if e.String != nil {
+		return aws.StringValue(e.String)
+	}
+	return strings.Join(e.StringSlice, ",")
 }

--- a/internal/pkg/manifest/lb_web_svc_test.go
+++ b/internal/pkg/manifest/lb_web_svc_test.go
@@ -1558,3 +1558,32 @@ func TestNetworkLoadBalancerConfiguration_IsEmpty(t *testing.T) {
 		})
 	}
 }
+
+func TestAlias_ToString(t *testing.T) {
+	testCases := map[string]struct {
+		inAlias Alias
+		wanted  string
+	}{
+		"alias using string": {
+			inAlias: Alias{
+				String: stringP("example.com"),
+			},
+			wanted: "example.com",
+		},
+		"alias using string slice": {
+			inAlias: Alias{
+				StringSlice: []string{"example.com", "v1.example.com"},
+			},
+			wanted: "example.com,v1.example.com",
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// WHEN
+			got := tc.inAlias.ToString()
+
+			// THEN
+			require.Equal(t, tc.wanted, got)
+		})
+	}
+}

--- a/internal/pkg/manifest/svc.go
+++ b/internal/pkg/manifest/svc.go
@@ -343,3 +343,19 @@ func (hc *HealthCheckArgsOrString) Path() *string {
 	}
 	return hc.HealthCheckArgs.Path
 }
+
+// Parse port-protocol string into individual port and protocol strings. Valid examples: 2000/udp, or 2000.
+func ParsePortMapping(s *string) (port *string, protocol *string, err error) {
+	if s == nil {
+		return nil, nil, nil
+	}
+	portProtocol := strings.Split(*s, "/")
+	switch len(portProtocol) {
+	case 1:
+		return aws.String(portProtocol[0]), nil, nil
+	case 2:
+		return aws.String(portProtocol[0]), aws.String(portProtocol[1]), nil
+	default:
+		return nil, nil, fmt.Errorf("cannot parse port mapping from %s", *s)
+	}
+}

--- a/internal/pkg/manifest/svc_test.go
+++ b/internal/pkg/manifest/svc_test.go
@@ -809,3 +809,40 @@ func TestQueueScaling_AcceptableBacklogPerTask(t *testing.T) {
 		})
 	}
 }
+
+func TestParsePortMapping(t *testing.T) {
+	testCases := map[string]struct {
+		inPort *string
+
+		wantedPort     *string
+		wantedProtocol *string
+		wantedErr      error
+	}{
+		"error parsing port": {
+			inPort:    stringP("1/2/3"),
+			wantedErr: errors.New("cannot parse port mapping from 1/2/3"),
+		},
+		"no error if input is empty": {},
+		"port number only": {
+			inPort:     stringP("443"),
+			wantedPort: stringP("443"),
+		},
+		"port and protocol": {
+			inPort:         stringP("443/tcp"),
+			wantedPort:     stringP("443"),
+			wantedProtocol: stringP("tcp"),
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			gotPort, gotProtocol, err := ParsePortMapping(tc.inPort)
+			if tc.wantedErr != nil {
+				require.EqualError(t, err, tc.wantedErr.Error())
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, gotPort, tc.wantedPort)
+				require.Equal(t, gotProtocol, tc.wantedProtocol)
+			}
+		})
+	}
+}

--- a/internal/pkg/manifest/validate.go
+++ b/internal/pkg/manifest/validate.go
@@ -32,6 +32,15 @@ const (
 	envFileExt = ".env"
 )
 
+const (
+	TCPUDP = "TCP_UDP"
+	tcp    = "TCP"
+	udp    = "UDP"
+	tls    = "TLS"
+)
+
+var validProtocols = []string{TCPUDP, tcp, udp, tls}
+
 var (
 	intRangeBandRegexp  = regexp.MustCompile(`^(\d+)-(\d+)$`)
 	volumesPathRegexp   = regexp.MustCompile(`^[a-zA-Z0-9\-\.\_/]+$`)
@@ -628,7 +637,14 @@ func validateNLBPort(port *string) error {
 		return nil
 	}
 	protocolVal := aws.StringValue(protocol)
-	if strings.ToLower(protocolVal) != "tcp" && strings.ToLower(protocolVal) != "udp" && strings.ToLower(protocolVal) != "tls" {
+	var isValidProtocol bool
+	for _, valid := range validProtocols {
+		if strings.EqualFold(protocolVal, valid) {
+			isValidProtocol = true
+			break
+		}
+	}
+	if !isValidProtocol {
 		return fmt.Errorf(`unrecognized protocol %s`, protocolVal)
 	}
 	return nil

--- a/internal/pkg/manifest/validate.go
+++ b/internal/pkg/manifest/validate.go
@@ -607,11 +607,29 @@ func (c NetworkLoadBalancerConfiguration) Validate() error {
 			missingField: "port",
 		}
 	}
+	if err := validateNLBPort(c.Port); err != nil {
+		return fmt.Errorf(`validate "port": %w`, err)
+	}
 	if err := c.HealthCheck.Validate(); err != nil {
 		return fmt.Errorf(`validate "healthcheck": %w`, err)
 	}
 	if err := c.Aliases.Validate(); err != nil {
 		return fmt.Errorf(`validate "alias": %w`, err)
+	}
+	return nil
+}
+
+func validateNLBPort(port *string) error {
+	_, protocol, err := ParsePortMapping(port)
+	if err != nil {
+		return err
+	}
+	if protocol == nil {
+		return nil
+	}
+	protocolVal := aws.StringValue(protocol)
+	if strings.ToLower(protocolVal) != "tcp" && strings.ToLower(protocolVal) != "udp" && strings.ToLower(protocolVal) != "tls" {
+		return fmt.Errorf(`unrecognized protocol %s`, protocolVal)
 	}
 	return nil
 }

--- a/internal/pkg/manifest/validate_test.go
+++ b/internal/pkg/manifest/validate_test.go
@@ -1043,6 +1043,40 @@ func TestNetworkLoadBalancerConfiguration_Validate(t *testing.T) {
 			wantedErrorMsgPrefix: `validate "nlb": `,
 			wantedError:          fmt.Errorf(`"port" must be specified`),
 		},
+		"error parsing port": {
+			nlb: NetworkLoadBalancerConfiguration{
+				Port: aws.String("sabotage/this/string"),
+			},
+			wantedErrorMsgPrefix: `validate "nlb": `,
+			wantedError:          fmt.Errorf(`validate "port": cannot parse port mapping from sabotage/this/string`),
+		},
+		"success if port is specified without protocol": {
+			nlb: NetworkLoadBalancerConfiguration{
+				Port: aws.String("443"),
+			},
+		},
+		"error if protocol is not recognized": {
+			nlb: NetworkLoadBalancerConfiguration{
+				Port: aws.String("443/tps"),
+			},
+			wantedErrorMsgPrefix: `validate "nlb": `,
+			wantedError:          fmt.Errorf(`validate "port": unrecognized protocol tps`),
+		},
+		"success if tcp": {
+			nlb: NetworkLoadBalancerConfiguration{
+				Port: aws.String("443/tcp"),
+			},
+		},
+		"success if udp": {
+			nlb: NetworkLoadBalancerConfiguration{
+				Port: aws.String("161/udp"),
+			},
+		},
+		"success if tls": {
+			nlb: NetworkLoadBalancerConfiguration{
+				Port: aws.String("443/tls"),
+			},
+		},
 	}
 
 	for name, tc := range testCases {

--- a/internal/pkg/manifest/validate_test.go
+++ b/internal/pkg/manifest/validate_test.go
@@ -1077,6 +1077,11 @@ func TestNetworkLoadBalancerConfiguration_Validate(t *testing.T) {
 				Port: aws.String("443/tls"),
 			},
 		},
+		"success if tcp_udp": {
+			nlb: NetworkLoadBalancerConfiguration{
+				Port: aws.String("443/TCP_udp"),
+			},
+		},
 	}
 
 	for name, tc := range testCases {

--- a/internal/pkg/template/templates/workloads/partials/cf/nlb.yml
+++ b/internal/pkg/template/templates/workloads/partials/cf/nlb.yml
@@ -18,7 +18,7 @@ NLBListener:
       - TargetGroupArn: !Ref NLBTargetGroup
         Type: forward
     LoadBalancerArn: !Ref PublicNetworkLoadBalancer
-    Port: {{ .NLB.Listener.Port }}
+    Port: !Ref NLBPort
     Protocol: {{ .NLB.Listener.Protocol }}
 {{- if eq .NLB.Listener.Protocol "TLS" }}
     Certificates:
@@ -78,9 +78,9 @@ NLBSecurityGroup:
 {{range $cidr := .NLB.PublicSubnetCIDRs}}
       - CidrIp: {{$cidr}}
         Description: Ingress to allow access from Network Load Balancer subnet
-        FromPort: {{ $.NLB.Listener.Port }}
+        FromPort: !Ref NLBPort
         IpProtocol: {{- if eq $.NLB.Listener.Protocol "TLS" }} TCP {{- else }} {{ $.NLB.Listener.Protocol }} {{- end}}
-        ToPort: {{ $.NLB.Listener.Port }}
+        ToPort: !Ref NLBPort
 {{end}}
     Tags:
       - Key: Name
@@ -129,7 +129,8 @@ NLBCustomDomainAction:
     ServiceName: !Ref WorkloadName
     RootDNSRole: {{ .AppDNSDelegationRole }}
     DomainName:  {{ .AppDNSName }}
-    Aliases: {{fmtSlice .NLB.Listener.Aliases }}
+    Aliases:
+      !Split [",", !Ref NLBAliases]
 
 NLBCustomDomainFunction:
   Type: AWS::Lambda::Function
@@ -202,7 +203,8 @@ NLBCertValidatorAction:
     ServiceName: !Ref WorkloadName
     RootDNSRole: {{ .AppDNSDelegationRole }}
     DomainName:  {{ .AppDNSName }}
-    Aliases: {{fmtSlice .NLB.Listener.Aliases }}
+    Aliases:
+      !Split [",", !Ref NLBAliases]
 
 NLBCertValidatorFunction:
   Type: AWS::Lambda::Function

--- a/internal/pkg/template/templates/workloads/services/lb-web/cf.yml
+++ b/internal/pkg/template/templates/workloads/services/lb-web/cf.yml
@@ -36,6 +36,13 @@ Parameters:
     Type: String
   TargetPort:
     Type: Number
+{{- if .NLB }}
+  NLBAliases:
+    Type: String
+    Default: ""
+  NLBPort:
+    Type: String
+{{- end }}
 {{- if .ALBEnabled}}
   HTTPSEnabled:
     Type: String
@@ -464,3 +471,9 @@ Outputs:
     Value: !GetAtt DiscoveryService.Arn
     Export:
       Name: !Sub ${AWS::StackName}-DiscoveryServiceARN
+  {{- if .NLB}}
+  PublicNetworkLoadBalancerDNSName:
+    Value: !GetAtt PublicNetworkLoadBalancer.DNSName
+    Export:
+      Name: !Sub ${AWS::StackName}-PublicNetworkLoadBalancerDNSName
+  {{- end}}

--- a/internal/pkg/template/workload.go
+++ b/internal/pkg/template/workload.go
@@ -208,7 +208,6 @@ type HTTPHealthCheckOpts struct {
 
 // NetworkLoadBalancerListener holds configuration that's need for a Network Load Balancer listener.
 type NetworkLoadBalancerListener struct {
-	Port            string
 	Protocol        string
 	TargetContainer string
 	TargetPort      string


### PR DESCRIPTION
This PR:
1. Gets NLB URL in describer. This affects the URL that Copilot shows at the end of service deployment, as well as `copilot svc show`.
2. Validate during manifest validation that the protocol is valid

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
