### PR TITLE
docs: add missing docs for 1.16

### DIFF
--- a/internal/pkg/cli/flag.go
+++ b/internal/pkg/cli/flag.go
@@ -162,8 +162,7 @@ Cannot be specified with '%s', '%s' or '%s'.`, appFlag, envFlag, taskDefaultFlag
 This flag is useful only when '%s' flag is specified`, secretsFlag)
 	subnetsFlagDescription = fmt.Sprintf(`Optional. The subnet IDs for the task to use. Can be specified multiple times.
 Cannot be specified with '%s', '%s' or '%s'.`, appFlag, envFlag, taskDefaultFlag)
-	securityGroupsFlagDescription = fmt.Sprintf(`Optional. The security group IDs for the task to use. Can be specified multiple times.
-Cannot be specified with '%s' or '%s'.`, appFlag, envFlag)
+	securityGroupsFlagDescription = "Optional. Additional security group IDs for the task to use. Can be specified multiple times."
 	taskRunDefaultFlagDescription = fmt.Sprintf(`Optional. Run tasks in default cluster and default subnets. 
 Cannot be specified with '%s', '%s' or '%s'.`, appFlag, envFlag, subnetsFlag)
 	taskExecDefaultFlagDescription = fmt.Sprintf(`Optional. Execute commands in running tasks in default cluster and default subnets. 

--- a/internal/pkg/cli/flag.go
+++ b/internal/pkg/cli/flag.go
@@ -144,11 +144,11 @@ var (
 	svcTypeFlagDescription = fmt.Sprintf(`Type of service to create. Must be one of:
 %s.`, strings.Join(template.QuoteSliceFunc(manifest.ServiceTypes()), ", "))
 	imageFlagDescription = fmt.Sprintf(`The location of an existing Docker image.
-Mutually exclusive with -%s, --%s.`, dockerFileFlagShort, dockerFileFlag)
+Cannot be specified with --%s or --%s.`, dockerFileFlag, dockerFileContextFlag)
 	dockerFileFlagDescription = fmt.Sprintf(`Path to the Dockerfile.
-Mutually exclusive with -%s, --%s.`, imageFlagShort, imageFlag)
+Cannot be specified with --%s.`, imageFlag)
 	dockerFileContextFlagDescription = fmt.Sprintf(`Path to the Docker build context.
-Mutually exclusive with -%s, --%s.`, imageFlagShort, imageFlag)
+Cannot be specified with --%s.`, imageFlag)
 	storageTypeFlagDescription = fmt.Sprintf(`Type of storage to add. Must be one of:
 %s.`, strings.Join(template.QuoteSliceFunc(storageTypes), ", "))
 	jobTypeFlagDescription = fmt.Sprintf(`Type of job to create. Must be one of:
@@ -157,22 +157,22 @@ Mutually exclusive with -%s, --%s.`, imageFlagShort, imageFlag)
 %s.`, strings.Join(template.QuoteSliceFunc(manifest.WorkloadTypes()), ", "))
 
 	clusterFlagDescription = fmt.Sprintf(`Optional. The short name or full ARN of the cluster to run the task in. 
-Cannot be specified with '%s', '%s' or '%s'.`, appFlag, envFlag, taskDefaultFlag)
+Cannot be specified with --%s, --%s or --%s.`, appFlag, envFlag, taskDefaultFlag)
 	acknowledgeSecretsAccessDescription = fmt.Sprintf(`Optional. Skip the confirmation question and grant access to the secrets specified by --secrets flag. 
 This flag is useful only when '%s' flag is specified`, secretsFlag)
 	subnetsFlagDescription = fmt.Sprintf(`Optional. The subnet IDs for the task to use. Can be specified multiple times.
-Cannot be specified with '%s', '%s' or '%s'.`, appFlag, envFlag, taskDefaultFlag)
+Cannot be specified with --%s, --%s or --%s.`, appFlag, envFlag, taskDefaultFlag)
 	securityGroupsFlagDescription = "Optional. Additional security group IDs for the task to use. Can be specified multiple times."
 	taskRunDefaultFlagDescription = fmt.Sprintf(`Optional. Run tasks in default cluster and default subnets. 
-Cannot be specified with '%s', '%s' or '%s'.`, appFlag, envFlag, subnetsFlag)
+Cannot be specified with --%s, --%s or --%s.`, appFlag, envFlag, subnetsFlag)
 	taskExecDefaultFlagDescription = fmt.Sprintf(`Optional. Execute commands in running tasks in default cluster and default subnets. 
-Cannot be specified with '%s' or '%s'.`, appFlag, envFlag)
+Cannot be specified with --%s or --%s.`, appFlag, envFlag)
 	taskDeleteDefaultFlagDescription = fmt.Sprintf(`Optional. Delete a task which was launched in the default cluster and subnets.
