### PR TITLE
refactor(secretsmanager): take as input a session like other aws pkgs

### DIFF
--- a/internal/pkg/aws/secretsmanager/secretsmanager.go
+++ b/internal/pkg/aws/secretsmanager/secretsmanager.go
@@ -8,10 +8,11 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws/session"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
-	"github.com/aws/copilot-cli/internal/pkg/aws/sessions"
 )
 
 type api interface {
@@ -25,19 +26,12 @@ type SecretsManager struct {
 	sessionRegion  string
 }
 
-// New returns a SecretsManager configured with the default session.
-func New() (*SecretsManager, error) {
-	p := sessions.NewProvider()
-	sess, err := p.Default()
-
-	if err != nil {
-		return nil, err
-	}
-
+// New returns a SecretsManager configured against the input session.
+func New(s *session.Session) *SecretsManager {
 	return &SecretsManager{
-		secretsManager: secretsmanager.New(sess),
-		sessionRegion:  *sess.Config.Region,
-	}, nil
+		secretsManager: secretsmanager.New(s),
+		sessionRegion:  *s.Config.Region,
+	}
 }
 
 var secretTags = func() []*secretsmanager.Tag {

--- a/internal/pkg/cli/pipeline_delete.go
+++ b/internal/pkg/cli/pipeline_delete.go
@@ -60,11 +60,6 @@ func newDeletePipelineOpts(vars deletePipelineVars) (*deletePipelineOpts, error)
 		return nil, fmt.Errorf("new workspace client: %w", err)
 	}
 
-	secretsmanager, err := secretsmanager.New()
-	if err != nil {
-		return nil, fmt.Errorf("new secrets manager client: %w", err)
-	}
-
 	defaultSess, err := sessions.NewProvider().Default()
 	if err != nil {
 		return nil, fmt.Errorf("default session: %w", err)
@@ -74,7 +69,7 @@ func newDeletePipelineOpts(vars deletePipelineVars) (*deletePipelineOpts, error)
 		deletePipelineVars: vars,
 		prog:               termprogress.NewSpinner(log.DiagnosticWriter),
 		prompt:             prompt.New(),
-		secretsmanager:     secretsmanager,
+		secretsmanager:     secretsmanager.New(defaultSess),
 		pipelineDeployer:   cloudformation.New(defaultSess),
 		ws:                 ws,
 	}

--- a/internal/pkg/cli/pipeline_init.go
+++ b/internal/pkg/cli/pipeline_init.go
@@ -114,11 +114,6 @@ func newInitPipelineOpts(vars initPipelineVars) (*initPipelineOpts, error) {
 		return nil, fmt.Errorf("new workspace client: %w", err)
 	}
 
-	secretsmanager, err := secretsmanager.New()
-	if err != nil {
-		return nil, fmt.Errorf("new secretsmanager client: %w", err)
-	}
-
 	p := sessions.NewProvider()
 	defaultSession, err := p.Default()
 	if err != nil {
@@ -135,7 +130,7 @@ func newInitPipelineOpts(vars initPipelineVars) (*initPipelineOpts, error) {
 	return &initPipelineOpts{
 		initPipelineVars: vars,
 		workspace:        ws,
-		secretsmanager:   secretsmanager,
+		secretsmanager:   secretsmanager.New(defaultSession),
 		parser:           template.New(),
 		sessProvider:     p,
 		cfnClient:        cloudformation.New(defaultSession),


### PR DESCRIPTION


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
