### PR TITLE
docs: add --app flag to svc-deploy.en.md

### DIFF
--- a/site/content/docs/commands/svc-deploy.en.md
+++ b/site/content/docs/commands/svc-deploy.en.md
@@ -18,6 +18,7 @@ The steps involved in service deploy are:
 ## What are the flags?
 
 ```bash
+  -a, --app string                     Name of the application.
   -e, --env string                     Name of the environment.
       --force                          Optional. Force a new service deployment using the existing image.
   -h, --help                           help for deploy


### PR DESCRIPTION
Currently [the documentation of `svc deploy`](https://aws.github.io/copilot-cli/en/docs/commands/svc-deploy/) lacks `--app` flag, so I added the flag.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
