### PR TITLE
test(integ): increase timeout duration to 120m from 60m

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ run-integ-test:
 	# Also adding count=1 so the test results aren't cached.
 	# This command also targets files with the build integration tag
 	# and runs tests which end in Integration.
-	go test -race -count=1 -timeout 60m -tags=integration ${PACKAGES}
+	go test -race -count=1 -timeout 120m -tags=integration ${PACKAGES}
 
 .PHONY: local-integ-test
 local-integ-test: package-custom-resources run-local-integ-test package-custom-resources-clean


### PR DESCRIPTION
Integ tests are timing out at 60m from time to time, increase the timeout to 2h.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
