### PR TITLE
feat(pipelines): Added partial support for arm64 platform in pipelines

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/ghv1_pipeline_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/ghv1_pipeline_integration_test.go
@@ -28,7 +28,8 @@ func TestGHv1Pipeline_Template(t *testing.T) {
 			PersonalAccessTokenSecretID: "my secret",
 		},
 		Build: &deploy.Build{
-			Image: "aws/codebuild/amazonlinux2-x86_64-standard:3.0",
+			Image:           "aws/codebuild/amazonlinux2-x86_64-standard:3.0",
+			EnvironmentType: "LINUX_CONTAINER",
 		},
 		Stages: []deploy.PipelineStage{
 			{

--- a/internal/pkg/deploy/pipeline.go
+++ b/internal/pkg/deploy/pipeline.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/aws/copilot-cli/internal/pkg/manifest"
 
@@ -24,6 +25,7 @@ const (
 	fmtErrPropertyNotAString = "property `%s` is not a string"
 
 	defaultPipelineBuildImage = "aws/codebuild/amazonlinux2-x86_64-standard:3.0"
+	defaultPipelineEnvironmentType = "LINUX_CONTAINER"
 )
 
 var (
@@ -67,6 +69,7 @@ type CreatePipelineInput struct {
 type Build struct {
 	// The URI that identifies the Docker image to use for this build project.
 	Image string
+	EnvironmentType string
 }
 
 // ArtifactBucket represents an S3 bucket used by the CodePipeline to store
@@ -237,11 +240,16 @@ func PipelineSourceFromManifest(mfSource *manifest.Source) (source interface{}, 
 // PipelineBuildFromManifest processes manifest info about the build project settings.
 func PipelineBuildFromManifest(mfBuild *manifest.Build) (build *Build) {
 	image := defaultPipelineBuildImage
+	environmentType := defaultPipelineEnvironmentType
 	if mfBuild != nil && mfBuild.Image != "" {
 		image = mfBuild.Image
 	}
+	if strings.Contains(image, "aarch64")  {
+		environmentType = "ARM_CONTAINER"
+	} 
 	return &Build{
 		Image: image,
+		EnvironmentType: environmentType,
 	}
 }
 

--- a/internal/pkg/deploy/pipeline_test.go
+++ b/internal/pkg/deploy/pipeline_test.go
@@ -206,7 +206,8 @@ func TestPipelineBuildFromManifest(t *testing.T) {
 		"set default image if not be specified in manifest": {
 			mfBuild: nil,
 			expectedBuild: &Build{
-				Image: defaultImage,
+				Image:           defaultImage,
+				EnvironmentType: "LINUX_CONTAINER",
 			},
 		},
 		"set image according to manifest": {
@@ -214,7 +215,17 @@ func TestPipelineBuildFromManifest(t *testing.T) {
 				Image: "aws/codebuild/standard:3.0",
 			},
 			expectedBuild: &Build{
-				Image: "aws/codebuild/standard:3.0",
+				Image:           "aws/codebuild/standard:3.0",
+				EnvironmentType: "LINUX_CONTAINER",
+			},
+		},
+		"set image according to manifest (ARM based)": {
+			mfBuild: &manifest.Build{
+				Image: "aws/codebuild/amazonlinux2-aarch64-standard:2.0",
+			},
+			expectedBuild: &Build{
+				Image:           "aws/codebuild/amazonlinux2-aarch64-standard:2.0",
+				EnvironmentType: "ARM_CONTAINER",
 			},
 		},
 	}

--- a/internal/pkg/template/templates/cicd/buildspec.yml
+++ b/internal/pkg/template/templates/cicd/buildspec.yml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      docker: 18
+      docker: 19
       ruby: 2.6
     commands:
       - echo "cd into $CODEBUILD_SRC_DIR"

--- a/internal/pkg/template/templates/cicd/pipeline_cfn.yml
+++ b/internal/pkg/template/templates/cicd/pipeline_cfn.yml
@@ -135,12 +135,17 @@ Resources:
       ServiceRole: !GetAtt BuildProjectRole.Arn
       Artifacts:
         Type: CODEPIPELINE
+      {{- if eq .Build.EnvironmentType "LINUX_CONTAINER"}}
       Cache:
         Modes:
           - LOCAL_DOCKER_LAYER_CACHE
         Type: LOCAL
+      {{- else }}
+      Cache:
+        Type: "NO_CACHE"
+      {{- end }}
       Environment:
-        Type: LINUX_CONTAINER
+        Type: {{.Build.EnvironmentType}}
         ComputeType: BUILD_GENERAL1_SMALL
         PrivilegedMode: true
         Image: {{.Build.Image}}


### PR DESCRIPTION
# Summary of changes:

This PR adds support for ARM64 based builds in the **pipeline** command by adding a new **EnvironmentType** which is automatically selected if the image name contains the string **aarch64**

It also updates the **docker runtime-version** to **19** as **18** isn't supported in ARM_CONTAINER at this time.

One thing this patch doesn't solve is to create a different **buildspec.yml** to point to the arm64 binaries for the copilot tool. This is because the lifecycle for the files seems to me to be different and I wasn't sure what is the best way to address this. At the moment, you need to manually change the following lines in your project ```buildspec.yml```:

``` yaml
phases:
  install:
    commands:
...
      - wget https://ecs-cli-v2-release.s3.amazonaws.com/copilot-linux-v1.13.0
      - mv ./copilot-linux-v1.13.0 ./copilot-linux
```

to

``` yaml
phases:
  install:
    commands:
...
      - wget https://ecs-cli-v2-release.s3.amazonaws.com/copilot-linux-arm64-v1.13.0
      - mv ./copilot-linux-arm64-v1.13.0 ./copilot-linux
``` 

This PR addresses #3158

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
