### PR TITLE
chore(repository): do not call API within constructor

### DIFF
--- a/internal/pkg/cli/deploy/deploy.go
+++ b/internal/pkg/cli/deploy/deploy.go
@@ -192,11 +192,8 @@ func newWorkloadDeployer(in *WorkloadDeployerInput) (*workloadDeployer, error) {
 		return nil, fmt.Errorf("initiate addons service: %w", err)
 	}
 	repoName := fmt.Sprintf("%s/%s", in.App.Name, in.Name)
-	imageBuilderPusher := &repository.Repository{
-		Name:     repoName,
-		Registry: ecr.New(defaultSessEnvRegion),
-		Uri:      resources.RepositoryURLs[in.Name],
-	}
+	imageBuilderPusher := repository.NewWithURI(
+		ecr.New(defaultSessEnvRegion), repoName, resources.RepositoryURLs[in.Name])
 	store, err := config.NewStore()
 	if err != nil {
 		return nil, fmt.Errorf("new config store: %w", err)

--- a/internal/pkg/cli/deploy/deploy.go
+++ b/internal/pkg/cli/deploy/deploy.go
@@ -24,6 +24,7 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/addon"
 	"github.com/aws/copilot-cli/internal/pkg/apprunner"
 	awscloudformation "github.com/aws/copilot-cli/internal/pkg/aws/cloudformation"
+	"github.com/aws/copilot-cli/internal/pkg/aws/ecr"
 	"github.com/aws/copilot-cli/internal/pkg/aws/partitions"
 	"github.com/aws/copilot-cli/internal/pkg/aws/s3"
 	"github.com/aws/copilot-cli/internal/pkg/aws/sessions"
@@ -191,9 +192,10 @@ func newWorkloadDeployer(in *WorkloadDeployerInput) (*workloadDeployer, error) {
 		return nil, fmt.Errorf("initiate addons service: %w", err)
 	}
 	repoName := fmt.Sprintf("%s/%s", in.App.Name, in.Name)
-	imageBuilderPusher, err := repository.New(repoName, defaultSessEnvRegion)
-	if err != nil {
-		return nil, fmt.Errorf("initiate image builder pusher: %w", err)
+	imageBuilderPusher := &repository.Repository{
+		Name:     repoName,
+		Registry: ecr.New(defaultSessEnvRegion),
+		Uri:      resources.RepositoryURLs[in.Name],
 	}
 	store, err := config.NewStore()
 	if err != nil {

--- a/internal/pkg/cli/deploy/deploy.go
+++ b/internal/pkg/cli/deploy/deploy.go
@@ -24,7 +24,6 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/addon"
 	"github.com/aws/copilot-cli/internal/pkg/apprunner"
 	awscloudformation "github.com/aws/copilot-cli/internal/pkg/aws/cloudformation"
-	"github.com/aws/copilot-cli/internal/pkg/aws/ecr"
 	"github.com/aws/copilot-cli/internal/pkg/aws/partitions"
 	"github.com/aws/copilot-cli/internal/pkg/aws/s3"
 	"github.com/aws/copilot-cli/internal/pkg/aws/sessions"
@@ -192,8 +191,7 @@ func newWorkloadDeployer(in *WorkloadDeployerInput) (*workloadDeployer, error) {
 		return nil, fmt.Errorf("initiate addons service: %w", err)
 	}
 	repoName := fmt.Sprintf("%s/%s", in.App.Name, in.Name)
-	registry := ecr.New(defaultSessEnvRegion)
-	imageBuilderPusher, err := repository.New(repoName, registry)
+	imageBuilderPusher, err := repository.New(repoName, defaultSessEnvRegion)
 	if err != nil {
 		return nil, fmt.Errorf("initiate image builder pusher: %w", err)
 	}

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -167,7 +167,7 @@ type imageBuilderPusher interface {
 }
 
 type repositoryURIGetter interface {
-	URI() string
+	URI() (string, error)
 }
 
 type repositoryService interface {

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -1517,11 +1517,12 @@ func (m *MockrepositoryURIGetter) EXPECT() *MockrepositoryURIGetterMockRecorder 
 }
 
 // URI mocks base method.
-func (m *MockrepositoryURIGetter) URI() string {
+func (m *MockrepositoryURIGetter) URI() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "URI")
 	ret0, _ := ret[0].(string)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // URI indicates an expected call of URI.
@@ -1569,11 +1570,12 @@ func (mr *MockrepositoryServiceMockRecorder) BuildAndPush(docker, args interface
 }
 
 // URI mocks base method.
-func (m *MockrepositoryService) URI() string {
+func (m *MockrepositoryService) URI() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "URI")
 	ret0, _ := ret[0].(string)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // URI indicates an expected call of URI.
@@ -1655,59 +1657,6 @@ func (m *Mocktemplater) Template() (string, error) {
 func (mr *MocktemplaterMockRecorder) Template() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Template", reflect.TypeOf((*Mocktemplater)(nil).Template))
-}
-
-// MockstackSerializer is a mock of stackSerializer interface.
-type MockstackSerializer struct {
-	ctrl     *gomock.Controller
-	recorder *MockstackSerializerMockRecorder
-}
-
-// MockstackSerializerMockRecorder is the mock recorder for MockstackSerializer.
-type MockstackSerializerMockRecorder struct {
-	mock *MockstackSerializer
-}
-
-// NewMockstackSerializer creates a new mock instance.
-func NewMockstackSerializer(ctrl *gomock.Controller) *MockstackSerializer {
-	mock := &MockstackSerializer{ctrl: ctrl}
-	mock.recorder = &MockstackSerializerMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockstackSerializer) EXPECT() *MockstackSerializerMockRecorder {
-	return m.recorder
-}
-
-// SerializedParameters mocks base method.
-func (m *MockstackSerializer) SerializedParameters() (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SerializedParameters")
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// SerializedParameters indicates an expected call of SerializedParameters.
-func (mr *MockstackSerializerMockRecorder) SerializedParameters() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SerializedParameters", reflect.TypeOf((*MockstackSerializer)(nil).SerializedParameters))
-}
-
-// Template mocks base method.
-func (m *MockstackSerializer) Template() (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Template")
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Template indicates an expected call of Template.
-func (mr *MockstackSerializerMockRecorder) Template() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Template", reflect.TypeOf((*MockstackSerializer)(nil).Template))
 }
 
 // Mockrunner is a mock of runner interface.
@@ -4318,44 +4267,6 @@ func (m *MockversionGetter) Version() (string, error) {
 func (mr *MockversionGetterMockRecorder) Version() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Version", reflect.TypeOf((*MockversionGetter)(nil).Version))
-}
-
-// MockendpointGetter is a mock of endpointGetter interface.
-type MockendpointGetter struct {
-	ctrl     *gomock.Controller
-	recorder *MockendpointGetterMockRecorder
-}
-
-// MockendpointGetterMockRecorder is the mock recorder for MockendpointGetter.
-type MockendpointGetterMockRecorder struct {
-	mock *MockendpointGetter
-}
-
-// NewMockendpointGetter creates a new mock instance.
-func NewMockendpointGetter(ctrl *gomock.Controller) *MockendpointGetter {
-	mock := &MockendpointGetter{ctrl: ctrl}
-	mock.recorder = &MockendpointGetterMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockendpointGetter) EXPECT() *MockendpointGetterMockRecorder {
-	return m.recorder
-}
-
-// ServiceDiscoveryEndpoint mocks base method.
-func (m *MockendpointGetter) ServiceDiscoveryEndpoint() (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ServiceDiscoveryEndpoint")
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ServiceDiscoveryEndpoint indicates an expected call of ServiceDiscoveryEndpoint.
-func (mr *MockendpointGetterMockRecorder) ServiceDiscoveryEndpoint() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceDiscoveryEndpoint", reflect.TypeOf((*MockendpointGetter)(nil).ServiceDiscoveryEndpoint))
 }
 
 // MockenvTemplater is a mock of envTemplater interface.

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -182,10 +182,7 @@ func newTaskRunOpts(vars runTaskVars) (*runTaskOpts, error) {
 
 	opts.configureRepository = func() error {
 		repoName := fmt.Sprintf(deploy.FmtTaskECRRepoName, opts.groupName)
-		opts.repository = &repository.Repository{
-			Name:     repoName,
-			Registry: ecr.New(opts.sess),
-		}
+		opts.repository = repository.New(ecr.New(opts.sess), repoName)
 		return nil
 	}
 

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -19,6 +19,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/arn"
 
 	awscloudformation "github.com/aws/copilot-cli/internal/pkg/aws/cloudformation"
+	"github.com/aws/copilot-cli/internal/pkg/aws/ecr"
 	"github.com/aws/copilot-cli/internal/pkg/describe"
 	"github.com/aws/copilot-cli/internal/pkg/logging"
 	"github.com/aws/copilot-cli/internal/pkg/term/prompt"
@@ -181,11 +182,10 @@ func newTaskRunOpts(vars runTaskVars) (*runTaskOpts, error) {
 
 	opts.configureRepository = func() error {
 		repoName := fmt.Sprintf(deploy.FmtTaskECRRepoName, opts.groupName)
-		repo, err := repository.New(repoName, opts.sess)
-		if err != nil {
-			return fmt.Errorf("initialize repository %s: %w", repoName, err)
+		opts.repository = &repository.Repository{
+			Name:     repoName,
+			Registry: ecr.New(opts.sess),
 		}
-		opts.repository = repo
 		return nil
 	}
 

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/copilot-cli/internal/pkg/aws/ec2"
-	"github.com/aws/copilot-cli/internal/pkg/aws/ecr"
 	awsecs "github.com/aws/copilot-cli/internal/pkg/aws/ecs"
 	"github.com/aws/copilot-cli/internal/pkg/aws/sessions"
 	"github.com/aws/copilot-cli/internal/pkg/config"
@@ -182,8 +181,7 @@ func newTaskRunOpts(vars runTaskVars) (*runTaskOpts, error) {
 
 	opts.configureRepository = func() error {
 		repoName := fmt.Sprintf(deploy.FmtTaskECRRepoName, opts.groupName)
-		registry := ecr.New(opts.sess)
-		repo, err := repository.New(repoName, registry)
+		repo, err := repository.New(repoName, opts.sess)
 		if err != nil {
 			return fmt.Errorf("initialize repository %s: %w", repoName, err)
 		}
@@ -571,7 +569,11 @@ func (o *runTaskOpts) Execute() error {
 		if o.imageTag != "" {
 			tag = o.imageTag
 		}
-		o.image = fmt.Sprintf(fmtImageURI, o.repository.URI(), tag)
+		uri, err := o.repository.URI()
+		if err != nil {
+			return fmt.Errorf("get ECR repository URI: %w", err)
+		}
+		o.image = fmt.Sprintf(fmtImageURI, uri, tag)
 		if err := o.updateTaskResources(); err != nil {
 			return err
 		}

--- a/internal/pkg/repository/repository_test.go
+++ b/internal/pkg/repository/repository_test.go
@@ -136,9 +136,9 @@ func TestRepository_BuildAndPush(t *testing.T) {
 			}
 
 			repo := &Repository{
-				Name:     inRepoName,
-				Registry: mockRepoGetter,
-				Uri:      tc.inURI,
+				name:     inRepoName,
+				registry: mockRepoGetter,
+				uri:      tc.inURI,
 			}
 
 			digest, err := repo.BuildAndPush(mockDocker, &dockerengine.BuildArguments{


### PR DESCRIPTION
<!-- Provide summary of changes -->
https://github.com/aws/copilot-cli/pull/3249 introduces a breaking change for pipeline users because it initiates ECR client to call DescribeRepositories which is not needed for our workload package and is not permitted by our pipeline codebuild role.

Prefer this change over https://github.com/aws/copilot-cli/pull/3257 because we want to init client within the `cli/deploy` package so that we can make `cli` package cleaner. Otherwise, it doesn't make a lot of sense for us to init these unrelated clients. The worst case all the `svc/job deploy/package` will have to init all the dependencies for `deploy`, which is very confusing and cumbersome.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
