### PR TITLE
chore: upload env template to s3 before deployments

### DIFF
--- a/internal/pkg/cli/env_init.go
+++ b/internal/pkg/cli/env_init.go
@@ -295,9 +295,9 @@ func (o *initEnvOpts) Execute() error {
 	if err != nil {
 		return err
 	}
-	urls, err := o.uploader.UploadEnvironmentCustomResources(s3.CompressAndUploadFunc(func(key string, objects ...s3.NamedBinary) (string, error) {
+	urls, err := o.uploader.UploadEnvironmentCustomResources(func(key string, objects ...s3.NamedBinary) (string, error) {
 		return s3Client.ZipAndUpload(resources.S3Bucket, key, objects...)
-	}))
+	})
 	if err != nil {
 		return fmt.Errorf("upload custom resources to bucket %s: %w", resources.S3Bucket, err)
 	}

--- a/internal/pkg/deploy/cloudformation/env.go
+++ b/internal/pkg/deploy/cloudformation/env.go
@@ -139,7 +139,16 @@ func (cf CloudFormation) UpgradeLegacyEnvironment(in *deploy.CreateEnvironmentIn
 }
 
 func (cf CloudFormation) upgradeEnvironment(in *deploy.CreateEnvironmentInput, transformParam func(param *awscfn.Parameter) *awscfn.Parameter) error {
-	s, err := toStack(stack.NewEnvStackConfig(in))
+	bucketARN, err := arn.Parse(in.ArtifactBucketARN)
+	if err != nil {
+		return err
+	}
+	stackConfig := stack.NewEnvStackConfig(in)
+	url, err := cf.uploadStackTemplateToS3(bucketARN.Resource, stackConfig)
+	if err != nil {
+		return err
+	}
+	s, err := toStackFromS3(stackConfig, url)
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/deploy/cloudformation/env.go
+++ b/internal/pkg/deploy/cloudformation/env.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/aws/aws-sdk-go/aws/arn"
+
 	"github.com/aws/aws-sdk-go/aws"
 	awscfn "github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/copilot-cli/internal/pkg/aws/cloudformation"
@@ -26,20 +28,29 @@ const (
 
 // DeployAndRenderEnvironment creates the CloudFormation stack for an environment, and render the stack creation to out.
 func (cf CloudFormation) DeployAndRenderEnvironment(out progress.FileWriter, env *deploy.CreateEnvironmentInput) error {
-	s, err := toStack(stack.NewEnvStackConfig(env))
+	bucketARN, err := arn.Parse(env.ArtifactBucketARN)
+	if err != nil {
+		return err
+	}
+	stackConfig := stack.NewEnvStackConfig(env)
+	url, err := cf.uploadStackTemplateToS3(bucketARN.Resource, stackConfig)
+	if err != nil {
+		return err
+	}
+	cfnStack, err := toStackFromS3(stackConfig, url)
 	if err != nil {
 		return err
 	}
 	spinner := progress.NewSpinner(out)
 	return cf.renderStackChanges(&renderStackChangesInput{
 		w:                out,
-		stackName:        s.Name,
-		stackDescription: fmt.Sprintf("Creating the infrastructure for the %s environment.", s.Name),
+		stackName:        cfnStack.Name,
+		stackDescription: fmt.Sprintf("Creating the infrastructure for the %s environment.", cfnStack.Name),
 		createChangeSet: func() (changeSetID string, err error) {
-			label := fmt.Sprintf("Proposing infrastructure changes for the %s environment.", s.Name)
+			label := fmt.Sprintf("Proposing infrastructure changes for the %s environment.", cfnStack.Name)
 			spinner.Start(label)
 			defer stopSpinner(spinner, err, label)
-			changeSetID, err = cf.cfnClient.Create(s)
+			changeSetID, err = cf.cfnClient.Create(cfnStack)
 			if err != nil {
 				return "", err
 			}


### PR DESCRIPTION
Upgrades the env stack template limit to 1MB from 50KB.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
