### PR TITLE
chore(cli): ensure new workloads are not named "pipelines"

### DIFF
--- a/internal/pkg/cli/validate.go
+++ b/internal/pkg/cli/validate.go
@@ -165,7 +165,8 @@ const regexpFindAllMatches = -1
 // reservedWorkloadNames is a constant map of reserved workload names that users are not allowed to name their workloads
 func reservedWorkloadNames() map[string]bool {
 	return map[string]bool{
-		"pipelines": true, // reserved to avoid directory conflict with copilot pipelines
+		"pipelines":    true, // reserved to avoid directory conflict with copilot pipelines
+		"environments": true, // reserved to avoid directory conflict with copilot enviornments
 	}
 }
 

--- a/internal/pkg/cli/validate.go
+++ b/internal/pkg/cli/validate.go
@@ -166,7 +166,7 @@ const regexpFindAllMatches = -1
 func reservedWorkloadNames() map[string]bool {
 	return map[string]bool{
 		"pipelines":    true, // reserved to avoid directory conflict with copilot pipelines
-		"environments": true, // reserved to avoid directory conflict with copilot enviornments
+		"environments": true, // reserved to avoid directory conflict with copilot environments
 	}
 }
 

--- a/internal/pkg/cli/validate_test.go
+++ b/internal/pkg/cli/validate_test.go
@@ -124,6 +124,11 @@ func TestValidateSvcName(t *testing.T) {
 			svcType: manifest.LoadBalancedWebServiceType,
 			wanted:  errValueBadFormat,
 		},
+		"is not a reserved name": {
+			val:     "pipelines",
+			svcType: manifest.LoadBalancedWebServiceType,
+			wanted:  errValueReserved,
+		},
 	}
 
 	for name, tc := range testCases {
@@ -882,6 +887,33 @@ func Test_validateSubscribe(t *testing.T) {
 			} else {
 				require.EqualError(t, err, tc.wantErr.Error())
 			}
+		})
+	}
+}
+
+func TestValidateJobName(t *testing.T) {
+	testCases := map[string]struct {
+		val    interface{}
+		wanted error
+	}{
+		"string as input": {
+			val:     "hello",
+			wanted:  nil,
+		},
+		"number as input": {
+			val:    1234,
+			wanted: errValueNotAString,
+		},
+		"is not a reserved name": {
+			val:    "pipelines",
+			wanted: errValueReserved,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got := validateJobName(tc.val)
+			require.True(t, errors.Is(got, tc.wanted), "got %v instead of %v", got, tc.wanted)
 		})
 	}
 }


### PR DESCRIPTION
With the new pipelines file structure, if a new workload is named `pipelines`, it will be potentially confusing with the copilot directory for pipelines. To avoid that issue, this change will ensure new workloads do not use that name.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
