### PR TITLE
fix: respect network replacement configured through manifest

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/rd_web_svc_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/rd_web_svc_test.go
@@ -22,7 +22,6 @@ import (
 )
 
 var (
-	testPublicPlacement  = manifest.PublicSubnetPlacement
 	testPrivatePlacement = manifest.PrivateSubnetPlacement
 )
 

--- a/internal/pkg/deploy/cloudformation/stack/rd_web_svc_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/rd_web_svc_test.go
@@ -221,7 +221,7 @@ func TestRequestDrivenWebService_Template(t *testing.T) {
 	}{
 		"should throw an error if env controller cannot be parsed": {
 			inManifest: func(mft manifest.RequestDrivenWebService) manifest.RequestDrivenWebService {
-				mft.Network.VPC.Placement = (*manifest.RequestDrivenWebServicePlacement)(&manifest.PrivateSubnetPlacement)
+				mft.Network.VPC.Placement = (*manifest.RequestDrivenWebServicePlacement)(manifest.PlacementP(manifest.PrivateSubnetPlacement))
 				return mft
 			},
 			mockDependencies: func(t *testing.T, ctrl *gomock.Controller, c *RequestDrivenWebService) {
@@ -243,7 +243,7 @@ func TestRequestDrivenWebService_Template(t *testing.T) {
 		"should be able to parse custom resource URLs when alias is enabled": {
 			inManifest: func(mft manifest.RequestDrivenWebService) manifest.RequestDrivenWebService {
 				mft.Alias = aws.String("convex.domain.com")
-				mft.Network.VPC.Placement = (*manifest.RequestDrivenWebServicePlacement)(&manifest.PrivateSubnetPlacement)
+				mft.Network.VPC.Placement = (*manifest.RequestDrivenWebServicePlacement)(manifest.PlacementP(manifest.PrivateSubnetPlacement))
 				return mft
 			},
 			inCustomResourceURLs: map[string]string{

--- a/internal/pkg/deploy/cloudformation/stack/rd_web_svc_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/rd_web_svc_test.go
@@ -21,6 +21,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var (
+	testPublicPlacement  = manifest.PublicSubnetPlacement
+	testPrivatePlacement = manifest.PrivateSubnetPlacement
+)
+
 var testRDWebServiceManifest = &manifest.RequestDrivenWebService{
 	Workload: manifest.Workload{
 		Name: aws.String(testServiceName),
@@ -221,7 +226,7 @@ func TestRequestDrivenWebService_Template(t *testing.T) {
 	}{
 		"should throw an error if env controller cannot be parsed": {
 			inManifest: func(mft manifest.RequestDrivenWebService) manifest.RequestDrivenWebService {
-				mft.Network.VPC.Placement = (*manifest.RequestDrivenWebServicePlacement)(manifest.PlacementP(manifest.PrivateSubnetPlacement))
+				mft.Network.VPC.Placement = (*manifest.RequestDrivenWebServicePlacement)(&testPrivatePlacement)
 				return mft
 			},
 			mockDependencies: func(t *testing.T, ctrl *gomock.Controller, c *RequestDrivenWebService) {
@@ -243,7 +248,7 @@ func TestRequestDrivenWebService_Template(t *testing.T) {
 		"should be able to parse custom resource URLs when alias is enabled": {
 			inManifest: func(mft manifest.RequestDrivenWebService) manifest.RequestDrivenWebService {
 				mft.Alias = aws.String("convex.domain.com")
-				mft.Network.VPC.Placement = (*manifest.RequestDrivenWebServicePlacement)(manifest.PlacementP(manifest.PrivateSubnetPlacement))
+				mft.Network.VPC.Placement = (*manifest.RequestDrivenWebServicePlacement)(&testPrivatePlacement)
 				return mft
 			},
 			inCustomResourceURLs: map[string]string{

--- a/internal/pkg/deploy/cloudformation/stack/worker_svc_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/worker_svc_test.go
@@ -261,7 +261,7 @@ Outputs:
 
 			if tc.setUpManifest != nil {
 				tc.setUpManifest(conf)
-				conf.manifest.Network.VPC.Placement = &manifest.PrivateSubnetPlacement
+				conf.manifest.Network.VPC.Placement = manifest.PlacementP(manifest.PrivateSubnetPlacement)
 				conf.manifest.Network.VPC.SecurityGroups = []string{"sg-1234"}
 			}
 

--- a/internal/pkg/deploy/cloudformation/stack/worker_svc_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/worker_svc_test.go
@@ -261,7 +261,7 @@ Outputs:
 
 			if tc.setUpManifest != nil {
 				tc.setUpManifest(conf)
-				conf.manifest.Network.VPC.Placement = manifest.PlacementP(manifest.PrivateSubnetPlacement)
+				conf.manifest.Network.VPC.Placement = &testPrivatePlacement
 				conf.manifest.Network.VPC.SecurityGroups = []string{"sg-1234"}
 			}
 

--- a/internal/pkg/manifest/backend_svc.go
+++ b/internal/pkg/manifest/backend_svc.go
@@ -153,7 +153,7 @@ func newDefaultBackendService() *BackendService {
 			},
 			Network: NetworkConfig{
 				VPC: vpcConfig{
-					Placement: PlacementP(PublicSubnetPlacement),
+					Placement: placementP(PublicSubnetPlacement),
 				},
 			},
 		},

--- a/internal/pkg/manifest/backend_svc.go
+++ b/internal/pkg/manifest/backend_svc.go
@@ -153,7 +153,7 @@ func newDefaultBackendService() *BackendService {
 			},
 			Network: NetworkConfig{
 				VPC: vpcConfig{
-					Placement: &PublicSubnetPlacement,
+					Placement: PlacementP(PublicSubnetPlacement),
 				},
 			},
 		},

--- a/internal/pkg/manifest/backend_svc_test.go
+++ b/internal/pkg/manifest/backend_svc_test.go
@@ -56,7 +56,7 @@ func TestNewBackendSvc(t *testing.T) {
 					},
 					Network: NetworkConfig{
 						VPC: vpcConfig{
-							Placement: &PublicSubnetPlacement,
+							Placement: PlacementP(PublicSubnetPlacement),
 						},
 					},
 				},
@@ -102,7 +102,7 @@ func TestNewBackendSvc(t *testing.T) {
 					},
 					Network: NetworkConfig{
 						VPC: vpcConfig{
-							Placement: &PublicSubnetPlacement,
+							Placement: PlacementP(PublicSubnetPlacement),
 						},
 					},
 				},
@@ -152,7 +152,7 @@ func TestNewBackendSvc(t *testing.T) {
 					},
 					Network: NetworkConfig{
 						VPC: vpcConfig{
-							Placement: &PublicSubnetPlacement,
+							Placement: PlacementP(PublicSubnetPlacement),
 						},
 					},
 				},

--- a/internal/pkg/manifest/backend_svc_test.go
+++ b/internal/pkg/manifest/backend_svc_test.go
@@ -56,7 +56,7 @@ func TestNewBackendSvc(t *testing.T) {
 					},
 					Network: NetworkConfig{
 						VPC: vpcConfig{
-							Placement: PlacementP(PublicSubnetPlacement),
+							Placement: placementP(PublicSubnetPlacement),
 						},
 					},
 				},
@@ -102,7 +102,7 @@ func TestNewBackendSvc(t *testing.T) {
 					},
 					Network: NetworkConfig{
 						VPC: vpcConfig{
-							Placement: PlacementP(PublicSubnetPlacement),
+							Placement: placementP(PublicSubnetPlacement),
 						},
 					},
 				},
@@ -152,7 +152,7 @@ func TestNewBackendSvc(t *testing.T) {
 					},
 					Network: NetworkConfig{
 						VPC: vpcConfig{
-							Placement: PlacementP(PublicSubnetPlacement),
+							Placement: placementP(PublicSubnetPlacement),
 						},
 					},
 				},

--- a/internal/pkg/manifest/job.go
+++ b/internal/pkg/manifest/job.go
@@ -163,7 +163,7 @@ func newDefaultScheduledJob() *ScheduledJob {
 			},
 			Network: NetworkConfig{
 				VPC: vpcConfig{
-					Placement: PlacementP(PublicSubnetPlacement),
+					Placement: placementP(PublicSubnetPlacement),
 				},
 			},
 		},

--- a/internal/pkg/manifest/job.go
+++ b/internal/pkg/manifest/job.go
@@ -163,7 +163,7 @@ func newDefaultScheduledJob() *ScheduledJob {
 			},
 			Network: NetworkConfig{
 				VPC: vpcConfig{
-					Placement: &PublicSubnetPlacement,
+					Placement: PlacementP(PublicSubnetPlacement),
 				},
 			},
 		},

--- a/internal/pkg/manifest/job_test.go
+++ b/internal/pkg/manifest/job_test.go
@@ -141,7 +141,7 @@ func TestScheduledJob_ApplyEnv(t *testing.T) {
 					},
 					Network: NetworkConfig{
 						VPC: vpcConfig{
-							Placement: &PublicSubnetPlacement,
+							Placement: PlacementP(PublicSubnetPlacement),
 						},
 					},
 				},
@@ -187,7 +187,7 @@ func TestScheduledJob_ApplyEnv(t *testing.T) {
 					},
 					Network: NetworkConfig{
 						VPC: vpcConfig{
-							Placement: &PublicSubnetPlacement,
+							Placement: PlacementP(PublicSubnetPlacement),
 						},
 					},
 				},

--- a/internal/pkg/manifest/job_test.go
+++ b/internal/pkg/manifest/job_test.go
@@ -141,7 +141,7 @@ func TestScheduledJob_ApplyEnv(t *testing.T) {
 					},
 					Network: NetworkConfig{
 						VPC: vpcConfig{
-							Placement: PlacementP(PublicSubnetPlacement),
+							Placement: placementP(PublicSubnetPlacement),
 						},
 					},
 				},
@@ -187,7 +187,7 @@ func TestScheduledJob_ApplyEnv(t *testing.T) {
 					},
 					Network: NetworkConfig{
 						VPC: vpcConfig{
-							Placement: PlacementP(PublicSubnetPlacement),
+							Placement: placementP(PublicSubnetPlacement),
 						},
 					},
 				},

