### PR TITLE
build: use "go install" install of "get"

### DIFF
--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -17,7 +17,7 @@ ENV PATH=$PATH:/usr/local/go/bin
 RUN rm go$GOLANG_VERSION.src.tar.gz
 RUN apk del go
 
-RUN go get github.com/onsi/ginkgo/ginkgo && go get github.com/onsi/gomega/...
+RUN go install github.com/onsi/ginkgo/ginkgo@latest
 
 # Copy the binary
 ADD bin/local/copilot-linux-amd64 /bin/copilot


### PR DESCRIPTION
We can no longer use "go get" to install commands.
Gomega wasn't an executable to begin with so I'm not sure what the "go get" was doing before. 
Removing it and going to see if it fixes the build.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
