### PR TITLE
test(e2e): bump base docker image to v20.10.13

### DIFF
--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:stable-dind
+FROM docker:20.10.13-dind
 
 ARG GOLANG_VERSION=1.17.1
 


### PR DESCRIPTION
Tested in CodeBuild and can see that `docker push` now has `--quiet`, our previous base image was last updated at least a year ago.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
