### PR TITLE
test(e2e): include pipeline name on pipeline init

### DIFF
--- a/e2e/internal/client/cli.go
+++ b/e2e/internal/client/cli.go
@@ -731,7 +731,7 @@ func (cli *CLI) PipelineShow(opts PipelineShowInput) (PipelineShowOutput, error)
 	return out, nil
 }
 
-// PipelineShow runs:
+// PipelineStatus runs:
 //	copilot pipeline show
 //	--name $n
 //	--json

--- a/e2e/internal/client/cli.go
+++ b/e2e/internal/client/cli.go
@@ -214,6 +214,33 @@ type PackageInput struct {
 	Tag     string
 }
 
+// PipelineInitInput contains the parameters for calling copilot pipeline init.
+type PipelineInitInput struct {
+	AppName      string
+	Name         string
+	URL          string
+	GitBranch    string
+	Environments []string
+}
+
+// PipelineDeployInput contains the parameters for calling copilot pipeline deploy.
+type PipelineDeployInput struct {
+	AppName string
+	Name    string
+}
+
+// PipelineShowInput contains the parameters for calling copilot pipeline show.
+type PipelineShowInput struct {
+	AppName string
+	Name    string
+}
+
+// PipelineStatusInput contains the parameters for calling copilot pipeline status.
+type PipelineStatusInput struct {
+	AppName string
+	Name    string
+}
+
 // NewCLI returns a wrapper around CLI.
 func NewCLI() (*CLI, error) {
 	// These tests should be run in a dockerfile so that
@@ -646,47 +673,86 @@ func (cli *CLI) AppShow(appName string) (*AppShowOutput, error) {
 	return toAppShowOutput(output)
 }
 
-// PipelineInit runs "copilot pipeline init".
-func (cli *CLI) PipelineInit(app, url, branch string, envs []string) (string, error) {
-	return cli.exec(
-		exec.Command(cli.path, "pipeline", "init",
-			"-a", app,
-			"-u", url,
-			"-b", branch,
-			"-e", strings.Join(envs, ",")))
-}
-
-// PipelineDeploy runs "copilot pipeline deploy".
-func (cli *CLI) PipelineDeploy(app string) (string, error) {
-	return cli.exec(exec.Command(cli.path, "pipeline", "deploy", "-a", app, "--yes"))
-}
-
-// PipelineShow runs "copilot pipeline show --json"
-func (cli *CLI) PipelineShow(app string) (*PipelineShowOutput, error) {
-	text, err := cli.exec(
-		exec.Command(cli.path, "pipeline", "show", "-a", app, "--json"))
-	if err != nil {
-		return nil, err
+// PipelineInit runs:
+//	copilot pipeline init
+//	--name $n
+//	--url $t
+//	--git-branch $b
+//	--environments $e[0],$e[1],...
+func (cli *CLI) PipelineInit(opts PipelineInitInput) (string, error) {
+	args := []string{
+		"pipeline",
+		"init",
+		"--name", opts.Name,
+		"--url", opts.URL,
+		"--git-branch", opts.GitBranch,
+		"--environments", strings.Join(opts.Environments, ","),
 	}
+
+	return cli.exec(exec.Command(cli.path, args...))
+}
+
+// PipelineDeploy runs:
+//	copilot pipeline deploy
+//	--name $n
+//	--yes
+func (cli *CLI) PipelineDeploy(opts PipelineDeployInput) (string, error) {
+	args := []string{
+		"pipeline",
+		"deploy",
+		"--name", opts.Name,
+		"--yes",
+	}
+
+	return cli.exec(exec.Command(cli.path, args...))
+}
+
+// PipelineShow runs:
+//	copilot pipeline show
+//	--name $n
+//	--json
+func (cli *CLI) PipelineShow(opts PipelineShowInput) (PipelineShowOutput, error) {
+	args := []string{
+		"pipeline",
+		"show",
+		"--name", opts.Name,
+		"--json",
+	}
+
+	text, err := cli.exec(exec.Command(cli.path, args...))
+	if err != nil {
+		return PipelineShowOutput{}, err
+	}
+
 	var out PipelineShowOutput
 	if err := json.Unmarshal([]byte(text), &out); err != nil {
-		return nil, err
+		return PipelineShowOutput{}, err
 	}
-	return &out, nil
+	return out, nil
 }
 
-// PipelineStatus runs "copilot pipeline status --json"
-func (cli *CLI) PipelineStatus(app string) (*PipelineStatusOutput, error) {
-	text, err := cli.exec(
-		exec.Command(cli.path, "pipeline", "status", "-a", app, "--json"))
-	if err != nil {
-		return nil, err
+// PipelineShow runs:
+//	copilot pipeline show
+//	--name $n
+//	--json
+func (cli *CLI) PipelineStatus(opts PipelineStatusInput) (PipelineStatusOutput, error) {
+	args := []string{
+		"pipeline",
+		"status",
+		"--name", opts.Name,
+		"--json",
 	}
+
+	text, err := cli.exec(exec.Command(cli.path, args...))
+	if err != nil {
+		return PipelineStatusOutput{}, err
+	}
+
 	var out PipelineStatusOutput
 	if err := json.Unmarshal([]byte(text), &out); err != nil {
-		return nil, err
+		return PipelineStatusOutput{}, err
 	}
-	return &out, nil
+	return out, nil
 }
 
 /*AppList runs:

--- a/e2e/internal/client/cli.go
+++ b/e2e/internal/client/cli.go
@@ -216,7 +216,6 @@ type PackageInput struct {
 
 // PipelineInitInput contains the parameters for calling copilot pipeline init.
 type PipelineInitInput struct {
-	AppName      string
 	Name         string
 	URL          string
 	GitBranch    string
@@ -225,20 +224,17 @@ type PipelineInitInput struct {
 
 // PipelineDeployInput contains the parameters for calling copilot pipeline deploy.
 type PipelineDeployInput struct {
-	AppName string
-	Name    string
+	Name string
 }
 
 // PipelineShowInput contains the parameters for calling copilot pipeline show.
 type PipelineShowInput struct {
-	AppName string
-	Name    string
+	Name string
 }
 
 // PipelineStatusInput contains the parameters for calling copilot pipeline status.
 type PipelineStatusInput struct {
-	AppName string
-	Name    string
+	Name string
 }
 
 // NewCLI returns a wrapper around CLI.

--- a/e2e/pipeline/pipeline_suite_test.go
+++ b/e2e/pipeline/pipeline_suite_test.go
@@ -22,7 +22,8 @@ var (
 
 // Application identifiers.
 var (
-	appName = fmt.Sprintf("e2e-pipeline-%d", time.Now().Unix())
+	appName      = fmt.Sprintf("e2e-pipeline-%d", time.Now().Unix())
+	pipelineName = "myPipeline"
 )
 
 // CodeCommit credentials.


### PR DESCRIPTION
Fix failed e2e test where we are not providing a name on `pipeline init`. Also refactor pipeline commands to match other commands.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
