### PR TITLE
chore: fix integration test

### DIFF
--- a/internal/pkg/cli/svc_deploy_test.go
+++ b/internal/pkg/cli/svc_deploy_test.go
@@ -234,6 +234,8 @@ func TestSvcDeployOpts_configureContainerImage(t *testing.T) {
 	mockError := errors.New("mockError")
 	mockManifest := []byte(`name: serviceA
 type: 'Load Balanced Web Service'
+http:
+  path: "/"
 image:
   build:
     dockerfile: path/to/Dockerfile
@@ -242,15 +244,20 @@ image:
 `)
 	mockManifestWithBadPlatform := []byte(`name: serviceA
 type: 'Load Balanced Web Service'
+http:
+  path: "/"
 platform: linus/abc123
 image:
   build:
     dockerfile: path/to/Dockerfile
     context: path
   port: 80
+
 `)
 	mockManifestWithGoodPlatform := []byte(`name: serviceA
 type: 'Load Balanced Web Service'
+http:
+  path: "/"
 platform: linux/amd64
 image:
   build:
@@ -260,18 +267,24 @@ image:
 `)
 	mockMftNoBuild := []byte(`name: serviceA
 type: 'Load Balanced Web Service'
+http:
+  path: "/"
 image:
   location: foo/bar
   port: 80
 `)
 	mockMftBuildString := []byte(`name: serviceA
 type: 'Load Balanced Web Service'
+http:
+  path: "/"
 image:
   build: path/to/Dockerfile
   port: 80
 `)
 	mockMftNoContext := []byte(`name: serviceA
 type: 'Load Balanced Web Service'
+http:
+  path: "/"
 image:
   build:
     dockerfile: path/to/Dockerfile
@@ -1071,6 +1084,7 @@ func TestSvcDeployOpts_deploySvc(t *testing.T) {
 							},
 							RoutingRule: manifest.RoutingRuleConfigOrBool{
 								RoutingRuleConfiguration: manifest.RoutingRuleConfiguration{
+									Path:  aws.String("/"),
 									Alias: tc.inAliases,
 								},
 							},

--- a/internal/pkg/deploy/cloudformation/cc_pipeline_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/cc_pipeline_integration_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/aws/copilot-cli/internal/pkg/aws/identity"
+	"github.com/aws/copilot-cli/internal/pkg/aws/partitions"
 	"github.com/aws/copilot-cli/internal/pkg/aws/s3"
 	"github.com/aws/copilot-cli/internal/pkg/config"
 	"github.com/aws/copilot-cli/internal/pkg/deploy"
@@ -180,6 +181,11 @@ func TestCCPipelineCreation(t *testing.T) {
 		}))
 		require.NoError(t, err)
 		environmentToDeploy.CustomResourcesURLs = urls
+
+		partition, err := partitions.Region(envRegion.ID()).Partition()
+		require.NoError(t, err)
+		environmentToDeploy.ArtifactBucketARN = s3.FormatARN(partition.ID(), envBucketName)
+		environmentToDeploy.ArtifactBucketKeyARN = regionalResource.KMSKeyARN
 
 		// Deploy the environment in the same tools account but in different
 		// region and wait for it to be complete

--- a/internal/pkg/manifest/validate.go
+++ b/internal/pkg/manifest/validate.go
@@ -550,7 +550,7 @@ func (CommandOverride) Validate() error {
 }
 
 func (r RoutingRuleConfigOrBool) Validate() error {
-	if aws.BoolValue(r.Enabled) == true {
+	if aws.BoolValue(r.Enabled) {
 		return &errFieldMustBeSpecified{
 			missingField: "path",
 		}

--- a/internal/pkg/manifest/validate.go
+++ b/internal/pkg/manifest/validate.go
@@ -549,6 +549,15 @@ func (CommandOverride) Validate() error {
 	return nil
 }
 
+func (r RoutingRuleConfigOrBool) Validate() error {
+	if aws.BoolValue(r.Enabled) == true {
+		return &errFieldMustBeSpecified{
+			missingField: "path",
+		}
+	}
+	return r.RoutingRuleConfiguration.Validate()
+}
+
 // Validate returns nil if RoutingRuleConfiguration is configured correctly.
 func (r RoutingRuleConfiguration) Validate() error {
 	var err error
@@ -572,6 +581,11 @@ func (r RoutingRuleConfiguration) Validate() error {
 	if r.ProtocolVersion != nil {
 		if !contains(strings.ToUpper(*r.ProtocolVersion), httpProtocolVersions) {
 			return fmt.Errorf(`"version" field value '%s' must be one of %s`, *r.ProtocolVersion, english.WordSeries(httpProtocolVersions, "or"))
+		}
+	}
+	if r.Path == nil {
+		return &errFieldMustBeSpecified{
+			missingField: "path",
 		}
 	}
 	return nil

--- a/internal/pkg/manifest/validate.go
+++ b/internal/pkg/manifest/validate.go
@@ -549,6 +549,7 @@ func (CommandOverride) Validate() error {
 	return nil
 }
 
+// Validate returns nil if RoutingRuleConfigOrBool is configured correctly.
 func (r RoutingRuleConfigOrBool) Validate() error {
 	if aws.BoolValue(r.Enabled) {
 		return &errFieldMustBeSpecified{

--- a/internal/pkg/manifest/validate_test.go
+++ b/internal/pkg/manifest/validate_test.go
@@ -68,6 +68,11 @@ func TestLoadBalancedWebService_Validate(t *testing.T) {
 							},
 						},
 					},
+					RoutingRule: RoutingRuleConfigOrBool{
+						RoutingRuleConfiguration: RoutingRuleConfiguration{
+							Path: stringP("/"),
+						},
+					},
 				},
 			},
 			wantedErrorMsgPrefix: `validate "sidecars[foo]": `,
@@ -79,6 +84,11 @@ func TestLoadBalancedWebService_Validate(t *testing.T) {
 					Network: NetworkConfig{
 						vpcConfig{
 							Placement: (*Placement)(aws.String("")),
+						},
+					},
+					RoutingRule: RoutingRuleConfigOrBool{
+						RoutingRuleConfiguration: RoutingRuleConfiguration{
+							Path: stringP("/"),
 						},
 					},
 				},
@@ -94,6 +104,11 @@ func TestLoadBalancedWebService_Validate(t *testing.T) {
 							{},
 						},
 					},
+					RoutingRule: RoutingRuleConfigOrBool{
+						RoutingRuleConfiguration: RoutingRuleConfiguration{
+							Path: stringP("/"),
+						},
+					},
 				},
 			},
 			wantedErrorMsgPrefix: `validate "publish": `,
@@ -107,6 +122,11 @@ func TestLoadBalancedWebService_Validate(t *testing.T) {
 							Path: "Family",
 						},
 					},
+					RoutingRule: RoutingRuleConfigOrBool{
+						RoutingRuleConfiguration: RoutingRuleConfiguration{
+							Path: stringP("/"),
+						},
+					},
 				},
 			},
 			wantedErrorMsgPrefix: `validate "taskdef_overrides[0]": `,
@@ -115,6 +135,11 @@ func TestLoadBalancedWebService_Validate(t *testing.T) {
 			lbConfig: LoadBalancedWebService{
 				LoadBalancedWebServiceConfig: LoadBalancedWebServiceConfig{
 					ImageConfig: testImageConfig,
+					RoutingRule: RoutingRuleConfigOrBool{
+						RoutingRuleConfiguration: RoutingRuleConfiguration{
+							Path: stringP("/"),
+						},
+					},
 				},
 			},
 			wantedError: fmt.Errorf(`"name" must be specified`),
@@ -126,6 +151,7 @@ func TestLoadBalancedWebService_Validate(t *testing.T) {
 					ImageConfig: testImageConfig,
 					RoutingRule: RoutingRuleConfigOrBool{
 						RoutingRuleConfiguration: RoutingRuleConfiguration{
+							Path:            stringP("/"),
 							TargetContainer: aws.String("foo"),
 						},
 					},
@@ -140,6 +166,7 @@ func TestLoadBalancedWebService_Validate(t *testing.T) {
 					ImageConfig: testImageConfig,
 					RoutingRule: RoutingRuleConfigOrBool{
 						RoutingRuleConfiguration: RoutingRuleConfiguration{
+							Path:            stringP("/"),
 							TargetContainer: aws.String("mockName"),
 						},
 					},
@@ -166,6 +193,11 @@ func TestLoadBalancedWebService_Validate(t *testing.T) {
 							Essential: aws.Bool(false),
 						},
 					},
+					RoutingRule: RoutingRuleConfigOrBool{
+						RoutingRuleConfiguration: RoutingRuleConfiguration{
+							Path: stringP("/"),
+						},
+					},
 				},
 			},
 			wantedErrorMsgPrefix: `validate container dependencies: `,
@@ -178,6 +210,11 @@ func TestLoadBalancedWebService_Validate(t *testing.T) {
 					TaskConfig: TaskConfig{
 						Platform:       PlatformArgsOrString{PlatformString: (*PlatformString)(aws.String("windows/amd64"))},
 						ExecuteCommand: ExecuteCommand{Enable: aws.Bool(true)},
+					},
+					RoutingRule: RoutingRuleConfigOrBool{
+						RoutingRuleConfiguration: RoutingRuleConfiguration{
+							Path: stringP("/"),
+						},
 					},
 				},
 			},
@@ -197,6 +234,11 @@ func TestLoadBalancedWebService_Validate(t *testing.T) {
 								Spot:         aws.Int(123),
 								workloadType: LoadBalancedWebServiceType,
 							},
+						},
+					},
+					RoutingRule: RoutingRuleConfigOrBool{
+						RoutingRuleConfiguration: RoutingRuleConfiguration{
+							Path: stringP("/"),
 						},
 					},
 				},
@@ -1002,8 +1044,13 @@ func TestRoutingRule_Validate(t *testing.T) {
 			},
 			wantedErrorMsgPrefix: `"version" field value 'quic' must be one of GRPC, HTTP1 or HTTP2`,
 		},
+		"error if path is missing": {
+			RoutingRule:          RoutingRuleConfiguration{},
+			wantedErrorMsgPrefix: `"path" must be specified`,
+		},
 		"should not error if protocol version is not uppercase": {
 			RoutingRule: RoutingRuleConfiguration{
+				Path:            stringP("/"),
 				ProtocolVersion: aws.String("gRPC"),
 			},
 		},


### PR DESCRIPTION
The failure was caused by #3183.

We add to the environment manager role additional permissions to put object into the S3 bucket. In normal workflow, the `Artifact...` data is passed from `cli` (e.g. `env init`) to the template. This is missing from the integ test.

An additional validation for `http.path` tags along. If `path` is missing, the deployment will fail anyway in a later stage. manifest validation could provide a more friendyl error mesage than the cfn error.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
