### PR TITLE
chore(cli): update `app delete` to delete multiple pipelines

### DIFF
--- a/internal/pkg/cli/app_delete.go
+++ b/internal/pkg/cli/app_delete.go
@@ -6,10 +6,10 @@ package cli
 import (
 	"errors"
 	"fmt"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/aws/copilot-cli/internal/pkg/aws/identity"
+	"github.com/aws/copilot-cli/internal/pkg/deploy"
 
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/copilot-cli/internal/pkg/aws/s3"
@@ -54,17 +54,18 @@ type deleteAppOpts struct {
 	deleteAppVars
 	spinner progress
 
-	store                store
-	ws                   wsFileDeleter
-	sessProvider         sessionProvider
-	cfn                  deployer
-	prompt               prompter
-	s3                   func(session *session.Session) bucketEmptier
-	svcDeleteExecutor    func(svcName string) (executor, error)
-	jobDeleteExecutor    func(jobName string) (executor, error)
-	envDeleteExecutor    func(envName string) (executeAsker, error)
-	taskDeleteExecutor   func(envName, taskName string) (executor, error)
-	deletePipelineRunner func() (cmd, error)
+	store                  store
+	ws                     wsFileDeleter
+	sessProvider           sessionProvider
+	cfn                    deployer
+	prompt                 prompter
+	codepipeline           pipelineGetter
+	s3                     func(session *session.Session) bucketEmptier
+	svcDeleteExecutor      func(svcName string) (executor, error)
+	jobDeleteExecutor      func(jobName string) (executor, error)
+	envDeleteExecutor      func(envName string) (executeAsker, error)
+	taskDeleteExecutor     func(envName, taskName string) (executor, error)
+	pipelineDeleteExecutor func(pipelineName string) (executor, error)
 }
 
 func newDeleteAppOpts(vars deleteAppVars) (*deleteAppOpts, error) {
@@ -135,7 +136,7 @@ func newDeleteAppOpts(vars deleteAppVars) (*deleteAppOpts, error) {
 			}
 			return opts, nil
 		},
-		deletePipelineRunner: func() (cmd, error) {
+		pipelineDeleteExecutor: func(pipelineName string) (executor, error) {
 			opts, err := newDeletePipelineOpts(deletePipelineVars{
 				appName:            vars.name,
 				skipConfirmation:   true,
@@ -199,10 +200,8 @@ func (o *deleteAppOpts) Execute() error {
 
 	// deletePipeline must happen before deleteAppResources and deleteWs, since the pipeline delete command relies
 	// on the application stackset as well as the workspace directory to still exist.
-	if err := o.deletePipeline(); err != nil {
-		if !errors.Is(err, workspace.ErrNoPipelineInWorkspace) {
-			return err
-		}
+	if err := o.deletePipelines(); err != nil {
+		return err
 	}
 
 	if err := o.deleteAppResources(); err != nil {
@@ -319,12 +318,24 @@ func (o *deleteAppOpts) emptyS3Bucket() error {
 	return nil
 }
 
-func (o *deleteAppOpts) deletePipeline() error {
-	cmd, err := o.deletePipelineRunner()
+func (o *deleteAppOpts) deletePipelines() error {
+	pipelines, err := o.codepipeline.ListPipelineNamesByTags(map[string]string{
+		deploy.AppTagKey: o.name,
+	})
 	if err != nil {
-		return err
+		return fmt.Errorf("list pipelines for application %s: %w", o.name, err)
 	}
-	return run(cmd)
+
+	for _, pipeline := range pipelines {
+		cmd, err := o.pipelineDeleteExecutor(pipeline)
+		if err != nil {
+			return err
+		}
+		if err := cmd.Execute(); err != nil {
+			return fmt.Errorf("execute pipeline delete: %w", err)
+		}
+	}
+	return nil
 }
 
 func (o *deleteAppOpts) deleteAppResources() error {

--- a/internal/pkg/cli/app_delete.go
+++ b/internal/pkg/cli/app_delete.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ssm"
+	"github.com/aws/copilot-cli/internal/pkg/aws/codepipeline"
 	"github.com/aws/copilot-cli/internal/pkg/aws/identity"
 	"github.com/aws/copilot-cli/internal/pkg/deploy"
 
@@ -91,6 +92,7 @@ func newDeleteAppOpts(vars deleteAppVars) (*deleteAppOpts, error) {
 		s3: func(session *session.Session) bucketEmptier {
 			return s3.New(session)
 		},
+		codepipeline: codepipeline.New(defaultSession),
 		svcDeleteExecutor: func(svcName string) (executor, error) {
 			opts, err := newDeleteSvcOpts(deleteSvcVars{
 				skipConfirmation: true, // always skip sub-confirmations
@@ -139,6 +141,7 @@ func newDeleteAppOpts(vars deleteAppVars) (*deleteAppOpts, error) {
 		pipelineDeleteExecutor: func(pipelineName string) (executor, error) {
 			opts, err := newDeletePipelineOpts(deletePipelineVars{
 				appName:            vars.name,
+				name:               pipelineName,
 				skipConfirmation:   true,
 				shouldDeleteSecret: true,
 			})

--- a/internal/pkg/cli/app_delete.go
+++ b/internal/pkg/cli/app_delete.go
@@ -201,7 +201,7 @@ func (o *deleteAppOpts) Execute() error {
 		return err
 	}
 
-	// deletePipeline must happen before deleteAppResources and deleteWs, since the pipeline delete command relies
+	// deletePipelines must happen before deleteAppResources and deleteWs, since the pipeline delete command relies
 	// on the application stackset as well as the workspace directory to still exist.
 	if err := o.deletePipelines(); err != nil {
 		return err

--- a/internal/pkg/cli/app_delete_test.go
+++ b/internal/pkg/cli/app_delete_test.go
@@ -129,6 +129,7 @@ func TestDeleteAppOpts_Ask(t *testing.T) {
 type deleteAppMocks struct {
 	spinner         *mocks.Mockprogress
 	store           *mocks.Mockstore
+	codepipeline    *mocks.MockpipelineGetter
 	ws              *mocks.MockwsFileDeleter
 	sessProvider    *sessions.Provider
 	deployer        *mocks.Mockdeployer
@@ -137,7 +138,7 @@ type deleteAppMocks struct {
 	envDeleter      *mocks.MockexecuteAsker
 	taskDeleter     *mocks.Mockexecutor
 	bucketEmptier   *mocks.MockbucketEmptier
-	pipelineDeleter *mocks.Mockcmd
+	pipelineDeleter *mocks.Mockexecutor
 }
 
 func TestDeleteAppOpts_Execute(t *testing.T) {
@@ -146,10 +147,16 @@ func TestDeleteAppOpts_Execute(t *testing.T) {
 		{
 			Name: "webapp",
 		},
+		{
+			Name: "backend",
+		},
 	}
 	mockJobs := []*config.Workload{
 		{
 			Name: "mailer",
+		},
+		{
+			Name: "bailer",
 		},
 	}
 	mockEnvs := []*config.Environment{
@@ -160,6 +167,10 @@ func TestDeleteAppOpts_Execute(t *testing.T) {
 	mockApp := &config.Application{
 		Name: "badgoose",
 	}
+	mockTags := map[string]string{
+		deploy.AppTagKey: mockAppName,
+	}
+	mockPipelines := []string{"pipeline1", "pipeline2", "pipeline3"}
 	mockResources := []*stack.AppRegionalResources{
 		{
 			Region:   "us-west-2",
@@ -185,11 +196,11 @@ func TestDeleteAppOpts_Execute(t *testing.T) {
 				gomock.InOrder(
 					// deleteSvcs
 					mocks.store.EXPECT().ListServices(mockAppName).Return(mockServices, nil),
-					mocks.svcDeleter.EXPECT().Execute().Return(nil),
+					mocks.svcDeleter.EXPECT().Execute().Return(nil).Times(2),
 
 					// deleteJobs
 					mocks.store.EXPECT().ListJobs(mockAppName).Return(mockJobs, nil),
-					mocks.jobDeleter.EXPECT().Execute().Return(nil),
+					mocks.jobDeleter.EXPECT().Execute().Return(nil).Times(2),
 
 					// listEnvs
 					mocks.store.EXPECT().ListEnvironments(mockAppName).Return(mockEnvs, nil),
@@ -209,62 +220,9 @@ func TestDeleteAppOpts_Execute(t *testing.T) {
 					mocks.bucketEmptier.EXPECT().EmptyBucket(mockResources[0].S3Bucket).Return(nil),
 					mocks.spinner.EXPECT().Stop(log.Ssuccess(deleteAppCleanResourcesStopMsg)),
 
-					// delete pipeline
-					mocks.pipelineDeleter.EXPECT().Validate().Return(nil),
-					mocks.pipelineDeleter.EXPECT().Ask().Return(nil),
-					mocks.pipelineDeleter.EXPECT().Execute().Return(nil),
-
-					// deleteAppResources
-					mocks.spinner.EXPECT().Start(deleteAppResourcesStartMsg),
-					mocks.deployer.EXPECT().DeleteApp(mockAppName).Return(nil),
-					mocks.spinner.EXPECT().Stop(log.Ssuccess(deleteAppResourcesStopMsg)),
-
-					// deleteAppConfigs
-					mocks.spinner.EXPECT().Start(deleteAppConfigStartMsg),
-					mocks.store.EXPECT().DeleteApplication(mockAppName).Return(nil),
-					mocks.spinner.EXPECT().Stop(log.Ssuccess(deleteAppConfigStopMsg)),
-
-					// deleteWs
-					mocks.spinner.EXPECT().Start(fmt.Sprintf(fmtDeleteAppWsStartMsg, workspace.SummaryFileName)),
-					mocks.ws.EXPECT().DeleteWorkspaceFile().Return(nil),
-					mocks.spinner.EXPECT().Stop(log.Ssuccess(fmt.Sprintf(fmtDeleteAppWsStopMsg, workspace.SummaryFileName))),
-				)
-			},
-			wantedError: nil,
-		},
-		"when pipeline manifest does not exist": {
-			appName: mockAppName,
-			setupMocks: func(mocks deleteAppMocks) {
-				gomock.InOrder(
-					// deleteSvcs
-					mocks.store.EXPECT().ListServices(mockAppName).Return(mockServices, nil),
-					mocks.svcDeleter.EXPECT().Execute().Return(nil),
-
-					// deleteJobs
-					mocks.store.EXPECT().ListJobs(mockAppName).Return(mockJobs, nil),
-					mocks.jobDeleter.EXPECT().Execute().Return(nil),
-
-					// listEnvs
-					mocks.store.EXPECT().ListEnvironments(mockAppName).Return(mockEnvs, nil),
-
-					// deleteTasks
-					mocks.deployer.EXPECT().ListTaskStacks(mockAppName, mockEnvs[0].Name).Return(nil, nil),
-
-					// deleteEnvs
-					mocks.envDeleter.EXPECT().Ask().Return(nil),
-					mocks.envDeleter.EXPECT().Execute().Return(nil),
-
-					// emptyS3bucket
-					mocks.store.EXPECT().GetApplication(mockAppName).Return(mockApp, nil),
-					mocks.deployer.EXPECT().GetRegionalAppResources(mockApp).Return(mockResources, nil),
-					mocks.spinner.EXPECT().Start(deleteAppCleanResourcesStartMsg),
-					mocks.bucketEmptier.EXPECT().EmptyBucket(mockResources[0].S3Bucket).Return(nil),
-					mocks.spinner.EXPECT().Stop(log.Ssuccess(deleteAppCleanResourcesStopMsg)),
-
-					// delete pipeline
-					mocks.pipelineDeleter.EXPECT().Validate().Return(nil),
-					mocks.pipelineDeleter.EXPECT().Ask().Return(nil),
-					mocks.pipelineDeleter.EXPECT().Execute().Return(nil),
+					// delete pipelines
+					mocks.codepipeline.EXPECT().ListPipelineNamesByTags(mockTags).Return(mockPipelines, nil),
+					mocks.pipelineDeleter.EXPECT().Execute().Return(nil).Times(3),
 
 					// deleteAppResources
 					mocks.spinner.EXPECT().Start(deleteAppResourcesStartMsg),
@@ -297,6 +255,7 @@ func TestDeleteAppOpts_Execute(t *testing.T) {
 			mockWorkspace := mocks.NewMockwsFileDeleter(ctrl)
 			mockSession := sessions.ImmutableProvider()
 			mockDeployer := mocks.NewMockdeployer(ctrl)
+			mockPipelineGetter := mocks.NewMockpipelineGetter(ctrl)
 
 			mockBucketEmptier := mocks.NewMockbucketEmptier(ctrl)
 			mockGetBucketEmptier := func(session *session.Session) bucketEmptier {
@@ -308,11 +267,11 @@ func TestDeleteAppOpts_Execute(t *testing.T) {
 			// DeleteEnvOpts, and DeletePipelineOpts. It allows us to instead simply
 			// test if the deletion of those resources succeeded or failed.
 			mockSvcDeleteExecutor := mocks.NewMockexecutor(ctrl)
-			mockSvcExecutorProvider := func(appName string) (executor, error) {
+			mockSvcExecutorProvider := func(svcName string) (executor, error) {
 				return mockSvcDeleteExecutor, nil
 			}
 			mockJobDeleteExecutor := mocks.NewMockexecutor(ctrl)
-			mockJobExecutorProvider := func(appName string) (executor, error) {
+			mockJobExecutorProvider := func(jobName string) (executor, error) {
 				return mockJobDeleteExecutor, nil
 			}
 			mockTaskDeleteExecutor := mocks.NewMockexecutor(ctrl)
@@ -324,9 +283,9 @@ func TestDeleteAppOpts_Execute(t *testing.T) {
 				return mockEnvDeleteExecutor, nil
 			}
 
-			mockPipelineDeleteCmd := mocks.NewMockcmd(ctrl)
-			mockRunnerProvider := func() (cmd, error) {
-				return mockPipelineDeleteCmd, nil
+			mockPipelineDeleteExecutor := mocks.NewMockexecutor(ctrl)
+			mockPipelineExecutorProvider := func(pipelineName string) (executor, error) {
+				return mockPipelineDeleteExecutor, nil
 			}
 
 			mocks := deleteAppMocks{
@@ -335,12 +294,13 @@ func TestDeleteAppOpts_Execute(t *testing.T) {
 				ws:              mockWorkspace,
 				sessProvider:    mockSession,
 				deployer:        mockDeployer,
+				codepipeline:    mockPipelineGetter,
 				svcDeleter:      mockSvcDeleteExecutor,
 				jobDeleter:      mockJobDeleteExecutor,
 				envDeleter:      mockEnvDeleteExecutor,
 				taskDeleter:     mockTaskDeleteExecutor,
 				bucketEmptier:   mockBucketEmptier,
-				pipelineDeleter: mockPipelineDeleteCmd,
+				pipelineDeleter: mockPipelineDeleteExecutor,
 			}
 			test.setupMocks(mocks)
 
@@ -348,17 +308,18 @@ func TestDeleteAppOpts_Execute(t *testing.T) {
 				deleteAppVars: deleteAppVars{
 					name: mockAppName,
 				},
-				spinner:              mockSpinner,
-				store:                mockStore,
-				ws:                   mockWorkspace,
-				sessProvider:         mockSession,
-				cfn:                  mockDeployer,
-				s3:                   mockGetBucketEmptier,
-				svcDeleteExecutor:    mockSvcExecutorProvider,
-				jobDeleteExecutor:    mockJobExecutorProvider,
-				envDeleteExecutor:    mockAskExecutorProvider,
-				taskDeleteExecutor:   mockTaskDeleteProvider,
-				deletePipelineRunner: mockRunnerProvider,
+				spinner:                mockSpinner,
+				store:                  mockStore,
+				ws:                     mockWorkspace,
+				codepipeline:           mockPipelineGetter,
+				sessProvider:           mockSession,
+				cfn:                    mockDeployer,
+				s3:                     mockGetBucketEmptier,
+				svcDeleteExecutor:      mockSvcExecutorProvider,
+				jobDeleteExecutor:      mockJobExecutorProvider,
+				envDeleteExecutor:      mockAskExecutorProvider,
+				taskDeleteExecutor:     mockTaskDeleteProvider,
+				pipelineDeleteExecutor: mockPipelineExecutorProvider,
 			}
 
 			// WHEN


### PR DESCRIPTION
Part of #3231.
Related: #3391.

`copilot app delete` should delete all pipelines deployed within an app.

```
% copilot app delete
Sure? Yes
✔ Deleted service be from environment test.
✔ Deleted resources of service be from application testing-app-delete.

✔ Deleted service be from application testing-app-delete.
✔ Deleted the stack of job job-in-main from environment test.
✔ Stopped running tasks of job job-in-main from environment test.
✔ Deleted resources of job job-in-main from application testing-app-delete.
✔ Deleted job job-in-main from application testing-app-delete.
✔ Deleted environment test from application testing-app-delete.
✔ Cleaned up deployment resources.
✔ Deleted pipeline second-pipeline from application testing-app-delete.
✔ Deleted pipeline first-named-pipeline from application testing-app-delete.
✔ Deleted application resources.
✔ Deleted application configuration.
✔ Deleted local .workspace file.
% 
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
