### PR TITLE
chore: refactor validation and ask for svc-deploy and svc-list

### DIFF
--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -148,11 +148,11 @@ func (o *deploySvcOpts) Ask() error {
 		return errNoAppInWorkspace
 	}
 
-	if err := o.validateAndAskSvcName(); err != nil {
+	if err := o.validateOrAskSvcName(); err != nil {
 		return err
 	}
 
-	if err := o.validateAndAskEnvName(); err != nil {
+	if err := o.validateOrAskEnvName(); err != nil {
 		return err
 	}
 	return nil
@@ -246,7 +246,7 @@ func (o *deploySvcOpts) validateEnvName() error {
 	return nil
 }
 
-func (o *deploySvcOpts) validateAndAskSvcName() error {
+func (o *deploySvcOpts) validateOrAskSvcName() error {
 	if o.name != "" {
 		return o.validateSvcName()
 	}
@@ -259,7 +259,7 @@ func (o *deploySvcOpts) validateAndAskSvcName() error {
 	return nil
 }
 
-func (o *deploySvcOpts) validateAndAskEnvName() error {
+func (o *deploySvcOpts) validateOrAskEnvName() error {
 	if o.envName != "" {
 		return o.validateEnvName()
 	}

--- a/internal/pkg/cli/svc_init.go
+++ b/internal/pkg/cli/svc_init.go
@@ -247,11 +247,11 @@ func (o *initSvcOpts) Ask() error {
 	if err := o.askSvcType(); err != nil {
 		return err
 	}
-	dfSelected, err := o.askDockerfile()
+	err = o.askDockerfile()
 	if err != nil {
 		return err
 	}
-	if !dfSelected {
+	if o.dockerfilePath == "" {
 		if err := o.askImage(); err != nil {
 			return err
 		}
@@ -398,21 +398,21 @@ func (o *initSvcOpts) askImage() error {
 }
 
 // isDfSelected indicates if any Dockerfile is in use.
-func (o *initSvcOpts) askDockerfile() (isDfSelected bool, err error) {
+func (o *initSvcOpts) askDockerfile() (err error) {
 	if o.dockerfilePath != "" || o.image != "" {
-		return true, nil
+		return nil
 	}
 	if err = o.dockerEngine.CheckDockerEngineRunning(); err != nil {
 		var errDaemon *dockerengine.ErrDockerDaemonNotResponsive
 		switch {
 		case errors.Is(err, dockerengine.ErrDockerCommandNotFound):
 			log.Info("Docker command is not found; Copilot won't build from a Dockerfile.\n")
-			return false, nil
+			return nil
 		case errors.As(err, &errDaemon):
 			log.Info("Docker daemon is not responsive; Copilot won't build from a Dockerfile.\n")
-			return false, nil
+			return nil
 		default:
-			return false, fmt.Errorf("check if docker engine is running: %w", err)
+			return fmt.Errorf("check if docker engine is running: %w", err)
 		}
 	}
 	df, err := o.sel.Dockerfile(
@@ -425,13 +425,13 @@ func (o *initSvcOpts) askDockerfile() (isDfSelected bool, err error) {
 		},
 	)
 	if err != nil {
-		return false, fmt.Errorf("select Dockerfile: %w", err)
+		return fmt.Errorf("select Dockerfile: %w", err)
 	}
 	if df == selector.DockerfilePromptUseImage {
-		return false, nil
+		return nil
 	}
 	o.dockerfilePath = df
-	return true, nil
+	return nil
 }
 
 func (o *initSvcOpts) askSvcPort() (err error) {

--- a/internal/pkg/cli/svc_init.go
+++ b/internal/pkg/cli/svc_init.go
@@ -398,11 +398,11 @@ func (o *initSvcOpts) askImage() error {
 }
 
 // isDfSelected indicates if any Dockerfile is in use.
-func (o *initSvcOpts) askDockerfile() (err error) {
+func (o *initSvcOpts) askDockerfile() error {
 	if o.dockerfilePath != "" || o.image != "" {
 		return nil
 	}
-	if err = o.dockerEngine.CheckDockerEngineRunning(); err != nil {
+	if err := o.dockerEngine.CheckDockerEngineRunning(); err != nil {
 		var errDaemon *dockerengine.ErrDockerDaemonNotResponsive
 		switch {
 		case errors.Is(err, dockerengine.ErrDockerCommandNotFound):

--- a/internal/pkg/cli/svc_list.go
+++ b/internal/pkg/cli/svc_list.go
@@ -68,9 +68,11 @@ func (o *listSvcOpts) Validate() error {
 	return nil
 }
 
-// Ask asks for fields that are required but not passed in.
+// Ask prompts for and validates any required flags.
 func (o *listSvcOpts) Ask() error {
 	if o.appName != "" {
+		// NOTE: Skip validating app name here because `Execute` will fail pretty soon with a clear error message.
+		// The validation (config.GetApplication) would only add additional operation time in this particular case.
 		return nil
 	}
 

--- a/internal/pkg/cli/validate.go
+++ b/internal/pkg/cli/validate.go
@@ -69,8 +69,6 @@ var (
 	errMissingPublishTopicField = errors.New("field `publish.topics[].name` cannot be empty")
 	errInvalidPubSubTopicName   = errors.New("topic names can only contain letters, numbers, underscores, and hyphens")
 	errSubscribeBadFormat       = errors.New("value must be of the form <serviceName>:<topicName>")
-
-	fmtErrTopicSubscriptionNotAllowed = "SNS topic %s does not exist in environment %s"
 )
 
 const fmtErrValueBadSize = "value must be between %d and %d characters in length"
@@ -154,8 +152,6 @@ var (
 	awsSNSTopicRegexp       = regexp.MustCompile(`^[a-zA-Z0-9_-]*$`) // Validates that an expression contains only letters, numbers, underscores, and hyphens.
 	regexpMatchSubscription = regexp.MustCompile(`^(\S+):(\S+)`)     // Validates that an expression contains the format serviceName:topicName
 )
-
-var resourceNameFormat = "%s-%s-%s-%s" // Format for copilot resource names of form app-env-svc-name
 
 const regexpFindAllMatches = -1
 

--- a/internal/pkg/cli/validate.go
+++ b/internal/pkg/cli/validate.go
@@ -19,7 +19,6 @@ import (
 	"github.com/spf13/afero"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/copilot-cli/internal/pkg/addon"
 	"github.com/aws/copilot-cli/internal/pkg/aws/apprunner"
 	"github.com/aws/copilot-cli/internal/pkg/manifest"
@@ -737,25 +736,6 @@ func validatePubSubName(name string) error {
 		return errInvalidPubSubTopicName
 	}
 
-	return nil
-}
-
-func validateTopicsExist(subscriptions []manifest.TopicSubscription, topicARNs []string, app, env string) error {
-	validTopicResources := make([]string, 0, len(topicARNs))
-	for _, topic := range topicARNs {
-		parsedTopic, err := arn.Parse(topic)
-		if err != nil {
-			continue
-		}
-		validTopicResources = append(validTopicResources, parsedTopic.Resource)
-	}
-
-	for _, ts := range subscriptions {
-		topicName := fmt.Sprintf(resourceNameFormat, app, env, aws.StringValue(ts.Service), aws.StringValue(ts.Name))
-		if !contains(topicName, validTopicResources) {
-			return fmt.Errorf(fmtErrTopicSubscriptionNotAllowed, topicName, env)
-		}
-	}
 	return nil
 }
 

--- a/internal/pkg/cli/validate_test.go
+++ b/internal/pkg/cli/validate_test.go
@@ -8,11 +8,9 @@ import (
 	"fmt"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/aws/copilot-cli/internal/pkg/workspace"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/copilot-cli/internal/pkg/manifest"
 
 	"github.com/spf13/afero"
@@ -883,62 +881,6 @@ func Test_validateSubscribe(t *testing.T) {
 				require.NoError(t, err)
 			} else {
 				require.EqualError(t, err, tc.wantErr.Error())
-			}
-		})
-	}
-}
-
-func Test_validateTopicsExist(t *testing.T) {
-	mockApp := "app"
-	mockEnv := "env"
-	mockAllowedTopics := []string{
-		"arn:aws:sqs:us-west-2:123456789012:app-env-database-events",
-		"arn:aws:sqs:us-west-2:123456789012:app-env-database-orders",
-		"arn:aws:sqs:us-west-2:123456789012:app-env-api-events",
-	}
-	duration10Hours := 10 * time.Hour
-	testGoodTopics := []manifest.TopicSubscription{
-		{
-			Name:    aws.String("events"),
-			Service: aws.String("database"),
-		},
-		{
-			Name:    aws.String("orders"),
-			Service: aws.String("database"),
-			Queue: manifest.SQSQueueOrBool{
-				Advanced: manifest.SQSQueue{
-					Retention: &duration10Hours,
-				},
-			},
-		},
-	}
-	testCases := map[string]struct {
-		inTopics    []manifest.TopicSubscription
-		inTopicARNs []string
-
-		wantErr string
-	}{
-		"empty subscriptions": {
-			inTopics:    nil,
-			inTopicARNs: mockAllowedTopics,
-		},
-		"topics are valid": {
-			inTopics:    testGoodTopics,
-			inTopicARNs: mockAllowedTopics,
-		},
-		"topic is invalid": {
-			inTopics:    testGoodTopics,
-			inTopicARNs: []string{},
-			wantErr:     "SNS topic app-env-database-events does not exist in environment env",
-		},
-	}
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			err := validateTopicsExist(tc.inTopics, tc.inTopicARNs, mockApp, mockEnv)
-			if tc.wantErr != "" {
-				require.EqualError(t, err, tc.wantErr)
-			} else {
-				require.NoError(t, err)
 			}
 		})
 	}


### PR DESCRIPTION
This PR refactors validation and ask for `svc deploy` and `svc list`. In addition, it also contains other minor changes:
1. Remove `validateTopicExists` from `cli` package as it's no longer used.
2. Refactor `askDockerfile` in `svc init` to simplify the logic
3. Refactor how we retrieve target app in `svc_deploy.go` to achieve statelessness for app.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
