### PR TITLE
chore: avoid init unnecessary clients for workload package

### DIFF
--- a/internal/pkg/cli/deploy/deploy_test.go
+++ b/internal/pkg/cli/deploy/deploy_test.go
@@ -30,15 +30,15 @@ import (
 )
 
 type deployMocks struct {
-	mockImageBuilderPusher     *mocks.MockimageBuilderPusher
+	mockImageBuilderPusher     *mocks.MockImageBuilderPusher
 	mockEndpointGetter         *mocks.MockendpointGetter
 	mockSpinner                *mocks.Mockspinner
 	mockPublicCIDRBlocksGetter *mocks.MockpublicCIDRBlocksGetter
 	mockSNSTopicsLister        *mocks.MocksnsTopicsLister
 	mockServiceDeployer        *mocks.MockserviceDeployer
 	mockServiceForceUpdater    *mocks.MockserviceForceUpdater
-	mockTemplater              *mocks.Mocktemplater
-	mockUploader               *mocks.Mockuploader
+	mockTemplater              *mocks.MockTemplater
+	mockUploader               *mocks.MockUploader
 	mockVersionGetter          *mocks.MockversionGetter
 	mockFileReader             *mocks.MockfileReader
 }
@@ -209,9 +209,9 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 			defer ctrl.Finish()
 
 			m := &deployMocks{
-				mockUploader:           mocks.NewMockuploader(ctrl),
-				mockTemplater:          mocks.NewMocktemplater(ctrl),
-				mockImageBuilderPusher: mocks.NewMockimageBuilderPusher(ctrl),
+				mockUploader:           mocks.NewMockUploader(ctrl),
+				mockTemplater:          mocks.NewMockTemplater(ctrl),
+				mockImageBuilderPusher: mocks.NewMockImageBuilderPusher(ctrl),
 				mockFileReader:         mocks.NewMockfileReader(ctrl),
 			}
 			tc.mock(m)
@@ -233,13 +233,14 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 					buildRequired: tc.inBuildRequired,
 				},
 
-				templater:          m.mockTemplater,
-				fs:                 m.mockFileReader,
-				s3Client:           m.mockUploader,
-				imageBuilderPusher: m.mockImageBuilderPusher,
+				fs: m.mockFileReader,
 			}
 
-			got, gotErr := deployer.UploadArtifacts()
+			got, gotErr := deployer.UploadArtifacts(&UploadArtifactsInput{
+				ImageBuilderPusher: m.mockImageBuilderPusher,
+				Templater:          m.mockTemplater,
+				Uploader:           m.mockUploader,
+			})
 
 			if tc.wantErr != nil {
 				require.EqualError(t, gotErr, tc.wantErr.Error())

--- a/internal/pkg/cli/deploy/mocks/mock_deploy.go
+++ b/internal/pkg/cli/deploy/mocks/mock_deploy.go
@@ -56,31 +56,31 @@ func (mr *MockActionRecommenderMockRecorder) RecommendedActions() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecommendedActions", reflect.TypeOf((*MockActionRecommender)(nil).RecommendedActions))
 }
 
