### PR TITLE
chore(pipelines): make hardcoded paths dynamic in buildspec and pipeline CFN template

### DIFF
--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -281,6 +281,7 @@ type wsWlDirReader interface {
 
 type wsPipelineReader interface {
 	wsPipelineGetter
+	Rel(path string) (string, error)
 }
 
 type wsPipelineGetter interface {

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -241,6 +241,7 @@ type wsPipelineManifestReader interface {
 type wsPipelineWriter interface {
 	WritePipelineBuildspec(marshaler encoding.BinaryMarshaler, name string) (string, error)
 	WritePipelineManifest(marshaler encoding.BinaryMarshaler, name string) (string, error)
+	Rel(path string) (string, error)
 }
 
 type serviceLister interface {

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -2270,13 +2270,7 @@ func (m *MockwsPipelineIniter) EXPECT() *MockwsPipelineIniterMockRecorder {
 	return m.recorder
 }
 
-// Rel mocks base method.
-func (m *MockwsPipelineWriter) Rel(path string) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Rel", path)
-	ret0, _ := ret[0].(string)
-
-  // ListPipelines mocks base method.
+// ListPipelines mocks base method.
 func (m *MockwsPipelineIniter) ListPipelines() ([]workspace.PipelineManifest, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListPipelines")
@@ -2285,15 +2279,25 @@ func (m *MockwsPipelineIniter) ListPipelines() ([]workspace.PipelineManifest, er
 	return ret0, ret1
 }
 
-// Rel indicates an expected call of Rel.
-func (mr *MockwsPipelineWriterMockRecorder) Rel(path interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Rel", reflect.TypeOf((*MockwsPipelineWriter)(nil).Rel), path)
-
-  // ListPipelines indicates an expected call of ListPipelines.
+// ListPipelines indicates an expected call of ListPipelines.
 func (mr *MockwsPipelineIniterMockRecorder) ListPipelines() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPipelines", reflect.TypeOf((*MockwsPipelineIniter)(nil).ListPipelines))
+}
+
+// Rel mocks base method.
+func (m *MockwsPipelineIniter) Rel(path string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Rel", path)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Rel indicates an expected call of Rel.
+func (mr *MockwsPipelineIniterMockRecorder) Rel(path interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Rel", reflect.TypeOf((*MockwsPipelineIniter)(nil).Rel), path)
 }
 
 // WritePipelineBuildspec mocks base method.

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -2270,6 +2270,21 @@ func (m *MockwsPipelineWriter) EXPECT() *MockwsPipelineWriterMockRecorder {
 	return m.recorder
 }
 
+// Rel mocks base method.
+func (m *MockwsPipelineWriter) Rel(path string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Rel", path)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Rel indicates an expected call of Rel.
+func (mr *MockwsPipelineWriterMockRecorder) Rel(path interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Rel", reflect.TypeOf((*MockwsPipelineWriter)(nil).Rel), path)
+}
+
 // WritePipelineBuildspec mocks base method.
 func (m *MockwsPipelineWriter) WritePipelineBuildspec(marshaler encoding.BinaryMarshaler, name string) (string, error) {
 	m.ctrl.T.Helper()

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -2784,6 +2784,21 @@ func (mr *MockwsPipelineReaderMockRecorder) ReadPipelineManifest(path interface{
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadPipelineManifest", reflect.TypeOf((*MockwsPipelineReader)(nil).ReadPipelineManifest), path)
 }
 
+// Rel mocks base method.
+func (m *MockwsPipelineReader) Rel(path string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Rel", path)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Rel indicates an expected call of Rel.
+func (mr *MockwsPipelineReaderMockRecorder) Rel(path interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Rel", reflect.TypeOf((*MockwsPipelineReader)(nil).Rel), path)
+}
+
 // MockwsPipelineGetter is a mock of wsPipelineGetter interface.
 type MockwsPipelineGetter struct {
 	ctrl     *gomock.Controller

--- a/internal/pkg/cli/pipeline_deploy.go
+++ b/internal/pkg/cli/pipeline_deploy.go
@@ -212,9 +212,9 @@ func (o *deployPipelineOpts) Execute() error {
 	o.shouldPromptUpdateConnection = bool
 
 	// Convert full manifest path to relative path.
-	relPath, err := relPath(o.pipeline.Path)
+	relPath, err := o.ws.Rel(o.pipeline.Path)
 	if err != nil {
-		return fmt.Errorf("convert pipeline manifest path: %w", err)
+		return err
 	}
 
 	// Convert environments to deployment stages.

--- a/internal/pkg/cli/pipeline_deploy.go
+++ b/internal/pkg/cli/pipeline_deploy.go
@@ -211,7 +211,7 @@ func (o *deployPipelineOpts) Execute() error {
 	}
 	o.shouldPromptUpdateConnection = bool
 
-	// Convert full manifest path to relative path.
+	// Convert full manifest path to relative path from workspace root.
 	relPath, err := o.ws.Rel(o.pipeline.Path)
 	if err != nil {
 		return err

--- a/internal/pkg/cli/pipeline_deploy.go
+++ b/internal/pkg/cli/pipeline_deploy.go
@@ -226,7 +226,7 @@ func (o *deployPipelineOpts) Execute() error {
 		AppName:         o.appName,
 		Name:            pipeline.Name,
 		Source:          source,
-		Build:           deploy.PipelineBuildFromManifest(pipeline.Build),
+		Build:           deploy.PipelineBuildFromManifest(pipeline.Build, pipeline.Name),
 		Stages:          stages,
 		ArtifactBuckets: artifactBuckets,
 		AdditionalTags:  o.app.Tags,

--- a/internal/pkg/cli/pipeline_deploy_test.go
+++ b/internal/pkg/cli/pipeline_deploy_test.go
@@ -235,6 +235,7 @@ func TestDeployPipelineOpts_Execute(t *testing.T) {
 					m.deployer.EXPECT().AddPipelineResourcesToApp(&app, region).Return(nil),
 					m.prog.EXPECT().Stop(log.Ssuccessf(fmtPipelineDeployResourcesComplete, appName)).Times(1),
 					m.ws.EXPECT().ReadPipelineManifest(pipelineManifestPath).Return(mockPipelineManifest, nil),
+					m.ws.EXPECT().Rel(pipelineManifestPath),
 					m.actionCmd.EXPECT().Execute().Times(2),
 
 					// convertStages
@@ -264,6 +265,7 @@ func TestDeployPipelineOpts_Execute(t *testing.T) {
 					m.deployer.EXPECT().AddPipelineResourcesToApp(&app, region).Return(nil),
 					m.prog.EXPECT().Stop(log.Ssuccessf(fmtPipelineDeployResourcesComplete, appName)).Times(1),
 					m.ws.EXPECT().ReadPipelineManifest(pipelineManifestPath).Return(mockPipelineManifest, nil),
+					m.ws.EXPECT().Rel(pipelineManifestPath).Times(1),
 					m.actionCmd.EXPECT().Execute().Times(2),
 
 					// convertStages
@@ -294,6 +296,7 @@ func TestDeployPipelineOpts_Execute(t *testing.T) {
 					m.deployer.EXPECT().AddPipelineResourcesToApp(&app, region).Return(nil),
 					m.prog.EXPECT().Stop(log.Ssuccessf(fmtPipelineDeployResourcesComplete, appName)).Times(1),
 					m.ws.EXPECT().ReadPipelineManifest(pipelineManifestPath).Return(mockPipelineManifest, nil),
+					m.ws.EXPECT().Rel(pipelineManifestPath).Times(1),
 					m.actionCmd.EXPECT().Execute().Times(2),
 
 					// convertStages
@@ -321,6 +324,7 @@ func TestDeployPipelineOpts_Execute(t *testing.T) {
 					m.deployer.EXPECT().AddPipelineResourcesToApp(&app, region).Return(nil),
 					m.prog.EXPECT().Stop(log.Ssuccessf(fmtPipelineDeployResourcesComplete, appName)).Times(1),
 					m.ws.EXPECT().ReadPipelineManifest(pipelineManifestPath).Return(mockPipelineManifest, nil),
+					m.ws.EXPECT().Rel(pipelineManifestPath).Times(1),
 					m.actionCmd.EXPECT().Execute().Times(2),
 
 					// convertStages
@@ -440,6 +444,7 @@ func TestDeployPipelineOpts_Execute(t *testing.T) {
 					m.deployer.EXPECT().AddPipelineResourcesToApp(&app, region).Return(nil),
 					m.prog.EXPECT().Stop(log.Ssuccessf(fmtPipelineDeployResourcesComplete, appName)).Times(1),
 					m.ws.EXPECT().ReadPipelineManifest(pipelineManifestPath).Return(mockPipelineManifest, nil),
+					m.ws.EXPECT().Rel(pipelineManifestPath).Times(1),
 					m.actionCmd.EXPECT().Execute().Return(errors.New("some error")),
 				)
 			},
@@ -455,6 +460,7 @@ func TestDeployPipelineOpts_Execute(t *testing.T) {
 					m.deployer.EXPECT().AddPipelineResourcesToApp(&app, region).Return(nil),
 					m.prog.EXPECT().Stop(log.Ssuccessf(fmtPipelineDeployResourcesComplete, appName)).Times(1),
 					m.ws.EXPECT().ReadPipelineManifest(pipelineManifestPath).Return(mockPipelineManifest, nil),
+					m.ws.EXPECT().Rel(pipelineManifestPath).Times(1),
 					m.actionCmd.EXPECT().Execute().Times(2),
 
 					// convertStages
@@ -477,6 +483,7 @@ func TestDeployPipelineOpts_Execute(t *testing.T) {
 					m.deployer.EXPECT().AddPipelineResourcesToApp(&app, region).Return(nil),
 					m.prog.EXPECT().Stop(log.Ssuccessf(fmtPipelineDeployResourcesComplete, appName)).Times(1),
 					m.ws.EXPECT().ReadPipelineManifest(pipelineManifestPath).Return(mockPipelineManifest, nil),
+					m.ws.EXPECT().Rel(pipelineManifestPath).Times(1),
 					m.actionCmd.EXPECT().Execute().Times(2),
 
 					// convertStages
@@ -502,6 +509,7 @@ func TestDeployPipelineOpts_Execute(t *testing.T) {
 					m.deployer.EXPECT().AddPipelineResourcesToApp(&app, region).Return(nil),
 					m.prog.EXPECT().Stop(log.Ssuccessf(fmtPipelineDeployResourcesComplete, appName)).Times(1),
 					m.ws.EXPECT().ReadPipelineManifest(pipelineManifestPath).Return(mockPipelineManifest, nil),
+					m.ws.EXPECT().Rel(pipelineManifestPath).Times(1),
 					m.actionCmd.EXPECT().Execute().Times(2),
 
 					// convertStages
@@ -531,6 +539,7 @@ func TestDeployPipelineOpts_Execute(t *testing.T) {
 					m.deployer.EXPECT().AddPipelineResourcesToApp(&app, region).Return(nil),
 					m.prog.EXPECT().Stop(log.Ssuccessf(fmtPipelineDeployResourcesComplete, appName)).Times(1),
 					m.ws.EXPECT().ReadPipelineManifest(pipelineManifestPath).Return(mockPipelineManifest, nil),
+					m.ws.EXPECT().Rel(pipelineManifestPath).Times(1),
 					m.actionCmd.EXPECT().Execute().Times(2),
 
 					// convertStages
@@ -586,6 +595,7 @@ func TestDeployPipelineOpts_Execute(t *testing.T) {
 					m.deployer.EXPECT().AddPipelineResourcesToApp(&app, region).Return(nil),
 					m.prog.EXPECT().Stop(log.Ssuccessf(fmtPipelineDeployResourcesComplete, appName)).Times(1),
 					m.ws.EXPECT().ReadPipelineManifest(pipelineManifestPath).Return(mockPipelineManifest, nil),
+					m.ws.EXPECT().Rel(pipelineManifestPath).Times(1),
 					m.actionCmd.EXPECT().Execute().Times(2),
 
 					// convertStages

--- a/internal/pkg/cli/pipeline_deploy_test.go
+++ b/internal/pkg/cli/pipeline_deploy_test.go
@@ -168,7 +168,8 @@ func TestDeployPipelineOpts_Execute(t *testing.T) {
 		region               = "us-west-2"
 		accountID            = "123456789012"
 		pipelineName         = "pipepiper"
-		pipelineManifestPath = "/copilot/pipelines/pipepiper/manifest.yml"
+		pipelineManifestPath = "someStuff/someMoreStuff/aws-copilot-sample-service/copilot/pipelines/pipepiper/manifest.yml"
+		relativePath         = "/copilot/pipelines/pipepiper/manifest.yml"
 	)
 	mockPipelineManifest := &manifest.Pipeline{
 		Name:    "pipepiper",
@@ -235,7 +236,7 @@ func TestDeployPipelineOpts_Execute(t *testing.T) {
 					m.deployer.EXPECT().AddPipelineResourcesToApp(&app, region).Return(nil),
 					m.prog.EXPECT().Stop(log.Ssuccessf(fmtPipelineDeployResourcesComplete, appName)).Times(1),
 					m.ws.EXPECT().ReadPipelineManifest(pipelineManifestPath).Return(mockPipelineManifest, nil),
-					m.ws.EXPECT().Rel(pipelineManifestPath),
+					m.ws.EXPECT().Rel(pipelineManifestPath).Return(relativePath, nil),
 					m.actionCmd.EXPECT().Execute().Times(2),
 
 					// convertStages
@@ -265,7 +266,7 @@ func TestDeployPipelineOpts_Execute(t *testing.T) {
 					m.deployer.EXPECT().AddPipelineResourcesToApp(&app, region).Return(nil),
 					m.prog.EXPECT().Stop(log.Ssuccessf(fmtPipelineDeployResourcesComplete, appName)).Times(1),
 					m.ws.EXPECT().ReadPipelineManifest(pipelineManifestPath).Return(mockPipelineManifest, nil),
-					m.ws.EXPECT().Rel(pipelineManifestPath).Times(1),
+					m.ws.EXPECT().Rel(pipelineManifestPath).Return(relativePath, nil),
 					m.actionCmd.EXPECT().Execute().Times(2),
 
 					// convertStages
@@ -296,7 +297,7 @@ func TestDeployPipelineOpts_Execute(t *testing.T) {
 					m.deployer.EXPECT().AddPipelineResourcesToApp(&app, region).Return(nil),
 					m.prog.EXPECT().Stop(log.Ssuccessf(fmtPipelineDeployResourcesComplete, appName)).Times(1),
 					m.ws.EXPECT().ReadPipelineManifest(pipelineManifestPath).Return(mockPipelineManifest, nil),
-					m.ws.EXPECT().Rel(pipelineManifestPath).Times(1),
+					m.ws.EXPECT().Rel(pipelineManifestPath).Return(relativePath, nil),
 					m.actionCmd.EXPECT().Execute().Times(2),
 
 					// convertStages
@@ -324,7 +325,7 @@ func TestDeployPipelineOpts_Execute(t *testing.T) {
 					m.deployer.EXPECT().AddPipelineResourcesToApp(&app, region).Return(nil),
 					m.prog.EXPECT().Stop(log.Ssuccessf(fmtPipelineDeployResourcesComplete, appName)).Times(1),
 					m.ws.EXPECT().ReadPipelineManifest(pipelineManifestPath).Return(mockPipelineManifest, nil),
-					m.ws.EXPECT().Rel(pipelineManifestPath).Times(1),
+					m.ws.EXPECT().Rel(pipelineManifestPath).Return(relativePath, nil),
 					m.actionCmd.EXPECT().Execute().Times(2),
 
 					// convertStages
@@ -444,7 +445,7 @@ func TestDeployPipelineOpts_Execute(t *testing.T) {
 					m.deployer.EXPECT().AddPipelineResourcesToApp(&app, region).Return(nil),
 					m.prog.EXPECT().Stop(log.Ssuccessf(fmtPipelineDeployResourcesComplete, appName)).Times(1),
 					m.ws.EXPECT().ReadPipelineManifest(pipelineManifestPath).Return(mockPipelineManifest, nil),
-					m.ws.EXPECT().Rel(pipelineManifestPath).Times(1),
+					m.ws.EXPECT().Rel(pipelineManifestPath).Return(relativePath, nil),
 					m.actionCmd.EXPECT().Execute().Return(errors.New("some error")),
 				)
 			},
@@ -460,7 +461,7 @@ func TestDeployPipelineOpts_Execute(t *testing.T) {
 					m.deployer.EXPECT().AddPipelineResourcesToApp(&app, region).Return(nil),
 					m.prog.EXPECT().Stop(log.Ssuccessf(fmtPipelineDeployResourcesComplete, appName)).Times(1),
 					m.ws.EXPECT().ReadPipelineManifest(pipelineManifestPath).Return(mockPipelineManifest, nil),
-					m.ws.EXPECT().Rel(pipelineManifestPath).Times(1),
+					m.ws.EXPECT().Rel(pipelineManifestPath).Return(relativePath, nil),
 					m.actionCmd.EXPECT().Execute().Times(2),
 
 					// convertStages
@@ -483,7 +484,7 @@ func TestDeployPipelineOpts_Execute(t *testing.T) {
 					m.deployer.EXPECT().AddPipelineResourcesToApp(&app, region).Return(nil),
 					m.prog.EXPECT().Stop(log.Ssuccessf(fmtPipelineDeployResourcesComplete, appName)).Times(1),
 					m.ws.EXPECT().ReadPipelineManifest(pipelineManifestPath).Return(mockPipelineManifest, nil),
-					m.ws.EXPECT().Rel(pipelineManifestPath).Times(1),
+					m.ws.EXPECT().Rel(pipelineManifestPath).Return(relativePath, nil),
 					m.actionCmd.EXPECT().Execute().Times(2),
 
 					// convertStages
@@ -509,7 +510,7 @@ func TestDeployPipelineOpts_Execute(t *testing.T) {
 					m.deployer.EXPECT().AddPipelineResourcesToApp(&app, region).Return(nil),
 					m.prog.EXPECT().Stop(log.Ssuccessf(fmtPipelineDeployResourcesComplete, appName)).Times(1),
 					m.ws.EXPECT().ReadPipelineManifest(pipelineManifestPath).Return(mockPipelineManifest, nil),
-					m.ws.EXPECT().Rel(pipelineManifestPath).Times(1),
+					m.ws.EXPECT().Rel(pipelineManifestPath).Return(relativePath, nil),
 					m.actionCmd.EXPECT().Execute().Times(2),
 
 					// convertStages
@@ -539,7 +540,7 @@ func TestDeployPipelineOpts_Execute(t *testing.T) {
 					m.deployer.EXPECT().AddPipelineResourcesToApp(&app, region).Return(nil),
 					m.prog.EXPECT().Stop(log.Ssuccessf(fmtPipelineDeployResourcesComplete, appName)).Times(1),
 					m.ws.EXPECT().ReadPipelineManifest(pipelineManifestPath).Return(mockPipelineManifest, nil),
-					m.ws.EXPECT().Rel(pipelineManifestPath).Times(1),
+					m.ws.EXPECT().Rel(pipelineManifestPath).Return(relativePath, nil),
 					m.actionCmd.EXPECT().Execute().Times(2),
 
 					// convertStages
@@ -595,7 +596,7 @@ func TestDeployPipelineOpts_Execute(t *testing.T) {
 					m.deployer.EXPECT().AddPipelineResourcesToApp(&app, region).Return(nil),
 					m.prog.EXPECT().Stop(log.Ssuccessf(fmtPipelineDeployResourcesComplete, appName)).Times(1),
 					m.ws.EXPECT().ReadPipelineManifest(pipelineManifestPath).Return(mockPipelineManifest, nil),
-					m.ws.EXPECT().Rel(pipelineManifestPath).Times(1),
+					m.ws.EXPECT().Rel(pipelineManifestPath).Return(relativePath, nil),
 					m.actionCmd.EXPECT().Execute().Times(2),
 
 					// convertStages

--- a/internal/pkg/cli/pipeline_init.go
+++ b/internal/pkg/cli/pipeline_init.go
@@ -583,8 +583,7 @@ func (o *initPipelineOpts) createPipelineManifest() error {
 		manifestExists = true
 		o.manifestPath = e.FileName
 	}
-
-	o.manifestPath, err = relPath(o.manifestPath)
+	o.manifestPath, err = o.workspace.Rel(o.manifestPath)
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/cli/pipeline_init.go
+++ b/internal/pkg/cli/pipeline_init.go
@@ -574,28 +574,26 @@ func (o *initPipelineOpts) createPipelineManifest() error {
 	}
 
 	var manifestExists bool
-	manifestPath, err := o.workspace.WritePipelineManifest(manifest, o.name)
+	o.manifestPath, err = o.workspace.WritePipelineManifest(manifest, o.name)
 	if err != nil {
 		e, ok := err.(*workspace.ErrFileExists)
 		if !ok {
 			return fmt.Errorf("write pipeline manifest to workspace: %w", err)
 		}
 		manifestExists = true
-		manifestPath = e.FileName
+		o.manifestPath = e.FileName
 	}
 
-	manifestPath, err = relPath(manifestPath)
+	o.manifestPath, err = relPath(o.manifestPath)
 	if err != nil {
 		return err
 	}
-
-	o.manifestPath = manifestPath
 
 	manifestMsgFmt := "Wrote the pipeline manifest for %s at '%s'\n"
 	if manifestExists {
 		manifestMsgFmt = "Pipeline manifest file for %s already exists at %s, skipping writing it.\n"
 	}
-	log.Successf(manifestMsgFmt, color.HighlightUserInput(o.repoName), color.HighlightResource(manifestPath))
+	log.Successf(manifestMsgFmt, color.HighlightUserInput(o.repoName), color.HighlightResource(o.manifestPath))
 	log.Infof(`The manifest contains configurations for your CodePipeline resources, such as your pipeline stages and build steps.
 Update the file to add additional stages, change the branch to be tracked, or add test commands or manual approval actions.
 `)

--- a/internal/pkg/cli/pipeline_init_test.go
+++ b/internal/pkg/cli/pipeline_init_test.go
@@ -381,8 +381,8 @@ func TestInitPipelineOpts_Ask(t *testing.T) {
 func TestInitPipelineOpts_Execute(t *testing.T) {
 	const (
 		wantedName          = "mypipe"
-		wantedManifestFile  = "/piplines/mypipe/manifest.yml"
-		wantedBuildspecFile = "/piplines/mypipe/buildspec.yml"
+		wantedManifestFile  = "/pipelines/mypipe/manifest.yml"
+		wantedBuildspecFile = "/pipelines/mypipe/buildspec.yml"
 	)
 
 	buildspecExistsErr := &workspace.ErrFileExists{FileName: wantedBuildspecFile}
@@ -886,7 +886,6 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 			inEnvConfigs: []*config.Environment{
 				{
 					Name: "test",
-					Prod: false,
 				},
 			},
 			inGitHubToken: "hunter2",

--- a/internal/pkg/cli/pipeline_init_test.go
+++ b/internal/pkg/cli/pipeline_init_test.go
@@ -383,6 +383,7 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 		wantedName          = "mypipe"
 		wantedManifestFile  = "/pipelines/mypipe/manifest.yml"
 		wantedBuildspecFile = "/pipelines/mypipe/buildspec.yml"
+		wantedRelativePath  = "/copilot/pipelines/mypipe/manifest.yml"
 	)
 
 	buildspecExistsErr := &workspace.ErrFileExists{FileName: wantedBuildspecFile}
@@ -422,6 +423,7 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 			mockWsWriter: func(m *mocks.MockwsPipelineWriter) {
 				m.EXPECT().WritePipelineManifest(gomock.Any(), wantedName).Return(wantedManifestFile, nil)
 				m.EXPECT().WritePipelineBuildspec(gomock.Any(), wantedName).Return(wantedBuildspecFile, nil)
+				m.EXPECT().Rel(wantedManifestFile).Return(wantedRelativePath, nil)
 			},
 			mockParser: func(m *templatemocks.MockParser) {
 				m.EXPECT().Parse(buildspecTemplatePath, gomock.Any()).Return(&template.Content{
@@ -464,6 +466,7 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 			mockWsWriter: func(m *mocks.MockwsPipelineWriter) {
 				m.EXPECT().WritePipelineManifest(gomock.Any(), wantedName).Return(wantedManifestFile, nil)
 				m.EXPECT().WritePipelineBuildspec(gomock.Any(), wantedName).Return(wantedBuildspecFile, nil)
+				m.EXPECT().Rel(wantedManifestFile).Return(wantedRelativePath, nil)
 			},
 			mockParser: func(m *templatemocks.MockParser) {
 				m.EXPECT().Parse(buildspecTemplatePath, gomock.Any()).Return(&template.Content{
@@ -508,6 +511,7 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 			mockWsWriter: func(m *mocks.MockwsPipelineWriter) {
 				m.EXPECT().WritePipelineManifest(gomock.Any(), wantedName).Return(wantedManifestFile, nil)
 				m.EXPECT().WritePipelineBuildspec(gomock.Any(), wantedName).Return(wantedBuildspecFile, nil)
+				m.EXPECT().Rel(wantedManifestFile).Return(wantedRelativePath, nil)
 			},
 			mockParser: func(m *templatemocks.MockParser) {
 				m.EXPECT().Parse(buildspecTemplatePath, gomock.Any()).Return(&template.Content{
@@ -549,6 +553,7 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 			mockWsWriter: func(m *mocks.MockwsPipelineWriter) {
 				m.EXPECT().WritePipelineManifest(gomock.Any(), wantedName).Return(wantedManifestFile, nil)
 				m.EXPECT().WritePipelineBuildspec(gomock.Any(), wantedName).Return(wantedBuildspecFile, nil)
+				m.EXPECT().Rel(wantedManifestFile).Return(wantedRelativePath, nil)
 			},
 			mockParser: func(m *templatemocks.MockParser) {
 				m.EXPECT().Parse(buildspecTemplatePath, gomock.Any()).Return(&template.Content{
@@ -590,6 +595,7 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 			mockWsWriter: func(m *mocks.MockwsPipelineWriter) {
 				m.EXPECT().WritePipelineManifest(gomock.Any(), wantedName).Return(wantedManifestFile, nil)
 				m.EXPECT().WritePipelineBuildspec(gomock.Any(), wantedName).Return(wantedBuildspecFile, nil)
+				m.EXPECT().Rel(wantedManifestFile).Return(wantedRelativePath, nil)
 			},
 			mockParser: func(m *templatemocks.MockParser) {
 				m.EXPECT().Parse(buildspecTemplatePath, gomock.Any()).Return(&template.Content{
@@ -638,6 +644,7 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 			mockWsWriter: func(m *mocks.MockwsPipelineWriter) {
 				m.EXPECT().WritePipelineManifest(gomock.Any(), wantedName).Return(wantedManifestFile, nil)
 				m.EXPECT().WritePipelineBuildspec(gomock.Any(), wantedName).Return(wantedBuildspecFile, nil)
+				m.EXPECT().Rel(wantedManifestFile).Return(wantedRelativePath, nil)
 			},
 			mockParser: func(m *templatemocks.MockParser) {
 				m.EXPECT().Parse(buildspecTemplatePath, gomock.Any()).Return(&template.Content{
@@ -683,6 +690,7 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 			mockWsWriter: func(m *mocks.MockwsPipelineWriter) {
 				m.EXPECT().WritePipelineManifest(gomock.Any(), wantedName).Return(wantedManifestFile, nil)
 				m.EXPECT().WritePipelineBuildspec(gomock.Any(), wantedName).Return(wantedBuildspecFile, nil)
+				m.EXPECT().Rel(wantedManifestFile).Return(wantedRelativePath, nil)
 			},
 			mockParser: func(m *templatemocks.MockParser) {
 				m.EXPECT().Parse(buildspecTemplatePath, gomock.Any()).Return(&template.Content{
@@ -715,7 +723,6 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 			inEnvConfigs: []*config.Environment{
 				{
 					Name: "test",
-					Prod: false,
 				},
 			},
 			inGitHubToken: "hunter2",
@@ -752,6 +759,7 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 			},
 			mockWsWriter: func(m *mocks.MockwsPipelineWriter) {
 				m.EXPECT().WritePipelineManifest(gomock.Any(), wantedName).Return(wantedManifestFile, nil)
+				m.EXPECT().Rel(wantedManifestFile).Return(wantedRelativePath, nil)
 			},
 			mockParser: func(m *templatemocks.MockParser) {},
 			mockStoreSvc: func(m *mocks.Mockstore) {
@@ -779,6 +787,7 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 			},
 			mockWsWriter: func(m *mocks.MockwsPipelineWriter) {
 				m.EXPECT().WritePipelineManifest(gomock.Any(), wantedName).Return(wantedManifestFile, nil)
+				m.EXPECT().Rel(wantedManifestFile).Return(wantedRelativePath, nil)
 			},
 			mockParser: func(m *templatemocks.MockParser) {},
 			mockStoreSvc: func(m *mocks.Mockstore) {
@@ -813,6 +822,7 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 			mockWsWriter: func(m *mocks.MockwsPipelineWriter) {
 				m.EXPECT().WritePipelineManifest(gomock.Any(), wantedName).Return(wantedManifestFile, nil)
 				m.EXPECT().WritePipelineBuildspec(gomock.Any(), wantedName).Times(0)
+				m.EXPECT().Rel(wantedManifestFile).Return(wantedRelativePath, nil)
 			},
 			mockParser: func(m *templatemocks.MockParser) {
 				m.EXPECT().Parse(buildspecTemplatePath, gomock.Any()).Return(nil, errors.New("some error"))
@@ -854,6 +864,7 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 			mockWsWriter: func(m *mocks.MockwsPipelineWriter) {
 				m.EXPECT().WritePipelineManifest(gomock.Any(), wantedName).Return("", manifestExistsErr)
 				m.EXPECT().WritePipelineBuildspec(gomock.Any(), wantedName).Return("", buildspecExistsErr)
+				m.EXPECT().Rel(wantedManifestFile).Return(wantedRelativePath, nil)
 			},
 			mockParser: func(m *templatemocks.MockParser) {
 				m.EXPECT().Parse(buildspecTemplatePath, gomock.Any()).Return(&template.Content{
@@ -897,6 +908,7 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 			},
 			mockWsWriter: func(m *mocks.MockwsPipelineWriter) {
 				m.EXPECT().WritePipelineManifest(gomock.Any(), wantedName).Return(wantedManifestFile, nil)
+				m.EXPECT().Rel(wantedManifestFile).Return(wantedRelativePath, nil)
 				m.EXPECT().WritePipelineBuildspec(gomock.Any(), wantedName).Return("", errors.New("some error"))
 			},
 			mockParser: func(m *templatemocks.MockParser) {

--- a/internal/pkg/deploy/cloudformation/stack/bb_pipeline_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/bb_pipeline_integration_test.go
@@ -30,7 +30,7 @@ func TestBB_Pipeline_Template(t *testing.T) {
 			Branch:               "main",
 			OutputArtifactFormat: "CODEBUILD_CLONE_REF",
 		},
-		Build: deploy.PipelineBuildFromManifest(nil, "phonetool-pipeline"),
+		Build: deploy.PipelineBuildFromManifest(nil, "copilot/pipelines/phonetool-pipeline/"),
 		Stages: []deploy.PipelineStage{
 			{
 				AssociatedEnvironment: &deploy.AssociatedEnvironment{

--- a/internal/pkg/deploy/cloudformation/stack/bb_pipeline_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/bb_pipeline_integration_test.go
@@ -30,7 +30,7 @@ func TestBB_Pipeline_Template(t *testing.T) {
 			Branch:               "main",
 			OutputArtifactFormat: "CODEBUILD_CLONE_REF",
 		},
-		Build: deploy.PipelineBuildFromManifest(nil),
+		Build: deploy.PipelineBuildFromManifest(nil, "phonetool-pipeline"),
 		Stages: []deploy.PipelineStage{
 			{
 				AssociatedEnvironment: &deploy.AssociatedEnvironment{

--- a/internal/pkg/deploy/cloudformation/stack/cc_pipeline_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/cc_pipeline_integration_test.go
@@ -30,7 +30,7 @@ func TestCC_Pipeline_Template(t *testing.T) {
 			Branch:               "main",
 			OutputArtifactFormat: "CODEBUILD_CLONE_REF",
 		},
-		Build: deploy.PipelineBuildFromManifest(nil),
+		Build: deploy.PipelineBuildFromManifest(nil, "phonetool-pipeline"),
 		Stages: []deploy.PipelineStage{
 			{
 				AssociatedEnvironment: &deploy.AssociatedEnvironment{

--- a/internal/pkg/deploy/cloudformation/stack/cc_pipeline_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/cc_pipeline_integration_test.go
@@ -30,7 +30,7 @@ func TestCC_Pipeline_Template(t *testing.T) {
 			Branch:               "main",
 			OutputArtifactFormat: "CODEBUILD_CLONE_REF",
 		},
-		Build: deploy.PipelineBuildFromManifest(nil, "phonetool-pipeline"),
+		Build: deploy.PipelineBuildFromManifest(nil, "copilot/pipelines/phonetool-pipeline/"),
 		Stages: []deploy.PipelineStage{
 			{
 				AssociatedEnvironment: &deploy.AssociatedEnvironment{

--- a/internal/pkg/deploy/cloudformation/stack/gh_pipeline_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/gh_pipeline_integration_test.go
@@ -29,7 +29,7 @@ func TestGHPipeline_Template(t *testing.T) {
 			RepositoryURL: "https://github.com/aws/phonetool",
 			Branch:        "mainline",
 		},
-		Build: deploy.PipelineBuildFromManifest(nil, "phonetool-pipeline"),
+		Build: deploy.PipelineBuildFromManifest(nil, "copilot/pipelines/phonetool-pipeline/"),
 		Stages: []deploy.PipelineStage{
 			{
 				AssociatedEnvironment: &deploy.AssociatedEnvironment{

--- a/internal/pkg/deploy/cloudformation/stack/gh_pipeline_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/gh_pipeline_integration_test.go
@@ -29,7 +29,7 @@ func TestGHPipeline_Template(t *testing.T) {
 			RepositoryURL: "https://github.com/aws/phonetool",
 			Branch:        "mainline",
 		},
-		Build: deploy.PipelineBuildFromManifest(nil),
+		Build: deploy.PipelineBuildFromManifest(nil, "phonetool-pipeline"),
 		Stages: []deploy.PipelineStage{
 			{
 				AssociatedEnvironment: &deploy.AssociatedEnvironment{

--- a/internal/pkg/deploy/cloudformation/stack/ghv1_pipeline_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/ghv1_pipeline_integration_test.go
@@ -30,6 +30,7 @@ func TestGHv1Pipeline_Template(t *testing.T) {
 		Build: &deploy.Build{
 			Image:           "aws/codebuild/amazonlinux2-x86_64-standard:3.0",
 			EnvironmentType: "LINUX_CONTAINER",
+			BuildspecPath:   "copilot/buildspec.yml",
 		},
 		Stages: []deploy.PipelineStage{
 			{

--- a/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/bb_template.yaml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/bb_template.yaml
@@ -131,7 +131,7 @@ Resources:
             Value: !Ref AWS::Partition
       Source:
         Type: CODEPIPELINE
-        BuildSpec: copilot/buildspec.yml
+        BuildSpec: copilot/pipelines/phonetool-pipeline/buildspec.yml
       TimeoutInMinutes: 60
   PipelineRole:
     Type: AWS::IAM::Role

--- a/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/cc_template.yaml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/cc_template.yaml
@@ -126,7 +126,7 @@ Resources:
             Value: !Ref AWS::Partition
       Source:
         Type: CODEPIPELINE
-        BuildSpec: copilot/buildspec.yml
+        BuildSpec: copilot/pipelines/phonetool-pipeline/buildspec.yml
       TimeoutInMinutes: 60
   PipelineRole:
     Type: AWS::IAM::Role

--- a/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/gh_template.yaml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/gh_template.yaml
@@ -127,7 +127,7 @@ Resources:
             Value: !Ref AWS::Partition
       Source:
         Type: CODEPIPELINE
-        BuildSpec: copilot/buildspec.yml
+        BuildSpec: copilot/pipelines/phonetool-pipeline/buildspec.yml
       TimeoutInMinutes: 60
   PipelineRole:
     Type: AWS::IAM::Role

--- a/internal/pkg/deploy/pipeline.go
+++ b/internal/pkg/deploy/pipeline.go
@@ -8,6 +8,7 @@ package deploy
 import (
 	"errors"
 	"fmt"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -20,10 +21,9 @@ import (
 const DefaultPipelineBranch = "main"
 
 const (
-	fmtInvalidRepo                  = "unable to parse the repository from the URL %+v"
-	fmtErrMissingProperty           = "missing `%s` in properties"
-	fmtErrPropertyNotAString        = "property `%s` is not a string"
-	fmtDefaultPipelineBuildspecPath = "copilot/pipelines/%s/buildspec.yml"
+	fmtInvalidRepo           = "unable to parse the repository from the URL %+v"
+	fmtErrMissingProperty    = "missing `%s` in properties"
+	fmtErrPropertyNotAString = "property `%s` is not a string"
 
 	defaultPipelineBuildImage      = "aws/codebuild/amazonlinux2-x86_64-standard:3.0"
 	defaultPipelineEnvironmentType = "LINUX_CONTAINER"
@@ -240,10 +240,10 @@ func PipelineSourceFromManifest(mfSource *manifest.Source) (source interface{}, 
 }
 
 // PipelineBuildFromManifest processes manifest info about the build project settings.
-func PipelineBuildFromManifest(mfBuild *manifest.Build, plName string) (build *Build) {
+func PipelineBuildFromManifest(mfBuild *manifest.Build, mfDirPath string) (build *Build) {
 	image := defaultPipelineBuildImage
 	environmentType := defaultPipelineEnvironmentType
-	path := fmt.Sprintf(fmtDefaultPipelineBuildspecPath, plName)
+	path := filepath.Join(mfDirPath, "buildspec.yml")
 	if mfBuild != nil && mfBuild.Image != "" {
 		image = mfBuild.Image
 	}

--- a/internal/pkg/deploy/pipeline_test.go
+++ b/internal/pkg/deploy/pipeline_test.go
@@ -5,6 +5,7 @@ package deploy
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/aws/copilot-cli/internal/pkg/manifest"
@@ -201,37 +202,44 @@ func TestPipelineBuildFromManifest(t *testing.T) {
 
 	testCases := map[string]struct {
 		mfBuild       *manifest.Build
+		pipelineName  string
 		expectedBuild *Build
 	}{
-		"set default image if not be specified in manifest": {
-			mfBuild: nil,
+		"set default image, env type, and path if not specified in manifest": {
+			mfBuild:      &manifest.Build{},
+			pipelineName: "my-pipeline",
 			expectedBuild: &Build{
 				Image:           defaultImage,
 				EnvironmentType: "LINUX_CONTAINER",
+				BuildspecPath:   fmt.Sprintf(fmtDefaultPipelineBuildspecPath, "my-pipeline"),
 			},
 		},
 		"set image according to manifest": {
 			mfBuild: &manifest.Build{
-				Image: "aws/codebuild/standard:3.0",
+				Image:     "aws/codebuild/standard:3.0",
+				Buildspec: "some/path",
 			},
 			expectedBuild: &Build{
 				Image:           "aws/codebuild/standard:3.0",
 				EnvironmentType: "LINUX_CONTAINER",
+				BuildspecPath:   "some/path",
 			},
 		},
 		"set image according to manifest (ARM based)": {
 			mfBuild: &manifest.Build{
-				Image: "aws/codebuild/amazonlinux2-aarch64-standard:2.0",
+				Image:     "aws/codebuild/amazonlinux2-aarch64-standard:2.0",
+				Buildspec: "some/path",
 			},
 			expectedBuild: &Build{
 				Image:           "aws/codebuild/amazonlinux2-aarch64-standard:2.0",
 				EnvironmentType: "ARM_CONTAINER",
+				BuildspecPath:   "some/path",
 			},
 		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			build := PipelineBuildFromManifest(tc.mfBuild)
+			build := PipelineBuildFromManifest(tc.mfBuild, tc.pipelineName)
 			require.Equal(t, tc.expectedBuild, build, "mismatched build")
 		})
 	}

--- a/internal/pkg/manifest/pipeline.go
+++ b/internal/pkg/manifest/pipeline.go
@@ -13,8 +13,6 @@ import (
 )
 
 const (
-	fmtDefaultPipelineBuildspecPath = "copilot/pipelines/%s/buildspec.yml"
-
 	GithubProviderName     = "GitHub"
 	GithubV1ProviderName   = "GitHubV1"
 	CodeCommitProviderName = "CodeCommit"

--- a/internal/pkg/manifest/pipeline.go
+++ b/internal/pkg/manifest/pipeline.go
@@ -13,6 +13,8 @@ import (
 )
 
 const (
+	fmtDefaultPipelineBuildspecPath = "copilot/pipelines/%s/buildspec.yml"
+
 	GithubProviderName     = "GitHub"
 	GithubV1ProviderName   = "GitHubV1"
 	CodeCommitProviderName = "CodeCommit"
@@ -178,7 +180,8 @@ type Source struct {
 
 // Build defines the build project to build and test image.
 type Build struct {
-	Image string `yaml:"image"`
+	Image     string `yaml:"image"`
+	Buildspec string `yaml:"buildspec"`
 }
 
 // PipelineStage represents a stage in the pipeline manifest

--- a/internal/pkg/manifest/pipeline.go
+++ b/internal/pkg/manifest/pipeline.go
@@ -179,7 +179,7 @@ type Source struct {
 // Build defines the build project to build and test image.
 type Build struct {
 	Image     string `yaml:"image"`
-	Buildspec string `yaml:"buildspec"`
+	Buildspec string `yaml:"buildspec,omitempty"`
 }
 
 // PipelineStage represents a stage in the pipeline manifest

--- a/internal/pkg/template/templates/cicd/buildspec.yml
+++ b/internal/pkg/template/templates/cicd/buildspec.yml
@@ -21,7 +21,7 @@ phases:
       - ls -l
       - export COLOR="false"
       # First, upgrade the cloudformation stack of every environment in the pipeline.
-      - pipeline=$(cat $CODEBUILD_SRC_DIR/copilot/pipeline.yml | ruby -ryaml -rjson -e 'puts JSON.pretty_generate(YAML.load(ARGF))')
+      - pipeline=$(cat $CODEBUILD_SRC_DIR/{{.ManifestPath}} | ruby -ryaml -rjson -e 'puts JSON.pretty_generate(YAML.load(ARGF))')
       - pl_envs=$(echo $pipeline | jq -r '.stages[].name')
       - >
         for pl_env in $pl_envs; do

--- a/internal/pkg/template/templates/cicd/pipeline_cfn.yml
+++ b/internal/pkg/template/templates/cicd/pipeline_cfn.yml
@@ -156,7 +156,7 @@ Resources:
             Value: !Ref AWS::Partition
       Source:
         Type: CODEPIPELINE
-        BuildSpec: copilot/buildspec.yml
+        BuildSpec: {{.Build.BuildspecPath}}
       TimeoutInMinutes: 60
   PipelineRole:
     Type: AWS::IAM::Role

--- a/internal/pkg/workspace/workspace.go
+++ b/internal/pkg/workspace/workspace.go
@@ -460,6 +460,15 @@ func (ws *Workspace) Path() (string, error) {
 	return filepath.Dir(copilotDirPath), nil
 }
 
+// Rel returns the path relative to the workspace root.
+func (ws *Workspace) Rel(fullPath string) (string, error) {
+	copiDir, err := ws.copilotDirPath()
+	if err != nil {
+		return "", fmt.Errorf("get path to Copilot dir: %w", err)
+	}
+	return filepath.Rel(filepath.Dir(copiDir), fullPath)
+}
+
 func (ws *Workspace) copilotDirPath() (string, error) {
 	if ws.copilotDir != "" {
 		return ws.copilotDir, nil


### PR DESCRIPTION
These changes point the buildspec to the pipeline manifest, whether it's at a legacy location or name-specific location, and also point the pipeline cfn template to the buildspec, whether it's at a legacy or location or a name-specific location. 

An added bonus is that users may indicate, in their pipeline manifests, paths to custom buildspecs.
```
build:
  buildspec: a/path/to/a/different/buildspec.yml
```   

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
