### PR TITLE
docs(ja): add hkford to CODEOWNERS for Japanese docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 
 * @aws/aws-ecs-devx
 
-*.ja.md @toricls
+*.ja.md @toricls @hkford


### PR DESCRIPTION


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