-Cannot be specified with '%s' or '%s'.`, appFlag, envFlag)
+Cannot be specified with --%s or --%s.`, appFlag, envFlag)
 	taskEnvFlagDescription = fmt.Sprintf(`Optional. Name of the environment.
-Cannot be specified with '%s', '%s' or '%s'.`, taskDefaultFlag, subnetsFlag, securityGroupsFlag)
+Cannot be specified with --%s, --%s or --%s.`, taskDefaultFlag, subnetsFlag, securityGroupsFlag)
 	taskAppFlagDescription = fmt.Sprintf(`Optional. Name of the application.
-Cannot be specified with '%s', '%s' or '%s'.`, taskDefaultFlag, subnetsFlag, securityGroupsFlag)
+Cannot be specified with --%s, --%s or --%s.`, taskDefaultFlag, subnetsFlag, securityGroupsFlag)
 	osFlagDescription   = fmt.Sprintf(`Optional. Operating system of the task. Must be specified along with '%s'.`, archFlag)
 	archFlagDescription = fmt.Sprintf(`Optional. Architecture of the task. Must be specified along with '%s'.`, osFlag)
 

--- a/site/content/docs/commands/job-package.en.md
+++ b/site/content/docs/commands/job-package.en.md
@@ -16,7 +16,7 @@ $ copilot job package
   -n, --name string         Name of the job.
       --output-dir string   Optional. Writes the stack template and template configuration to a directory.
       --tag string          Optional. The container image tag.
-      --upload-assets    Optional. Whether to upload assets (container images, Lambda functions, etc.).
+      --upload-assets       Optional. Whether to upload assets (container images, Lambda functions, etc.).
                             Uploaded asset locations are filled in the template configuration.
 ```
 

--- a/site/content/docs/commands/svc-package.en.md
+++ b/site/content/docs/commands/svc-package.en.md
@@ -16,7 +16,7 @@ $ copilot svc package
   -n, --name string         Name of the service.
       --output-dir string   Optional. Writes the stack template and template configuration to a directory.
       --tag string          Optional. The service's image tag.
-      --upload-assets    Optional. Whether to upload assets (container images, Lambda functions, etc.).
+      --upload-assets       Optional. Whether to upload assets (container images, Lambda functions, etc.).
                             Uploaded asset locations are filled in the template configuration.
 ```
 

