### PR TITLE
fix: validate app name before using it to validate svc name in `svc delete`

### DIFF
--- a/internal/pkg/cli/svc_delete.go
+++ b/internal/pkg/cli/svc_delete.go
@@ -99,11 +99,6 @@ func newDeleteSvcOpts(vars deleteSvcVars) (*deleteSvcOpts, error) {
 
 // Validate returns an error if the user inputs are invalid.
 func (o *deleteSvcOpts) Validate() error {
-	if o.name != "" {
-		if _, err := o.store.GetService(o.appName, o.name); err != nil {
-			return err
-		}
-	}
 	if o.envName != "" {
 		return o.validateEnvName()
 	}
@@ -112,11 +107,25 @@ func (o *deleteSvcOpts) Validate() error {
 
 // Ask prompts the user for any required flags.
 func (o *deleteSvcOpts) Ask() error {
-	if err := o.askAppName(); err != nil {
-		return err
+	if o.appName != "" {
+		if _, err := o.store.GetApplication(o.appName); err != nil {
+			return err
+		}
+	} else {
+		if err := o.askAppName(); err != nil {
+			return err
+		}
 	}
-	if err := o.askSvcName(); err != nil {
-		return err
+
+	if o.name != "" {
+		if _, err := o.store.GetService(o.appName, o.name); err != nil {
+			return err
+		}
+
+	} else {
+		if err := o.askSvcName(); err != nil {
+			return err
+		}
 	}
 
 	if o.skipConfirmation {
@@ -208,10 +217,6 @@ func (o *deleteSvcOpts) targetEnv() (*config.Environment, error) {
 }
 
 func (o *deleteSvcOpts) askAppName() error {
-	if o.appName != "" {
-		return nil
-	}
-
 	name, err := o.sel.Application(svcAppNamePrompt, svcAppNameHelpPrompt)
 	if err != nil {
 		return fmt.Errorf("select application name: %w", err)
@@ -221,10 +226,6 @@ func (o *deleteSvcOpts) askAppName() error {
 }
 
 func (o *deleteSvcOpts) askSvcName() error {
-	if o.name != "" {
-		return nil
-	}
-
 	name, err := o.sel.Service(svcDeleteNamePrompt, "", o.appName)
 	if err != nil {
 		return fmt.Errorf("select service: %w", err)

--- a/internal/pkg/cli/svc_delete.go
+++ b/internal/pkg/cli/svc_delete.go
@@ -125,6 +125,11 @@ func (o *deleteSvcOpts) Ask() error {
 		}
 	}
 
+	if o.envName != "" {
+		if err := o.validateEnvName(); err != nil {
+			return err
+		}
+	}
 	if o.skipConfirmation {
 		return nil
 	}
@@ -137,9 +142,6 @@ func (o *deleteSvcOpts) Ask() error {
 		// When a customer provides a particular environment,
 		// we'll just delete the service from that environment -
 		// but keep it in the app.
-		if err := o.validateEnvName(); err != nil {
-			return err
-		}
 		deletePrompt = fmt.Sprintf(fmtSvcDeleteFromEnvConfirmPrompt, o.name, o.envName)
 		deleteConfirmHelp = fmt.Sprintf(svcDeleteFromEnvConfirmHelp, o.envName)
 	}

--- a/internal/pkg/cli/svc_delete.go
+++ b/internal/pkg/cli/svc_delete.go
@@ -99,9 +99,6 @@ func newDeleteSvcOpts(vars deleteSvcVars) (*deleteSvcOpts, error) {
 
 // Validate returns an error if the user inputs are invalid.
 func (o *deleteSvcOpts) Validate() error {
-	if o.envName != "" {
-		return o.validateEnvName()
-	}
 	return nil
 }
 
@@ -140,6 +137,9 @@ func (o *deleteSvcOpts) Ask() error {
 		// When a customer provides a particular environment,
 		// we'll just delete the service from that environment -
 		// but keep it in the app.
+		if err := o.validateEnvName(); err != nil {
+			return err
+		}
 		deletePrompt = fmt.Sprintf(fmtSvcDeleteFromEnvConfirmPrompt, o.name, o.envName)
 		deleteConfirmHelp = fmt.Sprintf(svcDeleteFromEnvConfirmHelp, o.envName)
 	}

--- a/internal/pkg/cli/svc_delete.go
+++ b/internal/pkg/cli/svc_delete.go
@@ -97,12 +97,12 @@ func newDeleteSvcOpts(vars deleteSvcVars) (*deleteSvcOpts, error) {
 	}, nil
 }
 
-// Validate returns an error if the user inputs are invalid.
+// Validate returns an error for any invalid optional flags.
 func (o *deleteSvcOpts) Validate() error {
 	return nil
 }
 
-// Ask prompts the user for any required flags.
+// Ask prompts for and validates any required flags.
 func (o *deleteSvcOpts) Ask() error {
 	if o.appName != "" {
 		if _, err := o.store.GetApplication(o.appName); err != nil {

--- a/internal/pkg/cli/svc_delete.go
+++ b/internal/pkg/cli/svc_delete.go
@@ -118,7 +118,6 @@ func (o *deleteSvcOpts) Ask() error {
 		if _, err := o.store.GetService(o.appName, o.name); err != nil {
 			return err
 		}
-
 	} else {
 		if err := o.askSvcName(); err != nil {
 			return err

--- a/internal/pkg/cli/svc_delete_test.go
+++ b/internal/pkg/cli/svc_delete_test.go
@@ -32,37 +32,23 @@ func TestDeleteSvcOpts_Validate(t *testing.T) {
 			want:       nil,
 		},
 		"with all flags set": {
-			inAppName: "phonetool",
-			inEnvName: "test",
-			inName:    "api",
-			setupMocks: func(m *mocks.Mockstore) {
-				m.EXPECT().GetEnvironment("phonetool", "test").
-					Return(&config.Environment{Name: "test"}, nil)
-			},
-			want: nil,
+			inAppName:  "phonetool",
+			inEnvName:  "test",
+			inName:     "api",
+			setupMocks: func(m *mocks.Mockstore) {},
+			want:       nil,
 		},
 		"with env flag set": {
-			inAppName: "phonetool",
-			inEnvName: "test",
-			setupMocks: func(m *mocks.Mockstore) {
-				m.EXPECT().GetEnvironment("phonetool", "test").
-					Return(&config.Environment{Name: "test"}, nil)
-			},
-			want: nil,
+			inAppName:  "phonetool",
+			inEnvName:  "test",
+			setupMocks: func(m *mocks.Mockstore) {},
+			want:       nil,
 		},
 		"with svc flag set": {
 			inAppName:  "phonetool",
 			inName:     "api",
 			setupMocks: func(m *mocks.Mockstore) {},
 			want:       nil,
-		},
-		"with unknown environment": {
-			inAppName: "phonetool",
-			inEnvName: "test",
-			setupMocks: func(m *mocks.Mockstore) {
-				m.EXPECT().GetEnvironment("phonetool", "test").Return(nil, errors.New("unknown env"))
-			},
-			want: errors.New("get environment test from config store: unknown env"),
 		},
 	}
 
@@ -267,6 +253,7 @@ func TestDeleteSvcOpts_Ask(t *testing.T) {
 			envName:          "test",
 			skipConfirmation: false,
 			setUpMocks: func(m *svcDeleteAskMocks) {
+				m.store.EXPECT().GetEnvironment(testAppName, "test").Return(&config.Environment{}, nil)
 				m.prompt.EXPECT().Confirm(
 					fmt.Sprintf(fmtSvcDeleteFromEnvConfirmPrompt, testSvcName, "test"),
 					fmt.Sprintf(svcDeleteFromEnvConfirmHelp, "test"),

--- a/internal/pkg/cli/svc_delete_test.go
+++ b/internal/pkg/cli/svc_delete_test.go
@@ -274,8 +274,6 @@ func TestDeleteSvcOpts_Ask(t *testing.T) {
 			mockPrompter := mocks.NewMockprompter(ctrl)
 			mockSel := mocks.NewMockconfigSelector(ctrl)
 			mockStore := mocks.NewMockstore(ctrl)
-			// test.mockPrompt(mockPrompter)
-			// test.mockSel(mockSel)
 
 			m := &svcDeleteAskMocks{
 				sel:    mockSel,


### PR DESCRIPTION
This fixes a bug that surfaces in #3290. We should make sure that `o.appName` is specified (either through flag or prompts) before we use it to validate service name.

This PR also reflects a new coding pattern that we'd like to adopt: validate only optional flags in `Validate` and ask or validate required flag in `Ask`.

In `Ask`, if the prompt is a selection prompt, then after the prompt we shouldn't do existence check. For example, if we need to prompt to select from existing services from application, then we shouldn't validate whether the selected service exists in the application, because this is redundant.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
