### PR TITLE
build: upgrade to go1.18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
 
       - name: Set up Node
         uses: actions/setup-node@v1
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
 
       - name: Set up Node
         uses: actions/setup-node@v1
@@ -57,7 +57,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
 
       - name: Set up Node
         uses: actions/setup-node@v1
@@ -76,7 +76,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
 
       - name: Check out code
         uses: actions/checkout@v2
@@ -93,7 +93,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
 
       - name: Check out code
         uses: actions/checkout@v2

--- a/.release/buildspec.yml
+++ b/.release/buildspec.yml
@@ -6,8 +6,8 @@ phases:
       nodejs: 12
     commands:
       - 'cd $HOME/.goenv && git pull --ff-only && cd -'
-      - 'goenv install 1.17.1'
-      - 'goenv global 1.17.1'
+      - 'goenv install 1.18.0'
+      - 'goenv global 1.18.0'
   pre_build:
     commands:
       - echo "cd into $CODEBUILD_SRC_DIR"

--- a/.release/buildspec_e2e.yml
+++ b/.release/buildspec_e2e.yml
@@ -136,8 +136,8 @@ phases:
       nodejs: 12
     commands:
       - 'cd $HOME/.goenv && git pull --ff-only && cd -'
-      - 'goenv install 1.17.1'
-      - 'goenv global 1.17.1'
+      - 'goenv install 1.18.0'
+      - 'goenv global 1.18.0'
   pre_build:
     commands:
        - printenv DOCKERHUB_TOKEN | docker login --username ${DOCKERHUB_USERNAME} --password-stdin

--- a/.release/buildspec_integ.yml
+++ b/.release/buildspec_integ.yml
@@ -15,8 +15,8 @@ phases:
       nodejs: 12
     commands:
       - 'cd $HOME/.goenv && git pull --ff-only && cd -'
-      - 'goenv install 1.17.1'
-      - 'goenv global 1.17.1'
+      - 'goenv install 1.18.0'
+      - 'goenv global 1.18.0'
   build:
     commands:
       - echo `git rev-parse HEAD` # Do not delete; for pipeline logging purposes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Please read it over and let us know if it's not up-to-date (or, even better, sub
 
 ### Environment
 
-- Make sure you are using Go 1.17 (`go version`).
+- Make sure you are using Go 1.18 (`go version`).
 - Fork the repository.
 - Clone your forked repository locally.
 - We use Go Modules to manage dependencies, so you can develop outside of your $GOPATH.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17
+FROM golang:1.18
 # We need to have both nodejs and go to build the binaries.
 # We could use multi-stage builds but that would require significantly changing our Makefile.
 RUN apt-get update

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker:20.10.13-dind
 
-ARG GOLANG_VERSION=1.17.1
+ARG GOLANG_VERSION=1.18
 
 # Docker needs somewhere to put creds from docker login.
 RUN wget https://github.com/docker/docker-credential-helpers/releases/download/v0.6.0/docker-credential-pass-v0.6.0-amd64.tar.gz && tar -xf docker-credential-pass-v0.6.0-amd64.tar.gz && chmod +x docker-credential-pass &&  mv docker-credential-pass /bin

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/copilot-cli
 
-go 1.17
+go 1.18
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.2


### PR DESCRIPTION
Unfortunately, the spec for go1.18.1 is not yet available here:
https://github.com/syndbg/goenv/tree/master/plugins/go-build/share/go-build


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