--- a/site/content/docs/commands/task-run.en.md
+++ b/site/content/docs/commands/task-run.en.md
@@ -20,44 +20,59 @@ Generally, the steps involved in task run are:
 
 ## What are the flags?
 ```
-    --app string                     Optional. Name of the application.
-                                     Cannot be specified with 'default', 'subnets' or 'security-groups'.
-    --cluster string                 Optional. The short name or full ARN of the cluster to run the task in.
-    --command string                 Optional. The command that is passed to "docker run" to override the default command.
-    --count int                      Optional. The number of tasks to set up. (default 1)
-    --cpu int                        Optional. The number of CPU units to reserve for each task. (default 256)
-    --default                        Optional. Run tasks in default cluster and default subnets.
-                                     Cannot be specified with 'app', 'env' or 'subnets'.
-    --dockerfile string              Path to the Dockerfile.
-                                     Mutually exclusive with -i,   --image (default "Dockerfile").
-    --entrypoint string              Optional. The entrypoint that is passed to "docker run" to override the default entrypoint.
-    --env string                     Optional. Name of the environment.
-                                     Cannot be specified with 'default', 'subnets' or 'security-groups'.
-    --env-vars stringToString        Optional. Environment variables specified by key=value separated by commas. (default [])
-    --execution-role string          Optional. The role that grants the container agent permission to make AWS API calls.
-    --follow                         Optional. Specifies if the logs should be streamed.
-    --generate-cmd string            Optional. Generate a command with a pre-filled value for each flag.
-                                     To use it for an ECS service, specify --generate-cmd <cluster name>/<service name>.
-                                     Alternatively, if the service or job is created with Copilot, specify --generate-cmd <application>/<environment>/<service or job name>.
-                                     Cannot be specified with any other flags.
--h, --help                           help for run
-    --image string                   The location of an existing Docker image.
-                                     Mutually exclusive with -d,  --dockerfile.
-    --memory int                     Optional. The amount of memory to reserve in MiB for each task. (default 512)
-    --platform-arch string           Optional. Architecture of the task. Must be specified along with 'platform-os'.
-    --platform-os string             Optional. Operating system of the task. Must be specified along with 'platform-arch'.
-    --resource-tags stringToString   Optional. Labels with a key and value separated by commas.
-                                     Allows you to categorize resources. (default [])
-    --secrets stringToString         Optional. Secrets to inject into the container. Specified by key=value separated by commas. (default [])
-    --security-groups strings        Optional. The security group IDs for the task to use. Can be specified multiple times.
-                                     Cannot be specified with 'app' or 'env'.
-    --subnets strings                Optional. The subnet IDs for the task to use. Can be specified multiple times.
-                                     Cannot be specified with 'app', 'env' or 'default'.
-    --tag string                     Optional. The container image tag in addition to "latest".
--n, --task-group-name string         Optional. The group name of the task. Tasks with the same group name share the same set of resources.
-    --task-role string               Optional. The role for the task to use.
+Name Flags
+  -n, --task-group-name string   Optional. The group name of the task. 
+                                 Tasks with the same group name share the same set of resources. 
+                                 (default directory name)
+
+Build Flags
+      --build-context string   Path to the Docker build context.
+                               Mutually exclusive with -i, --image.
+      --dockerfile string      Path to the Dockerfile.
+                               Mutually exclusive with -i, --image. (default "Dockerfile")
+  -i, --image string           The location of an existing Docker image.
+                               Mutually exclusive with -d, --dockerfile.
+      --tag string             Optional. The container image tag in addition to "latest".
+
+Placement Flags
+      --app string                Optional. Name of the application.
+                                  Cannot be specified with 'default', 'subnets' or 'security-groups'.
+      --cluster string            Optional. The short name or full ARN of the cluster to run the task in. 
+                                  Cannot be specified with 'app', 'env' or 'default'.
+      --default                   Optional. Run tasks in default cluster and default subnets. 
+                                  Cannot be specified with 'app', 'env' or 'subnets'.
+      --env string                Optional. Name of the environment.
+                                  Cannot be specified with 'default', 'subnets' or 'security-groups'.
+      --security-groups strings   Optional. Additional security group IDs for the task to use. Can be specified multiple times.
+      --subnets strings           Optional. The subnet IDs for the task to use. Can be specified multiple times.
+                                  Cannot be specified with 'app', 'env' or 'default'.
+
+Task Configuration Flags
+      --acknowledge-secrets-access     Optional. Skip the confirmation question and grant access to the secrets specified by --secrets flag. 
+                                       This flag is useful only when 'secrets' flag is specified
+      --command string                 Optional. The command that is passed to "docker run" to override the default command.
+      --count int                      Optional. The number of tasks to set up. (default 1)
+      --cpu int                        Optional. The number of CPU units to reserve for each task. (default 256)
+      --entrypoint string              Optional. The entrypoint that is passed to "docker run" to override the default entrypoint.
+      --env-vars stringToString        Optional. Environment variables specified by key=value separated by commas. (default [])
+      --execution-role string          Optional. The ARN of the role that grants the container agent permission to make AWS API calls.
+      --memory int                     Optional. The amount of memory to reserve in MiB for each task. (default 512)
+      --platform-arch string           Optional. Architecture of the task. Must be specified along with 'platform-os'.
+      --platform-os string             Optional. Operating system of the task. Must be specified along with 'platform-arch'.
+      --resource-tags stringToString   Optional. Labels with a key and value separated by commas.
+                                       Allows you to categorize resources. (default [])
+      --secrets stringToString         Optional. Secrets to inject into the container. Specified by key=value separated by commas. (default [])
+      --task-role string               Optional. The ARN of the role for the task to use.
+
+Utility Flags
+      --follow                Optional. Specifies if the logs should be streamed.
+      --generate-cmd string   Optional. Generate a command with a pre-filled value for each flag.
+                              To use it for an ECS service, specify --generate-cmd <cluster name>/<service name>.
+                              Alternatively, if the service or job is created with Copilot, specify --generate-cmd <application>/<environment>/<service or job name>.
+                              Cannot be specified with any other flags.
 ```
