### PR TITLE
test(e2e): change env region

### DIFF
--- a/.release/buildspec_e2e.yml
+++ b/.release/buildspec_e2e.yml
@@ -129,7 +129,7 @@ batch:
         variables:
           TEST_SUITE: multi-pipeline
           APP_REGION: ap-northeast-3
-          TESTENV_REGION: ap-northeast-3
+          TESTENV_REGION: ap-northeast-1
           PRODENV_REGION: ap-southeast-1
     - identifier: worker
       env:


### PR DESCRIPTION
Service Discovery is not supported in the previous region (ap-northeast-3).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
