### PR TITLE
chore(cli): allow pipeline deletion outside of workspace

### DIFF
--- a/internal/pkg/aws/secretsmanager/mocks/mock_secretsmanager.go
+++ b/internal/pkg/aws/secretsmanager/mocks/mock_secretsmanager.go
@@ -63,3 +63,18 @@ func (mr *MockapiMockRecorder) DeleteSecret(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSecret", reflect.TypeOf((*Mockapi)(nil).DeleteSecret), arg0)
 }
+
+// DescribeSecret mocks base method.
+func (m *Mockapi) DescribeSecret(input *secretsmanager.DescribeSecretInput) (*secretsmanager.DescribeSecretOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeSecret", input)
+	ret0, _ := ret[0].(*secretsmanager.DescribeSecretOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeSecret indicates an expected call of DescribeSecret.
+func (mr *MockapiMockRecorder) DescribeSecret(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSecret", reflect.TypeOf((*Mockapi)(nil).DescribeSecret), input)
+}

--- a/internal/pkg/aws/secretsmanager/secretsmanager.go
+++ b/internal/pkg/aws/secretsmanager/secretsmanager.go
@@ -83,8 +83,14 @@ func (s *SecretsManager) DeleteSecret(secretName string) error {
 	return nil
 }
 
+type DescribeSecretOutput struct {
+	Name *string
+	CreatedDate *time.Time
+	Tags []*secretsmanager.Tag
+}
+
 // DescribeSecret retrieves the details of a secret.
-func (s *SecretsManager) DescribeSecret(secretName string) (*secretsmanager.DescribeSecretOutput, error) {
+func (s *SecretsManager) DescribeSecret(secretName string) (*DescribeSecretOutput, error) {
 	resp, err := s.secretsManager.DescribeSecret(&secretsmanager.DescribeSecretInput{
 		SecretId: aws.String(secretName),
 	})
@@ -99,7 +105,12 @@ func (s *SecretsManager) DescribeSecret(secretName string) (*secretsmanager.Desc
 		}
 		return nil, fmt.Errorf("describe secret %s: %w", secretName, err)
 	}
-	return resp, nil
+
+	return &DescribeSecretOutput{
+		Name:        resp.Name,
+		CreatedDate: resp.CreatedDate,
+		Tags:        resp.Tags,
+	}, nil
 }
 
 // ErrSecretAlreadyExists occurs if a secret with the same name already exists.

--- a/internal/pkg/aws/secretsmanager/secretsmanager.go
+++ b/internal/pkg/aws/secretsmanager/secretsmanager.go
@@ -84,9 +84,9 @@ func (s *SecretsManager) DeleteSecret(secretName string) error {
 }
 
 type DescribeSecretOutput struct {
-	Name *string
+	Name        *string
 	CreatedDate *time.Time
-	Tags []*secretsmanager.Tag
+	Tags        []*secretsmanager.Tag
 }
 
 // DescribeSecret retrieves the details of a secret.

--- a/internal/pkg/aws/secretsmanager/secretsmanager.go
+++ b/internal/pkg/aws/secretsmanager/secretsmanager.go
@@ -130,5 +130,5 @@ type ErrSecretNotFound struct {
 }
 
 func (err *ErrSecretNotFound) Error() string {
-	return fmt.Sprintf("secret %s was not found", err.secretName)
+	return fmt.Sprintf("secret %s was not found: %s", err.secretName, err.parentErr)
 }

--- a/internal/pkg/aws/secretsmanager/secretsmanager.go
+++ b/internal/pkg/aws/secretsmanager/secretsmanager.go
@@ -78,7 +78,7 @@ func (s *SecretsManager) DeleteSecret(secretName string) error {
 	})
 
 	if err != nil {
-		return fmt.Errorf("delete secret %s from secrets manager: %+v", secretName, err)
+		return fmt.Errorf("delete secret %s from secrets manager: %w", secretName, err)
 	}
 	return nil
 }
@@ -93,7 +93,7 @@ func (s *SecretsManager) DescribeSecret(secretName string) (*secretsmanager.Desc
 			if aerr.Code() == secretsmanager.ErrCodeResourceNotFoundException {
 				return nil, &ErrSecretNotFound{
 					secretName: secretName,
-					parentErr: err,
+					parentErr:  err,
 				}
 			}
 		}