-## Example
+
+## Examples
 Run a task using your local Dockerfile and display log streams after the task is running. 
 You will be prompted to specify an environment for the tasks to run in.
 ```

--- a/site/content/docs/commands/task-run.en.md
+++ b/site/content/docs/commands/task-run.en.md
@@ -27,25 +27,25 @@ Name Flags
 
 Build Flags
       --build-context string   Path to the Docker build context.
-                               Mutually exclusive with -i, --image.
+                               Cannot be specified with --image.
       --dockerfile string      Path to the Dockerfile.
-                               Mutually exclusive with -i, --image. (default "Dockerfile")
+                               Cannot be specified with --image. (default "Dockerfile")
   -i, --image string           The location of an existing Docker image.
-                               Mutually exclusive with -d, --dockerfile.
+                               Cannot be specified with --dockerfile or --build-context.
       --tag string             Optional. The container image tag in addition to "latest".
 
 Placement Flags
       --app string                Optional. Name of the application.
-                                  Cannot be specified with 'default', 'subnets' or 'security-groups'.
+                                  Cannot be specified with --default, --subnets or --security-groups.
       --cluster string            Optional. The short name or full ARN of the cluster to run the task in. 
-                                  Cannot be specified with 'app', 'env' or 'default'.
+                                  Cannot be specified with --app, --env or --default.
       --default                   Optional. Run tasks in default cluster and default subnets. 
-                                  Cannot be specified with 'app', 'env' or 'subnets'.
+                                  Cannot be specified with --app, --env or --subnets.
       --env string                Optional. Name of the environment.
-                                  Cannot be specified with 'default', 'subnets' or 'security-groups'.
+                                  Cannot be specified with --default, --subnets or --security-groups.
       --security-groups strings   Optional. Additional security group IDs for the task to use. Can be specified multiple times.
       --subnets strings           Optional. The subnet IDs for the task to use. Can be specified multiple times.
-                                  Cannot be specified with 'app', 'env' or 'default'.
+                                  Cannot be specified with --app, --env or --default.
 
 Task Configuration Flags
       --acknowledge-secrets-access     Optional. Skip the confirmation question and grant access to the secrets specified by --secrets flag. 

--- a/site/content/docs/manifest/backend-service.en.md
+++ b/site/content/docs/manifest/backend-service.en.md
@@ -2,60 +2,60 @@ List of all available properties for a `'Backend Service'` manifest. To learn ab
 
 ???+ note "Sample manifest for an api service"
 
-```yaml
-    # Your service name will be used in naming your resources like log groups, ECS services, etc.
-    name: api
-    type: Backend Service
-
-    # Your service is reachable at "http://api.${COPILOT_SERVICE_DISCOVERY_ENDPOINT}:8080" but is not public.
-
-    # Configuration for your containers and service.
-    image:
-      build: ./api/Dockerfile
-      port: 8080
-      healthcheck:
-        command: ["CMD-SHELL", "curl -f http://localhost:8080 || exit 1"]
-        interval: 10s
-        retries: 2
-        timeout: 5s
-        start_period: 0s
-
-    cpu: 256
-    memory: 512
-    count: 1
-    exec: true
-
-    storage:
-      volumes:
-        myEFSVolume:
-          path: '/etc/mount1'
-          read_only: true
-          efs:
-            id: fs-12345678
-            root_dir: '/'
-            auth:
-              iam: true
-              access_point_id: fsap-12345678
-
-    network:
-      vpc:
-        placement: 'private'
-        security_groups: ['sg-05d7cd12cceeb9a6e']
-
-    variables:
-      LOG_LEVEL: info
-    env_file: log.env
-    secrets:
-      GITHUB_TOKEN: GITHUB_TOKEN
-
-    # You can override any of the values defined above by environment.
-    environments:
-      test:
-        count:
-          spot: 2
-      production:
-        count: 2
-```
+    ```yaml
+        # Your service name will be used in naming your resources like log groups, ECS services, etc.
+        name: api
+        type: Backend Service
+    
+        # Your service is reachable at "http://api.${COPILOT_SERVICE_DISCOVERY_ENDPOINT}:8080" but is not public.
+    
+        # Configuration for your containers and service.
+        image:
+          build: ./api/Dockerfile
+          port: 8080
+          healthcheck:
+            command: ["CMD-SHELL", "curl -f http://localhost:8080 || exit 1"]
+            interval: 10s
+            retries: 2
+            timeout: 5s
+            start_period: 0s
+    
+        cpu: 256
+        memory: 512
+        count: 1
+        exec: true
+    
+        storage:
+          volumes:
+            myEFSVolume:
+              path: '/etc/mount1'
+              read_only: true
+              efs:
+                id: fs-12345678
+                root_dir: '/'
+                auth:
+                  iam: true
+                  access_point_id: fsap-12345678
+    
+        network:
+          vpc:
+            placement: 'private'
+            security_groups: ['sg-05d7cd12cceeb9a6e']
+    
+        variables:
+          LOG_LEVEL: info
+        env_file: log.env
+        secrets:
+          GITHUB_TOKEN: GITHUB_TOKEN
+    
+        # You can override any of the values defined above by environment.
+        environments:
+          test:
+            count:
+              spot: 2
+          production:
+            count: 2
+    ```
 
 <a id="name" href="#name" class="field">`name`</a> <span class="type">String</span>
 The name of your service.

--- a/site/content/docs/manifest/lb-web-service.en.md
+++ b/site/content/docs/manifest/lb-web-service.en.md
@@ -2,67 +2,67 @@ List of all available properties for a `'Load Balanced Web Service'` manifest. T
 
 ???+ note "Sample manifest for a frontend service"
 
-```yaml
-    # Your service name will be used in naming your resources like log groups, ECS services, etc.
-    name: frontend
-    type: Load Balanced Web Service
-
-    # Distribute traffic to your service.
-    http:
-      path: '/'
-      healthcheck:
-        path: '/_healthcheck'
-        success_codes: '200,301'
-        healthy_threshold: 3
-        unhealthy_threshold: 2
-        interval: 15s
-        timeout: 10s
-        grace_period: 45s
-      deregistration_delay: 5s
-      stickiness: false
-      allowed_source_ips: ["10.24.34.0/23"]
-      alias: example.com
-
-    nlb:
-      port: 443/tls
-
-    # Configuration for your containers and service.
-    image:
-      build:
-        dockerfile: ./frontend/Dockerfile
-        context: ./frontend
-      port: 80
-
-    cpu: 256
-    memory: 512
-    count:
-      range: 1-10
-      cpu_percentage: 70
-      memory_percentage: 80
-      requests: 10000
-      response_time: 2s
-    exec: true
-
-    variables:
-      LOG_LEVEL: info
-    env_file: log.env
-    secrets:
-      GITHUB_TOKEN: GITHUB_TOKEN
-
-    # You can override any of the values defined above by environment.
-    environments:
-      test:
+    ```yaml
+        # Your service name will be used in naming your resources like log groups, ECS services, etc.
+        name: frontend
+        type: Load Balanced Web Service
+    
+        # Distribute traffic to your service.
+        http:
+          path: '/'
+          healthcheck:
+            path: '/_healthcheck'
+            success_codes: '200,301'
+            healthy_threshold: 3
+            unhealthy_threshold: 2
+            interval: 15s
+            timeout: 10s
+            grace_period: 45s
+          deregistration_delay: 5s
+          stickiness: false
+          allowed_source_ips: ["10.24.34.0/23"]
+          alias: example.com
+    
+        nlb:
+          port: 443/tls
+    
+        # Configuration for your containers and service.
+        image:
+          build:
+            dockerfile: ./frontend/Dockerfile
+            context: ./frontend
+          port: 80
+    
+        cpu: 256
+        memory: 512
         count:
-          range:
-            min: 1
-            max: 10
-            spot_from: 2
-      staging:
-        count:
-          spot: 2
-      production:
-        count: 2
-```
+          range: 1-10
+          cpu_percentage: 70
+          memory_percentage: 80
+          requests: 10000
+          response_time: 2s
+        exec: true
+    
+        variables:
+          LOG_LEVEL: info
+        env_file: log.env
+        secrets:
+          GITHUB_TOKEN: GITHUB_TOKEN
+    
+        # You can override any of the values defined above by environment.
+        environments:
+          test:
+            count:
+              range:
+                min: 1
+                max: 10
+                spot_from: 2
+          staging:
+            count:
+              spot: 2
+          production:
+            count: 2
+    ```
 
 <a id="name" href="#name" class="field">`name`</a> <span class="type">String</span>  
 The name of your service.

--- a/site/content/docs/manifest/pipeline.en.md
+++ b/site/content/docs/manifest/pipeline.en.md
@@ -3,14 +3,13 @@ List of all available properties for a Copilot pipeline manifest. To learn more 
 ???+ note "Sample manifest for a pipeline triggered from a GitHub repo"
 
     ```yaml
