### PR TITLE
docs: Updated Environments Concept Page

### DIFF
--- a/site/content/docs/concepts/environments.en.md
+++ b/site/content/docs/concepts/environments.en.md
@@ -29,9 +29,9 @@ When you first create a new environment, no services are deployed to it. To depl
 
 ### VPC and Networking
 
-Each environment gets its own multi-AZ VPC. Your VPC is the network boundary of your environment, allowing the traffic you expect in and out, and blocking the rest. The VPCs Copilot creates are spread across two availability zones to help balance availability and cost - with each AZ getting a public and private subnet.
+Each environment gets its own multi-AZ VPC. Your VPC is the network boundary of your environment, allowing the traffic you expect in and out, and blocking the rest. The VPCs Copilot creates are spread across two availability zones, with each AZ getting a public and private subnet, following [AWS best practices](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-security-best-practices.html). Your services are launched in the public subnets, to help manage costs. Services can be reached only through your load balancer.
 
-Your services are launched in the public subnets but can be reached only through your load balancer.
+Workload subnet placement can be modified using the `network.vpc.placement` field in the AWS Copilot CLI manifest. For additional details, see this field in the [Backend Service](../manifest/backend-service.en.md), [Load Balanced Web Service](../manifest/lb-web-service.en.md), [Request-Driven Web Service](../manifest/rd-web-service.en.md), [Scheduled Job](../manifest/scheduled-job.en.md), or [Worker Service](../manifest/worker-service.en.md) manifest specifications.
 
 ###  Load Balancers and DNS
 


### PR DESCRIPTION
- Changed verbiage in VPC and Networking section to explain workloads are placed in public subnet as a cost optimization.

Related to #2848 . Updated Copilot docs Concepts | Environments page explaining why Copilot places workloads in public subnet. While not changing Copilot's behavior, this lets users know why the default approach was chosen and how they can go about changing it if so desired.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
