### PR TITLE
chore: revert "fallback to no 'bucket-owner-full-control' when access denied" (#3559)

### DIFF
--- a/internal/pkg/aws/s3/s3.go
+++ b/internal/pkg/aws/s3/s3.go
@@ -10,20 +10,16 @@ import (
 	"fmt"
 	"io"
 	"strings"
-
+	
 	"github.com/aws/aws-sdk-go/aws/awserr"
-
+	
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 )
 
-// S3 error codes.
-const (
-	errCodeNotFound     = "NotFound"
-	errCodeAccessDenied = "AccessDenied"
-)
+const notFound = "NotFound"
 
 type s3ManagerAPI interface {
 	Upload(input *s3manager.UploadInput, options ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error)
@@ -172,7 +168,7 @@ func (s *S3) isBucketExists(bucket string) (bool, error) {
 	}
 	_, err := s.s3Client.HeadBucket(input)
 	if err != nil {
-		if aerr, ok := err.(awserr.Error); ok && aerr.Code() == errCodeNotFound {
+		if aerr, ok := err.(awserr.Error); ok && aerr.Code() == notFound {
 			return false, nil
 		}
 		return false, err
@@ -182,36 +178,15 @@ func (s *S3) isBucketExists(bucket string) (bool, error) {
 }
 
 func (s *S3) upload(bucket, key string, buf io.Reader) (string, error) {
-	resp, err := s.s3Manager.Upload(&s3manager.UploadInput{
+	in := &s3manager.UploadInput{
 		Body:   buf,
 		Bucket: aws.String(bucket),
 		Key:    aws.String(key),
-		ACL:    aws.String(s3.ObjectCannedACLBucketOwnerFullControl),
-	})
-	if err != nil {
-		aerr, ok := err.(awserr.Error)
-		switch {
-		case ok && aerr.Code() == errCodeAccessDenied:
-			// See #3556. Although the client tries to grant the object ownership to the bucket, this operation can fail
-			// if the role assumed by the client, such as the EnvManagerRole, doesn't have the PutObjectAcl permission.
-			// In that scenario, fallback to the default behavior of the session's account owning the object.
-			return s.uploadWithoutACL(bucket, key, buf)
-		default:
-			return "", fmt.Errorf("upload %s to bucket %s: %w", key, bucket, err)
-		}
-
+		ACL: aws.String(s3.ObjectCannedACLBucketOwnerFullControl),
 	}
-	return resp.Location, nil
-}
-
-func (s *S3) uploadWithoutACL(bucket, key string, buf io.Reader) (string, error) {
-	resp, err := s.s3Manager.Upload(&s3manager.UploadInput{
-		Body:   buf,
-		Bucket: aws.String(bucket),
-		Key:    aws.String(key),
-	})
+	resp, err := s.s3Manager.Upload(in)
 	if err != nil {
-		return "", fmt.Errorf("upload %s to bucket %s without bucket owner full control: %w", key, bucket, err)
+		return "", fmt.Errorf("upload %s to bucket %s: %w", key, bucket, err)
 	}
 	return resp.Location, nil
 }

--- a/internal/pkg/aws/s3/s3_test.go
+++ b/internal/pkg/aws/s3/s3_test.go
@@ -109,7 +109,7 @@ func TestS3_Upload(t *testing.T) {
 			},
 			wantError: fmt.Errorf("upload mockFileName to bucket mockBucket: some error"),
 		},
-		"should upload to the s3 bucket with bucket owner ACL by default": {
+		"should upload to the s3 bucket": {
 			mockS3ManagerClient: func(m *mocks.Mocks3ManagerAPI) {
 				m.EXPECT().Upload(gomock.Any()).Do(func(in *s3manager.UploadInput, _ ...func(*s3manager.Uploader)) {
 					b, err := ioutil.ReadAll(in.Body)
@@ -121,22 +121,6 @@ func TestS3_Upload(t *testing.T) {
 				}).Return(&s3manager.UploadOutput{
 					Location: "mockURL",
 				}, nil)
-			},
-			wantedURL: "mockURL",
-		},
-		"on AccessDenied error from S3, should fallback to uploading to s3 bucket without any explicit ACLs": {
-			mockS3ManagerClient: func(m *mocks.Mocks3ManagerAPI) {
-				gomock.InOrder(
-					m.EXPECT().Upload(gomock.Any()).Return(nil, awserr.New(errCodeAccessDenied, "not allowed", nil)),
-					m.EXPECT().Upload(gomock.Any()).DoAndReturn(func(in *s3manager.UploadInput, _ ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error) {
-						require.Equal(t, "mockBucket", aws.StringValue(in.Bucket))
-						require.Equal(t, "mockFileName", aws.StringValue(in.Key))
-						require.Nil(t, in.ACL)
-						return &s3manager.UploadOutput{
-							Location: "mockURL",
-						}, nil
-					}),
-				)
 			},
 			wantedURL: "mockURL",
 		},
@@ -157,10 +141,10 @@ func TestS3_Upload(t *testing.T) {
 
 			gotURL, gotErr := service.Upload("mockBucket", "mockFileName", bytes.NewBuffer([]byte("bar")))
 
-			if tc.wantError != nil {
+			if gotErr != nil {
 				require.EqualError(t, gotErr, tc.wantError.Error())
 			} else {
-				require.NoError(t, gotErr)
+				require.Equal(t, gotErr, nil)
 				require.Equal(t, gotURL, tc.wantedURL)
 			}
 		})
@@ -350,7 +334,7 @@ func TestS3_EmptyBucket(t *testing.T) {
 			mockS3Client: func(m *mocks.Mocks3API) {
 				m.EXPECT().HeadBucket(&s3.HeadBucketInput{
 					Bucket: aws.String("mockBucket"),
-				}).Return(nil, awserr.New(errCodeNotFound, "message", nil))
+				}).Return(nil, awserr.New(notFound, "message", nil))
 			},
 
 			wantErr: nil,


### PR DESCRIPTION
Reverting #3559 as we are opting for a different approach to fix the bug. The new fix is coming up soon. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