-        name: pipeline-sample-app-frontend
-        version: 1
+        name: frontend
     
         source:
           provider: GitHub
           properties:
             branch: main
-            repository: https://github.com/<user>/sample-app-frontend
+            repository: https://github.com/<user>/frontend
             # Optional: specify the name of an existing CodeStar Connections connection.
             connection_name: a-connection
     

--- a/site/content/docs/manifest/pipeline.en.md
+++ b/site/content/docs/manifest/pipeline.en.md
@@ -2,31 +2,31 @@ List of all available properties for a Copilot pipeline manifest. To learn more 
 
 ???+ note "Sample manifest for a pipeline triggered from a GitHub repo"
 
-```yaml
-    name: pipeline-sample-app-frontend
-    version: 1
-
-    source:
-      provider: GitHub
-      properties:
-        branch: main
-        repository: https://github.com/<user>/sample-app-frontend
-        # Optional: specify the name of an existing CodeStar Connections connection.
-        connection_name: a-connection
-
-    build:
-      image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
-
-    stages:
-        -
-          name: test
-          test_commands:
-            - make test
-            - echo "woo! Tests passed"
-        -
-          name: prod
-          requires_approval: true
-```
+    ```yaml
+        name: pipeline-sample-app-frontend
+        version: 1
+    
+        source:
+          provider: GitHub
+          properties:
+            branch: main
+            repository: https://github.com/<user>/sample-app-frontend
+            # Optional: specify the name of an existing CodeStar Connections connection.
+            connection_name: a-connection
+    
+        build:
+          image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+    
+        stages:
+            -
+              name: test
+              test_commands:
+                - make test
+                - echo "woo! Tests passed"
+            -
+              name: prod
+              requires_approval: true
+    ```
 
 <a id="name" href="#name" class="field">`name`</a> <span class="type">String</span>  
 The name of your pipeline.