--- a/internal/pkg/manifest/lb_web_svc.go
+++ b/internal/pkg/manifest/lb_web_svc.go
@@ -134,7 +134,7 @@ func newDefaultLoadBalancedWebService() *LoadBalancedWebService {
 			},
 			Network: NetworkConfig{
 				VPC: vpcConfig{
-					Placement: &PublicSubnetPlacement,
+					Placement: PlacementP(PublicSubnetPlacement),
 				},
 			},
 		},

--- a/internal/pkg/manifest/lb_web_svc.go
+++ b/internal/pkg/manifest/lb_web_svc.go
@@ -134,7 +134,7 @@ func newDefaultLoadBalancedWebService() *LoadBalancedWebService {
 			},
 			Network: NetworkConfig{
 				VPC: vpcConfig{
-					Placement: PlacementP(PublicSubnetPlacement),
+					Placement: placementP(PublicSubnetPlacement),
 				},
 			},
 		},

--- a/internal/pkg/manifest/lb_web_svc_test.go
+++ b/internal/pkg/manifest/lb_web_svc_test.go
@@ -72,7 +72,7 @@ func TestNewHTTPLoadBalancedWebService(t *testing.T) {
 					},
 					Network: NetworkConfig{
 						VPC: vpcConfig{
-							Placement: PlacementP(PublicSubnetPlacement),
+							Placement: placementP(PublicSubnetPlacement),
 						},
 					},
 				},
