### PR TITLE
feat: allow `secrets` to refer to SecretsManager secrets by name

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/backend_svc.go
+++ b/internal/pkg/deploy/cloudformation/stack/backend_svc.go
@@ -117,7 +117,7 @@ func (s *BackendService) Template() (string, error) {
 	}
 	content, err := s.parser.ParseBackendService(template.WorkloadOpts{
 		Variables:                s.manifest.BackendServiceConfig.Variables,
-		Secrets:                  s.manifest.BackendServiceConfig.Secrets,
+		Secrets:                  convertSecrets(s.manifest.BackendServiceConfig.Secrets),
 		NestedStack:              addonsOutputs,
 		AddonsExtraParams:        addonsParams,
 		Sidecars:                 sidecars,

--- a/internal/pkg/deploy/cloudformation/stack/lb_web_svc.go
+++ b/internal/pkg/deploy/cloudformation/stack/lb_web_svc.go
@@ -200,7 +200,7 @@ func (s *LoadBalancedWebService) Template() (string, error) {
 	}
 	content, err := s.parser.ParseLoadBalancedWebService(template.WorkloadOpts{
 		Variables:                      s.manifest.TaskConfig.Variables,
-		Secrets:                        s.manifest.TaskConfig.Secrets,
+		Secrets:                        convertSecrets(s.manifest.TaskConfig.Secrets),
 		Aliases:                        aliases,
 		NestedStack:                    addonsOutputs,
 		AddonsExtraParams:              addonsParams,

--- a/internal/pkg/deploy/cloudformation/stack/scheduled_job.go
+++ b/internal/pkg/deploy/cloudformation/stack/scheduled_job.go
@@ -158,7 +158,7 @@ func (j *ScheduledJob) Template() (string, error) {
 
 	content, err := j.parser.ParseScheduledJob(template.WorkloadOpts{
 		Variables:                j.manifest.Variables,
-		Secrets:                  j.manifest.Secrets,
+		Secrets:                  convertSecrets(j.manifest.Secrets),
 		NestedStack:              addonsOutputs,
 		AddonsExtraParams:        addonsParams,
 		Sidecars:                 sidecars,

--- a/internal/pkg/deploy/cloudformation/stack/transformers.go
+++ b/internal/pkg/deploy/cloudformation/stack/transformers.go
@@ -778,3 +778,18 @@ func convertHTTPVersion(protocolVersion *string) *string {
 	pv := strings.ToUpper(*protocolVersion)
 	return &pv
 }
+
+func convertSecrets(secrets map[string]manifest.Secret) map[string]template.Secret {
+	if len(secrets) == 0 {
+		return nil
+	}
+	m := make(map[string]template.Secret)
+	for name, mftSecret := range secrets {
+		var tplSecret template.Secret = template.SecretFromSSMOrARN(mftSecret.Value())
+		if mftSecret.IsSecretsManagerName() {
+			tplSecret = template.SecretFromSecretsManager(mftSecret.Value())
+		}
+		m[name] = tplSecret
+	}
+	return m
+}

--- a/internal/pkg/deploy/cloudformation/stack/worker_svc.go
+++ b/internal/pkg/deploy/cloudformation/stack/worker_svc.go
@@ -118,7 +118,7 @@ func (s *WorkerService) Template() (string, error) {
 	}
 	content, err := s.parser.ParseWorkerService(template.WorkloadOpts{
 		Variables:                      s.manifest.WorkerServiceConfig.Variables,
-		Secrets:                        s.manifest.WorkerServiceConfig.Secrets,
+		Secrets:                        convertSecrets(s.manifest.WorkerServiceConfig.Secrets),
 		NestedStack:                    addonsOutputs,
 		AddonsExtraParams:              addonsParams,
 		Sidecars:                       sidecars,

--- a/internal/pkg/manifest/applyenv_test.go
+++ b/internal/pkg/manifest/applyenv_test.go
@@ -651,49 +651,49 @@ func TestApplyEnv_MapToString(t *testing.T) {
 	}{
 		"map upserted": {
 			inSvc: func(svc *LoadBalancedWebService) {
-				svc.TaskConfig.Secrets = map[string]string{
-					"secret1": "the secret sauce is mole",
-					"secret2": "the secret agent is johnny rivers",
+				svc.TaskConfig.Variables = map[string]string{
+					"var1": "the secret sauce is mole",
+					"var2": "the secret agent is johnny rivers",
 				}
-				svc.Environments["test"].TaskConfig.Secrets = map[string]string{
-					"secret1": "the secret sauce is blue cheese which has mold in it",
-					"secret3": "the secret route is through egypt",
+				svc.Environments["test"].TaskConfig.Variables = map[string]string{
+					"var1": "the secret sauce is blue cheese which has mold in it",
+					"var3": "the secret route is through egypt",
 				}
 			},
 			wanted: func(svc *LoadBalancedWebService) {
-				svc.TaskConfig.Secrets = map[string]string{
-					"secret1": "the secret sauce is blue cheese which has mold in it", // Overridden.
-					"secret2": "the secret agent is johnny rivers",                    // Kept.
-					"secret3": "the secret route is through egypt",                    // Appended
+				svc.TaskConfig.Variables = map[string]string{
+					"var1": "the secret sauce is blue cheese which has mold in it", // Overridden.
+					"var2": "the secret agent is johnny rivers",                    // Kept.
+					"var3": "the secret route is through egypt",                    // Appended
 				}
 			},
 		},
 		"map not overridden by zero map": {
 			inSvc: func(svc *LoadBalancedWebService) {
-				svc.TaskConfig.Secrets = map[string]string{
-					"secret1": "the secret sauce is mole",
-					"secret2": "the secret agent man is johnny rivers",
+				svc.TaskConfig.Variables = map[string]string{
+					"var1": "the secret sauce is mole",
+					"var2": "the secret agent man is johnny rivers",
 				}
-				svc.Environments["test"].TaskConfig.Secrets = map[string]string{}
+				svc.Environments["test"].TaskConfig.Variables = map[string]string{}
 			},
 			wanted: func(svc *LoadBalancedWebService) {
-				svc.TaskConfig.Secrets = map[string]string{
-					"secret1": "the secret sauce is mole",
-					"secret2": "the secret agent man is johnny rivers",
+				svc.TaskConfig.Variables = map[string]string{
+					"var1": "the secret sauce is mole",
+					"var2": "the secret agent man is johnny rivers",
 				}
 			},
 		},
 		"map not overridden": {
 			inSvc: func(svc *LoadBalancedWebService) {
-				svc.TaskConfig.Secrets = map[string]string{
-					"secret1": "the secret sauce is mole",
-					"secret2": "the secret agent man is johnny rivers",
+				svc.TaskConfig.Variables = map[string]string{
+					"var1": "the secret sauce is mole",
+					"var2": "the secret agent man is johnny rivers",
 				}
 			},
 			wanted: func(svc *LoadBalancedWebService) {
-				svc.TaskConfig.Secrets = map[string]string{
-					"secret1": "the secret sauce is mole",
-					"secret2": "the secret agent man is johnny rivers",
+				svc.TaskConfig.Variables = map[string]string{
+					"var1": "the secret sauce is mole",
+					"var2": "the secret agent man is johnny rivers",
 				}
 			},
 		},

--- a/internal/pkg/manifest/lb_web_svc_test.go
+++ b/internal/pkg/manifest/lb_web_svc_test.go
@@ -418,9 +418,9 @@ func TestLoadBalancedWebService_ApplyEnv(t *testing.T) {
 							"LOG_LEVEL":      "DEBUG",
 							"DDB_TABLE_NAME": "awards",
 						},
-						Secrets: map[string]string{
-							"GITHUB_TOKEN": "1111",
-							"TWILIO_TOKEN": "1111",
+						Secrets: map[string]Secret{
+							"GITHUB_TOKEN": {from: aws.String("1111")},
+							"TWILIO_TOKEN": {from: aws.String("1111")},
 						},
 						Storage: Storage{
 							Volumes: map[string]*Volume{
@@ -567,9 +567,9 @@ func TestLoadBalancedWebService_ApplyEnv(t *testing.T) {
 							"LOG_LEVEL":      "DEBUG",
 							"DDB_TABLE_NAME": "awards-prod",
 						},
-						Secrets: map[string]string{
-							"GITHUB_TOKEN": "1111",
-							"TWILIO_TOKEN": "1111",
+						Secrets: map[string]Secret{
+							"GITHUB_TOKEN": {from: aws.String("1111")},
+							"TWILIO_TOKEN": {from: aws.String("1111")},
 						},
 						Storage: Storage{
 							Volumes: map[string]*Volume{

--- a/internal/pkg/manifest/svc_test.go
+++ b/internal/pkg/manifest/svc_test.go
@@ -126,8 +126,8 @@ environments:
 							Variables: map[string]string{
 								"LOG_LEVEL": "WARN",
 							},
-							Secrets: map[string]string{
-								"DB_PASSWORD": "MYSQL_DB_PASSWORD",
+							Secrets: map[string]Secret{
+								"DB_PASSWORD": {from: aws.String("MYSQL_DB_PASSWORD")},
 							},
 						},
 						Sidecars: map[string]*SidecarConfig{
@@ -264,8 +264,8 @@ secrets:
 							ExecuteCommand: ExecuteCommand{
 								Enable: aws.Bool(false),
 							},
-							Secrets: map[string]string{
-								"API_TOKEN": "SUBS_API_TOKEN",
+							Secrets: map[string]Secret{
+								"API_TOKEN": {from: aws.String("SUBS_API_TOKEN")},
 							},
 						},
 						Network: NetworkConfig{

--- a/internal/pkg/manifest/validate.go
+++ b/internal/pkg/manifest/validate.go
@@ -1250,6 +1250,11 @@ func (r OverrideRule) Validate() error {
 	return nil
 }
 
+// Validate is a no-op for Secrets.
+func (s Secret) Validate() error {
+	return nil
+}
+
 type validateDependenciesOpts struct {
 	mainContainerName string
 	sidecarConfig     map[string]*SidecarConfig

--- a/internal/pkg/manifest/workload_ecs.go
+++ b/internal/pkg/manifest/workload_ecs.go
@@ -95,7 +95,7 @@ type TaskConfig struct {
 	ExecuteCommand ExecuteCommand       `yaml:"exec"`
 	Variables      map[string]string    `yaml:"variables"`
 	EnvFile        *string              `yaml:"env_file"`
-	Secrets        map[string]string    `yaml:"secrets"`
+	Secrets        map[string]Secret    `yaml:"secrets"`
 	Storage        Storage              `yaml:"storage"`
 }
 

--- a/internal/pkg/manifest/workload_ecs_test.go
+++ b/internal/pkg/manifest/workload_ecs_test.go
@@ -4,6 +4,7 @@
 package manifest
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -73,6 +74,110 @@ count: 1`),
 				require.Equal(t, tc.wantedStruct.Enable, b.ExecuteCommand.Enable)
 				require.Equal(t, tc.wantedStruct.Config, b.ExecuteCommand.Config)
 			}
+		})
+	}
+}
+
+func TestSecret_UnmarshalYAML(t *testing.T) {
+	testCases := map[string]struct {
+		in string
+
+		wanted    Secret
+		wantedErr error
+	}{
+		"should return an error if the input cannot be unmarshal to a Secret": {
+			in:        "key: value",
+			wantedErr: errors.New(`cannot marshal "secret" field to a string or "secretsmanager" object`),
+		},
+		"should be able to unmarshal an SSM parameter name": {
+			in:     "/github/token",
+			wanted: Secret{from: aws.String("/github/token")},
+		},
+		"should be able to unmarshal a SecretsManager ARN": {
+			in:     "arn:aws:secretsmanager:us-west-2:111122223333:secret:aes128-1a2b3c",
+			wanted: Secret{from: aws.String("arn:aws:secretsmanager:us-west-2:111122223333:secret:aes128-1a2b3c")},
+		},
+		"should be able to unmarshal a SecretsManager name": {
+			in:     "secretsmanager: aes128-1a2b3c",
+			wanted: Secret{fromSecretsManager: secretsManagerSecret{Name: aws.String("aes128-1a2b3c")}},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// GIVEN
+			actual := Secret{}
+
+			// WHEN
+			err := yaml.Unmarshal([]byte(tc.in), &actual)
+
+			// THEN
+			if tc.wantedErr == nil {
+				require.NoError(t, err)
+				require.Equal(t, tc.wanted, actual)
+			} else {
+				require.EqualError(t, err, tc.wantedErr.Error())
+			}
+		})
+	}
+}
+
+func TestSecret_IsSecretsManagerName(t *testing.T) {
+	testCases := map[string]struct {
+		in     Secret
+		wanted bool
+	}{
+		"should return false if the secret refers to an SSM parameter": {
+			in: Secret{from: aws.String("/github/token")},
+		},
+		"should return true if the secret refers to a SecretsManager secret name": {
+			in:     Secret{fromSecretsManager: secretsManagerSecret{Name: aws.String("aes128-1a2b3c")}},
+			wanted: true,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.wanted, tc.in.IsSecretsManagerName())
+		})
+	}
+}
+
+func TestSecret_Value(t *testing.T) {
+	testCases := map[string]struct {
+		in     Secret
+		wanted string
+	}{
+		"should return the SSM parameter name if the secret is just a string": {
+			in:     Secret{from: aws.String("/github/token")},
+			wanted: "/github/token",
+		},
+		"should return the SecretsManager secret name when the secret is from SecretsManager": {
+			in:     Secret{fromSecretsManager: secretsManagerSecret{Name: aws.String("aes128-1a2b3c")}},
+			wanted: "aes128-1a2b3c",
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.wanted, tc.in.Value())
+		})
+	}
+}
+
+func TestSecretsManagerSecret_IsEmpty(t *testing.T) {
+	testCases := map[string]struct {
+		in     secretsManagerSecret
+		wanted bool
+	}{
+		"should return true on empty struct": {in: secretsManagerSecret{}, wanted: true},
+		"should return false if the name is provided": {
+			in: secretsManagerSecret{
+				Name: aws.String("aes128-1a2b3c"),
+			},
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.wanted, tc.in.IsEmpty())
 		})
 	}
 }

--- a/internal/pkg/template/templates/workloads/partials/cf/secrets.yml
+++ b/internal/pkg/template/templates/workloads/partials/cf/secrets.yml
@@ -1,8 +1,14 @@
 {{- if hasSecrets .}}
-Secrets:{{range $name, $valueFrom := .Secrets}}
+Secrets:
+{{- range $name, $secret := .Secrets}}
 - Name: {{$name}}
-  ValueFrom: {{$valueFrom}}{{end}}{{end}}{{if .NestedStack}}{{$stackName := .NestedStack.StackName}}{{range $secret := .NestedStack.SecretOutputs}}
+  ValueFrom: {{if not $secret.RequiresSub }}{{$secret.ValueFrom}}{{- else}} !Sub 'arn:${AWS::Partition}:{{$secret.Service}}:${AWS::Region}:${AWS::AccountId}:{{$secret.ValueFrom}}' {{- end }}
+{{- end}}
+{{- end}}
+{{- if .NestedStack}}{{$stackName := .NestedStack.StackName}}
+{{- range $secret := .NestedStack.SecretOutputs}}
 - Name: {{toSnakeCase $secret}}
   ValueFrom:
-    Fn::GetAtt: [{{$stackName}}, Outputs.{{$secret}}]{{end}}
+    Fn::GetAtt: [{{$stackName}}, Outputs.{{$secret}}]
+{{- end}}
 {{- end}}

--- a/internal/pkg/template/workload.go
+++ b/internal/pkg/template/workload.go
@@ -49,7 +49,6 @@ const (
 	OSWindowsServerCore = "WINDOWS_SERVER_2019_CORE"
 
 	ArchX86   = "X86_64"
-	ArchARM   = "ARM"
 	ArchARM64 = "ARM64"
 )
 
@@ -441,7 +440,7 @@ func (p RuntimePlatformOpts) isEmpty() bool {
 type WorkloadOpts struct {
 	// Additional options that are common between **all** workload templates.
 	Variables                map[string]string
-	Secrets                  map[string]string
+	Secrets                  map[string]Secret
 	Aliases                  []string
 	Tags                     map[string]string        // Used by App Runner workloads to tag App Runner service resources
 	NestedStack              *WorkloadNestedStackOpts // Outputs from nested stacks such as the addons stack.

--- a/internal/pkg/template/workload_test.go
+++ b/internal/pkg/template/workload_test.go
@@ -300,7 +300,7 @@ func TestSsmOrSecretARN_ValueFrom(t *testing.T) {
 }
 
 func TestSecretsManagerName_RequiresSub(t *testing.T) {
-	require.True(t, secretsManagerName{}.RequiresSub(), "secrets refering a SecretsManager name need to be expanded to a full ARN")
+	require.True(t, secretsManagerName{}.RequiresSub(), "secrets referring to a SecretsManager name need to be expanded to a full ARN")
 }
 
 func TestSecretsManagerName_Service(t *testing.T) {

--- a/internal/pkg/template/workload_test.go
+++ b/internal/pkg/template/workload_test.go
@@ -122,14 +122,14 @@ func TestHasSecrets(t *testing.T) {
 		},
 		"no secrets": {
 			in: WorkloadOpts{
-				Secrets: map[string]string{},
+				Secrets: map[string]Secret{},
 			},
 			wanted: false,
 		},
 		"service has secrets": {
 			in: WorkloadOpts{
-				Secrets: map[string]string{
-					"hello": "world",
+				Secrets: map[string]Secret{
+					"hello": SecretFromSSMOrARN("world"),
 				},
 			},
 			wanted: true,

--- a/internal/pkg/template/workload_test.go
+++ b/internal/pkg/template/workload_test.go
@@ -290,3 +290,23 @@ func TestRuntimePlatformOpts_IsDefault(t *testing.T) {
 		})
 	}
 }
+
+func TestSsmOrSecretARN_RequiresSub(t *testing.T) {
+	require.False(t, ssmOrSecretARN{}.RequiresSub(), "SSM Parameter Store or secret ARNs do not require !Sub")
+}
+
+func TestSsmOrSecretARN_ValueFrom(t *testing.T) {
+	require.Equal(t, "/github/token", SecretFromSSMOrARN("/github/token").ValueFrom())
+}
+
+func TestSecretsManagerName_RequiresSub(t *testing.T) {
+	require.True(t, secretsManagerName{}.RequiresSub(), "secrets refering a SecretsManager name need to be expanded to a full ARN")
+}
+
+func TestSecretsManagerName_Service(t *testing.T) {
+	require.Equal(t, "secretsmanager", secretsManagerName{}.Service())
+}
+
+func TestSecretsManagerName_ValueFrom(t *testing.T) {
+	require.Equal(t, "secret:aes128-1a2b3c", SecretFromSecretsManager("aes128-1a2b3c").ValueFrom())
+}


### PR DESCRIPTION
Resolves #2898

I'll update the secrets for sidecars and logging in a separate PR later. This is just for the main container.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