-// MockimageBuilderPusher is a mock of imageBuilderPusher interface.
-type MockimageBuilderPusher struct {
+// MockImageBuilderPusher is a mock of ImageBuilderPusher interface.
+type MockImageBuilderPusher struct {
 	ctrl     *gomock.Controller
-	recorder *MockimageBuilderPusherMockRecorder
+	recorder *MockImageBuilderPusherMockRecorder
 }
 
-// MockimageBuilderPusherMockRecorder is the mock recorder for MockimageBuilderPusher.
-type MockimageBuilderPusherMockRecorder struct {
-	mock *MockimageBuilderPusher
+// MockImageBuilderPusherMockRecorder is the mock recorder for MockImageBuilderPusher.
+type MockImageBuilderPusherMockRecorder struct {
+	mock *MockImageBuilderPusher
 }
 
-// NewMockimageBuilderPusher creates a new mock instance.
-func NewMockimageBuilderPusher(ctrl *gomock.Controller) *MockimageBuilderPusher {
-	mock := &MockimageBuilderPusher{ctrl: ctrl}
-	mock.recorder = &MockimageBuilderPusherMockRecorder{mock}
+// NewMockImageBuilderPusher creates a new mock instance.
+func NewMockImageBuilderPusher(ctrl *gomock.Controller) *MockImageBuilderPusher {
+	mock := &MockImageBuilderPusher{ctrl: ctrl}
+	mock.recorder = &MockImageBuilderPusherMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockimageBuilderPusher) EXPECT() *MockimageBuilderPusherMockRecorder {
+func (m *MockImageBuilderPusher) EXPECT() *MockImageBuilderPusherMockRecorder {
 	return m.recorder
 }
 
 // BuildAndPush mocks base method.
-func (m *MockimageBuilderPusher) BuildAndPush(docker repository.ContainerLoginBuildPusher, args *dockerengine.BuildArguments) (string, error) {
+func (m *MockImageBuilderPusher) BuildAndPush(docker repository.ContainerLoginBuildPusher, args *dockerengine.BuildArguments) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BuildAndPush", docker, args)
 	ret0, _ := ret[0].(string)
@@ -89,36 +89,36 @@ func (m *MockimageBuilderPusher) BuildAndPush(docker repository.ContainerLoginBu
 }
 
 // BuildAndPush indicates an expected call of BuildAndPush.
-func (mr *MockimageBuilderPusherMockRecorder) BuildAndPush(docker, args interface{}) *gomock.Call {
+func (mr *MockImageBuilderPusherMockRecorder) BuildAndPush(docker, args interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildAndPush", reflect.TypeOf((*MockimageBuilderPusher)(nil).BuildAndPush), docker, args)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildAndPush", reflect.TypeOf((*MockImageBuilderPusher)(nil).BuildAndPush), docker, args)
 }
 
-// Mockuploader is a mock of uploader interface.
-type Mockuploader struct {
+// MockUploader is a mock of Uploader interface.
+type MockUploader struct {
 	ctrl     *gomock.Controller
-	recorder *MockuploaderMockRecorder
+	recorder *MockUploaderMockRecorder
 }
 
-// MockuploaderMockRecorder is the mock recorder for Mockuploader.
-type MockuploaderMockRecorder struct {
-	mock *Mockuploader
+// MockUploaderMockRecorder is the mock recorder for MockUploader.
+type MockUploaderMockRecorder struct {
+	mock *MockUploader
 }
 
-// NewMockuploader creates a new mock instance.
-func NewMockuploader(ctrl *gomock.Controller) *Mockuploader {
-	mock := &Mockuploader{ctrl: ctrl}
-	mock.recorder = &MockuploaderMockRecorder{mock}
+// NewMockUploader creates a new mock instance.
+func NewMockUploader(ctrl *gomock.Controller) *MockUploader {
+	mock := &MockUploader{ctrl: ctrl}
+	mock.recorder = &MockUploaderMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *Mockuploader) EXPECT() *MockuploaderMockRecorder {
+func (m *MockUploader) EXPECT() *MockUploaderMockRecorder {
 	return m.recorder
 }
 
 // Upload mocks base method.
-func (m *Mockuploader) Upload(bucket, key string, data io.Reader) (string, error) {
+func (m *MockUploader) Upload(bucket, key string, data io.Reader) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Upload", bucket, key, data)
 	ret0, _ := ret[0].(string)
@@ -127,13 +127,13 @@ func (m *Mockuploader) Upload(bucket, key string, data io.Reader) (string, error
 }
 
 // Upload indicates an expected call of Upload.
-func (mr *MockuploaderMockRecorder) Upload(bucket, key, data interface{}) *gomock.Call {
+func (mr *MockUploaderMockRecorder) Upload(bucket, key, data interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upload", reflect.TypeOf((*Mockuploader)(nil).Upload), bucket, key, data)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upload", reflect.TypeOf((*MockUploader)(nil).Upload), bucket, key, data)
 }
 
 // ZipAndUpload mocks base method.
-func (m *Mockuploader) ZipAndUpload(bucket, key string, files ...s3.NamedBinary) (string, error) {
+func (m *MockUploader) ZipAndUpload(bucket, key string, files ...s3.NamedBinary) (string, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{bucket, key}
 	for _, a := range files {
@@ -146,37 +146,37 @@ func (m *Mockuploader) ZipAndUpload(bucket, key string, files ...s3.NamedBinary)
 }
 
 // ZipAndUpload indicates an expected call of ZipAndUpload.
-func (mr *MockuploaderMockRecorder) ZipAndUpload(bucket, key interface{}, files ...interface{}) *gomock.Call {
+func (mr *MockUploaderMockRecorder) ZipAndUpload(bucket, key interface{}, files ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{bucket, key}, files...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ZipAndUpload", reflect.TypeOf((*Mockuploader)(nil).ZipAndUpload), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ZipAndUpload", reflect.TypeOf((*MockUploader)(nil).ZipAndUpload), varargs...)
 }
 
-// Mocktemplater is a mock of templater interface.
-type Mocktemplater struct {
+// MockTemplater is a mock of Templater interface.
+type MockTemplater struct {
 	ctrl     *gomock.Controller
-	recorder *MocktemplaterMockRecorder
+	recorder *MockTemplaterMockRecorder
 }
 
-// MocktemplaterMockRecorder is the mock recorder for Mocktemplater.
-type MocktemplaterMockRecorder struct {
-	mock *Mocktemplater
+// MockTemplaterMockRecorder is the mock recorder for MockTemplater.
+type MockTemplaterMockRecorder struct {
+	mock *MockTemplater
 }
 
-// NewMocktemplater creates a new mock instance.
-func NewMocktemplater(ctrl *gomock.Controller) *Mocktemplater {
-	mock := &Mocktemplater{ctrl: ctrl}
-	mock.recorder = &MocktemplaterMockRecorder{mock}
+// NewMockTemplater creates a new mock instance.
+func NewMockTemplater(ctrl *gomock.Controller) *MockTemplater {
+	mock := &MockTemplater{ctrl: ctrl}
+	mock.recorder = &MockTemplaterMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *Mocktemplater) EXPECT() *MocktemplaterMockRecorder {
+func (m *MockTemplater) EXPECT() *MockTemplaterMockRecorder {
 	return m.recorder
 }
 
 // Template mocks base method.
-func (m *Mocktemplater) Template() (string, error) {
+func (m *MockTemplater) Template() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Template")
 	ret0, _ := ret[0].(string)
@@ -185,9 +185,9 @@ func (m *Mocktemplater) Template() (string, error) {
 }
 
 // Template indicates an expected call of Template.
-func (mr *MocktemplaterMockRecorder) Template() *gomock.Call {
+func (mr *MockTemplaterMockRecorder) Template() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Template", reflect.TypeOf((*Mocktemplater)(nil).Template))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Template", reflect.TypeOf((*MockTemplater)(nil).Template))
 }
 
 // MockstackSerializer is a mock of stackSerializer interface.

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -600,7 +600,7 @@ type interpolator interface {
 }
 
 type workloadDeployer interface {
-	UploadArtifacts() (*clideploy.UploadArtifactsOutput, error)
+	UploadArtifacts(in *clideploy.UploadArtifactsInput) (*clideploy.UploadArtifactsOutput, error)
 	DeployWorkload(in *clideploy.DeployWorkloadInput) (clideploy.ActionRecommender, error)
 }
 

--- a/internal/pkg/cli/job_deploy_test.go
+++ b/internal/pkg/cli/job_deploy_test.go
@@ -228,7 +228,7 @@ func TestJobDeployOpts_Execute(t *testing.T) {
 				m.mockEnvUpgrader.EXPECT().Execute().Return(nil)
 				m.mockWsReader.EXPECT().ReadWorkloadManifest(mockJobName).Return([]byte(""), nil)
 				m.mockInterpolator.EXPECT().Interpolate("").Return("", nil)
-				m.mockDeployer.EXPECT().UploadArtifacts().Return(nil, mockError)
+				m.mockDeployer.EXPECT().UploadArtifacts(gomock.Any()).Return(nil, mockError)
 			},
 
 			wantedError: fmt.Errorf("upload deploy resources for job upload: some error"),
@@ -238,7 +238,7 @@ func TestJobDeployOpts_Execute(t *testing.T) {
 				m.mockEnvUpgrader.EXPECT().Execute().Return(nil)
 				m.mockWsReader.EXPECT().ReadWorkloadManifest(mockJobName).Return([]byte(""), nil)
 				m.mockInterpolator.EXPECT().Interpolate("").Return("", nil)
-				m.mockDeployer.EXPECT().UploadArtifacts().Return(&deploy.UploadArtifactsOutput{}, nil)
+				m.mockDeployer.EXPECT().UploadArtifacts(gomock.Any()).Return(&deploy.UploadArtifactsOutput{}, nil)
 				m.mockDeployer.EXPECT().DeployWorkload(gomock.Any()).Return(nil, mockError)
 			},
 

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -1657,59 +1657,6 @@ func (mr *MocktemplaterMockRecorder) Template() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Template", reflect.TypeOf((*Mocktemplater)(nil).Template))
 }
 
-// MockstackSerializer is a mock of stackSerializer interface.
-type MockstackSerializer struct {
-	ctrl     *gomock.Controller
-	recorder *MockstackSerializerMockRecorder
-}
-
-// MockstackSerializerMockRecorder is the mock recorder for MockstackSerializer.
-type MockstackSerializerMockRecorder struct {
-	mock *MockstackSerializer
-}
-
-// NewMockstackSerializer creates a new mock instance.
-func NewMockstackSerializer(ctrl *gomock.Controller) *MockstackSerializer {
-	mock := &MockstackSerializer{ctrl: ctrl}
-	mock.recorder = &MockstackSerializerMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockstackSerializer) EXPECT() *MockstackSerializerMockRecorder {
-	return m.recorder
-}
-
-// SerializedParameters mocks base method.
-func (m *MockstackSerializer) SerializedParameters() (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SerializedParameters")
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// SerializedParameters indicates an expected call of SerializedParameters.
-func (mr *MockstackSerializerMockRecorder) SerializedParameters() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SerializedParameters", reflect.TypeOf((*MockstackSerializer)(nil).SerializedParameters))
-}
-
-// Template mocks base method.
-func (m *MockstackSerializer) Template() (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Template")
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Template indicates an expected call of Template.
-func (mr *MockstackSerializerMockRecorder) Template() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Template", reflect.TypeOf((*MockstackSerializer)(nil).Template))
-}
-
 // Mockrunner is a mock of runner interface.
 type Mockrunner struct {
 	ctrl     *gomock.Controller
@@ -4320,44 +4267,6 @@ func (mr *MockversionGetterMockRecorder) Version() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Version", reflect.TypeOf((*MockversionGetter)(nil).Version))
 }
 
-// MockendpointGetter is a mock of endpointGetter interface.
-type MockendpointGetter struct {
-	ctrl     *gomock.Controller
-	recorder *MockendpointGetterMockRecorder
-}
-
-// MockendpointGetterMockRecorder is the mock recorder for MockendpointGetter.
-type MockendpointGetterMockRecorder struct {
-	mock *MockendpointGetter
-}
-
-// NewMockendpointGetter creates a new mock instance.
-func NewMockendpointGetter(ctrl *gomock.Controller) *MockendpointGetter {
-	mock := &MockendpointGetter{ctrl: ctrl}
-	mock.recorder = &MockendpointGetterMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockendpointGetter) EXPECT() *MockendpointGetterMockRecorder {
-	return m.recorder
-}
-
-// ServiceDiscoveryEndpoint mocks base method.
-func (m *MockendpointGetter) ServiceDiscoveryEndpoint() (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ServiceDiscoveryEndpoint")
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ServiceDiscoveryEndpoint indicates an expected call of ServiceDiscoveryEndpoint.
-func (mr *MockendpointGetterMockRecorder) ServiceDiscoveryEndpoint() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceDiscoveryEndpoint", reflect.TypeOf((*MockendpointGetter)(nil).ServiceDiscoveryEndpoint))
-}
-
 // MockenvTemplater is a mock of envTemplater interface.
 type MockenvTemplater struct {
 	ctrl     *gomock.Controller
@@ -6397,18 +6306,18 @@ func (mr *MockworkloadDeployerMockRecorder) DeployWorkload(in interface{}) *gomo
 }
 
 // UploadArtifacts mocks base method.
-func (m *MockworkloadDeployer) UploadArtifacts() (*deploy.UploadArtifactsOutput, error) {
+func (m *MockworkloadDeployer) UploadArtifacts(in *deploy.UploadArtifactsInput) (*deploy.UploadArtifactsOutput, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UploadArtifacts")
+	ret := m.ctrl.Call(m, "UploadArtifacts", in)
 	ret0, _ := ret[0].(*deploy.UploadArtifactsOutput)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UploadArtifacts indicates an expected call of UploadArtifacts.
-func (mr *MockworkloadDeployerMockRecorder) UploadArtifacts() *gomock.Call {
+func (mr *MockworkloadDeployerMockRecorder) UploadArtifacts(in interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadArtifacts", reflect.TypeOf((*MockworkloadDeployer)(nil).UploadArtifacts))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadArtifacts", reflect.TypeOf((*MockworkloadDeployer)(nil).UploadArtifacts), in)
 }
 
 // MockworkloadTemplateGenerator is a mock of workloadTemplateGenerator interface.

--- a/internal/pkg/cli/svc_deploy_test.go
+++ b/internal/pkg/cli/svc_deploy_test.go
@@ -236,7 +236,7 @@ func TestSvcDeployOpts_Execute(t *testing.T) {
 				m.mockEnvUpgrader.EXPECT().Execute().Return(nil)
 				m.mockWsReader.EXPECT().ReadWorkloadManifest(mockSvcName).Return([]byte(""), nil)
 				m.mockInterpolator.EXPECT().Interpolate("").Return("", nil)
-				m.mockDeployer.EXPECT().UploadArtifacts().Return(nil, mockError)
+				m.mockDeployer.EXPECT().UploadArtifacts(gomock.Any()).Return(nil, mockError)
 			},
 
 			wantedError: fmt.Errorf("upload deploy resources for service frontend: some error"),
@@ -246,7 +246,7 @@ func TestSvcDeployOpts_Execute(t *testing.T) {
 				m.mockEnvUpgrader.EXPECT().Execute().Return(nil)
 				m.mockWsReader.EXPECT().ReadWorkloadManifest(mockSvcName).Return([]byte(""), nil)
 				m.mockInterpolator.EXPECT().Interpolate("").Return("", nil)
-				m.mockDeployer.EXPECT().UploadArtifacts().Return(&deploy.UploadArtifactsOutput{}, nil)
+				m.mockDeployer.EXPECT().UploadArtifacts(gomock.Any()).Return(&deploy.UploadArtifactsOutput{}, nil)
 				m.mockDeployer.EXPECT().DeployWorkload(gomock.Any()).Return(nil, mockError)
 			},
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
https://github.com/aws/copilot-cli/pull/3249 introduces a breaking change for pipeline users because it initiates ECR client to call `DescribeRepositories` which is not needed for our workload package and is not permitted by our pipeline codebuild role.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
