### PR TITLE
build: publish docs only when a release is published

### DIFF
--- a/.github/workflows/doc_builder.yml
+++ b/.github/workflows/doc_builder.yml
@@ -1,8 +1,7 @@
 name: Publish docs via GitHub Pages
 on:
-  push:
-    tags:       
-      - v*
+  release:
+    types: [published]
   # Allow the workflow to be triggered also manually.
   workflow_dispatch:
 


### PR DESCRIPTION
Previously, we were publishing the docs when a "v*" tag was added.
This meant that the docs got out before the github release was public.
This PR changes the trigger action so that only once the release is
actually available publicly, then the docs will be published.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
