### PR TITLE
fix(s3): fallback to no "bucket-owner-full-control" when access denied

### DIFF
--- a/internal/pkg/cli/env_upgrade_test.go
+++ b/internal/pkg/cli/env_upgrade_test.go
@@ -240,7 +240,7 @@ func TestEnvUpgradeOpts_Execute(t *testing.T) {
 					},
 					uploader: mockUploader,
 					appCFN:   mockAppCFN,
-					newS3: func(region string) (uploader, error) {
+					newS3: func(_ *config.Environment) (uploader, error) {
 						return mocks.NewMockuploader(ctrl), nil
 					},
 				}
@@ -315,7 +315,7 @@ func TestEnvUpgradeOpts_Execute(t *testing.T) {
 					},
 					uploader: mockUploader,
 					appCFN:   mockAppCFN,
-					newS3: func(region string) (uploader, error) {
+					newS3: func(_ *config.Environment) (uploader, error) {
 						return mocks.NewMockuploader(ctrl), nil
 					},
 				}
@@ -393,7 +393,7 @@ func TestEnvUpgradeOpts_Execute(t *testing.T) {
 					},
 					uploader: mockUploader,
 					appCFN:   mockAppCFN,
-					newS3: func(region string) (uploader, error) {
+					newS3: func(_ *config.Environment) (uploader, error) {
 						return mocks.NewMockuploader(ctrl), nil
 					},
 				}
@@ -464,7 +464,7 @@ func TestEnvUpgradeOpts_Execute(t *testing.T) {
 					},
 					uploader: mockUploader,
 					appCFN:   mockAppCFN,
-					newS3: func(region string) (uploader, error) {
+					newS3: func(_ *config.Environment) (uploader, error) {
 						return mocks.NewMockuploader(ctrl), nil
 					},
 				}
@@ -520,7 +520,7 @@ func TestEnvUpgradeOpts_Execute(t *testing.T) {
 					},
 					uploader: mockUploader,
 					appCFN:   mockAppCFN,
-					newS3: func(region string) (uploader, error) {
+					newS3: func(_ *config.Environment) (uploader, error) {
 						return mocks.NewMockuploader(ctrl), nil
 					},
 				}


### PR DESCRIPTION
Fixes #3556

I'd like to also create a `Logger` object to log when this issue happens, but that'll be in a separate PR

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