@@ -146,7 +146,7 @@ func TestNewHTTPLoadBalancedWebService(t *testing.T) {
 					},
 					Network: NetworkConfig{
 						VPC: vpcConfig{
-							Placement: PlacementP(PublicSubnetPlacement),
+							Placement: placementP(PublicSubnetPlacement),
 						},
 					},
 				},
@@ -454,7 +454,7 @@ func TestLoadBalancedWebService_ApplyEnv(t *testing.T) {
 					},
 					Network: NetworkConfig{
 						VPC: vpcConfig{
-							Placement:      PlacementP(PublicSubnetPlacement),
+							Placement:      placementP(PublicSubnetPlacement),
 							SecurityGroups: []string{"sg-123"},
 						},
 					},
@@ -615,7 +615,7 @@ func TestLoadBalancedWebService_ApplyEnv(t *testing.T) {
 					},
 					Network: NetworkConfig{
 						VPC: vpcConfig{
-							Placement:      PlacementP(PublicSubnetPlacement),
+							Placement:      placementP(PublicSubnetPlacement),
 							SecurityGroups: []string{"sg-456", "sg-789"},
 						},
 					},
@@ -686,7 +686,7 @@ func TestLoadBalancedWebService_ApplyEnv(t *testing.T) {
 					},
 					Network: NetworkConfig{
 						VPC: vpcConfig{
-							Placement:      PlacementP(PublicSubnetPlacement),
+							Placement:      placementP(PublicSubnetPlacement),
 							SecurityGroups: []string{"sg-456", "sg-789"},
 						},
 					},
