### PR TITLE
fix: simplify and fix buildspec and pipeline CFN template

### DIFF
--- a/internal/pkg/cli/flag.go
+++ b/internal/pkg/cli/flag.go
@@ -202,7 +202,7 @@ const (
 	resourceTagsFlagDescription = `Optional. Labels with a key and value separated by commas.
 Allows you to categorize resources.`
 	stackOutputDirFlagDescription  = "Optional. Writes the stack template and template configuration to a directory."
-	uploadResourcesFlagDescription = "Optional. Whether to upload dependency resources (e.g., an image that needs to be built and pushed), so that the output of `copilot svc package` can be directly used for deployment."
+	uploadResourcesFlagDescription = "Optional. Whether to upload dependency resources (e.g., an image that needs to be built and pushed), so that the output can be directly used for deployment."
 	prodEnvFlagDescription         = "If the environment contains production services."
 
 	limitFlagDescription = `Optional. The maximum number of log events returned. Default is 10

--- a/internal/pkg/cli/flag.go
+++ b/internal/pkg/cli/flag.go
@@ -32,7 +32,7 @@ const (
 	imageTagFlag          = "tag"
 	resourceTagsFlag      = "resource-tags"
 	stackOutputDirFlag    = "output-dir"
-	uploadResourcesFlag   = "upload-resources"
+	uploadAssetsFlag      = "upload-resources"
 	limitFlag             = "limit"
 	followFlag            = "follow"
 	sinceFlag             = "since"
@@ -201,9 +201,10 @@ const (
 	imageTagFlagDescription     = `Optional. The container image tag.`
 	resourceTagsFlagDescription = `Optional. Labels with a key and value separated by commas.
 Allows you to categorize resources.`
-	stackOutputDirFlagDescription  = "Optional. Writes the stack template and template configuration to a directory."
-	uploadResourcesFlagDescription = "Optional. Whether to upload dependency resources (e.g., an image that needs to be built and pushed), so that the output can be directly used for deployment."
-	prodEnvFlagDescription         = "If the environment contains production services."
+	stackOutputDirFlagDescription = "Optional. Writes the stack template and template configuration to a directory."
+	uploadAssetsFlagDescription   = `Optional. Whether to upload assets (container images, Lambda functions).
+Uploaded asset locations are filled in the template configuration.`
+	prodEnvFlagDescription = "If the environment contains production services."
 
 	limitFlagDescription = `Optional. The maximum number of log events returned. Default is 10
 unless any time filtering flags are set.`

--- a/internal/pkg/cli/flag.go
+++ b/internal/pkg/cli/flag.go
@@ -32,7 +32,7 @@ const (
 	imageTagFlag          = "tag"
 	resourceTagsFlag      = "resource-tags"
 	stackOutputDirFlag    = "output-dir"
-	uploadAssetsFlag      = "upload-resources"
+	uploadAssetsFlag      = "upload-assets"
 	limitFlag             = "limit"
 	followFlag            = "follow"
 	sinceFlag             = "since"
@@ -202,7 +202,7 @@ const (
 	resourceTagsFlagDescription = `Optional. Labels with a key and value separated by commas.
 Allows you to categorize resources.`
 	stackOutputDirFlagDescription = "Optional. Writes the stack template and template configuration to a directory."
-	uploadAssetsFlagDescription   = `Optional. Whether to upload assets (container images, Lambda functions).
+	uploadAssetsFlagDescription   = `Optional. Whether to upload assets (container images, Lambda functions, etc.).
 Uploaded asset locations are filled in the template configuration.`
 	prodEnvFlagDescription = "If the environment contains production services."
 

--- a/internal/pkg/cli/job_list.go
+++ b/internal/pkg/cli/job_list.go
@@ -80,11 +80,6 @@ func (o *listJobOpts) Execute() error {
 	return nil
 }
 
-// RecommendActions is a no-op for this command.
-func (o *listJobOpts) RecommendActions() error {
-	return nil
-}
-
 func buildJobListCmd() *cobra.Command {
 	vars := listWkldVars{}
 	cmd := &cobra.Command{

--- a/internal/pkg/cli/job_list.go
+++ b/internal/pkg/cli/job_list.go
@@ -41,7 +41,7 @@ func newListJobOpts(vars listWkldVars) (*listJobOpts, error) {
 		Store: store,
 		Out:   os.Stdout,
 
-		ShowLocalJobs: vars.shouldOutputJSON,
+		ShowLocalJobs: vars.shouldShowLocalWorkloads,
 		OutputJSON:    vars.shouldOutputJSON,
 	}
 
@@ -53,6 +53,12 @@ func newListJobOpts(vars listWkldVars) (*listJobOpts, error) {
 	}, nil
 }
 
+// Validate is a no-op for this command.
+func (o *listJobOpts) Validate() error {
+	return nil
+}
+
+// Ask asks for fields that are required but not passed in.
 func (o *listJobOpts) Ask() error {
 	if o.appName != "" {
 		return nil
@@ -71,6 +77,11 @@ func (o *listJobOpts) Execute() error {
 	if err := o.list.Write(o.appName); err != nil {
 		return err
 	}
+	return nil
+}
+
+// RecommendActions is a no-op for this command.
+func (o *listJobOpts) RecommendActions() error {
 	return nil
 }
 

--- a/internal/pkg/cli/job_package.go
+++ b/internal/pkg/cli/job_package.go
@@ -25,12 +25,12 @@ const (
 )
 
 type packageJobVars struct {
-	name            string
-	envName         string
-	appName         string
-	tag             string
-	outputDir       string
-	uploadResources bool
+	name         string
+	envName      string
+	appName      string
+	tag          string
+	outputDir    string
+	uploadAssets bool
 }
 
 type packageJobOpts struct {
@@ -70,12 +70,12 @@ func newPackageJobOpts(vars packageJobVars) (*packageJobOpts, error) {
 	opts.newPackageCmd = func(o *packageJobOpts) {
 		opts.packageCmd = &packageSvcOpts{
 			packageSvcVars: packageSvcVars{
-				name:            o.name,
-				envName:         o.envName,
-				appName:         o.appName,
-				tag:             imageTagFromGit(o.runner, o.tag),
-				outputDir:       o.outputDir,
-				uploadResources: o.uploadResources,
+				name:         o.name,
+				envName:      o.envName,
+				appName:      o.appName,
+				tag:          imageTagFromGit(o.runner, o.tag),
+				outputDir:    o.outputDir,
+				uploadAssets: o.uploadAssets,
 			},
 			runner:           o.runner,
 			initAddonsClient: initPackageAddonsClient,
@@ -187,6 +187,6 @@ func buildJobPackageCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&vars.appName, appFlag, appFlagShort, tryReadingAppName(), appFlagDescription)
 	cmd.Flags().StringVar(&vars.tag, imageTagFlag, "", imageTagFlagDescription)
 	cmd.Flags().StringVar(&vars.outputDir, stackOutputDirFlag, "", stackOutputDirFlagDescription)
-	cmd.Flags().BoolVar(&vars.uploadResources, uploadResourcesFlag, false, uploadResourcesFlagDescription)
+	cmd.Flags().BoolVar(&vars.uploadAssets, uploadAssetsFlag, false, uploadAssetsFlagDescription)
 	return cmd
 }

--- a/internal/pkg/cli/list/list.go
+++ b/internal/pkg/cli/list/list.go
@@ -62,6 +62,16 @@ type SvcListWriter struct {
 	Out   io.Writer // The writer where output will be written.
 }
 
+// ServiceJSONOutput is the output struct for service list.
+type ServiceJSONOutput struct {
+	Services []*config.Workload `json:"services"`
+}
+
+// JobJSONOutput is the output struct for job list.
+type JobJSONOutput struct {
+	Jobs []*config.Workload `json:"jobs"`
+}
+
 // Jobs lists all jobs, either locally or in the workspace, and writes the output to a writer.
 func (l *JobListWriter) Write(appName string) error {
 	if _, err := l.Store.GetApplication(appName); err != nil {
@@ -154,10 +164,7 @@ func humanOutput(wklds []*config.Workload, w io.Writer) {
 }
 
 func (l *SvcListWriter) jsonOutputSvcs(svcs []*config.Workload) (string, error) {
-	type out struct {
-		Services []*config.Workload `json:"services"`
-	}
-	b, err := json.Marshal(out{Services: svcs})
+	b, err := json.Marshal(ServiceJSONOutput{Services: svcs})
 	if err != nil {
 		return "", fmt.Errorf("marshal services: %w", err)
 	}
@@ -165,10 +172,7 @@ func (l *SvcListWriter) jsonOutputSvcs(svcs []*config.Workload) (string, error) 
 }
 
 func (l *JobListWriter) jsonOutputJobs(jobs []*config.Workload) (string, error) {
-	type out struct {
-		Jobs []*config.Workload `json:"jobs"`
-	}
-	b, err := json.Marshal(out{Jobs: jobs})
+	b, err := json.Marshal(JobJSONOutput{Jobs: jobs})
 	if err != nil {
 		return "", fmt.Errorf("marshal jobs: %w", err)
 	}

--- a/internal/pkg/cli/pipeline_deploy.go
+++ b/internal/pkg/cli/pipeline_deploy.go
@@ -4,12 +4,16 @@
 package cli
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 
 	"github.com/aws/copilot-cli/internal/pkg/aws/cloudformation"
 	cs "github.com/aws/copilot-cli/internal/pkg/aws/codestar"
 	"github.com/aws/copilot-cli/internal/pkg/aws/sessions"
+	"github.com/aws/copilot-cli/internal/pkg/cli/list"
 	"github.com/aws/copilot-cli/internal/pkg/config"
 	"github.com/aws/copilot-cli/internal/pkg/deploy"
 	deploycfn "github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation"
@@ -17,6 +21,7 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/term/color"
 	"github.com/aws/copilot-cli/internal/pkg/term/log"
 	"github.com/aws/copilot-cli/internal/pkg/term/prompt"
+	"github.com/aws/copilot-cli/internal/pkg/term/selector"
 	"github.com/aws/copilot-cli/internal/pkg/workspace"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -60,8 +65,14 @@ type deployPipelineOpts struct {
 	envStore         environmentStore
 	ws               wsPipelineReader
 	codestar         codestar
+	newSvcListCmd    func(io.Writer) actionCommand
+	newJobListCmd    func(io.Writer) actionCommand
 
 	shouldPromptUpdateConnection bool
+
+	// cache variables
+	svcBuffer *bytes.Buffer
+	jobBuffer *bytes.Buffer
 }
 
 func newDeployPipelineOpts(vars deployPipelineVars) (*deployPipelineOpts, error) {
@@ -95,16 +106,59 @@ func newDeployPipelineOpts(vars deployPipelineVars) (*deployPipelineOpts, error)
 		prog:               termprogress.NewSpinner(log.DiagnosticWriter),
 		prompt:             prompt.New(),
 		codestar:           cs.New(defaultSession),
+		newSvcListCmd: func(w io.Writer) actionCommand {
+			return &listSvcOpts{
+				listWkldVars: listWkldVars{
+					appName: vars.appName,
+				},
+				sel: selector.NewSelect(prompt.New(), store),
+				list: &list.SvcListWriter{
+					Ws:    ws,
+					Store: store,
+					Out:   w,
+
+					ShowLocalSvcs: true,
+					OutputJSON:    true,
+				},
+			}
+		},
+		newJobListCmd: func(w io.Writer) actionCommand {
+			return &listJobOpts{
+				listWkldVars: listWkldVars{
+					appName: vars.appName,
+				},
+				sel: selector.NewSelect(prompt.New(), store),
+				list: &list.JobListWriter{
+					Ws:    ws,
+					Store: store,
+					Out:   w,
+
+					ShowLocalJobs: true,
+					OutputJSON:    true,
+				},
+			}
+		},
+		svcBuffer: &bytes.Buffer{},
+		jobBuffer: &bytes.Buffer{},
 	}, nil
 }
 
 // Validate returns an error if the flag values passed by the user are invalid.
 func (o *deployPipelineOpts) Validate() error {
 	if o.name != "" {
-		if err := o.validatePipelineName(); err != nil {
+		pipeline, err := o.getPipelineMft()
+		if err != nil {
 			return err
 		}
+		if pipeline.Name != o.name {
+			return fmt.Errorf(`pipeline %s not found in the workspace`, color.HighlightUserInput(o.name))
+		}
 	}
+	return nil
+}
+
+// Ask is a no-op for this command.
+func (o *deployPipelineOpts) Ask() error {
 	return nil
 }
 
@@ -120,16 +174,9 @@ func (o *deployPipelineOpts) Execute() error {
 	o.prog.Stop(log.Ssuccessf(fmtPipelineDeployResourcesComplete, color.HighlightUserInput(o.appName)))
 
 	// Read pipeline manifest.
-	data, err := o.ws.ReadPipelineManifest()
+	pipeline, err := o.getPipelineMft()
 	if err != nil {
-		return fmt.Errorf("read pipeline manifest: %w", err)
-	}
-	pipeline, err := manifest.UnmarshalPipeline(data)
-	if err != nil {
-		return fmt.Errorf("unmarshal pipeline manifest: %w", err)
-	}
-	if err := pipeline.Validate(); err != nil {
-		return fmt.Errorf("validate pipeline: %w", err)
+		return err
 	}
 	// Set pipeline name; if passed in with flag, should be identical.
 	o.name = pipeline.Name
@@ -179,28 +226,27 @@ func (o *deployPipelineOpts) Execute() error {
 	return nil
 }
 
-func (o *deployPipelineOpts) validatePipelineName() error {
+func (o *deployPipelineOpts) getPipelineMft() (*manifest.PipelineManifest, error) {
 	data, err := o.ws.ReadPipelineManifest()
 	if err != nil {
-		return fmt.Errorf("read pipeline manifest: %w", err)
+		return nil, fmt.Errorf("read pipeline manifest: %w", err)
 	}
 	pipeline, err := manifest.UnmarshalPipeline(data)
 	if err != nil {
-		return fmt.Errorf("unmarshal pipeline manifest: %w", err)
+		return nil, fmt.Errorf("unmarshal pipeline manifest: %w", err)
 	}
-	if pipeline.Name != o.name {
-		return fmt.Errorf(`pipeline %s not found in the workspace`, color.HighlightUserInput(o.name))
+	if err := pipeline.Validate(); err != nil {
+		return nil, fmt.Errorf("validate pipeline: %w", err)
 	}
-	return nil
+	return pipeline, nil
 }
 
 func (o *deployPipelineOpts) convertStages(manifestStages []manifest.PipelineStage) ([]deploy.PipelineStage, error) {
 	var stages []deploy.PipelineStage
-	workloads, err := o.ws.ListWorkloads()
+	workloads, err := o.getLocalWorkloads()
 	if err != nil {
-		return nil, fmt.Errorf("get workload names from workspace: %w", err)
+		return nil, err
 	}
-
 	for _, stage := range manifestStages {
 		env, err := o.envStore.GetEnvironment(o.appName, stage.Name)
 		if err != nil {
@@ -221,6 +267,30 @@ func (o *deployPipelineOpts) convertStages(manifestStages []manifest.PipelineSta
 	}
 
 	return stages, nil
+}
+
+func (o deployPipelineOpts) getLocalWorkloads() ([]string, error) {
+	var localWklds []string
+	if err := o.newSvcListCmd(o.svcBuffer).Execute(); err != nil {
+		return nil, fmt.Errorf("get local services: %w", err)
+	}
+	if err := o.newJobListCmd(o.jobBuffer).Execute(); err != nil {
+		return nil, fmt.Errorf("get local jobs: %w", err)
+	}
+	svcOutput, jobOutput := &list.ServiceJSONOutput{}, &list.JobJSONOutput{}
+	if err := json.Unmarshal(o.svcBuffer.Bytes(), svcOutput); err != nil {
+		return nil, fmt.Errorf("unmarshal service list output; %w", err)
+	}
+	for _, svc := range svcOutput.Services {
+		localWklds = append(localWklds, svc.Name)
+	}
+	if err := json.Unmarshal(o.jobBuffer.Bytes(), jobOutput); err != nil {
+		return nil, fmt.Errorf("unmarshal job list output; %w", err)
+	}
+	for _, job := range jobOutput.Jobs {
+		localWklds = append(localWklds, job.Name)
+	}
+	return localWklds, nil
 }
 
 func (o *deployPipelineOpts) getArtifactBuckets() ([]deploy.ArtifactBucket, error) {
@@ -344,18 +414,7 @@ func buildPipelineDeployCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if err := opts.Validate(); err != nil {
-				return err
-			}
-			if err := opts.Execute(); err != nil {
-				return err
-			}
-			log.Infoln()
-			log.Infoln("Recommended follow-up actions:")
-			for _, followup := range opts.RecommendedActions() {
-				log.Infof("- %s\n", followup)
-			}
-			return nil
+			return run(opts)
 		}),
 	}
 	cmd.Flags().StringVarP(&vars.appName, appFlag, appFlagShort, tryReadingAppName(), appFlagDescription)

--- a/internal/pkg/cli/pipeline_deploy_test.go
+++ b/internal/pkg/cli/pipeline_deploy_test.go
@@ -333,7 +333,7 @@ version: 1
 					m.ws.EXPECT().ReadPipelineManifest().Return([]byte(content), nil),
 				)
 			},
-			expectedError: fmt.Errorf("validate pipeline: pipeline name '12345678101234567820123456783012345678401234567850123456786012345678701234567880123456789012345671001' must be shorter than 100 characters"),
+			expectedError: fmt.Errorf("validate pipeline manifest: pipeline name '12345678101234567820123456783012345678401234567850123456786012345678701234567880123456789012345671001' must be shorter than 100 characters"),
 		},
 		"returns an error if provider is not a supported type": {
 			inApp:     &app,
@@ -580,10 +580,10 @@ stages:
 				envStore:         mockEnvStore,
 				prog:             mockProgress,
 				prompt:           mockPrompt,
-				newSvcListCmd: func(w io.Writer) actionCommand {
+				newSvcListCmd: func(w io.Writer) cmd {
 					return mockActionCmd
 				},
-				newJobListCmd: func(w io.Writer) actionCommand {
+				newJobListCmd: func(w io.Writer) cmd {
 					return mockActionCmd
 				},
 				svcBuffer: bytes.NewBufferString(`{"services":[{"app":"badgoose","name":"frontend","type":""}]}`),
@@ -744,10 +744,10 @@ func TestDeployPipelineOpts_convertStages(t *testing.T) {
 				},
 				envStore: mockEnvStore,
 				ws:       mockWorkspace,
-				newSvcListCmd: func(w io.Writer) actionCommand {
+				newSvcListCmd: func(w io.Writer) cmd {
 					return mockActionCmd
 				},
-				newJobListCmd: func(w io.Writer) actionCommand {
+				newJobListCmd: func(w io.Writer) cmd {
 					return mockActionCmd
 				},
 				svcBuffer: bytes.NewBufferString(`{"services":[{"app":"badgoose","name":"frontend","type":""}]}`),

--- a/internal/pkg/cli/svc_list.go
+++ b/internal/pkg/cli/svc_list.go
@@ -55,6 +55,11 @@ func newListSvcOpts(vars listWkldVars) (*listSvcOpts, error) {
 	}, nil
 }
 
+// Validate is a no-op for this command.
+func (o *listSvcOpts) Validate() error {
+	return nil
+}
+
 // Ask asks for fields that are required but not passed in.
 func (o *listSvcOpts) Ask() error {
 	if o.appName != "" {
@@ -71,11 +76,15 @@ func (o *listSvcOpts) Ask() error {
 
 // Execute lists the services through the prompt.
 func (o *listSvcOpts) Execute() error {
-
 	if err := o.list.Write(o.appName); err != nil {
 		return err
 	}
 
+	return nil
+}
+
+// RecommendActions is a no-op for this command.
+func (o *listSvcOpts) RecommendActions() error {
 	return nil
 }
 

--- a/internal/pkg/cli/svc_list.go
+++ b/internal/pkg/cli/svc_list.go
@@ -83,11 +83,6 @@ func (o *listSvcOpts) Execute() error {
 	return nil
 }
 
-// RecommendActions is a no-op for this command.
-func (o *listSvcOpts) RecommendActions() error {
-	return nil
-}
-
 // buildSvcListCmd builds the command for listing services in an appication.
 func buildSvcListCmd() *cobra.Command {
 	vars := listWkldVars{}

--- a/internal/pkg/cli/svc_package.go
+++ b/internal/pkg/cli/svc_package.go
@@ -45,12 +45,12 @@ var initPackageAddonsClient = func(o *packageSvcOpts) error {
 }
 
 type packageSvcVars struct {
-	name            string
-	envName         string
-	appName         string
-	tag             string
-	outputDir       string
-	uploadResources bool
+	name         string
+	envName      string
+	appName      string
+	tag          string
+	outputDir    string
+	uploadAssets bool
 
 	// To facilitate unit tests.
 	clientConfigured bool
@@ -301,7 +301,7 @@ func (o *packageSvcOpts) getSvcTemplates(env *config.Environment) (*wkldCfnTempl
 	uploadOut := clideploy.UploadArtifactsOutput{
 		ImageDigest: aws.String(""),
 	}
-	if o.uploadResources {
+	if o.uploadAssets {
 		out, err := generator.UploadArtifacts()
 		if err != nil {
 			return nil, fmt.Errorf("upload resources required for deployment for %s: %w", o.name, err)
@@ -402,6 +402,6 @@ func buildSvcPackageCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&vars.appName, appFlag, appFlagShort, tryReadingAppName(), appFlagDescription)
 	cmd.Flags().StringVar(&vars.tag, imageTagFlag, "", imageTagFlagDescription)
 	cmd.Flags().StringVar(&vars.outputDir, stackOutputDirFlag, "", stackOutputDirFlagDescription)
-	cmd.Flags().BoolVar(&vars.uploadResources, uploadResourcesFlag, false, uploadResourcesFlagDescription)
+	cmd.Flags().BoolVar(&vars.uploadAssets, uploadAssetsFlag, false, uploadAssetsFlagDescription)
 	return cmd
 }

--- a/internal/pkg/cli/svc_package_test.go
+++ b/internal/pkg/cli/svc_package_test.go
@@ -240,7 +240,7 @@ count: 1`
 				envName:          "test",
 				tag:              "1234",
 				clientConfigured: true,
-				uploadResources:  true,
+				uploadAssets:     true,
 			},
 			mockDependencies: func(ctrl *gomock.Controller, opts *packageSvcOpts) {
 				mockWs := mocks.NewMockwsWlDirReader(ctrl)

--- a/internal/pkg/template/templates/cicd/buildspec.yml
+++ b/internal/pkg/template/templates/cicd/buildspec.yml
@@ -56,14 +56,14 @@ phases:
         for env in $pl_envs; do
           tag=$(sed 's/:/-/g' <<<"${CODEBUILD_BUILD_ID##*:}-${env}" | rev | cut -c 1-128 | rev)
           for svc in $svcs; do
-          ./copilot-linux svc package -n $svc -e $env --output-dir './infrastructure' --tag $tag --upload-resources;
+          ./copilot-linux svc package -n $svc -e $env --output-dir './infrastructure' --tag $tag --upload-assets;
           if [ $? -ne 0 ]; then
             echo "Cloudformation stack and config files were not generated. Please check build logs to see if there was a manifest validation error." 1>&2;
             exit 1;
           fi
           done;
           for job in $jobs; do
-          ./copilot-linux job package -n $job -e $env --output-dir './infrastructure' --tag $tag --upload-resources;
+          ./copilot-linux job package -n $job -e $env --output-dir './infrastructure' --tag $tag --upload-assets;
           if [ $? -ne 0 ]; then
             echo "Cloudformation stack and config files were not generated. Please check build logs to see if there was a manifest validation error." 1>&2;
             exit 1;

--- a/internal/pkg/template/templates/cicd/buildspec.yml
+++ b/internal/pkg/template/templates/cicd/buildspec.yml
@@ -56,14 +56,14 @@ phases:
         for env in $pl_envs; do
           tag=$(sed 's/:/-/g' <<<"${CODEBUILD_BUILD_ID##*:}-${env}" | rev | cut -c 1-128 | rev)
           for svc in $svcs; do
-          ./copilot-linux svc package -n $svc -e $env --output-dir './infrastructure' --tag $tag;
+          ./copilot-linux svc package -n $svc -e $env --output-dir './infrastructure' --tag $tag --upload-resources;
           if [ $? -ne 0 ]; then
             echo "Cloudformation stack and config files were not generated. Please check build logs to see if there was a manifest validation error." 1>&2;
             exit 1;
           fi
           done;
           for job in $jobs; do
-          ./copilot-linux job package -n $job -e $env --output-dir './infrastructure' --tag $tag;
+          ./copilot-linux job package -n $job -e $env --output-dir './infrastructure' --tag $tag --upload-resources;
           if [ $? -ne 0 ]; then
             echo "Cloudformation stack and config files were not generated. Please check build logs to see if there was a manifest validation error." 1>&2;
             exit 1;
@@ -71,113 +71,6 @@ phases:
           done;
         done;
       - ls -lah ./infrastructure
-      # Concatenate jobs and services into one var for addons and env file
-      - WORKLOADS=$(echo $jobs $svcs)
-      # If addons exists, upload addons templates to each S3 bucket and write template URL to template config files.
-      - |
-        for workload in $WORKLOADS; do
-          ADDONSFILE=./infrastructure/$workload.addons.stack.yml
-          if [ -f "$ADDONSFILE" ]; then
-            tmp=$(mktemp)
-            timestamp=$(date +%s){{range $bucket := .ArtifactBuckets}}
-            aws s3 cp "$ADDONSFILE" "s3://{{$bucket.BucketName}}/manual/$timestamp/$workload.addons.stack.yml";{{range $envName := $bucket.Environments}}
-            jq --arg a "https://{{$bucket.BucketName}}.s3.{{$bucket.Region}}.amazonaws.com/manual/$timestamp/$workload.addons.stack.yml" '.Parameters.AddonsTemplateURL = $a' ./infrastructure/$workload-{{$envName}}.params.json > "$tmp" && mv "$tmp" ./infrastructure/$workload-{{$envName}}.params.json{{end}}{{end}}
-          fi
-        done;
-      # If env file exists, upload the env file to each S3 bucket and write template URL to template config files.
-      - |
-        for workload in $WORKLOADS; do
-          manifest=$(cat $CODEBUILD_SRC_DIR/copilot/$workload/manifest.yml | ruby -ryaml -rjson -e 'puts JSON.pretty_generate(YAML.load(ARGF))')
-          type=$(echo $manifest | jq -r '.type')
-          if [ "$type" = "Request-Driven Web Service" ]; then
-            echo "skipping env file uploading for Request-Driven Web Service $workload";
-            continue
-          fi
-          for env in $pl_envs; do
-            env_files=$(echo $manifest | jq --arg env "$env" '{base_env_file: .env_file, env_env_file: (.environments? | .[$env]? | .env_file?) }')
-            env_file=$(echo $env_files | jq -r 'if (.env_env_file == null) then .base_env_file else .env_env_file end')
-            ENVFILE="./$env_file"
-            if [ -f "$ENVFILE" ]; then{{range $bucket := .ArtifactBuckets}}{{range $envName := $bucket.Environments}}
-              if [ $env = {{$envName}} ]; then
-                tmp=$(mktemp)
-                checksum=$(cat $ENVFILE | sha256sum | head -c 64)
-                aws s3 cp "$ENVFILE" "s3://{{$bucket.BucketName}}/manual/$checksum/$env_file";
-                jq --arg a "arn:$PARTITION:s3:::{{$bucket.BucketName}}/manual/$checksum/$env_file" '.Parameters.EnvFileARN = $a' ./infrastructure/$workload-{{$envName}}.params.json > "$tmp" && mv "$tmp" ./infrastructure/$workload-{{$envName}}.params.json
-              fi{{end}}{{end}}
-            fi
-          done;
-        done;
-      # Build images
-      # - For each manifest file:
-      #   - Read the path to the Dockerfile by translating the YAML file into JSON.
-      #   - Run docker build.
-      #   - For each environment:
-      #     - Retrieve the ECR repository.
-      #     - Login and push the image.
-      - >
-        for workload in $WORKLOADS; do
-          manifest=$(cat $CODEBUILD_SRC_DIR/copilot/$workload/manifest.yml | ruby -ryaml -rjson -e 'puts JSON.pretty_generate(YAML.load(ARGF))')
-          for env in $pl_envs; do
-            tag=$(sed 's/:/-/g' <<<"${CODEBUILD_BUILD_ID##*:}-${env}" | rev | cut -c 1-128 | rev)
-            images=$(echo $manifest | jq --arg env "$env" '{base_image: .image, env_image: (.environments? | .[$env]? | .image? // {}) }')
-            image=$(echo $images | jq 'if (.env_image | length == 0) then .base_image else (.base_image | del(.location)) * .env_image end')
-            image_location=$(echo $image | jq '.location')
-            if [ ! "$image_location" = null ]; then
-              echo "skipping image building because location is provided as $image_location";
-              continue
-            fi
-            base_dockerfile=$(echo $image | jq '.build')
-            build_dockerfile=$(echo $image | jq -r '.build?.dockerfile? // ""')
-            build_context=$(echo $image | jq -r '.build?.context? // ""')
-            build_target=$(echo $image | jq -r '.build?.target? // ""')
-            dockerfile_args=$(echo $image | jq '.build?.args? // "" | to_entries?')
-            build_cache_from=$(echo $image | jq -r '.build?.cache_from? // ""')
-            df_rel_path=$( echo $base_dockerfile | sed 's/"//g')
-            if [ -n "$build_dockerfile" ]; then 
-              df_rel_path=$build_dockerfile
-            fi
-            df_path=$df_rel_path
-            df_dir_path=$(dirname "$df_path")
-            if [ -n "$build_context" ]; then
-              df_dir_path=$build_context
-            fi
-            platform_string=$(echo $manifest | jq -r '.platform // ""')
-            platform_os=$(echo $manifest | jq -r '.platform?.osfamily? // ""')
-            platform_arch=$(echo $manifest | jq -r '.platform?.architecture? // ""')
-            if [ "$platform_os" -a "$platform_arch" ]; then
-              platform_string="$platform_os/$platform_arch"
-            fi
-            build_args=
-            if [ -n "$dockerfile_args" ]; then
-              for arg in $(echo $dockerfile_args | jq -r '.[] | "\(.key)=\(.value)"'); do 
-                build_args="$build_args--build-arg $arg "
-              done
-            fi
-            if [ -n "$build_target" ]; then
-              build_args="$build_args--target $build_target "
-            fi
-            if [ -n "$build_cache_from" ]; then
-              for arg in $(echo $build_cache_from | jq -r '.[]'); do
-                build_args="$build_args--cache-from $arg "
-              done
-            fi
-            if [ -n "$platform_string" ]; then
-              build_args="$build_args--platform $platform_string "
-            fi
-            echo "Name: $workload"
-            echo "Relative Dockerfile path: $df_rel_path"
-            echo "Docker build context: $df_dir_path"
-            echo "Docker build args: $build_args"
-            echo "Running command: docker build -t $workload:$tag $build_args-f $df_path $df_dir_path";
-            docker build -t $workload:$tag $build_args-f $df_path $df_dir_path;
-            image_id=$(docker images -q $workload:$tag);
-            repo=$(cat $CODEBUILD_SRC_DIR/infrastructure/$workload-$env.params.json | jq -r '.Parameters.ContainerImage');
-            region=$(echo $repo | cut -d'.' -f4);
-            $(aws ecr get-login-password --region $region | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$region.amazonaws.com);
-            docker tag $image_id $repo;
-            docker push $repo;
-          done;
-        done;
 artifacts:
   files:
     - "infrastructure/*"

--- a/internal/pkg/workspace/workspace.go
+++ b/internal/pkg/workspace/workspace.go
@@ -152,7 +152,7 @@ func (ws *Workspace) ListJobs() ([]string, error) {
 	})
 }
 
-// ListWorkloads returns the name of all the workloads in the workspace.
+// ListWorkloads returns the name of all the workloads in the workspace (could be unregistered in SSM).
 func (ws *Workspace) ListWorkloads() ([]string, error) {
 	return ws.listWorkloads(func(wlType string) bool {
 		return true

--- a/site/content/docs/commands/job-package.en.md
+++ b/site/content/docs/commands/job-package.en.md
@@ -16,7 +16,8 @@ $ copilot job package
   -n, --name string         Name of the job.
       --output-dir string   Optional. Writes the stack template and template configuration to a directory.
       --tag string          Optional. The container image tag.
-      --upload-resources    Optional. Whether to upload dependency resources (e.g., an image that needs to be built and pushed), so that the output can be directly used for deployment.
+      --upload-resources    Optional. Whether to upload assets (container images, Lambda functions).
+                            Uploaded asset locations are filled in the template configuration.
 ```
 
 ## Examples

--- a/site/content/docs/commands/job-package.en.md
+++ b/site/content/docs/commands/job-package.en.md
@@ -16,7 +16,7 @@ $ copilot job package
   -n, --name string         Name of the job.
       --output-dir string   Optional. Writes the stack template and template configuration to a directory.
       --tag string          Optional. The container image tag.
-      --upload-resources    Optional. Whether to upload assets (container images, Lambda functions).
+      --upload-assets    Optional. Whether to upload assets (container images, Lambda functions, etc.).
                             Uploaded asset locations are filled in the template configuration.
 ```
 

--- a/site/content/docs/commands/job-package.en.md
+++ b/site/content/docs/commands/job-package.en.md
@@ -16,7 +16,7 @@ $ copilot job package
   -n, --name string         Name of the job.
       --output-dir string   Optional. Writes the stack template and template configuration to a directory.
       --tag string          Optional. The container image tag.
-      --upload-resources    Optional. Whether to upload dependency resources (e.g., an image that needs to be built and pushed), so that the output of `copilot svc package` can be directly used for deployment.
+      --upload-resources    Optional. Whether to upload dependency resources (e.g., an image that needs to be built and pushed), so that the output can be directly used for deployment.
 ```
 
 ## Examples

--- a/site/content/docs/commands/svc-package.en.md
+++ b/site/content/docs/commands/svc-package.en.md
@@ -16,7 +16,7 @@ $ copilot svc package
   -n, --name string         Name of the service.
       --output-dir string   Optional. Writes the stack template and template configuration to a directory.
       --tag string          Optional. The service's image tag.
-      --upload-resources    Optional. Whether to upload dependency resources (e.g., an image that needs to be built and pushed), so that the output of `copilot svc package` can be directly used for deployment.
+      --upload-resources    Optional. Whether to upload dependency resources (e.g., an image that needs to be built and pushed), so that the output can be directly used for deployment.
 ```
 
 ## Example

--- a/site/content/docs/commands/svc-package.en.md
+++ b/site/content/docs/commands/svc-package.en.md
@@ -16,7 +16,8 @@ $ copilot svc package
   -n, --name string         Name of the service.
       --output-dir string   Optional. Writes the stack template and template configuration to a directory.
       --tag string          Optional. The service's image tag.
-      --upload-resources    Optional. Whether to upload dependency resources (e.g., an image that needs to be built and pushed), so that the output can be directly used for deployment.
+      --upload-resources    Optional. Whether to upload assets (container images, Lambda functions).
+                            Uploaded asset locations are filled in the template configuration.
 ```
 
 ## Example

--- a/site/content/docs/commands/svc-package.en.md
+++ b/site/content/docs/commands/svc-package.en.md
@@ -16,7 +16,7 @@ $ copilot svc package
   -n, --name string         Name of the service.
       --output-dir string   Optional. Writes the stack template and template configuration to a directory.
       --tag string          Optional. The service's image tag.
-      --upload-resources    Optional. Whether to upload assets (container images, Lambda functions).
+      --upload-assets    Optional. Whether to upload assets (container images, Lambda functions, etc.).
                             Uploaded asset locations are filled in the template configuration.
 ```
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
This PR simplifies pipeline buildspec and fixes two bugs:

1. Some parts of the buildspec file generated by `pipeline init` are always static (for example the S3 bucket mentioned above) which should be dynamic. The reason behind that is: if the user creates another environment in a new region, the pipeline won’t work for the new environment anymore because we won’t upload those prerequisite to the new S3 bucket.
2. Pipeline CFN template grabs all the local workloads by checking their local files, which is problematic if the workload has been deleted before.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
