### PR TITLE
chore(cli): fix `pipeline deploy` so appName isn't empty

### DIFF
--- a/internal/pkg/cli/pipeline_deploy.go
+++ b/internal/pkg/cli/pipeline_deploy.go
@@ -157,15 +157,15 @@ func (o *deployPipelineOpts) Validate() error {
 	}
 	o.appName = o.wsAppName
 
-	if err := o.getTargetApp(); err != nil {
-		return err
-	}
-
 	return nil
 }
 
 // Ask prompts the user for any unprovided required fields and validates them.
 func (o *deployPipelineOpts) Ask() error {
+	if err := o.getTargetApp(); err != nil {
+		return err
+	}
+
 	if o.name != "" {
 		return o.validatePipelineName()
 	}

--- a/internal/pkg/cli/pipeline_deploy.go
+++ b/internal/pkg/cli/pipeline_deploy.go
@@ -75,7 +75,7 @@ type deployPipelineOpts struct {
 	newJobListCmd    func(io.Writer) cmd
 
 	// cached variables
-	app              			 *config.Application
+	app                          *config.Application
 	pipeline                     *workspace.PipelineManifest
 	shouldPromptUpdateConnection bool
 	pipelineMft                  *manifest.Pipeline

--- a/internal/pkg/cli/pipeline_deploy_test.go
+++ b/internal/pkg/cli/pipeline_deploy_test.go
@@ -65,7 +65,7 @@ func TestDeployPipelineOpts_Validate(t *testing.T) {
 			inWsAppName: testAppName,
 			inAppName:   testAppName,
 			mockStore: func(m *mocks.Mockstore) {
-				m.EXPECT().GetApplication(testAppName).Return(nil, nil)
+				m.EXPECT().GetApplication(testAppName).Return(nil, nil).Times(2)
 			},
 
 			wantedAppName: testAppName,
@@ -84,9 +84,10 @@ func TestDeployPipelineOpts_Validate(t *testing.T) {
 				deployPipelineVars: deployPipelineVars{
 					appName: tc.inAppName,
 					name:    tc.inPipelineName,
+					wsAppName: tc.inWsAppName,
+
 				},
 				store:     mockStore,
-				wsAppName: tc.inWsAppName,
 			}
 
 			// WHEN

--- a/internal/pkg/cli/pipeline_deploy_test.go
+++ b/internal/pkg/cli/pipeline_deploy_test.go
@@ -82,12 +82,11 @@ func TestDeployPipelineOpts_Validate(t *testing.T) {
 			tc.mockStore(mockStore)
 			opts := deployPipelineOpts{
 				deployPipelineVars: deployPipelineVars{
-					appName: tc.inAppName,
-					name:    tc.inPipelineName,
+					appName:   tc.inAppName,
+					name:      tc.inPipelineName,
 					wsAppName: tc.inWsAppName,
-
 				},
-				store:     mockStore,
+				store: mockStore,
 			}
 
 			// WHEN

--- a/internal/pkg/cli/svc_list.go
+++ b/internal/pkg/cli/svc_list.go
@@ -86,7 +86,6 @@ func (o *listSvcOpts) Ask() error {
 
 // Execute lists the services through the prompt.
 func (o *listSvcOpts) Execute() error {
-	fmt.Println("app name in svc list: ", o.appName)
 	if err := o.list.Write(o.appName); err != nil {
 		return err
 	}

--- a/internal/pkg/cli/svc_list.go
+++ b/internal/pkg/cli/svc_list.go
@@ -86,6 +86,7 @@ func (o *listSvcOpts) Ask() error {
 
 // Execute lists the services through the prompt.
 func (o *listSvcOpts) Execute() error {
+	fmt.Println("app name in svc list: ", o.appName)
 	if err := o.list.Write(o.appName); err != nil {
 		return err
 	}


### PR DESCRIPTION
Previously, `tryReadingAppName()` was the default appName value at the `cmd.Flags()` level.
When we added `wsAppName` and `validateInputApp()` to 1. ensure proper failure/error messaging if the user was not in the workspace and 2. prevent overriding the workspace app name with the app flag value, we introduced a bug:
In the constructors for `SvcListCmd` and `JobListCmd`, we have `appName: vars.appName` and those were empty because we were calling `tryReadingAppName()` later. 
This change assigns `vars.appName` earlier.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