@@ -710,7 +710,7 @@ func TestLoadBalancedWebService_ApplyEnv(t *testing.T) {
 					},
 					Network: NetworkConfig{
 						VPC: vpcConfig{
-							Placement:      PlacementP(PublicSubnetPlacement),
+							Placement:      placementP(PublicSubnetPlacement),
 							SecurityGroups: []string{"sg-456", "sg-789"},
 						},
 					},

--- a/internal/pkg/manifest/lb_web_svc_test.go
+++ b/internal/pkg/manifest/lb_web_svc_test.go
@@ -72,7 +72,7 @@ func TestNewHTTPLoadBalancedWebService(t *testing.T) {
 					},
 					Network: NetworkConfig{
 						VPC: vpcConfig{
-							Placement: &PublicSubnetPlacement,
+							Placement: PlacementP(PublicSubnetPlacement),
 						},
 					},
 				},
@@ -146,7 +146,7 @@ func TestNewHTTPLoadBalancedWebService(t *testing.T) {
 					},
 					Network: NetworkConfig{
 						VPC: vpcConfig{
-							Placement: &PublicSubnetPlacement,
+							Placement: PlacementP(PublicSubnetPlacement),
 						},
 					},
 				},
@@ -454,7 +454,7 @@ func TestLoadBalancedWebService_ApplyEnv(t *testing.T) {
 					},
 					Network: NetworkConfig{
 						VPC: vpcConfig{
-							Placement:      &PublicSubnetPlacement,
+							Placement:      PlacementP(PublicSubnetPlacement),
 							SecurityGroups: []string{"sg-123"},
 						},
 					},
@@ -615,7 +615,7 @@ func TestLoadBalancedWebService_ApplyEnv(t *testing.T) {
 					},
 					Network: NetworkConfig{
 						VPC: vpcConfig{
-							Placement:      &PublicSubnetPlacement,
+							Placement:      PlacementP(PublicSubnetPlacement),
 							SecurityGroups: []string{"sg-456", "sg-789"},
 						},
 					},
@@ -686,7 +686,7 @@ func TestLoadBalancedWebService_ApplyEnv(t *testing.T) {
 					},
 					Network: NetworkConfig{
 						VPC: vpcConfig{
-							Placement:      &PublicSubnetPlacement,
+							Placement:      PlacementP(PublicSubnetPlacement),
 							SecurityGroups: []string{"sg-456", "sg-789"},
 						},
 					},