--- a/site/content/docs/manifest/rd-web-service.en.md
+++ b/site/content/docs/manifest/rd-web-service.en.md
@@ -2,41 +2,41 @@ List of all available properties for a `'Request-Driven Web Service'` manifest.
 
 ???+ note "Sample manifest for a frontend service"
 
-```yaml
-    # Your service name will be used in naming your resources like log groups, App Runner services, etc.
-    name: frontend
-    type: Request-Driven Web Service
-
-    http:
-      healthcheck:
-        path: '/_healthcheck'
-        healthy_threshold: 3
-        unhealthy_threshold: 5
-        interval: 10s
-        timeout: 5s
-      alias: web.example.com
-
-    # Configuration for your containers and service.
-    image:
-      build: ./frontend/Dockerfile
-      port: 80
-    cpu: 1024
-    memory: 2048
-
-    network:
-      vpc:
-        placement: 'private'
-
-    variables:
-      LOG_LEVEL: info
+    ```yaml
+        # Your service name will be used in naming your resources like log groups, App Runner services, etc.
+        name: frontend
+        type: Request-Driven Web Service
     
-    tags:
-      owner: frontend-team
-
-    environments:
-      test:
-        LOG_LEVEL: debug
-```
+        http:
+          healthcheck:
+            path: '/_healthcheck'
+            healthy_threshold: 3
+            unhealthy_threshold: 5
+            interval: 10s
+            timeout: 5s
+          alias: web.example.com
+    
+        # Configuration for your containers and service.
+        image:
+          build: ./frontend/Dockerfile
+          port: 80
+        cpu: 1024
+        memory: 2048
+    
+        network:
+          vpc:
+            placement: 'private'
+    
+        variables:
+          LOG_LEVEL: info
+        
+        tags:
+          owner: frontend-team
+    
+        environments:
+          test:
+            LOG_LEVEL: debug
+    ```
 
 <a id="name" href="#name" class="field">`name`</a> <span class="type">String</span>  
 The name of your service.

--- a/site/content/docs/manifest/scheduled-job.en.md
+++ b/site/content/docs/manifest/scheduled-job.en.md
@@ -2,34 +2,34 @@ List of all available properties for a `'Scheduled Job'` manifest. To learn abou
 
 ???+ note "Sample manifest for a report generator cronjob"
 
-```yaml
-    # Your job name will be used in naming your resources like log groups, ECS Tasks, etc.
-    name: report-generator
-    type: Scheduled Job
-
-    on:
-      schedule: "@daily"
-    cpu: 256
-    memory: 512
-    retries: 3
-    timeout: 1h
-
-    image:
-      # Path to your service's Dockerfile.
-      build: ./Dockerfile
-
-    variables:
-      LOG_LEVEL: info
-    env_file: log.env
-    secrets:
-      GITHUB_TOKEN: GITHUB_TOKEN
-
-    # You can override any of the values defined above by environment.
-    environments:
-      prod:
-        cpu: 2048               # Larger CPU value for prod environment
-        memory: 4096
-```
+    ```yaml
+        # Your job name will be used in naming your resources like log groups, ECS Tasks, etc.
+        name: report-generator
+        type: Scheduled Job
+    
+        on:
+          schedule: "@daily"
+        cpu: 256
+        memory: 512
+        retries: 3
+        timeout: 1h
+    
+        image:
+          # Path to your service's Dockerfile.
+          build: ./Dockerfile
+    
+        variables:
+          LOG_LEVEL: info
+        env_file: log.env
+        secrets:
+          GITHUB_TOKEN: GITHUB_TOKEN
+    
+        # You can override any of the values defined above by environment.
+        environments:
+          prod:
+            cpu: 2048               # Larger CPU value for prod environment
+            memory: 4096
+    ```
 
 <a id="name" href="#name" class="field">`name`</a> <span class="type">String</span>  
 The name of your job.

