### PR TITLE
fix: stop truncating logs to 10 at a time when running `svc logs --follow`

### DIFF
--- a/internal/pkg/cli/svc_logs.go
+++ b/internal/pkg/cli/svc_logs.go
@@ -225,7 +225,7 @@ func (o *svcLogsOpts) askSvcEnvName() error {
 func parseSince(since time.Duration) *int64 {
 	sinceSec := int64(since.Round(time.Second).Seconds())
 	timeNow := time.Now().Add(time.Duration(-sinceSec) * time.Second)
-	return aws.Int64(timeNow.Unix() * 1000)
+	return aws.Int64(timeNow.UnixMilli())
 }
 
 func parseRFC3339(timeStr string) (int64, error) {
@@ -233,7 +233,7 @@ func parseRFC3339(timeStr string) (int64, error) {
 	if err != nil {
 		return 0, fmt.Errorf("reading time value %s: %w", timeStr, err)
 	}
-	return startTimeTmp.Unix() * 1000, nil
+	return startTimeTmp.UnixMilli(), nil
 }
 
 // buildSvcLogsCmd builds the command for displaying service logs in an application.

--- a/internal/pkg/logging/service.go
+++ b/internal/pkg/logging/service.go
@@ -81,7 +81,7 @@ func (o WriteLogEventsOpts) startTime(now func() time.Time) *int64 {
 	}
 	if o.Follow {
 		// Start following log events from current timestamp.
-		return aws.Int64(now().Unix() * 1000) // Multiplied by 1000 to convert the Unix() timestamp in seconds to milliseconds
+		return aws.Int64(now().UnixMilli())
 	}
 	return nil
 }

--- a/internal/pkg/logging/service.go
+++ b/internal/pkg/logging/service.go
@@ -65,12 +65,16 @@ func (o WriteLogEventsOpts) limit() *int64 {
 	if o.Limit != nil {
 		return o.Limit
 	}
-	if o.StartTime != nil || o.EndTime != nil {
+	if o.hasTimeFilters() {
 		// If time filtering is set, then set limit to be maximum number.
 		// https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_GetLogEvents.html#CWL-GetLogEvents-request-limit
 		return nil
 	}
 	return aws.Int64(defaultServiceLogsLimit)
+}
+
+func (o WriteLogEventsOpts) hasTimeFilters() bool {
+	return o.Follow || o.StartTime != nil || o.EndTime != nil
 }
 
 // NewServiceClient returns a ServiceClient for the svc service under env and app.

--- a/internal/pkg/logging/service_test.go
+++ b/internal/pkg/logging/service_test.go
@@ -121,7 +121,7 @@ firelens_log_router/fcfe4 10.0.0.00 - - [01/Jan/1970 01:01:01] "WARN some warnin
 							require.Equal(t, param.LogStreams, []string{"mockLogStreamPrefix/mockTaskID1", "mockLogStreamPrefix/mockTaskID2"})
 							var val *int64 = nil // Explicitly mark that nil is of type *int64 otherwise require.Equal returns an error.
 							require.Equal(t, param.Limit, val)
-							require.Equal(t, param.StartTime, aws.Int64(mockCurrentTimestamp.Unix()*1000))
+							require.Equal(t, param.StartTime, aws.Int64(mockCurrentTimestamp.UnixMilli()))
 						}).
 						Return(&cloudwatchlogs.LogEventsOutput{
 							Events:              logEvents,

--- a/internal/pkg/logging/service_test.go
+++ b/internal/pkg/logging/service_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/copilot-cli/internal/pkg/aws/cloudwatchlogs"
@@ -56,6 +57,7 @@ firelens_log_router/fcfe4 10.0.0.00 - - [01/Jan/1970 01:01:01] "WARN some warnin
 	mockLimit := aws.Int64(100)
 	var mockNilLimit *int64
 	mockStartTime := aws.Int64(123456789)
+	mockCurrentTimestamp := time.Date(2020, 11, 23, 0, 0, 0, 0, time.UTC) // Copilot GA date :).
 	testCases := map[string]struct {
 		follow     bool
 		limit      *int64
@@ -119,6 +121,7 @@ firelens_log_router/fcfe4 10.0.0.00 - - [01/Jan/1970 01:01:01] "WARN some warnin
 							require.Equal(t, param.LogStreams, []string{"mockLogStreamPrefix/mockTaskID1", "mockLogStreamPrefix/mockTaskID2"})
 							var val *int64 = nil // Explicitly mark that nil is of type *int64 otherwise require.Equal returns an error.
 							require.Equal(t, param.Limit, val)
+							require.Equal(t, param.StartTime, aws.Int64(mockCurrentTimestamp.Unix()*1000))
 						}).
 						Return(&cloudwatchlogs.LogEventsOutput{
 							Events:              logEvents,
@@ -179,6 +182,9 @@ firelens_log_router/fcfe4 10.0.0.00 - - [01/Jan/1970 01:01:01] "WARN some warnin
 				logStreamNamePrefix: mockLogStreamPrefix,
 				eventsGetter:        mocklogGetter,
 				w:                   b,
+				now: func() time.Time {
+					return mockCurrentTimestamp
+				},
 			}
 
 			// WHEN

--- a/internal/pkg/logging/service_test.go
+++ b/internal/pkg/logging/service_test.go
@@ -54,7 +54,6 @@ firelens_log_router/fcfe4 10.0.0.00 - - [01/Jan/1970 01:01:01] "WARN some warnin
 		},
 	}
 	mockLimit := aws.Int64(100)