@@ -111,6 +111,7 @@ type ErrSecretAlreadyExists struct {
 func (err *ErrSecretAlreadyExists) Error() string {
 	return fmt.Sprintf("secret %s already exists", err.secretName)
 }
+
 // ErrSecretNotFound occurs if a secret with the given name does not exist.
 type ErrSecretNotFound struct {
 	secretName string

--- a/internal/pkg/aws/secretsmanager/secretsmanager_test.go
+++ b/internal/pkg/aws/secretsmanager/secretsmanager_test.go
@@ -173,9 +173,8 @@ func TestSecretsManager_DescribeSecret(t *testing.T) {
 	mockAwsErr := awserr.New(secretsmanager.ErrCodeResourceNotFoundException, "", nil)
 
 	tests := map[string]struct {
-		inSecretName   string
-		inSecretString string
-		callMock       func(m *mocks.Mockapi)
+		inSecretName string
+		callMock     func(m *mocks.Mockapi)
 
 		expectedResp  *secretsmanager.DescribeSecretOutput
 		expectedError error

--- a/internal/pkg/aws/secretsmanager/secretsmanager_test.go
+++ b/internal/pkg/aws/secretsmanager/secretsmanager_test.go
@@ -7,6 +7,7 @@ package secretsmanager
 import (
 	"errors"
 	"fmt"
+	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	"testing"
 	"time"
 
@@ -15,7 +16,6 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/aws/secretsmanager/mocks"
 	"github.com/golang/mock/gomock"
 
-	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	"github.com/stretchr/testify/require"
 )
 
@@ -161,14 +161,18 @@ func TestSecretsManager_DeleteSecret(t *testing.T) {
 }
 
 func TestSecretsManager_DescribeSecret(t *testing.T) {
+	mockTime := time.Now()
 	mockSecretName := "github-token-backend-badgoose"
 	mockError := errors.New("mockError")
-	mockOutput := &secretsmanager.DescribeSecretOutput{
-		ARN:                aws.String("arn-goose"),
-		CreatedDate:        aws.Time(time.Now()),
-		Name:               aws.String(mockSecretName),
-		Tags:               []*secretsmanager.Tag{},
-		VersionIdsToStages: nil,
+	mockAPIOutput := &secretsmanager.DescribeSecretOutput{
+		CreatedDate: aws.Time(mockTime),
+		Name:        aws.String(mockSecretName),
+		Tags: []*secretsmanager.Tag{},
+	}
+	mockOutput := &DescribeSecretOutput{
+		CreatedDate: aws.Time(mockTime),
+		Name:        aws.String(mockSecretName),
+		Tags: []*secretsmanager.Tag{},
 	}
 	mockAwsErr := awserr.New(secretsmanager.ErrCodeResourceNotFoundException, "", nil)
 
@@ -176,7 +180,7 @@ func TestSecretsManager_DescribeSecret(t *testing.T) {
 		inSecretName string
 		callMock     func(m *mocks.Mockapi)
 
-		expectedResp  *secretsmanager.DescribeSecretOutput
+		expectedResp  *DescribeSecretOutput
 		expectedError error
 	}{
 		"should wrap error returned by DescribeSecret": {
@@ -207,7 +211,7 @@ func TestSecretsManager_DescribeSecret(t *testing.T) {
 			callMock: func(m *mocks.Mockapi) {
 				m.EXPECT().DescribeSecret(&secretsmanager.DescribeSecretInput{
 					SecretId: aws.String(mockSecretName),
-				}).Return(mockOutput, nil)
+				}).Return(mockAPIOutput, nil)
 			},
 			expectedResp:  mockOutput,
 			expectedError: nil,

--- a/internal/pkg/aws/secretsmanager/secretsmanager_test.go
+++ b/internal/pkg/aws/secretsmanager/secretsmanager_test.go
@@ -167,12 +167,12 @@ func TestSecretsManager_DescribeSecret(t *testing.T) {
 	mockAPIOutput := &secretsmanager.DescribeSecretOutput{
 		CreatedDate: aws.Time(mockTime),
 		Name:        aws.String(mockSecretName),
-		Tags: []*secretsmanager.Tag{},
+		Tags:        []*secretsmanager.Tag{},
 	}
 	mockOutput := &DescribeSecretOutput{
 		CreatedDate: aws.Time(mockTime),
 		Name:        aws.String(mockSecretName),
-		Tags: []*secretsmanager.Tag{},
+		Tags:        []*secretsmanager.Tag{},
 	}
 	mockAwsErr := awserr.New(secretsmanager.ErrCodeResourceNotFoundException, "", nil)
 
@@ -248,7 +248,6 @@ func TestSecretsManager_DescribeSecret(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, tc.expectedResp, resp)
 			}
-			require.Equal(t, tc.expectedError, err)
 		})
 	}
 }

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -5,10 +5,10 @@ package cli
 
 import (
 	"encoding"
+	"github.com/aws/copilot-cli/internal/pkg/aws/secretsmanager"
 	"io"
 
 	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	awscloudformation "github.com/aws/copilot-cli/internal/pkg/aws/cloudformation"
 	"github.com/aws/copilot-cli/internal/pkg/aws/codepipeline"
 	"github.com/aws/copilot-cli/internal/pkg/aws/ec2"

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -5,6 +5,7 @@ package cli
 
 import (
 	"encoding"
+	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	"github.com/aws/copilot-cli/internal/pkg/manifest"
 	"io"
 
@@ -160,6 +161,7 @@ type secretCreator interface {
 }
 
 type secretDeleter interface {
+	DescribeSecret(secretName string) (*secretsmanager.DescribeSecretOutput, error)
 	DeleteSecret(secretName string) error
 }
 

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -10,6 +10,7 @@ import (
 	reflect "reflect"
 
 	session "github.com/aws/aws-sdk-go/aws/session"
+	secretsmanager "github.com/aws/aws-sdk-go/service/secretsmanager"
 	cloudformation "github.com/aws/copilot-cli/internal/pkg/aws/cloudformation"
 	codepipeline "github.com/aws/copilot-cli/internal/pkg/aws/codepipeline"
 	ec2 "github.com/aws/copilot-cli/internal/pkg/aws/ec2"
@@ -1381,6 +1382,21 @@ func (mr *MocksecretsManagerMockRecorder) DeleteSecret(secretName interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSecret", reflect.TypeOf((*MocksecretsManager)(nil).DeleteSecret), secretName)
 }
 
+// DescribeSecret mocks base method.
+func (m *MocksecretsManager) DescribeSecret(secretName string) (*secretsmanager.DescribeSecretOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeSecret", secretName)
+	ret0, _ := ret[0].(*secretsmanager.DescribeSecretOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeSecret indicates an expected call of DescribeSecret.
+func (mr *MocksecretsManagerMockRecorder) DescribeSecret(secretName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSecret", reflect.TypeOf((*MocksecretsManager)(nil).DescribeSecret), secretName)
+}
+
 // MocksecretCreator is a mock of secretCreator interface.
 type MocksecretCreator struct {
 	ctrl     *gomock.Controller
@@ -1454,6 +1470,21 @@ func (m *MocksecretDeleter) DeleteSecret(secretName string) error {
 func (mr *MocksecretDeleterMockRecorder) DeleteSecret(secretName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSecret", reflect.TypeOf((*MocksecretDeleter)(nil).DeleteSecret), secretName)
+}
+
+// DescribeSecret mocks base method.
+func (m *MocksecretDeleter) DescribeSecret(secretName string) (*secretsmanager.DescribeSecretOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeSecret", secretName)
+	ret0, _ := ret[0].(*secretsmanager.DescribeSecretOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeSecret indicates an expected call of DescribeSecret.
+func (mr *MocksecretDeleterMockRecorder) DescribeSecret(secretName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSecret", reflect.TypeOf((*MocksecretDeleter)(nil).DescribeSecret), secretName)
 }
 
 // MockimageBuilderPusher is a mock of imageBuilderPusher interface.
@@ -6459,6 +6490,21 @@ func (mr *MockworkloadDeployerMockRecorder) DeployWorkload(in interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeployWorkload", reflect.TypeOf((*MockworkloadDeployer)(nil).DeployWorkload), in)
 }
 
+// IsServiceAvailableInRegion mocks base method.
+func (m *MockworkloadDeployer) IsServiceAvailableInRegion(region string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsServiceAvailableInRegion", region)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IsServiceAvailableInRegion indicates an expected call of IsServiceAvailableInRegion.
+func (mr *MockworkloadDeployerMockRecorder) IsServiceAvailableInRegion(region interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsServiceAvailableInRegion", reflect.TypeOf((*MockworkloadDeployer)(nil).IsServiceAvailableInRegion), region)
+}
+
 // UploadArtifacts mocks base method.
 func (m *MockworkloadDeployer) UploadArtifacts() (*deploy.UploadArtifactsOutput, error) {
 	m.ctrl.T.Helper()
@@ -6472,21 +6518,6 @@ func (m *MockworkloadDeployer) UploadArtifacts() (*deploy.UploadArtifactsOutput,
 func (mr *MockworkloadDeployerMockRecorder) UploadArtifacts() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadArtifacts", reflect.TypeOf((*MockworkloadDeployer)(nil).UploadArtifacts))
-}
-
-// IsServiceAvailableInRegion mocks base method.
-func (m *MockworkloadDeployer) IsServiceAvailableInRegion(region string) (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsServiceAvailableInRegion", region)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// IsServiceAvailableInRegion indicates an expected call of UploadArtifacts.
-func (mr *MockworkloadDeployerMockRecorder) IsServiceAvailableInRegion(region string) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsServiceAvailableInRegion", reflect.TypeOf((*MockworkloadDeployer)(nil).IsServiceAvailableInRegion), region)
 }
 
 // MockworkloadTemplateGenerator is a mock of workloadTemplateGenerator interface.

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -10,12 +10,12 @@ import (
 	reflect "reflect"
 
 	session "github.com/aws/aws-sdk-go/aws/session"
-	secretsmanager "github.com/aws/aws-sdk-go/service/secretsmanager"
 	cloudformation "github.com/aws/copilot-cli/internal/pkg/aws/cloudformation"
 	codepipeline "github.com/aws/copilot-cli/internal/pkg/aws/codepipeline"
 	ec2 "github.com/aws/copilot-cli/internal/pkg/aws/ec2"
 	ecs "github.com/aws/copilot-cli/internal/pkg/aws/ecs"
 	s3 "github.com/aws/copilot-cli/internal/pkg/aws/s3"
+	secretsmanager "github.com/aws/copilot-cli/internal/pkg/aws/secretsmanager"
 	ssm "github.com/aws/copilot-cli/internal/pkg/aws/ssm"
 	deploy "github.com/aws/copilot-cli/internal/pkg/cli/deploy"
 	config "github.com/aws/copilot-cli/internal/pkg/config"

--- a/internal/pkg/cli/pipeline_delete.go
+++ b/internal/pkg/cli/pipeline_delete.go
@@ -203,7 +203,7 @@ func (o *deletePipelineOpts) getSecret() error {
 
 // With GHv1 sources, we stored access tokens in SecretsManager. Pipelines generated prior to Copilot v1.4 have secrets named 'github-token-[appName]-[repoName]'. Pipelines prior to 1.16(?) were given default names of `pipeline-[appName]-[repoName]`. Users may have changed pipeline names, so this is our best-guess approach to deleting legacy pipeline secrets.
 func (o *deletePipelineOpts) pipelineSecretName() string {
-	appAndRepo := strings.TrimPrefix(o.name,"pipeline-")
+	appAndRepo := strings.TrimPrefix(o.name, "pipeline-")
 	return fmt.Sprintf("github-token-%s", appAndRepo)
 }
 

--- a/internal/pkg/cli/pipeline_delete.go
+++ b/internal/pkg/cli/pipeline_delete.go
@@ -193,7 +193,6 @@ func (o *deletePipelineOpts) getSecret() error {
 
 	for _, tag := range output.Tags {
 		if aws.StringValue(tag.Key) == deploy.AppTagKey && aws.StringValue(tag.Value) == output.CreatedDate.UTC().Format(time.UnixDate) {
-			log.Infof("Found the Copilot-generated secret '%s' used to connect to your GitHub source repo.\n", o.ghAccessTokenSecretName)
 			return nil
 		}
 	}

--- a/internal/pkg/cli/pipeline_delete.go
+++ b/internal/pkg/cli/pipeline_delete.go
@@ -186,7 +186,7 @@ func (o *deletePipelineOpts) getSecret() error {
 		// Check for Copilot-assigned tag for added assurance. If tags not found, fall through.
 		for _, tag := range output.Tags {
 			if aws.StringValue(tag.Key) == "copilot-application" && aws.StringValue(tag.Value) == output.CreatedDate.UTC().Format(time.UnixDate) {
-				log.Infof("Found secret '%s'.\n", o.ghAccessTokenSecretName)
+				log.Infof("Found the Copilot-generated secret '%s' used to connect to your GitHub source repo.\n", o.ghAccessTokenSecretName)
 				return nil
 			}
 		}
@@ -196,7 +196,6 @@ func (o *deletePipelineOpts) getSecret() error {
 		return fmt.Errorf("describe secret %s: %w", o.ghAccessTokenSecretName, err)
 	}
 	// To get here, either the secret was found but tags didn't match, or Secrets Manager returned a ResourceNotFoundException.
-	log.Infof("Found no Copilot-generated Secrets Manager secrets to delete for pipeline '%s'.\n", o.name)
 	o.ghAccessTokenSecretName = ""
 	return nil
 }

--- a/internal/pkg/cli/pipeline_delete.go
+++ b/internal/pkg/cli/pipeline_delete.go
@@ -203,7 +203,7 @@ func (o *deletePipelineOpts) getSecret() error {
 
 // With GHv1 sources, we stored access tokens in SecretsManager. Pipelines generated prior to Copilot v1.4 have secrets named 'github-token-[appName]-[repoName]'. Pipelines prior to 1.16(?) were given default names of `pipeline-[appName]-[repoName]`. Users may have changed pipeline names, so this is our best-guess approach to deleting legacy pipeline secrets.
 func (o *deletePipelineOpts) pipelineSecretName() string {
-	appAndRepo := strings.TrimPrefix(o.name, fmt.Sprintf("pipeline-"))
+	appAndRepo := strings.TrimPrefix(o.name,"pipeline-")
 	return fmt.Sprintf("github-token-%s", appAndRepo)
 }
 

--- a/internal/pkg/cli/pipeline_delete.go
+++ b/internal/pkg/cli/pipeline_delete.go
@@ -201,7 +201,7 @@ func (o *deletePipelineOpts) getSecret() error {
 	return nil
 }
 
-// With GHv1 sources, we stored access tokens in SecretsManager. Pipelines generated prior to Copilot v1.4 have secrets named 'github-token-[appName]-[repoName]'. Pipelines prior to 1.16(?) were given default names of `pipeline-[appName]-[repoName]`. Users may have changed pipeline names, so this is our best-guess approach to deleting lingering legacy pipeline secrets.
+// With GHv1 sources, we stored access tokens in SecretsManager. Pipelines generated prior to Copilot v1.4 have secrets named 'github-token-[appName]-[repoName]'. Pipelines prior to 1.16(?) were given default names of `pipeline-[appName]-[repoName]`. Users may have changed pipeline names, so this is our best-guess approach to deleting legacy pipeline secrets.
 func (o *deletePipelineOpts) pipelineSecretName() string {
 	appAndRepo := strings.TrimPrefix(o.name, fmt.Sprintf("pipeline-"))
 	return fmt.Sprintf("github-token-%s", appAndRepo)

--- a/internal/pkg/cli/pipeline_delete_test.go
+++ b/internal/pkg/cli/pipeline_delete_test.go
@@ -192,8 +192,7 @@ func TestDeletePipelineOpts_Ask(t *testing.T) {
 
 func TestDeletePipelineOpts_Execute(t *testing.T) {
 	mockTime := time.Now()
-	mockResp := &sdkSecretsmanager.DescribeSecretOutput{
-		ARN:         aws.String("arn-goose"),
+	mockResp := &secretsmanager.DescribeSecretOutput{
 		CreatedDate: aws.Time(mockTime),
 		Name:        aws.String(testPipelineSecret),
 		Tags: []*sdkSecretsmanager.Tag{
@@ -202,10 +201,8 @@ func TestDeletePipelineOpts_Execute(t *testing.T) {
 				Value: aws.String(mockTime.UTC().Format(time.UnixDate)),
 			},
 		},
-		VersionIdsToStages: nil,
 	}
-	mockBadResp := &sdkSecretsmanager.DescribeSecretOutput{
-		ARN:         aws.String("arn-goose"),
+	mockBadResp := &secretsmanager.DescribeSecretOutput{
 		CreatedDate: aws.Time(mockTime),
 		Name:        aws.String(testPipelineSecret),
 		Tags: []*sdkSecretsmanager.Tag{
@@ -214,7 +211,6 @@ func TestDeletePipelineOpts_Execute(t *testing.T) {
 				Value: aws.String(mockTime.UTC().Format(time.UnixDate)),
 			},
 		},
-		VersionIdsToStages: nil,
 	}
 	testError := errors.New("some error")
 	testCases := map[string]struct {

--- a/internal/pkg/cli/pipeline_delete_test.go
+++ b/internal/pkg/cli/pipeline_delete_test.go
@@ -22,8 +22,6 @@ const (
 	testAppName        = "badgoose"
 	testPipelineName   = "pipeline-badgoose-honkpipes"
 	testPipelineSecret = "github-token-badgoose-honkpipes"
-
-	pipelineManifestLegacyPath = "copilot/pipeline.yml"
 )
 
 type deletePipelineMocks struct {

--- a/internal/pkg/cli/pipeline_delete_test.go
+++ b/internal/pkg/cli/pipeline_delete_test.go
@@ -191,26 +191,27 @@ func TestDeletePipelineOpts_Ask(t *testing.T) {
 }
 
 func TestDeletePipelineOpts_Execute(t *testing.T) {
+	mockTime := time.Now()
 	mockResp := &sdkSecretsmanager.DescribeSecretOutput{
 		ARN:         aws.String("arn-goose"),
-		CreatedDate: aws.Time(time.Now()),
+		CreatedDate: aws.Time(mockTime),
 		Name:        aws.String(testPipelineSecret),
 		Tags: []*sdkSecretsmanager.Tag{
 			{
 				Key:   aws.String("copilot-application"),
-				Value: aws.String(time.Now().UTC().Format(time.UnixDate)),
+				Value: aws.String(mockTime.UTC().Format(time.UnixDate)),
 			},
 		},
 		VersionIdsToStages: nil,
 	}
 	mockBadResp := &sdkSecretsmanager.DescribeSecretOutput{
 		ARN:         aws.String("arn-goose"),
-		CreatedDate: aws.Time(time.Now()),
+		CreatedDate: aws.Time(mockTime),
 		Name:        aws.String(testPipelineSecret),
 		Tags: []*sdkSecretsmanager.Tag{
 			{
 				Key:   aws.String("someOtherKey"),
-				Value: aws.String(time.Now().UTC().Format(time.UnixDate)),
+				Value: aws.String(mockTime.UTC().Format(time.UnixDate)),
 			},
 		},
 		VersionIdsToStages: nil,

--- a/internal/pkg/cli/pipeline_delete_test.go
+++ b/internal/pkg/cli/pipeline_delete_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	sdkSecretsmanager "github.com/aws/aws-sdk-go/service/secretsmanager"
 	"github.com/aws/copilot-cli/internal/pkg/aws/secretsmanager"
+	"github.com/aws/copilot-cli/internal/pkg/deploy"
 	"testing"
 	"time"
 
@@ -197,7 +198,7 @@ func TestDeletePipelineOpts_Execute(t *testing.T) {
 		Name:        aws.String(testPipelineSecret),
 		Tags: []*sdkSecretsmanager.Tag{
 			{
-				Key:   aws.String("copilot-application"),
+				Key:   aws.String(deploy.AppTagKey),
 				Value: aws.String(mockTime.UTC().Format(time.UnixDate)),
 			},
 		},

--- a/internal/pkg/cli/pipeline_delete_test.go
+++ b/internal/pkg/cli/pipeline_delete_test.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/aws/aws-sdk-go/aws"
-	secretsmanager2 "github.com/aws/aws-sdk-go/service/secretsmanager"
+	sdkSecretsmanager "github.com/aws/aws-sdk-go/service/secretsmanager"
 	"github.com/aws/copilot-cli/internal/pkg/aws/secretsmanager"
 	"testing"
 	"time"
@@ -59,7 +59,7 @@ func TestDeletePipelineOpts_Ask(t *testing.T) {
 
 			wantedAppName:      testAppName,
 			wantedPipelineName: testPipelineName,
-			wantedError: nil,
+			wantedError:        nil,
 		},
 		"errors if passed-in app name invalid": {
 			skipConfirmation: true,
@@ -193,11 +193,11 @@ func TestDeletePipelineOpts_Ask(t *testing.T) {
 }
 
 func TestDeletePipelineOpts_Execute(t *testing.T) {
-	mockResp := &secretsmanager2.DescribeSecretOutput{
+	mockResp := &sdkSecretsmanager.DescribeSecretOutput{
 		ARN:         aws.String("arn-goose"),
 		CreatedDate: aws.Time(time.Now()),
 		Name:        aws.String(testPipelineSecret),
-		Tags: []*secretsmanager2.Tag{
+		Tags: []*sdkSecretsmanager.Tag{
 			{
 				Key:   aws.String("copilot-application"),
 				Value: aws.String(time.Now().UTC().Format(time.UnixDate)),
@@ -205,11 +205,11 @@ func TestDeletePipelineOpts_Execute(t *testing.T) {
 		},
 		VersionIdsToStages: nil,
 	}
-	mockBadResp := &secretsmanager2.DescribeSecretOutput{
+	mockBadResp := &sdkSecretsmanager.DescribeSecretOutput{
 		ARN:         aws.String("arn-goose"),
 		CreatedDate: aws.Time(time.Now()),
 		Name:        aws.String(testPipelineSecret),
-		Tags: []*secretsmanager2.Tag{
+		Tags: []*sdkSecretsmanager.Tag{
 			{
 				Key:   aws.String("someOtherKey"),
 				Value: aws.String(time.Now().UTC().Format(time.UnixDate)),


### PR DESCRIPTION
Fixes https://github.com/aws/copilot-cli/issues/3299.

Previously, we were reading the pipeline manifest 1. to fetch the pipeline name and 2. to look for `access-token-secret`. In order to allow pipeline deletion from outside of the workspace (because it is more flexible and also makes `app delete` more useful), we cannot rely on reading the pipeline manifest because it is inaccessible from outside of the workspace.

Changes in https://github.com/aws/copilot-cli/pull/3382 leveraged the new DeployedPipelines selector in `pipeline delete` so the user can choose the pipeline they would like to delete. This PR solves the remaining problem of how to delete the pipeline secret. Prior to v.1.4 (introduction of CodeStar Connections), Copilot stored GitHub access tokens as secrets in AWS Secrets Manager. Without reading the manifest, we can look for secrets named and tagged with the conventions `pipeline init` followed for GHv1 source connections. If folks changed their pipeline names or secrets tags, we may not catch the secrets. We do log an error saying that we didn't find any secrets, so they are at least aware that no secrets are being deleted. It's obviously better to err on the side of not deleting than deleting. If we do find a secret that we think is a Copilot secret, we prompt for confirmation before proceeding (unless the user passed in the `--delete-secret` flag.

With a pipeline matching the defaults, pipeline name `pipeline-appName-repoName` and secret `github-token-appName-repoName` with tag `Key: "copilot-application"` `Value: [timeStampAtTimeOfInit]`:
```
 % copilot pipeline delete
Found secret 'github-token-muckles-aws-copilot-sample-service'.
Sure? Yes // confirming that the user wants to delete the pipeline

  Are you sure you want to delete the source secret github-token-muckles-aws-copilot-sample-service associated with pipeline pipeline-muckles-aws-copilot-sample-service? [? for help] (y/N) 
```
Without a pipeline match:
```
% copilot pipeline delete
Found no Secrets Manager secrets to delete for pipeline secondPipeline.
Sure? No
✘ pipeline delete cancelled - no changes made
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