--- a/site/content/docs/manifest/worker-service.en.md
+++ b/site/content/docs/manifest/worker-service.en.md
@@ -2,50 +2,53 @@ List of all available properties for a `'Worker Service'` manifest. To learn abo
 
 ???+ note "Sample manifest for a worker service"
 
-```yaml
-    # Your service name will be used in naming your resources like log groups, ECS services, etc.
-    name: orders-worker
-    type: Worker Service
+    ```yaml
+        # Your service name will be used in naming your resources like log groups, ECS services, etc.
+        name: orders-worker
+        type: Worker Service
+    
+        image:
+          build: ./orders/Dockerfile
+    
+        subscribe:
+          topics:
+            - name: events
+              service: api
+              filter_policy:
+                event:
+                - anything-but: order_cancelled
+            - name: events
+              service: fe
+          queue:
+            retention: 96h
+            timeout: 30s
+            dead_letter:
+              tries: 10
+    
+        cpu: 256
+        memory: 512
+        count: 1
+    
+        variables:
+          LOG_LEVEL: info
+        env_file: log.env
+        secrets:
+          GITHUB_TOKEN: GITHUB_TOKEN
+    
+        # You can override any of the values defined above by environment.
+        environments:
+          production:
+            count:
+              range:
+                min: 1
+                max: 50
+                spot_from: 26
+              queue_delay:
+                acceptable_latency: 1m
+                msg_processing_time: 250ms
+    ```
 
-    image:
-      build: ./orders/Dockerfile
-
-    subscribe:
-      topics:
-        - name: events
-          service: api
-        - name: events
-          service: fe
-      queue:
-        retention: 96h
-        timeout: 30s
-        dead_letter:
-          tries: 10
-
-    cpu: 256
-    memory: 512
-    count: 1
-
-    variables:
-      LOG_LEVEL: info
-    env_file: log.env
-    secrets:
-      GITHUB_TOKEN: GITHUB_TOKEN
-
-    # You can override any of the values defined above by environment.
-    environments:
-      production:
-        count:
-          range:
-            min: 1
-            max: 50
-            spot_from: 26
-          queue_delay:
-            acceptable_latency: 1m
-            msg_processing_time: 250ms
-```
-
-<a id="name" href="#name" class="field">`name`</a> <span class="type">String</span>
+<a id="name" href="#name" class="field">`name`</a> <span class="type">String</span>  
 The name of your service.
 
 <div class="separator"></div>