-	mockDefaultLimit := aws.Int64(10)
 	var mockNilLimit *int64
 	mockStartTime := aws.Int64(123456789)
 	testCases := map[string]struct {
@@ -118,7 +117,8 @@ firelens_log_router/fcfe4 10.0.0.00 - - [01/Jan/1970 01:01:01] "WARN some warnin
 					m.logGetter.EXPECT().LogEvents(gomock.Any()).
 						Do(func(param cloudwatchlogs.LogEventsOpts) {
 							require.Equal(t, param.LogStreams, []string{"mockLogStreamPrefix/mockTaskID1", "mockLogStreamPrefix/mockTaskID2"})
-							require.Equal(t, param.Limit, mockDefaultLimit)
+							var val *int64 = nil // Explicitly mark that nil is of type *int64 otherwise require.Equal returns an error.
+							require.Equal(t, param.Limit, val)
 						}).
 						Return(&cloudwatchlogs.LogEventsOutput{
 							Events:              logEvents,
@@ -136,6 +136,26 @@ firelens_log_router/fcfe4 10.0.0.00 - - [01/Jan/1970 01:01:01] "WARN some warnin
 firelens_log_router/fcfe4 10.0.0.00 - - [01/Jan/1970 01:01:01] "FATA some error" - -
 firelens_log_router/fcfe4 10.0.0.00 - - [01/Jan/1970 01:01:01] "WARN some warning" - -
 firelens_log_router/fcfe4 10.0.0.00 - - [01/Jan/1970 01:01:01] "GET / HTTP/1.1" 404 -
+`,
+		},
+		"success with no filtering": {
+			taskIDs: []string{"mockTaskID1"},
+			setupMocks: func(m serviceLogsMocks) {
+				gomock.InOrder(
+					m.logGetter.EXPECT().LogEvents(gomock.Any()).
+						Do(func(param cloudwatchlogs.LogEventsOpts) {
+							require.Equal(t, param.LogStreams, []string{"mockLogStreamPrefix/mockTaskID1"})
+							require.Equal(t, param.Limit, aws.Int64(10))
+						}).
+						Return(&cloudwatchlogs.LogEventsOutput{
+							Events: logEvents,
+						}, nil),
+				)
+			},
+
+			wantedContent: `firelens_log_router/fcfe4 10.0.0.00 - - [01/Jan/1970 01:01:01] "GET / HTTP/1.1" 200 -
+firelens_log_router/fcfe4 10.0.0.00 - - [01/Jan/1970 01:01:01] "FATA some error" - -
+firelens_log_router/fcfe4 10.0.0.00 - - [01/Jan/1970 01:01:01] "WARN some warning" - -
 `,
 		},
 	}


### PR DESCRIPTION
Fixes #3220 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
