### PR TITLE
chore: fix integration test from #3173

### DIFF
--- a/internal/pkg/template/template_integration_test.go
+++ b/internal/pkg/template/template_integration_test.go
@@ -290,7 +290,8 @@ func TestTemplate_ParseLoadBalancedWebService(t *testing.T) {
 DiscoveryServiceArn:
   Fn::GetAtt: [DiscoveryService, Arn]
 `,
-				ALBEnabled: true},
+				ALBEnabled: true
+			},
 		},
 		"renders a valid template with Windows platform": {
 			opts: template.WorkloadOpts{

--- a/internal/pkg/template/template_integration_test.go
+++ b/internal/pkg/template/template_integration_test.go
@@ -122,6 +122,7 @@ func TestTemplate_ParseLoadBalancedWebService(t *testing.T) {
 					AssignPublicIP: template.EnablePublicIP,
 					SubnetsType:    template.PublicSubnetsPlacement,
 				},
+				ALBEnabled: true,
 			},
 		},
 		"renders a valid grpc template by default": {
@@ -133,6 +134,7 @@ func TestTemplate_ParseLoadBalancedWebService(t *testing.T) {
 					AssignPublicIP: template.EnablePublicIP,
 					SubnetsType:    template.PublicSubnetsPlacement,
 				},
+				ALBEnabled: true,
 			},
 		},
 		"renders a valid template with addons with no outputs": {
@@ -146,6 +148,7 @@ func TestTemplate_ParseLoadBalancedWebService(t *testing.T) {
 					SubnetsType:    template.PublicSubnetsPlacement,
 				},
 				ServiceDiscoveryEndpoint: "test.app.local",
+				ALBEnabled:               true,
 			},
 		},
 		"renders a valid template with addons with outputs": {
@@ -162,6 +165,7 @@ func TestTemplate_ParseLoadBalancedWebService(t *testing.T) {
 					SubnetsType:    template.PublicSubnetsPlacement,
 				},
 				ServiceDiscoveryEndpoint: "test.app.local",
+				ALBEnabled:               true,
 			},
 		},
 		"renders a valid template with private subnet placement": {
@@ -210,6 +214,7 @@ func TestTemplate_ParseLoadBalancedWebService(t *testing.T) {
 						},
 					},
 				},
+				ALBEnabled: true,
 			},
 		},
 		"renders a valid template with minimal storage options": {
@@ -243,6 +248,7 @@ func TestTemplate_ParseLoadBalancedWebService(t *testing.T) {
 						},
 					},
 				},
+				ALBEnabled: true,
 			},
 		},
 		"renders a valid template with ephemeral storage": {
@@ -256,6 +262,7 @@ func TestTemplate_ParseLoadBalancedWebService(t *testing.T) {
 				Storage: &template.StorageOpts{
 					Ephemeral: aws.Int(500),
 				},
+				ALBEnabled: true,
 			},
 		},
 		"renders a valid template with entrypoint and command overrides": {
@@ -268,6 +275,7 @@ func TestTemplate_ParseLoadBalancedWebService(t *testing.T) {
 					AssignPublicIP: template.EnablePublicIP,
 					SubnetsType:    template.PublicSubnetsPlacement,
 				},
+				ALBEnabled: true,
 			},
 		},
 		"renders a valid template with additional addons parameters": {
@@ -282,7 +290,7 @@ func TestTemplate_ParseLoadBalancedWebService(t *testing.T) {
 DiscoveryServiceArn:
   Fn::GetAtt: [DiscoveryService, Arn]
 `,
-			},
+				ALBEnabled: true},
 		},
 		"renders a valid template with Windows platform": {
 			opts: template.WorkloadOpts{
@@ -296,6 +304,7 @@ DiscoveryServiceArn:
 					Arch: "x86_64",
 				},
 				ServiceDiscoveryEndpoint: "test.app.local",
+				ALBEnabled:               true,
 			},
 		},
 	}

--- a/internal/pkg/template/template_integration_test.go
+++ b/internal/pkg/template/template_integration_test.go
@@ -290,7 +290,7 @@ func TestTemplate_ParseLoadBalancedWebService(t *testing.T) {
 DiscoveryServiceArn:
   Fn::GetAtt: [DiscoveryService, Arn]
 `,
-				ALBEnabled: true
+				ALBEnabled: true,
 			},
 		},
 		"renders a valid template with Windows platform": {


### PR DESCRIPTION
#3173 causes integration test to fail because of the addition of `ALBEnabled` into the go template variable. The variable is used at [this line](https://github.com/aws/copilot-cli/blob/9a7bceeb273f577153427ad682199284ebbdc8fe/internal/pkg/template/templates/workloads/services/lb-web/cf.yml#L144) which renders the `DependsOn` field depending on whether ALB/NLB is enabled. Because the test `template.WorkloadOpts` object has neither `ALBEnabled` nor `NLB` set, it renders a `null` at `DependsOn` which prevents the template from passing the CFN validation.

Note that this doesn't happen in real usage, i.e. when running `copilot` commands. This is because it would have been caught during manifest validation if neither ALB nor NLB is enabled.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
