### PR TITLE
chore(env): enable importing VPCs with only public (no private) subnets

### DIFF
--- a/internal/pkg/cli/env_init.go
+++ b/internal/pkg/cli/env_init.go
@@ -532,15 +532,16 @@ If you proceed without at least two public subnets, you will not be able to depl
 			IsPublic: false,
 		})
 		if err != nil {
-			if err == selector.ErrSubnetsNotFound {
-				log.Errorf(`No existing private subnets were found in VPC %s. You can either:
-- Create new private subnets and then import them.
-- Use the default Copilot environment configuration.
+			if errors.Is(err, selector.ErrSubnetsNotFound) {
+				log.Warningf(`No existing private subnets were found in VPC %s.
+If you proceed without at least two private subnets, you may not be able to access 
+all Copilot features with this environment in the future.
 `, o.importVPC.ID)
+			} else {
+				return fmt.Errorf("select private subnets: %w", err)
 			}
-			return fmt.Errorf("select private subnets: %w", err)
 		}
-		if len(privateSubnets) < 2 {
+		if len(privateSubnets) == 1 {
 			return errors.New("select private subnets: at least two private subnets must be selected")
 		}
 		o.importVPC.PrivateSubnetIDs = privateSubnets

--- a/internal/pkg/cli/env_init.go
+++ b/internal/pkg/cli/env_init.go
@@ -533,9 +533,8 @@ If you proceed without at least two public subnets, you will not be able to depl
 		})
 		if err != nil {
 			if errors.Is(err, selector.ErrSubnetsNotFound) {
-				log.Warningf(`No existing private subnets were found in VPC %s.
-If you proceed without at least two private subnets, you may not be able to access 
-all Copilot features with this environment in the future.
+				log.Warningf(`No existing private subnets were found in VPC %s. 
+If you proceed without private subnets, you will not be able to add them after this environment is created.
 `, o.importVPC.ID)
 			} else {
 				return fmt.Errorf("select private subnets: %w", err)

--- a/internal/pkg/cli/env_init.go
+++ b/internal/pkg/cli/env_init.go
@@ -545,6 +545,9 @@ If you proceed without private subnets, you will not be able to add them after t
 		}
 		o.importVPC.PrivateSubnetIDs = privateSubnets
 	}
+	if len(o.importVPC.PublicSubnetIDs) + len(o.importVPC.PrivateSubnetIDs) == 0 {
+		return errors.New("VPC must have subnets in order to proceed with environment creation")
+	}
 	return nil
 }
 

--- a/internal/pkg/cli/env_init_test.go
+++ b/internal/pkg/cli/env_init_test.go
@@ -523,6 +523,22 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 					Return([]string{"mockPrivateSubnet", "anotherMockPrivateSubnet"}, nil)
 			},
 		},
+		"success with selecting two public subnets and zero private subnets": {
+			inAppName: mockApp,
+			inEnv:     mockEnv,
+			inProfile: mockProfile,
+			setupMocks: func(m initEnvMocks) {
+				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(mockSession, nil)
+				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, "", envInitCustomizedEnvTypes, gomock.Any()).
+					Return(envInitImportEnvResourcesSelectOption, nil)
+				m.selVPC.EXPECT().VPC(envInitVPCSelectPrompt, "").Return("mockVPC", nil)
+				m.ec2Client.EXPECT().HasDNSSupport("mockVPC").Return(true, nil)
+				m.selVPC.EXPECT().Subnets(mockPublicSubnetInput).
+					Return([]string{"mockPublicSubnet", "anotherMockPublicSubnet"}, nil)
+				m.selVPC.EXPECT().Subnets(mockPrivateSubnetInput).
+					Return([]string{}, nil)
+			},
+		},
 		"success with importing env resources with no flags": {
 			inAppName: mockApp,
 			inEnv:     mockEnv,

--- a/internal/pkg/cli/env_init_test.go
+++ b/internal/pkg/cli/env_init_test.go
@@ -630,6 +630,23 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 					Return([]string{"mockPrivateSubnet", "anotherMockPrivateSubnet"}, nil)
 			},
 		},
+		"error if no subnets selected": {
+			inAppName: mockApp,
+			inEnv:     mockEnv,
+			inProfile: mockProfile,
+			inImportVPCVars: importVPCVars{
+				ID: "mockVPC",
+			},
+			setupMocks: func(m initEnvMocks) {
+				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(mockSession, nil)
+				m.ec2Client.EXPECT().HasDNSSupport("mockVPC").Return(true, nil)
+				m.selVPC.EXPECT().Subnets(mockPublicSubnetInput).
+					Return(nil, nil)
+				m.selVPC.EXPECT().Subnets(mockPrivateSubnetInput).
+					Return(nil, nil)
+			},
+			wantedError: fmt.Errorf("VPC must have subnets in order to proceed with environment creation"),
+		},
 		"fail to get VPC CIDR": {
 			inAppName: mockApp,
 			inEnv:     mockEnv,

--- a/site/content/docs/developing/custom-environment-resources.en.md
+++ b/site/content/docs/developing/custom-environment-resources.en.md
@@ -17,7 +17,7 @@ Which credentials would you like to use to create name? [profile default]
   > No, I'd like to import existing resources (VPC, subnets).
 ```
 
-You may use the import feature to bring a VPC with only two public subnets and no private subnets such as a default VPC), or to bring a VPC with only two private subnets and no public subnets for your workloads that are not internet-facing. (For more details on the resources you'll need for isolated networks, go [here](https://github.com/aws/copilot-cli/discussions/2378).)
+You may use the import feature to bring a VPC with only two public subnets and no private subnets (such as a default VPC), or to bring a VPC with only two private subnets and no public subnets for your workloads that are not internet-facing. (For more details on the resources you'll need for isolated networks, go [here](https://github.com/aws/copilot-cli/discussions/2378).)
 
 ## Modifying Copilot's default resources 
 When you select the default configuration, Copilot follows [AWS best practices](https://aws.amazon.com/blogs/containers/amazon-ecs-availability-best-practices/) and creates a VPC with two public and two private subnets, with one of each type in one of two Availability Zones. 

--- a/site/content/docs/developing/custom-environment-resources.en.md
+++ b/site/content/docs/developing/custom-environment-resources.en.md
@@ -17,7 +17,7 @@ Which credentials would you like to use to create name? [profile default]
   > No, I'd like to import existing resources (VPC, subnets).
 ```
 
-You may use the import feature to bring a VPC with only two private subnets and no public subnets for your workloads that are not internet-facing. (For more details on the resources you'll need for isolated networks, go [here](https://github.com/aws/copilot-cli/discussions/2378).)
+You may use the import feature to bring a VPC with only two public subnets and no private subnets such as a default VPC), or to bring a VPC with only two private subnets and no public subnets for your workloads that are not internet-facing. (For more details on the resources you'll need for isolated networks, go [here](https://github.com/aws/copilot-cli/discussions/2378).)
 
 ## Modifying Copilot's default resources 
 When you select the default configuration, Copilot follows [AWS best practices](https://aws.amazon.com/blogs/containers/amazon-ecs-availability-best-practices/) and creates a VPC with two public and two private subnets, with one of each type in one of two Availability Zones. 


### PR DESCRIPTION
Currently, users have the option to create environments with imported VPCs that have only private subnets. They are warned that load balancing will not work, but are allowed to proceed. 

These changes enable a similar warn-but-allow workflow. The benefit is increased flexibility; for one, folks new to AWS can more easily try out Copilot with their default VPC. The downside is that in the future, if we add features that require private subnets (like internal load balancers), these environments won't have that option.

Fixes #3282.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