@@ -55,7 +58,7 @@ The architecture type for your service. [Worker Services](../concepts/services.e
 
 <div class="separator"></div>
 
-<a id="subscribe" href="#subscribe" class="field">`subscribe`</a> <span class="type">Map</span>
+<a id="subscribe" href="#subscribe" class="field">`subscribe`</a> <span class="type">Map</span>  
 The `subscribe` section allows worker services to create subscriptions to the SNS topics exposed by other Copilot services in the same application and environment. Each topic can define its own SQS queue, but by default all topics are subscribed to the worker service's default queue.
 
 ```yaml
@@ -73,31 +76,55 @@ subscribe:
     delay: 30s
 ```
 
-<span class="parent-field">subscribe.</span><a id="subscribe-queue" href="#subscribe-queue" class="field">`queue`</a> <span class="type">Map</span>
+<span class="parent-field">subscribe.</span><a id="subscribe-queue" href="#subscribe-queue" class="field">`queue`</a> <span class="type">Map</span>  
 By default, a service level queue is always created. `queue` allows customization of certain attributes of that default queue.
 
-<span class="parent-field">subscribe.queue.</span><a id="subscribe-queue-delay" href="#subscribe-queue-delay" class="field">`delay`</a> <span class="type">Duration</span>
+<span class="parent-field">subscribe.queue.</span><a id="subscribe-queue-delay" href="#subscribe-queue-delay" class="field">`delay`</a> <span class="type">Duration</span>  
 The time in seconds for which the delivery of all messages in the queue is delayed. Default 0s. Range 0s-15m.
 
-<span class="parent-field">subscribe.queue.</span><a id="subscribe-queue-retention" href="#subscribe-queue-retention" class="field">`retention`</a> <span class="type">Duration</span>
+<span class="parent-field">subscribe.queue.</span><a id="subscribe-queue-retention" href="#subscribe-queue-retention" class="field">`retention`</a> <span class="type">Duration</span>  
 Retention specifies the time a message will remain in the queue before being deleted. Default 4d. Range 60s-336h.
 
-<span class="parent-field">subscribe.queue.</span><a id="subscribe-queue-timeout" href="#subscribe-queue-timeout" class="field">`timeout`</a> <span class="type">Duration</span>
+<span class="parent-field">subscribe.queue.</span><a id="subscribe-queue-timeout" href="#subscribe-queue-timeout" class="field">`timeout`</a> <span class="type">Duration</span>  
 Timeout defines the length of time a message is unavailable after being delivered. Default 30s. Range 0s-12h.
 
-<span class="parent-field">subscribe.queue.dead_letter.</span><a id="subscribe-queue-dead-letter-tries" href="#subscribe-queue-dead-letter-tries" class="field">`tries`</a> <span class="type">Integer</span>
+<span class="parent-field">subscribe.queue.dead_letter.</span><a id="subscribe-queue-dead-letter-tries" href="#subscribe-queue-dead-letter-tries" class="field">`tries`</a> <span class="type">Integer</span>  
 If specified, creates a dead letter queue and a redrive policy which routes messages to the DLQ after `tries` attempts. That is, if a worker service fails to process a message successfully `tries` times, it will be routed to the DLQ for examination instead of redriven.
 
-<span class="parent-field">subscribe.</span><a id="subscribe-topics" href="#subscribe-topics" class="field">`topics`</a> <span class="type">Array of `topic`s</span>
+<span class="parent-field">subscribe.</span><a id="subscribe-topics" href="#subscribe-topics" class="field">`topics`</a> <span class="type">Array of `topic`s</span>  
 Contains information about which SNS topics the worker service should subscribe to.
 
-<span class="parent-field">topic.</span><a id="topic-name" href="#topic-name" class="field">`name`</a> <span class="type">String</span>
+<span class="parent-field">topic.</span><a id="topic-name" href="#topic-name" class="field">`name`</a> <span class="type">String</span>  
 Required. The name of the SNS topic to subscribe to.
 
-<span class="parent-field">topic.</span><a id="topic-service" href="#topic-service" class="field">`service`</a> <span class="type">String</span>
+<span class="parent-field">topic.</span><a id="topic-service" href="#topic-service" class="field">`service`</a> <span class="type">String</span>  
 Required. The service this SNS topic is exposed by. Together with the topic name, this uniquely identifies an SNS topic in the copilot environment.
 
-<span class="parent-field">topic.</span><a id="topic-queue" href="#topic-queue" class="field">`queue`</a> <span class="type">Boolean or Map</span>
+<span class="parent-field">topic.</span><a id="topic-filter-policy" href="#topic-filter-policy" class="field">`filter_policy`</a> <span class="type">Map</span>  
+Optional. Specify a SNS subscription filter policy to evaluate incoming message attributes against the policy.  
+The filter policy can be specified in JSON, for example:
+```json 
+filter_policy: {"store":["example_corp"],"event":[{"anything-but":"order_cancelled"}],"customer_interests":["rugby","football","baseball"],"price_usd":[{"numeric":[">=",100]}]}
+```
+or alternatively as a map in YAML:
+```yaml 
+filter_policy:
+  store:
+    - example_corp
+  event:
+    - anything-but: order_cancelled
+  cutomer_interests:
+    - rugby
+    - football
+    - baseball
+  price_usd:
+    - numeric:
+      - ">="
+      - 100
+```
+For additional information on how to write filter policies, see the [SNS documentation](https://docs.aws.amazon.com/sns/latest/dg/sns-subscription-filter-policies.html).
+
+<span class="parent-field">topic.</span><a id="topic-queue" href="#topic-queue" class="field">`queue`</a> <span class="type">Boolean or Map</span>  
 Optional. Specify SQS queue configuration for the topic. If specified as `true`, the queue will be created  with default configuration. Specify this field as a map for customization of certain attributes for this topic-specific queue.
 
 {% include 'image-config.en.md' %}


### PR DESCRIPTION
Add docs for:
- `filter_policy` for worker services
- fmt a bunch of commands by adding appropriate indentation
- update `task run` to remove the restriction of security groups with the `--app` and `--env` flags

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
