### PR TITLE
chore(cli): change Validate/Ask roles for `pipeline show`

### DIFF
--- a/internal/pkg/cli/pipeline_show.go
+++ b/internal/pkg/cli/pipeline_show.go
@@ -100,21 +100,19 @@ func (o *showPipelineOpts) Validate() error {
 func (o *showPipelineOpts) Ask() error {
 	if o.name != "" {
 		// Validate the passed-in pipeline name.
-		if _, err := o.codepipeline.GetPipeline(o.name); err != nil {
+		_, err := o.codepipeline.GetPipeline(o.name)
+		if err != nil {
 			return fmt.Errorf("validate pipeline name %s: %w", o.name, err)
 		}
-	} else {
-		// Check presence of appName in order to fetch pipelines.
-		if o.appName == "" {
-			if err := o.askAppName(); err != nil {
-				return err
-			}
-		}
-		if err := o.askPipelineName(); err != nil {
+		return nil
+	}
+	// Check presence of appName in order to fetch pipelines.
+	if o.appName == "" {
+		if err := o.askAppName(); err != nil {
 			return err
 		}
 	}
-	return nil
+	return o.askPipelineName()
 }
 
 // Execute shows details about the pipeline.

--- a/internal/pkg/cli/pipeline_show.go
+++ b/internal/pkg/cli/pipeline_show.go
@@ -195,9 +195,6 @@ func (o *showPipelineOpts) getPipelineNameFromManifest() (string, error) {
 
 // Execute shows details about the pipeline.
 func (o *showPipelineOpts) Execute() error {
-	if o.name == "" {
-		return nil
-	}
 	err := o.initDescriber(o.shouldOutputResources)
 	if err != nil {
 		return err

--- a/internal/pkg/cli/pipeline_show.go
+++ b/internal/pkg/cli/pipeline_show.go
@@ -34,7 +34,7 @@ const (
 
 type showPipelineVars struct {
 	appName               string
-	name          string
+	name                  string
 	shouldOutputJSON      bool
 	shouldOutputResources bool
 }
@@ -46,7 +46,7 @@ type showPipelineOpts struct {
 	w             io.Writer
 	ws            wsPipelineReader
 	store         applicationStore
-	codepipeline   pipelineGetter
+	codepipeline  pipelineGetter
 	describer     describer
 	initDescriber func(bool) error
 	sel           appSelector
@@ -70,7 +70,7 @@ func newShowPipelineOpts(vars showPipelineVars) (*showPipelineOpts, error) {
 		showPipelineVars: vars,
 		ws:               ws,
 		store:            store,
-		codepipeline:      codepipeline.New(defaultSession),
+		codepipeline:     codepipeline.New(defaultSession),
 		sel:              selector.NewSelect(prompter, store),
 		prompt:           prompter,
 		w:                log.OutputWriter,

--- a/internal/pkg/cli/pipeline_show.go
+++ b/internal/pkg/cli/pipeline_show.go
@@ -160,7 +160,6 @@ func (o *showPipelineOpts) askPipelineName() error {
 
 	if len(pipelineNames) == 0 {
 		return fmt.Errorf("No deployed pipelines found for application %s.\n", color.HighlightUserInput(o.appName))
-		return nil
 	}
 
 	if len(pipelineNames) == 1 {

--- a/internal/pkg/cli/pipeline_show.go
+++ b/internal/pkg/cli/pipeline_show.go
@@ -170,19 +170,6 @@ func (o *showPipelineOpts) retrieveAllPipelines() ([]string, error) {
 	return pipelines, nil
 }
 
-func (o *showPipelineOpts) getPipelineNameFromManifest() (string, error) {
-	path, err := o.ws.PipelineManifestLegacyPath()
-	if err != nil {
-		return "", err
-	}
-	manifest, err := o.ws.ReadPipelineManifest(path)
-	if err != nil {
-		return "", err
-	}
-
-	return manifest.Name, nil
-}
-
 // Execute shows details about the pipeline.
 func (o *showPipelineOpts) Execute() error {
 	err := o.initDescriber(o.shouldOutputResources)

--- a/internal/pkg/cli/pipeline_show.go
+++ b/internal/pkg/cli/pipeline_show.go
@@ -133,7 +133,7 @@ func (o *showPipelineOpts) askPipelineName() error {
 	}
 
 	if errors.Is(err, workspace.ErrNoPipelineInWorkspace) {
-		log.Infof("No pipeline manifest in workspace for application %s, looking for deployed pipelines\n", color.HighlightUserInput(o.appName))
+		log.Infof("No pipeline manifest in workspace for application %s; looking for deployed pipelines.\n", color.HighlightUserInput(o.appName))
 	}
 
 	// find deployed pipelines

--- a/internal/pkg/cli/pipeline_show_test.go
+++ b/internal/pkg/cli/pipeline_show_test.go
@@ -20,16 +20,16 @@ import (
 )
 
 type showPipelineMocks struct {
-	store       *mocks.Mockstore
-	ws          *mocks.MockwsPipelineReader
-	prompt      *mocks.Mockprompter
+	store        *mocks.Mockstore
+	ws           *mocks.MockwsPipelineReader
+	prompt       *mocks.Mockprompter
 	codepipeline *mocks.MockpipelineGetter
-	sel         *mocks.MockappSelector
+	sel          *mocks.MockappSelector
 }
 
 func TestPipelineShow_Validate(t *testing.T) {
 	const (
-		mockAppName      = "dinder"
+		mockAppName = "dinder"
 	)
 	mockError := errors.New("mock error")
 	testCases := map[string]struct {
@@ -41,7 +41,7 @@ func TestPipelineShow_Validate(t *testing.T) {
 		expectedErr error
 	}{
 		"with valid application name via flag": {
-			inAppName:      mockAppName,
+			inAppName: mockAppName,
 			setupMocks: func(mocks showPipelineMocks) {
 				gomock.InOrder(
 					mocks.store.EXPECT().GetApplication(mockAppName).Return(&config.Application{
@@ -53,7 +53,7 @@ func TestPipelineShow_Validate(t *testing.T) {
 			expectedErr: nil,
 		},
 		"with invalid app name": {
-			inAppName:      mockAppName,
+			inAppName: mockAppName,
 			setupMocks: func(mocks showPipelineMocks) {
 				gomock.InOrder(
 					mocks.store.EXPECT().GetApplication(mockAppName).Return(nil, mockError),
@@ -66,9 +66,9 @@ func TestPipelineShow_Validate(t *testing.T) {
 			setupMocks: func(mocks showPipelineMocks) {
 				gomock.InOrder(
 					mocks.sel.EXPECT().Application(gomock.Any(), gomock.Any()).Return(mockAppName, nil))
-},
-expectedApp: mockAppName,
-expectedErr: nil,
+			},
+			expectedApp: mockAppName,
+			expectedErr: nil,
 		},
 		"error if problem selecting app": {
 			setupMocks: func(mocks showPipelineMocks) {
@@ -90,18 +90,18 @@ expectedErr: nil,
 			mockSel := mocks.NewMockappSelector(ctrl)
 
 			mocks := showPipelineMocks{
-				store:       mockStoreReader,
-				sel: mockSel,
+				store: mockStoreReader,
+				sel:   mockSel,
 			}
 
 			tc.setupMocks(mocks)
 
 			opts := &showPipelineOpts{
 				showPipelineVars: showPipelineVars{
-					appName:      tc.inAppName,
+					appName: tc.inAppName,
 				},
-				store:       mockStoreReader,
-				sel: mockSel,
+				store: mockStoreReader,
+				sel:   mockSel,
 			}
 
 			// WHEN
@@ -120,7 +120,7 @@ expectedErr: nil,
 
 func TestPipelineShow_Ask(t *testing.T) {
 	const (
-		mockAppName = "dinder"
+		mockAppName                = "dinder"
 		mockPipelineName           = "pipeline-dinder-badgoose-repo"
 		pipelineManifestLegacyPath = "copilot/pipeline.yml"
 	)
@@ -239,9 +239,9 @@ func TestPipelineShow_Ask(t *testing.T) {
 			mockPipelineSvc := mocks.NewMockpipelineGetter(ctrl)
 
 			mocks := showPipelineMocks{
-				store:       mockStoreReader,
-				ws:          mockWorkspace,
-				prompt:      mockPrompt,
+				store:        mockStoreReader,
+				ws:           mockWorkspace,
+				prompt:       mockPrompt,
 				codepipeline: mockPipelineSvc,
 			}
 
@@ -249,13 +249,13 @@ func TestPipelineShow_Ask(t *testing.T) {
 
 			opts := &showPipelineOpts{
 				showPipelineVars: showPipelineVars{
-					appName:      mockAppName,
-					name: tc.inPipelineName,
+					appName: mockAppName,
+					name:    tc.inPipelineName,
 				},
-				store:       mockStoreReader,
-				ws:          mockWorkspace,
+				store:        mockStoreReader,
+				ws:           mockWorkspace,
 				codepipeline: mockPipelineSvc,
-				prompt:      mockPrompt,
+				prompt:       mockPrompt,
 			}
 
 			// WHEN
@@ -337,7 +337,7 @@ func TestPipelineShow_Execute(t *testing.T) {
 			opts := &showPipelineOpts{
 				showPipelineVars: showPipelineVars{
 					shouldOutputJSON: tc.shouldOutputJSON,
-					name:     tc.inPipelineName,
+					name:             tc.inPipelineName,
 				},
 				describer:     mockDescriber,
 				initDescriber: func(bool) error { return nil },

--- a/internal/pkg/describe/mocks/mock_service.go
+++ b/internal/pkg/describe/mocks/mock_service.go
@@ -82,6 +82,21 @@ func (mr *MockConfigStoreSvcMockRecorder) ListEnvironments(appName interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEnvironments", reflect.TypeOf((*MockConfigStoreSvc)(nil).ListEnvironments), appName)
 }
 
+// ListJobs mocks base method.
+func (m *MockConfigStoreSvc) ListJobs(appName string) ([]*config.Workload, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListJobs", appName)
+	ret0, _ := ret[0].([]*config.Workload)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListJobs indicates an expected call of ListJobs.
+func (mr *MockConfigStoreSvcMockRecorder) ListJobs(appName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListJobs", reflect.TypeOf((*MockConfigStoreSvc)(nil).ListJobs), appName)
+}
+
 // ListServices mocks base method.
 func (m *MockConfigStoreSvc) ListServices(appName string) ([]*config.Workload, error) {
 	m.ctrl.T.Helper()
@@ -95,20 +110,6 @@ func (m *MockConfigStoreSvc) ListServices(appName string) ([]*config.Workload, e
 func (mr *MockConfigStoreSvcMockRecorder) ListServices(appName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServices", reflect.TypeOf((*MockConfigStoreSvc)(nil).ListServices), appName)
-}
-
-// ListJobs mocks base method.
-func (m *MockConfigStoreSvc) ListJobs(appName string) ([]*config.Workload, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListJobs", appName)
-	ret0, _ := ret[0].([]*config.Workload)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-func (mr *MockConfigStoreSvcMockRecorder) ListJobs(appName interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListJobs", reflect.TypeOf((*MockConfigStoreSvc)(nil).ListJobs), appName)
 }
 
 // MockDeployedEnvServicesLister is a mock of DeployedEnvServicesLister interface.
@@ -134,21 +135,6 @@ func (m *MockDeployedEnvServicesLister) EXPECT() *MockDeployedEnvServicesListerM
 	return m.recorder
 }
 
-// ListDeployedServices mocks base method.
-func (m *MockDeployedEnvServicesLister) ListDeployedServices(appName, envName string) ([]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListDeployedServices", appName, envName)
-	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListDeployedServices indicates an expected call of ListDeployedServices.
-func (mr *MockDeployedEnvServicesListerMockRecorder) ListDeployedServices(appName, envName interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDeployedServices", reflect.TypeOf((*MockDeployedEnvServicesLister)(nil).ListDeployedServices), appName, envName)
-}
-
 // ListDeployedJobs mocks base method.
 func (m *MockDeployedEnvServicesLister) ListDeployedJobs(appName, envName string) ([]string, error) {
 	m.ctrl.T.Helper()
@@ -162,6 +148,21 @@ func (m *MockDeployedEnvServicesLister) ListDeployedJobs(appName, envName string
 func (mr *MockDeployedEnvServicesListerMockRecorder) ListDeployedJobs(appName, envName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDeployedJobs", reflect.TypeOf((*MockDeployedEnvServicesLister)(nil).ListDeployedJobs), appName, envName)
+}
+
+// ListDeployedServices mocks base method.
+func (m *MockDeployedEnvServicesLister) ListDeployedServices(appName, envName string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListDeployedServices", appName, envName)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListDeployedServices indicates an expected call of ListDeployedServices.
+func (mr *MockDeployedEnvServicesListerMockRecorder) ListDeployedServices(appName, envName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDeployedServices", reflect.TypeOf((*MockDeployedEnvServicesLister)(nil).ListDeployedServices), appName, envName)
 }
 
 // ListEnvironmentsDeployedTo mocks base method.


### PR DESCRIPTION
This command assumes the workspace appName but allows overriding in order to show non-local app pipeline info.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