@@ -710,7 +710,7 @@ func TestLoadBalancedWebService_ApplyEnv(t *testing.T) {
 					},
 					Network: NetworkConfig{
 						VPC: vpcConfig{
-							Placement:      &PublicSubnetPlacement,
+							Placement:      PlacementP(PublicSubnetPlacement),
 							SecurityGroups: []string{"sg-456", "sg-789"},
 						},
 					},

--- a/internal/pkg/manifest/svc_test.go
+++ b/internal/pkg/manifest/svc_test.go
@@ -151,7 +151,7 @@ environments:
 						},
 						Network: NetworkConfig{
 							VPC: vpcConfig{
-								Placement: PlacementP(PublicSubnetPlacement),
+								Placement: placementP(PublicSubnetPlacement),
 							},
 						},
 						TaskDefOverrides: []OverrideRule{
@@ -270,7 +270,7 @@ secrets:
 						},
 						Network: NetworkConfig{
 							VPC: vpcConfig{
-								Placement: PlacementP(PublicSubnetPlacement),
+								Placement: placementP(PublicSubnetPlacement),
 							},
 						},
 					},
@@ -333,7 +333,7 @@ subscribe:
 						},
 						Network: NetworkConfig{
 							VPC: vpcConfig{
-								Placement: PlacementP(PublicSubnetPlacement),
+								Placement: placementP(PublicSubnetPlacement),
 							},
 						},
 						Subscribe: SubscribeConfig{

--- a/internal/pkg/manifest/svc_test.go
+++ b/internal/pkg/manifest/svc_test.go
@@ -151,7 +151,7 @@ environments:
 						},
 						Network: NetworkConfig{
 							VPC: vpcConfig{
-								Placement: &PublicSubnetPlacement,
+								Placement: PlacementP(PublicSubnetPlacement),
 							},
 						},
 						TaskDefOverrides: []OverrideRule{
@@ -270,7 +270,7 @@ secrets:
 						},
 						Network: NetworkConfig{
 							VPC: vpcConfig{
-								Placement: &PublicSubnetPlacement,
+								Placement: PlacementP(PublicSubnetPlacement),
 							},
 						},
 					},
@@ -333,7 +333,7 @@ subscribe:
 						},
 						Network: NetworkConfig{
 							VPC: vpcConfig{
-								Placement: &PublicSubnetPlacement,
+								Placement: PlacementP(PublicSubnetPlacement),
 							},
 						},
 						Subscribe: SubscribeConfig{

--- a/internal/pkg/manifest/worker_svc.go
+++ b/internal/pkg/manifest/worker_svc.go
@@ -237,7 +237,7 @@ func newDefaultWorkerService() *WorkerService {
 			},
 			Network: NetworkConfig{
 				VPC: vpcConfig{
-					Placement: &PublicSubnetPlacement,
+					Placement: PlacementP(PublicSubnetPlacement),
 				},
 			},
 		},

--- a/internal/pkg/manifest/worker_svc.go
+++ b/internal/pkg/manifest/worker_svc.go
@@ -237,7 +237,7 @@ func newDefaultWorkerService() *WorkerService {
 			},
 			Network: NetworkConfig{
 				VPC: vpcConfig{
-					Placement: PlacementP(PublicSubnetPlacement),
+					Placement: placementP(PublicSubnetPlacement),
 				},
 			},
 		},

--- a/internal/pkg/manifest/worker_svc_test.go
+++ b/internal/pkg/manifest/worker_svc_test.go
@@ -71,7 +71,7 @@ func TestNewWorkerSvc(t *testing.T) {
 					},
 					Network: NetworkConfig{
 						VPC: vpcConfig{
-							Placement: &PublicSubnetPlacement,
+							Placement: PlacementP(PublicSubnetPlacement),
 						},
 					},
 				},
@@ -112,7 +112,7 @@ func TestNewWorkerSvc(t *testing.T) {
 					},
 					Network: NetworkConfig{
 						VPC: vpcConfig{
-							Placement: &PublicSubnetPlacement,
+							Placement: PlacementP(PublicSubnetPlacement),
 						},
 					},
 				},

