### PR TITLE
test(integ): ignore Metadata.Version in env template comparisons

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/env_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/env_integration_test.go
@@ -77,6 +77,8 @@ observability:
 			require.NoError(t, err, "serialize template")
 			actualObj := make(map[any]any)
 			require.NoError(t, yaml.Unmarshal([]byte(actual), actualObj))
+			actualMetadata := actualObj["Metadata"].(map[string]any) // We remove the Version from the expected template, as the latest env version always changes.
+			delete(actualMetadata, "Version")
 
 			// THEN
 			require.Equal(t, wantedObj, actualObj)

--- a/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-imported-certs-observability.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-imported-certs-observability.yml
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MIT-0
 Description: CloudFormation environment template for infrastructure shared among Copilot workloads.
 Metadata:
-  Version: v1.9.0
   Manifest: |
     name: test
     type: Environment


### PR DESCRIPTION

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
