### PR TITLE
chore: use conditional before `!Split` to pass empty list

### DIFF
--- a/internal/pkg/template/templates/workloads/partials/cf/nlb.yml
+++ b/internal/pkg/template/templates/workloads/partials/cf/nlb.yml
@@ -146,7 +146,10 @@ NLBCustomDomainAction:
     RootDNSRole: {{ .AppDNSDelegationRole }}
     DomainName:  {{ .AppDNSName }}
     Aliases:
-      !Split [",", !Ref NLBAliases]
+      !If
+        - HasNLBAliases
+        - []
+        - !Split [",", !Ref NLBAliases]
 
 NLBCustomDomainFunction:
   Type: AWS::Lambda::Function
@@ -220,7 +223,10 @@ NLBCertValidatorAction:
     RootDNSRole: {{ .AppDNSDelegationRole }}
     DomainName:  {{ .AppDNSName }}
     Aliases:
-      !Split [",", !Ref NLBAliases]
+      !If
+      - HasNLBAliases
+      - []
+      - !Split [",", !Ref NLBAliases]
 
 NLBCertValidatorFunction:
   Type: AWS::Lambda::Function

--- a/internal/pkg/template/templates/workloads/services/lb-web/cf.yml
+++ b/internal/pkg/template/templates/workloads/services/lb-web/cf.yml
@@ -69,6 +69,10 @@ Conditions:
     !Not [!Equals [!Ref AddonsTemplateURL, ""]]
   HasEnvFile:
     !Not [!Equals [!Ref EnvFileARN, ""]]
+{{- if .NLB}}
+  HasNLBAliases:
+    !Equals [!Ref NLBAliases, ""]
+{{- end}}
 Resources:
 {{include "loggroup" . | indent 2}}
 


### PR DESCRIPTION
This is a bug found from a recent manual test. 

`!Split` returns an array of one empty string if given an empty string. This is not we want - if given an empty string, we want `Aliases` to receive an empty array.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
