### PR TITLE
fix: render buildspec path with '/' even on Windows

### DIFF
--- a/internal/pkg/cli/pipeline_init.go
+++ b/internal/pkg/cli/pipeline_init.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -673,7 +674,7 @@ func (o *initPipelineOpts) createBuildspec() error {
 	}{
 		BinaryS3BucketPath: binaryS3BucketPath,
 		Version:            version.Version,
-		ManifestPath:       o.manifestPath,
+		ManifestPath:       filepath.ToSlash(o.manifestPath), // The manifest path must be rendered in the buildspec with '/' instead of os-specific separator.
 		ArtifactBuckets:    artifactBuckets,
 	})
 	if err != nil {

--- a/internal/pkg/deploy/pipeline.go
+++ b/internal/pkg/deploy/pipeline.go
@@ -101,7 +101,7 @@ func (b *Build) Init(mfBuild *manifest.Build, mfDirPath string) {
 	}
 	b.Image = image
 	b.EnvironmentType = environmentType
-	b.BuildspecPath = path
+	b.BuildspecPath = filepath.ToSlash(path) // Buildspec path must be with '/' because CloudFormation expects forward-slash separated file path.
 }
 
 // ArtifactBucket represents an S3 bucket used by the CodePipeline to store


### PR DESCRIPTION
Fixes #3468 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