--- a/internal/pkg/manifest/worker_svc_test.go
+++ b/internal/pkg/manifest/worker_svc_test.go
@@ -71,7 +71,7 @@ func TestNewWorkerSvc(t *testing.T) {
 					},
 					Network: NetworkConfig{
 						VPC: vpcConfig{
-							Placement: PlacementP(PublicSubnetPlacement),
+							Placement: placementP(PublicSubnetPlacement),
 						},
 					},
 				},
@@ -112,7 +112,7 @@ func TestNewWorkerSvc(t *testing.T) {
 					},
 					Network: NetworkConfig{
 						VPC: vpcConfig{
-							Placement: PlacementP(PublicSubnetPlacement),
+							Placement: placementP(PublicSubnetPlacement),
 						},
 					},
 				},

--- a/internal/pkg/manifest/workload.go
+++ b/internal/pkg/manifest/workload.go
@@ -395,7 +395,7 @@ func (c *NetworkConfig) UnmarshalYAML(value *yaml.Node) error {
 	if err := value.Decode(&conf); err != nil {
 		return err
 	}
-	if conf.VPC.isEmpty() { // If after unmarshaling the user did not specify VPC configuration then reset it to public.
+	if conf.VPC.isEmpty() { // If after unmarshalling the user did not specify VPC configuration then reset it to public.
 		conf.VPC = defaultVPCConf
 	}
 	*c = NetworkConfig(conf)

--- a/internal/pkg/manifest/workload.go
+++ b/internal/pkg/manifest/workload.go
@@ -24,12 +24,12 @@ const (
 
 const (
 	// AWS VPC subnet placement options.
-	PublicSubnetPlacement  = "public"
-	PrivateSubnetPlacement = "private"
+	PublicSubnetPlacement  = Placement("public")
+	PrivateSubnetPlacement = Placement("private")
 )
 
 // All placement options.
-var subnetPlacements = []string{PublicSubnetPlacement, PrivateSubnetPlacement}
+var subnetPlacements = []string{string(PublicSubnetPlacement), string(PrivateSubnetPlacement)}
 
 // Error definitions.
 var (
@@ -73,7 +73,6 @@ func UnmarshalWorkload(in []byte) (WorkloadManifest, error) {
 	switch typeVal {
 	case LoadBalancedWebServiceType:
 		m = newDefaultLoadBalancedWebService()
-
 	case RequestDrivenWebServiceType:
 		m = newDefaultRequestDrivenWebService()
 	case BackendServiceType:
@@ -531,15 +530,6 @@ func DockerfileBuildRequired(svc interface{}) (bool, error) {
 	return required, nil
 }
 
-// PlacementP converts a string to a `Placement` type and returns its pointer.
-func PlacementP(p string) *Placement {
-	if p == "" {
-		return nil
-	}
-	placement := Placement(p)
-	return &placement
-}
-
 func stringP(s string) *string {
 	if s == "" {
 		return nil
@@ -552,4 +542,12 @@ func uint16P(n uint16) *uint16 {
 		return nil
 	}
 	return &n
+}
+
+func placementP(p Placement) *Placement {
+	if p == "" {
+		return nil
+	}
+	placement := p
+	return &placement
 }

--- a/internal/pkg/manifest/workload.go
+++ b/internal/pkg/manifest/workload.go
@@ -23,13 +23,13 @@ const (
 )
 
 // AWS VPC subnet placement options.
-var (
-	PublicSubnetPlacement  = Placement("public")
-	PrivateSubnetPlacement = Placement("private")
-
-	// All placement options.
-	subnetPlacements = []string{string(PublicSubnetPlacement), string(PrivateSubnetPlacement)}
+const (
+	PublicSubnetPlacement  = "public"
+	PrivateSubnetPlacement = "private"
 )
+
+// All placement options.
+var subnetPlacements = []string{PublicSubnetPlacement, PrivateSubnetPlacement}
 
 // Error definitions.
 var (
@@ -543,4 +543,12 @@ func uint16P(n uint16) *uint16 {
 		return nil
 	}
 	return &n
+}
+
+func PlacementP(p string) *Placement {
+	if p == "" {
+		return nil
+	}
+	placement := Placement(p)
+	return &placement
 }

--- a/internal/pkg/manifest/workload.go
+++ b/internal/pkg/manifest/workload.go
@@ -531,6 +531,15 @@ func DockerfileBuildRequired(svc interface{}) (bool, error) {
 	return required, nil
 }
 
+// PlacementP converts a string to a `Placement` type and returns its pointer.
+func PlacementP(p string) *Placement {
+	if p == "" {
+		return nil
+	}
+	placement := Placement(p)
+	return &placement
+}
+
 func stringP(s string) *string {
 	if s == "" {
 		return nil
@@ -543,12 +552,4 @@ func uint16P(n uint16) *uint16 {
 		return nil
 	}
 	return &n
-}
-
-func PlacementP(p string) *Placement {
-	if p == "" {
-		return nil
-	}
-	placement := Placement(p)
-	return &placement
 }

--- a/internal/pkg/manifest/workload.go
+++ b/internal/pkg/manifest/workload.go
@@ -22,8 +22,8 @@ const (
 	defaultDockerfileName = "Dockerfile"
 )
 
-// AWS VPC subnet placement options.
 const (
+	// AWS VPC subnet placement options.
 	PublicSubnetPlacement  = "public"
 	PrivateSubnetPlacement = "private"
 )

--- a/internal/pkg/manifest/workload.go
+++ b/internal/pkg/manifest/workload.go
@@ -381,27 +381,6 @@ func (c *NetworkConfig) IsEmpty() bool {
 	return c.VPC.isEmpty()
 }
 
-// UnmarshalYAML ensures that a NetworkConfig always defaults to public subnets.
-// If the user specified a placement that's not valid then throw an error.
-func (c *NetworkConfig) UnmarshalYAML(value *yaml.Node) error {
-	type networkWithDefaults NetworkConfig
-	publicPlacement := Placement(PublicSubnetPlacement)
-	defaultVPCConf := vpcConfig{
-		Placement: &publicPlacement,
-	}
-	conf := networkWithDefaults{
-		VPC: defaultVPCConf,
-	}
-	if err := value.Decode(&conf); err != nil {
-		return err
-	}
-	if conf.VPC.isEmpty() { // If after unmarshalling the user did not specify VPC configuration then reset it to public.
-		conf.VPC = defaultVPCConf
-	}
-	*c = NetworkConfig(conf)
-	return nil
-}
-
 // Placement represents where to place tasks (public or private subnets).
 type Placement string
 

--- a/internal/pkg/manifest/workload_test.go
+++ b/internal/pkg/manifest/workload_test.go
@@ -641,7 +641,7 @@ network:
 `,
 			wantedConfig: &NetworkConfig{
 				VPC: vpcConfig{
-					Placement:      PlacementP("public"),
+					Placement:      placementP("public"),
 					SecurityGroups: []string{"sg-1234", "sg-4567"},
 				},
 			},

--- a/internal/pkg/manifest/workload_test.go
+++ b/internal/pkg/manifest/workload_test.go
@@ -627,9 +627,7 @@ network:
   vpc:
 `,
 			wantedConfig: &NetworkConfig{
-				VPC: vpcConfig{
-					Placement: &PublicSubnetPlacement,
-				},
+				VPC: vpcConfig{},
 			},
 		},
 		"unmarshals successfully for public placement with security groups": {
@@ -643,7 +641,7 @@ network:
 `,
 			wantedConfig: &NetworkConfig{
 				VPC: vpcConfig{
-					Placement:      &PublicSubnetPlacement,
+					Placement:      PlacementP("public"),
 					SecurityGroups: []string{"sg-1234", "sg-4567"},
 				},
 			},


### PR DESCRIPTION
This PR fixes #3346 by:
1. Remove the custom unmarshal logic of `network` field. The logic preset the network's placement value, which causes the bug that's seen in #3346.
2. Use `const` instead of `var` for placement types.
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
