### PR TITLE
chore(e2e): restore `EnableExec` field for tasks

### DIFF
--- a/internal/pkg/task/config_runner.go
+++ b/internal/pkg/task/config_runner.go
@@ -81,6 +81,7 @@ func (r *ConfigRunner) Run() ([]*Task, error) {
 		TaskFamilyName:  taskFamilyName(r.GroupName),
 		StartedBy:       startedBy,
 		PlatformVersion: platformVersion,
+		EnableExec:      true,
 	})
 	if err != nil {
 		return nil, &errRunTask{

--- a/internal/pkg/task/config_runner_test.go
+++ b/internal/pkg/task/config_runner_test.go
@@ -122,6 +122,7 @@ func TestNetworkConfigRunner_Run(t *testing.T) {
 					TaskFamilyName:  taskFamilyName("my-task"),
 					StartedBy:       startedBy,
 					PlatformVersion: "LATEST",
+					EnableExec:      true,
 				}).Return([]*ecs.Task{&taskWithENI}, nil)
 			},
 
@@ -166,6 +167,7 @@ func TestNetworkConfigRunner_Run(t *testing.T) {
 					TaskFamilyName:  taskFamilyName("my-task"),
 					StartedBy:       startedBy,
 					PlatformVersion: "LATEST",
+					EnableExec:      true,
 				}).Return([]*ecs.Task{&taskWithENI}, nil)
 			},
 
@@ -198,6 +200,7 @@ func TestNetworkConfigRunner_Run(t *testing.T) {
 					TaskFamilyName:  taskFamilyName("my-task"),
 					StartedBy:       startedBy,
 					PlatformVersion: "LATEST",
+					EnableExec:      true,
 				}).Return([]*ecs.Task{
 					&taskWithENI,
 					&taskWithNoENI,
@@ -240,6 +243,7 @@ func TestNetworkConfigRunner_Run(t *testing.T) {
 					TaskFamilyName:  taskFamilyName("my-task"),
 					StartedBy:       startedBy,
 					PlatformVersion: "LATEST",
+					EnableExec:      true,
 				}).Return([]*ecs.Task{&taskWithENI}, nil)
 			},
 
@@ -275,6 +279,7 @@ func TestNetworkConfigRunner_Run(t *testing.T) {
 					TaskFamilyName:  taskFamilyName("my-task"),
 					StartedBy:       startedBy,
 					PlatformVersion: "1.0.0",
+					EnableExec:      true,
 				}).Return([]*ecs.Task{&taskWithENI}, nil)
 			},
 

--- a/internal/pkg/task/env_runner.go
+++ b/internal/pkg/task/env_runner.go
@@ -99,6 +99,7 @@ func (r *EnvRunner) Run() ([]*Task, error) {
 		TaskFamilyName:  taskFamilyName(r.GroupName),
 		StartedBy:       startedBy,
 		PlatformVersion: platformVersion,
+		EnableExec:      true,
 	})
 	if err != nil {
 		return nil, &errRunTask{

--- a/internal/pkg/task/env_runner_test.go
+++ b/internal/pkg/task/env_runner_test.go
@@ -169,6 +169,7 @@ func TestEnvRunner_Run(t *testing.T) {
 					TaskFamilyName:  taskFamilyName("my-task"),
 					StartedBy:       startedBy,
 					PlatformVersion: "LATEST",
+					EnableExec:      true,
 				}).Return(nil, errors.New("error running task"))
 			},
 			mockEnvironmentDescriber: mockEnvironmentDescriberValid,
@@ -194,6 +195,7 @@ func TestEnvRunner_Run(t *testing.T) {
 					TaskFamilyName:  taskFamilyName("my-task"),
 					StartedBy:       startedBy,
 					PlatformVersion: "LATEST",
+					EnableExec:      true,
 				}).Return([]*ecs.Task{&taskWithENI}, nil)
 			},
 			mockEnvironmentDescriber: mockEnvironmentDescriberValid,
@@ -222,6 +224,7 @@ func TestEnvRunner_Run(t *testing.T) {
 					TaskFamilyName:  taskFamilyName("my-task"),
 					StartedBy:       startedBy,
 					PlatformVersion: "LATEST",
+					EnableExec:      true,
 				}).Return([]*ecs.Task{&taskWithENI}, nil)
 			},
 			mockEnvironmentDescriber: mockEnvironmentDescriberValid,
@@ -251,6 +254,7 @@ func TestEnvRunner_Run(t *testing.T) {
 					TaskFamilyName:  taskFamilyName("my-task"),
 					StartedBy:       startedBy,
 					PlatformVersion: "1.0.0",
+					EnableExec:      true,
 				}).Return([]*ecs.Task{&taskWithENI}, nil)
 			},
 			mockEnvironmentDescriber: mockEnvironmentDescriberValid,
@@ -278,6 +282,7 @@ func TestEnvRunner_Run(t *testing.T) {
 					TaskFamilyName:  taskFamilyName("my-task"),
 					StartedBy:       startedBy,
 					PlatformVersion: "LATEST",
+					EnableExec:      true,
 				}).Return([]*ecs.Task{
 					&taskWithENI,
 					&taskWithNoENI,


### PR DESCRIPTION


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
