### PR TITLE
fix: nlb + autoscaling missing resource role

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/http-full-config-template.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/http-full-config-template.yml
@@ -344,6 +344,8 @@ Resources:
       Role: !GetAtt "RulePriorityFunctionRole.Arn"
       Runtime: nodejs12.x
   RulePriorityFunctionRole:
+    Metadata:
+      'aws:copilot:description': "An IAM Role for RulePriorityFunction"
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/http-full-config-template.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/http-full-config-template.yml
@@ -345,7 +345,7 @@ Resources:
       Runtime: nodejs12.x
   RulePriorityFunctionRole:
     Metadata:
-      'aws:copilot:description': "An IAM Role for RulePriorityFunction"
+      'aws:copilot:description': "An IAM Role to describe load balancer rules for assigning a priority"
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/http-full-config-template.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/http-full-config-template.yml
@@ -341,11 +341,9 @@ Resources:
       Handler: "index.nextAvailableRulePriorityHandler"
       Timeout: 600
       MemorySize: 512
-      Role: !GetAtt "CustomResourceRole.Arn"
+      Role: !GetAtt "RulePriorityFunctionRole.Arn"
       Runtime: nodejs12.x
-  CustomResourceRole:
-    Metadata:
-      "aws:copilot:description": "An IAM role used by custom resources to describe your ECS service"
+  RulePriorityFunctionRole:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
@@ -358,6 +356,8 @@ Resources:
             Action:
               - sts:AssumeRole
       Path: /
+      ManagedPolicyArns:
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
       Policies:
         - PolicyName: "RulePriorityGeneratorAccess"
           PolicyDocument:
@@ -367,8 +367,6 @@ Resources:
                 Action:
                   - elasticloadbalancing:DescribeRules
                 Resource: "*"
-      ManagedPolicyArns:
-        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
   HTTPRulePriorityAction:
     Metadata:
       "aws:copilot:description": "A custom resource assigning priority for HTTP listener rules"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/http-only-path-template.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/http-only-path-template.yml
@@ -334,11 +334,9 @@ Resources:
       Handler: "index.nextAvailableRulePriorityHandler"
       Timeout: 600
       MemorySize: 512
-      Role: !GetAtt "CustomResourceRole.Arn"
+      Role: !GetAtt "RulePriorityFunctionRole.Arn"
       Runtime: nodejs12.x
-  CustomResourceRole:
-    Metadata:
-      "aws:copilot:description": "An IAM role used by custom resources to describe your ECS service"
+  RulePriorityFunctionRole:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
@@ -351,6 +349,8 @@ Resources:
             Action:
               - sts:AssumeRole
       Path: /
+      ManagedPolicyArns:
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
       Policies:
         - PolicyName: "RulePriorityGeneratorAccess"
           PolicyDocument:
@@ -360,8 +360,6 @@ Resources:
                 Action:
                   - elasticloadbalancing:DescribeRules
                 Resource: "*"
-      ManagedPolicyArns:
-        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
   HTTPRulePriorityAction:
     Metadata:
       "aws:copilot:description": "A custom resource assigning priority for HTTP listener rules"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/http-only-path-template.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/http-only-path-template.yml
@@ -338,7 +338,7 @@ Resources:
       Runtime: nodejs12.x
   RulePriorityFunctionRole:
     Metadata:
-      'aws:copilot:description': "An IAM Role for RulePriorityFunction"
+      'aws:copilot:description': "An IAM Role to describe load balancer rules for assigning a priority"
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/http-only-path-template.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/http-only-path-template.yml
@@ -337,6 +337,8 @@ Resources:
       Role: !GetAtt "RulePriorityFunctionRole.Arn"
       Runtime: nodejs12.x
   RulePriorityFunctionRole:
+    Metadata:
+      'aws:copilot:description': "An IAM Role for RulePriorityFunction"
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-grpc-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-grpc-test.stack.yml
@@ -256,6 +256,8 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Role: !GetAtt 'DynamicDesiredCountFunctionRole.Arn'
       Runtime: nodejs12.x
   DynamicDesiredCountFunctionRole:
+    Metadata:
+      'aws:copilot:description': "An IAM Role for DynamicDesiredCountFunction"
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
@@ -469,6 +471,8 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Role: !GetAtt 'RulePriorityFunctionRole.Arn'
       Runtime: nodejs12.x
   RulePriorityFunctionRole:
+    Metadata:
+      'aws:copilot:description': "An IAM Role for RulePriorityFunction"
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-grpc-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-grpc-test.stack.yml
@@ -253,8 +253,50 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Handler: "index.handler"
       Timeout: 600
       MemorySize: 512
-      Role: !GetAtt 'CustomResourceRole.Arn'
+      Role: !GetAtt 'DynamicDesiredCountFunctionRole.Arn'
       Runtime: nodejs12.x
+  DynamicDesiredCountFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Path: /
+      ManagedPolicyArns:
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyName: "DelegateDesiredCountAccess"
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: ECS
+                Effect: Allow
+                Action:
+                  - ecs:DescribeServices
+                Resource: "*"
+                Condition:
+                  ArnEquals:
+                    'ecs:cluster':
+                      Fn::Sub:
+                        - arn:${AWS::Partition}:ecs:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}
+                        - ClusterName:
+                            Fn::ImportValue: !Sub '${AppName}-${EnvName}-ClusterId'
+              - Sid: ResourceGroups
+                Effect: Allow
+                Action:
+                  - resource-groups:GetResources
+                Resource: "*"
+              - Sid: Tags
+                Effect: Allow
+                Action:
+                  - "tag:GetResources"
+                Resource: "*"
   AutoScalingRole:
     Metadata:
       'aws:copilot:description': 'An IAM role for container auto scaling'
@@ -424,11 +466,9 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Handler: "index.nextAvailableRulePriorityHandler"
       Timeout: 600
       MemorySize: 512
-      Role: !GetAtt 'CustomResourceRole.Arn'
+      Role: !GetAtt 'RulePriorityFunctionRole.Arn'
       Runtime: nodejs12.x
-  CustomResourceRole:
-    Metadata:
-      'aws:copilot:description': 'An IAM role used by custom resources to describe your ECS service'
+  RulePriorityFunctionRole:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
@@ -441,43 +481,17 @@ Resources: # If a bucket URL is specified, that means the template exists.
             Action:
               - sts:AssumeRole
       Path: /
+      ManagedPolicyArns:
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
       Policies:
-        - PolicyName: "DNSandACMAccess"
+        - PolicyName: "RulePriorityGeneratorAccess"
           PolicyDocument:
-            Version: '2012-10-17'
+            Version: "2012-10-17"
             Statement:
               - Effect: Allow
                 Action:
                   - elasticloadbalancing:DescribeRules
                 Resource: "*"
-        - PolicyName: "DelegateDesiredCountAccess"
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-              - Sid: ECS
-                Effect: Allow
-                Action:
-                  - ecs:DescribeServices
-                Resource: "*"
-                Condition:
-                  ArnEquals:
-                    'ecs:cluster':
-                      Fn::Sub:
-                        - arn:${AWS::Partition}:ecs:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}
-                        - ClusterName:
-                            Fn::ImportValue: !Sub '${AppName}-${EnvName}-ClusterId'
-              - Sid: ResourceGroups
-                Effect: Allow
-                Action:
-                  - resource-groups:GetResources
-                Resource: "*"
-              - Sid: Tags
-                Effect: Allow
-                Action:
-                  - "tag:GetResources"
-                Resource: "*"
-      ManagedPolicyArns:
-        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
   HTTPSRulePriorityAction:
     Metadata:
       'aws:copilot:description': 'A custom resource assigning priority for HTTPS listener rules'

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-grpc-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-grpc-test.stack.yml
@@ -257,7 +257,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Runtime: nodejs12.x
   DynamicDesiredCountFunctionRole:
     Metadata:
-      'aws:copilot:description': "An IAM Role for DynamicDesiredCountFunction"
+      'aws:copilot:description': "An IAM Role for describing number of running tasks in your ECS service"
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
@@ -472,7 +472,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Runtime: nodejs12.x
   RulePriorityFunctionRole:
     Metadata:
-      'aws:copilot:description': "An IAM Role for RulePriorityFunction"
+      'aws:copilot:description': "An IAM Role to describe load balancer rules for assigning a priority"
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-dev.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-dev.stack.yml
@@ -357,7 +357,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Runtime: nodejs12.x
   RulePriorityFunctionRole:
     Metadata:
-      'aws:copilot:description': "An IAM Role for RulePriorityFunction"
+      'aws:copilot:description': "An IAM Role to describe load balancer rules for assigning a priority"
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-dev.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-dev.stack.yml
@@ -356,6 +356,8 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Role: !GetAtt 'RulePriorityFunctionRole.Arn'
       Runtime: nodejs12.x
   RulePriorityFunctionRole:
+    Metadata:
+      'aws:copilot:description': "An IAM Role for RulePriorityFunction"
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-dev.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-dev.stack.yml
@@ -353,11 +353,9 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Handler: "index.nextAvailableRulePriorityHandler"
       Timeout: 600
       MemorySize: 512
-      Role: !GetAtt 'CustomResourceRole.Arn'
+      Role: !GetAtt 'RulePriorityFunctionRole.Arn'
       Runtime: nodejs12.x
-  CustomResourceRole:
-    Metadata:
-      'aws:copilot:description': 'An IAM role used by custom resources to describe your ECS service'
+  RulePriorityFunctionRole:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
@@ -370,17 +368,17 @@ Resources: # If a bucket URL is specified, that means the template exists.
             Action:
               - sts:AssumeRole
       Path: /
+      ManagedPolicyArns:
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
       Policies:
-        - PolicyName: "DNSandACMAccess"
+        - PolicyName: "RulePriorityGeneratorAccess"
           PolicyDocument:
-            Version: '2012-10-17'
+            Version: "2012-10-17"
             Statement:
               - Effect: Allow
                 Action:
                   - elasticloadbalancing:DescribeRules
                 Resource: "*"
-      ManagedPolicyArns:
-        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
   LoadBalancerDNSAlias:
     Metadata:
       'aws:copilot:description': 'The default alias record for the application load balancer'

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-prod.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-prod.stack.yml
@@ -315,6 +315,8 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Role: !GetAtt 'DynamicDesiredCountFunctionRole.Arn'
       Runtime: nodejs12.x
   DynamicDesiredCountFunctionRole:
+    Metadata:
+      'aws:copilot:description': "An IAM Role for DynamicDesiredCountFunction"
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
@@ -533,6 +535,8 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Runtime: nodejs12.x
   RulePriorityFunctionRole:
     Type: AWS::IAM::Role
+    Metadata:
+      'aws:copilot:description': "An IAM Role for RulePriorityFunction"
     Properties:
       AssumeRolePolicyDocument:
         Version: 2012-10-17

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-prod.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-prod.stack.yml
@@ -316,7 +316,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Runtime: nodejs12.x
   DynamicDesiredCountFunctionRole:
     Metadata:
-      'aws:copilot:description': "An IAM Role for DynamicDesiredCountFunction"
+      'aws:copilot:description': "An IAM Role for describing number of running tasks in your ECS service"
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
@@ -536,7 +536,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
   RulePriorityFunctionRole:
     Type: AWS::IAM::Role
     Metadata:
-      'aws:copilot:description': "An IAM Role for RulePriorityFunction"
+      'aws:copilot:description': "An IAM Role to describe load balancer rules for assigning a priority"
     Properties:
       AssumeRolePolicyDocument:
         Version: 2012-10-17

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-prod.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-prod.stack.yml
@@ -312,8 +312,50 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Handler: "index.handler"
       Timeout: 600
       MemorySize: 512
-      Role: !GetAtt 'CustomResourceRole.Arn'
+      Role: !GetAtt 'DynamicDesiredCountFunctionRole.Arn'
       Runtime: nodejs12.x
+  DynamicDesiredCountFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Path: /
+      ManagedPolicyArns:
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyName: "DelegateDesiredCountAccess"
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: ECS
+                Effect: Allow
+                Action:
+                  - ecs:DescribeServices
+                Resource: "*"
+                Condition:
+                  ArnEquals:
+                    'ecs:cluster':
+                      Fn::Sub:
+                        - arn:${AWS::Partition}:ecs:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}
+                        - ClusterName:
+                            Fn::ImportValue: !Sub '${AppName}-${EnvName}-ClusterId'
+              - Sid: ResourceGroups
+                Effect: Allow
+                Action:
+                  - resource-groups:GetResources
+                Resource: "*"
+              - Sid: Tags
+                Effect: Allow
+                Action:
+                  - "tag:GetResources"
+                Resource: "*"
   AutoScalingRole:
     Metadata:
       'aws:copilot:description': 'An IAM role for container auto scaling'
@@ -487,11 +529,9 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Handler: "index.nextAvailableRulePriorityHandler"
       Timeout: 600
       MemorySize: 512
-      Role: !GetAtt 'CustomResourceRole.Arn'
+      Role: !GetAtt 'RulePriorityFunctionRole.Arn'
       Runtime: nodejs12.x
-  CustomResourceRole:
-    Metadata:
-      'aws:copilot:description': 'An IAM role used by custom resources to describe your ECS service'
+  RulePriorityFunctionRole:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
@@ -504,43 +544,17 @@ Resources: # If a bucket URL is specified, that means the template exists.
             Action:
               - sts:AssumeRole
       Path: /
+      ManagedPolicyArns:
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
       Policies:
-        - PolicyName: "DNSandACMAccess"
+        - PolicyName: "RulePriorityGeneratorAccess"
           PolicyDocument:
-            Version: '2012-10-17'
+            Version: "2012-10-17"
             Statement:
               - Effect: Allow
                 Action:
                   - elasticloadbalancing:DescribeRules
                 Resource: "*"
-        - PolicyName: "DelegateDesiredCountAccess"
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-              - Sid: ECS
-                Effect: Allow
-                Action:
-                  - ecs:DescribeServices
-                Resource: "*"
-                Condition:
-                  ArnEquals:
-                    'ecs:cluster':
-                      Fn::Sub:
-                        - arn:${AWS::Partition}:ecs:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}
-                        - ClusterName:
-                            Fn::ImportValue: !Sub '${AppName}-${EnvName}-ClusterId'
-              - Sid: ResourceGroups
-                Effect: Allow
-                Action:
-                  - resource-groups:GetResources
-                Resource: "*"
-              - Sid: Tags
-                Effect: Allow
-                Action:
-                  - "tag:GetResources"
-                Resource: "*"
-      ManagedPolicyArns:
-        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
   HTTPSRulePriorityAction:
     Metadata:
       'aws:copilot:description': 'A custom resource assigning priority for HTTPS listener rules'

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-staging.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-staging.stack.yml
@@ -362,6 +362,8 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Role: !GetAtt 'RulePriorityFunctionRole.Arn'
       Runtime: nodejs12.x
   RulePriorityFunctionRole:
+    Metadata:
+      'aws:copilot:description': "An IAM Role for RulePriorityFunction"
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-staging.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-staging.stack.yml
@@ -363,7 +363,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Runtime: nodejs12.x
   RulePriorityFunctionRole:
     Metadata:
-      'aws:copilot:description': "An IAM Role for RulePriorityFunction"
+      'aws:copilot:description': "An IAM Role to describe load balancer rules for assigning a priority"
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-staging.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-staging.stack.yml
@@ -359,11 +359,9 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Handler: "index.nextAvailableRulePriorityHandler"
       Timeout: 600
       MemorySize: 512
-      Role: !GetAtt 'CustomResourceRole.Arn'
+      Role: !GetAtt 'RulePriorityFunctionRole.Arn'
       Runtime: nodejs12.x
-  CustomResourceRole:
-    Metadata:
-      'aws:copilot:description': 'An IAM role used by custom resources to describe your ECS service'
+  RulePriorityFunctionRole:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
@@ -376,17 +374,17 @@ Resources: # If a bucket URL is specified, that means the template exists.
             Action:
               - sts:AssumeRole
       Path: /
+      ManagedPolicyArns:
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
       Policies:
-        - PolicyName: "DNSandACMAccess"
+        - PolicyName: "RulePriorityGeneratorAccess"
           PolicyDocument:
-            Version: '2012-10-17'
+            Version: "2012-10-17"
             Statement:
               - Effect: Allow
                 Action:
                   - elasticloadbalancing:DescribeRules
                 Resource: "*"
-      ManagedPolicyArns:
-        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
   HTTPSRulePriorityAction:
     Metadata:
       'aws:copilot:description': 'A custom resource assigning priority for HTTPS listener rules'

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-test.stack.yml
@@ -253,8 +253,50 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Handler: "index.handler"
       Timeout: 600
       MemorySize: 512
-      Role: !GetAtt 'CustomResourceRole.Arn'
+      Role: !GetAtt 'DynamicDesiredCountFunctionRole.Arn'
       Runtime: nodejs12.x
+  DynamicDesiredCountFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Path: /
+      ManagedPolicyArns:
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyName: "DelegateDesiredCountAccess"
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: ECS
+                Effect: Allow
+                Action:
+                  - ecs:DescribeServices
+                Resource: "*"
+                Condition:
+                  ArnEquals:
+                    'ecs:cluster':
+                      Fn::Sub:
+                        - arn:${AWS::Partition}:ecs:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}
+                        - ClusterName:
+                            Fn::ImportValue: !Sub '${AppName}-${EnvName}-ClusterId'
+              - Sid: ResourceGroups
+                Effect: Allow
+                Action:
+                  - resource-groups:GetResources
+                Resource: "*"
+              - Sid: Tags
+                Effect: Allow
+                Action:
+                  - "tag:GetResources"
+                Resource: "*"
   AutoScalingRole:
     Metadata:
       'aws:copilot:description': 'An IAM role for container auto scaling'
@@ -423,11 +465,9 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Handler: "index.nextAvailableRulePriorityHandler"
       Timeout: 600
       MemorySize: 512
-      Role: !GetAtt 'CustomResourceRole.Arn'
+      Role: !GetAtt 'RulePriorityFunctionRole.Arn'
       Runtime: nodejs12.x
-  CustomResourceRole:
-    Metadata:
-      'aws:copilot:description': 'An IAM role used by custom resources to describe your ECS service'
+  RulePriorityFunctionRole:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
@@ -440,43 +480,17 @@ Resources: # If a bucket URL is specified, that means the template exists.
             Action:
               - sts:AssumeRole
       Path: /
+      ManagedPolicyArns:
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
       Policies:
-        - PolicyName: "DNSandACMAccess"
+        - PolicyName: "RulePriorityGeneratorAccess"
           PolicyDocument:
-            Version: '2012-10-17'
+            Version: "2012-10-17"
             Statement:
               - Effect: Allow
                 Action:
                   - elasticloadbalancing:DescribeRules
                 Resource: "*"
-        - PolicyName: "DelegateDesiredCountAccess"
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-              - Sid: ECS
-                Effect: Allow
-                Action:
-                  - ecs:DescribeServices
-                Resource: "*"
-                Condition:
-                  ArnEquals:
-                    'ecs:cluster':
-                      Fn::Sub:
-                        - arn:${AWS::Partition}:ecs:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}
-                        - ClusterName:
-                            Fn::ImportValue: !Sub '${AppName}-${EnvName}-ClusterId'
-              - Sid: ResourceGroups
-                Effect: Allow
-                Action:
-                  - resource-groups:GetResources
-                Resource: "*"
-              - Sid: Tags
-                Effect: Allow
-                Action:
-                  - "tag:GetResources"
-                Resource: "*"
-      ManagedPolicyArns:
-        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
   HTTPSRulePriorityAction:
     Metadata:
       'aws:copilot:description': 'A custom resource assigning priority for HTTPS listener rules'

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-test.stack.yml
@@ -257,7 +257,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Runtime: nodejs12.x
   DynamicDesiredCountFunctionRole:
     Metadata:
-      'aws:copilot:description': "An IAM Role for DynamicDesiredCountFunction"
+      'aws:copilot:description': "An IAM Role for describing number of running tasks in your ECS service"
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
@@ -471,7 +471,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Runtime: nodejs12.x
   RulePriorityFunctionRole:
     Metadata:
-      'aws:copilot:description': "An IAM Role for RulePriorityFunction"
+      'aws:copilot:description': "An IAM Role to describe load balancer rules for assigning a priority"
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-test.stack.yml
@@ -256,6 +256,8 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Role: !GetAtt 'DynamicDesiredCountFunctionRole.Arn'
       Runtime: nodejs12.x
   DynamicDesiredCountFunctionRole:
+    Metadata:
+      'aws:copilot:description': "An IAM Role for DynamicDesiredCountFunction"
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
@@ -468,6 +470,8 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Role: !GetAtt 'RulePriorityFunctionRole.Arn'
       Runtime: nodejs12.x
   RulePriorityFunctionRole:
+    Metadata:
+      'aws:copilot:description': "An IAM Role for RulePriorityFunction"
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/windows-svc-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/windows-svc-test.stack.yml
@@ -339,11 +339,9 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Handler: "index.nextAvailableRulePriorityHandler"
       Timeout: 600
       MemorySize: 512
-      Role: !GetAtt 'CustomResourceRole.Arn'
+      Role: !GetAtt 'RulePriorityFunctionRole.Arn'
       Runtime: nodejs12.x
-  CustomResourceRole:
-    Metadata:
-      'aws:copilot:description': 'An IAM role used by custom resources to describe your ECS service'
+  RulePriorityFunctionRole:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
@@ -356,17 +354,17 @@ Resources: # If a bucket URL is specified, that means the template exists.
             Action:
               - sts:AssumeRole
       Path: /
+      ManagedPolicyArns:
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
       Policies:
-        - PolicyName: "DNSandACMAccess"
+        - PolicyName: "RulePriorityGeneratorAccess"
           PolicyDocument:
-            Version: '2012-10-17'
+            Version: "2012-10-17"
             Statement:
               - Effect: Allow
                 Action:
                   - elasticloadbalancing:DescribeRules
                 Resource: "*"
-      ManagedPolicyArns:
-        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
   HTTPRulePriorityAction:
     Metadata:
       'aws:copilot:description': 'A custom resource assigning priority for HTTP listener rules'

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/windows-svc-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/windows-svc-test.stack.yml
@@ -342,6 +342,8 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Role: !GetAtt 'RulePriorityFunctionRole.Arn'
       Runtime: nodejs12.x
   RulePriorityFunctionRole:
+    Metadata:
+      'aws:copilot:description': "An IAM Role for RulePriorityFunction"
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/windows-svc-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/windows-svc-test.stack.yml
@@ -343,7 +343,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Runtime: nodejs12.x
   RulePriorityFunctionRole:
     Metadata:
-      'aws:copilot:description': "An IAM Role for RulePriorityFunction"
+      'aws:copilot:description': "An IAM Role to describe load balancer rules for assigning a priority"
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/worker-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/worker-test.stack.yml
@@ -220,8 +220,50 @@ Resources:
       Handler: "index.handler"
       Timeout: 600
       MemorySize: 512
-      Role: !GetAtt 'CustomResourceRole.Arn'
+      Role: !GetAtt 'DynamicDesiredCountFunctionRole.Arn'
       Runtime: nodejs12.x
+  DynamicDesiredCountFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Path: /
+      ManagedPolicyArns:
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyName: "DelegateDesiredCountAccess"
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: ECS
+                Effect: Allow
+                Action:
+                  - ecs:DescribeServices
+                Resource: "*"
+                Condition:
+                  ArnEquals:
+                    'ecs:cluster':
+                      Fn::Sub:
+                        - arn:${AWS::Partition}:ecs:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}
+                        - ClusterName:
+                            Fn::ImportValue: !Sub '${AppName}-${EnvName}-ClusterId'
+              - Sid: ResourceGroups
+                Effect: Allow
+                Action:
+                  - resource-groups:GetResources
+                Resource: "*"
+              - Sid: Tags
+                Effect: Allow
+                Action:
+                  - "tag:GetResources"
+                Resource: "*"
   AutoScalingRole:
     Metadata:
       'aws:copilot:description': 'An IAM role for container auto scaling'
@@ -386,50 +428,6 @@ Resources:
               Value: !GetAtt dogsvcgiveshuskiesEventsQueue.QueueName
           Unit: Count
         TargetValue: 900
-  CustomResourceRole:
-    Metadata:
-      'aws:copilot:description': 'An IAM role used by custom resources to describe your ECS service'
-    Type: AWS::IAM::Role
-    Properties:
-      AssumeRolePolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service:
-                - lambda.amazonaws.com
-            Action:
-              - sts:AssumeRole
-      Path: /
-      Policies:
-        - PolicyName: "DelegateDesiredCountAccess"
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-              - Sid: ECS
-                Effect: Allow
-                Action:
-                  - ecs:DescribeServices
-                Resource: "*"
-                Condition:
-                  ArnEquals:
-                    'ecs:cluster':
-                      Fn::Sub:
-                        - arn:${AWS::Partition}:ecs:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}
-                        - ClusterName:
-                            Fn::ImportValue: !Sub '${AppName}-${EnvName}-ClusterId'
-              - Sid: ResourceGroups
-                Effect: Allow
-                Action:
-                  - resource-groups:GetResources
-                Resource: "*"
-              - Sid: Tags
-                Effect: Allow
-                Action:
-                  - "tag:GetResources"
-                Resource: "*"
-      ManagedPolicyArns:
-        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
   Service:
     DependsOn:
       - EnvControllerAction

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/worker-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/worker-test.stack.yml
@@ -223,6 +223,8 @@ Resources:
       Role: !GetAtt 'DynamicDesiredCountFunctionRole.Arn'
       Runtime: nodejs12.x
   DynamicDesiredCountFunctionRole:
+    Metadata:
+      'aws:copilot:description': "An IAM Role for DynamicDesiredCountFunction"
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/worker-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/worker-test.stack.yml
@@ -224,7 +224,7 @@ Resources:
       Runtime: nodejs12.x
   DynamicDesiredCountFunctionRole:
     Metadata:
-      'aws:copilot:description': "An IAM Role for DynamicDesiredCountFunction"
+      'aws:copilot:description': "An IAM Role for describing number of running tasks in your ECS service"
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:

--- a/internal/pkg/template/templates/workloads/partials/cf/alb.yml
+++ b/internal/pkg/template/templates/workloads/partials/cf/alb.yml
@@ -51,6 +51,8 @@ RulePriorityFunction:
     Runtime: nodejs12.x
 
 RulePriorityFunctionRole:
+  Metadata:
+    'aws:copilot:description': "An IAM Role for RulePriorityFunction"
   Type: AWS::IAM::Role
   Properties:
     AssumeRolePolicyDocument:

--- a/internal/pkg/template/templates/workloads/partials/cf/alb.yml
+++ b/internal/pkg/template/templates/workloads/partials/cf/alb.yml
@@ -52,7 +52,7 @@ RulePriorityFunction:
 
 RulePriorityFunctionRole:
   Metadata:
-    'aws:copilot:description': "An IAM Role for RulePriorityFunction"
+    'aws:copilot:description': "An IAM Role to describe load balancer rules for assigning a priority"
   Type: AWS::IAM::Role
   Properties:
     AssumeRolePolicyDocument:

--- a/internal/pkg/template/templates/workloads/partials/cf/alb.yml
+++ b/internal/pkg/template/templates/workloads/partials/cf/alb.yml
@@ -1,6 +1,6 @@
 TargetGroup:
   Metadata:
-    'aws:copilot:description': 'A target group to connect the load balancer to your service'
+    'aws:copilot:description': "A target group to connect the load balancer to your service"
   Type: AWS::ElasticLoadBalancingV2::TargetGroup
   Properties:
     HealthCheckPath: {{.HTTPHealthCheck.HealthCheckPath}} # Default is '/'.
@@ -30,7 +30,7 @@ TargetGroup:
     {{- end}}
     TargetGroupAttributes:
       - Key: deregistration_delay.timeout_seconds
-        Value: {{.DeregistrationDelay}}  # ECS Default is 300; Copilot default is 60.
+        Value: {{.DeregistrationDelay}} # ECS Default is 300; Copilot default is 60.
       - Key: stickiness.enabled
         Value: !Ref Stickiness
     TargetType: ip
@@ -47,8 +47,33 @@ RulePriorityFunction:
     Handler: "index.nextAvailableRulePriorityHandler"
     Timeout: 600
     MemorySize: 512
-    Role: !GetAtt 'CustomResourceRole.Arn'
+    Role: !GetAtt "RulePriorityFunctionRole.Arn"
     Runtime: nodejs12.x
+
+RulePriorityFunctionRole:
+  Type: AWS::IAM::Role
+  Properties:
+    AssumeRolePolicyDocument:
+      Version: 2012-10-17
+      Statement:
+        - Effect: Allow
+          Principal:
+            Service:
+              - lambda.amazonaws.com
+          Action:
+            - sts:AssumeRole
+    Path: /
+    ManagedPolicyArns:
+      - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+    Policies:
+      - PolicyName: "RulePriorityGeneratorAccess"
+        PolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+            - Effect: Allow
+              Action:
+                - elasticloadbalancing:DescribeRules
+              Resource: "*"
 
 {{- if .HTTPSListener}}
 {{include "https-listener" .}}

--- a/internal/pkg/template/templates/workloads/partials/cf/autoscaling.yml
+++ b/internal/pkg/template/templates/workloads/partials/cf/autoscaling.yml
@@ -23,8 +23,52 @@ DynamicDesiredCountFunction:
     Handler: "index.handler"
     Timeout: 600
     MemorySize: 512
-    Role: !GetAtt 'CustomResourceRole.Arn'
+    Role: !GetAtt 'DynamicDesiredCountFunctionRole.Arn'
     Runtime: nodejs12.x
+
+DynamicDesiredCountFunctionRole:
+  Type: AWS::IAM::Role
+  Properties:
+    AssumeRolePolicyDocument:
+      Version: 2012-10-17
+      Statement:
+        - Effect: Allow
+          Principal:
+            Service:
+              - lambda.amazonaws.com
+          Action:
+            - sts:AssumeRole
+    Path: /
+    ManagedPolicyArns:
+      - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+    Policies:
+      - PolicyName: "DelegateDesiredCountAccess"
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+            - Sid: ECS
+              Effect: Allow
+              Action:
+                - ecs:DescribeServices
+              Resource: "*"
+              Condition: 
+                ArnEquals: 
+                  'ecs:cluster':
+                    Fn::Sub:
+                      - arn:${AWS::Partition}:ecs:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}
+                      - ClusterName:
+                          Fn::ImportValue:
+                            !Sub '${AppName}-${EnvName}-ClusterId'
+            - Sid: ResourceGroups
+              Effect: Allow
+              Action:
+                - resource-groups:GetResources
+              Resource: "*"
+            - Sid: Tags
+              Effect: Allow
+              Action:
+                - "tag:GetResources"
+              Resource: "*"
 
 AutoScalingRole:
   Metadata:

--- a/internal/pkg/template/templates/workloads/partials/cf/autoscaling.yml
+++ b/internal/pkg/template/templates/workloads/partials/cf/autoscaling.yml
@@ -27,6 +27,8 @@ DynamicDesiredCountFunction:
     Runtime: nodejs12.x
 
 DynamicDesiredCountFunctionRole:
+  Metadata:
+    'aws:copilot:description': "An IAM Role for DynamicDesiredCountFunction"
   Type: AWS::IAM::Role
   Properties:
     AssumeRolePolicyDocument:

--- a/internal/pkg/template/templates/workloads/partials/cf/autoscaling.yml
+++ b/internal/pkg/template/templates/workloads/partials/cf/autoscaling.yml
@@ -28,7 +28,7 @@ DynamicDesiredCountFunction:
 
 DynamicDesiredCountFunctionRole:
   Metadata:
-    'aws:copilot:description': "An IAM Role for DynamicDesiredCountFunction"
+    'aws:copilot:description': "An IAM Role for describing number of running tasks in your ECS service"
   Type: AWS::IAM::Role
   Properties:
     AssumeRolePolicyDocument:

--- a/internal/pkg/template/templates/workloads/services/backend/cf.yml
+++ b/internal/pkg/template/templates/workloads/services/backend/cf.yml
@@ -80,67 +80,6 @@ Resources:
 {{include "alb" . | indent 2}}
 {{end}}
 
-  {{- if or .ALBEnabled .Autoscaling}}
-  CustomResourceRole:
-    Metadata:
-      'aws:copilot:description': 'An IAM role used by custom resources to describe your ECS service'
-    Type: AWS::IAM::Role
-    Properties:
-      AssumeRolePolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          -
-            Effect: Allow
-            Principal:
-              Service:
-                - lambda.amazonaws.com
-            Action:
-              - sts:AssumeRole
-      Path: /
-      ManagedPolicyArns:
-        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
-      Policies:
-      {{- if .ALBEnabled}}
-        - PolicyName: "RulePriorityGeneratorAccess"
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-            - Effect: Allow
-              Action:
-                - elasticloadbalancing:DescribeRules
-              Resource: "*"
-      {{- end}}
-      {{- if .Autoscaling }}
-        - PolicyName: "DelegateDesiredCountAccess"
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-            - Sid: ECS
-              Effect: Allow
-              Action:
-                - ecs:DescribeServices
-              Resource: "*"
-              Condition: 
-                ArnEquals: 
-                  'ecs:cluster':
-                    Fn::Sub:
-                      - arn:${AWS::Partition}:ecs:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}
-                      - ClusterName:
-                          Fn::ImportValue:
-                            !Sub '${AppName}-${EnvName}-ClusterId'
-            - Sid: ResourceGroups
-              Effect: Allow
-              Action:
-                - resource-groups:GetResources
-              Resource: "*"
-            - Sid: Tags
-              Effect: Allow
-              Action:
-                - "tag:GetResources"
-              Resource: "*"
-      {{- end}}
-  {{- end}}
-
   Service:
     Metadata:
       'aws:copilot:description': 'An ECS service to run and maintain your tasks in the environment cluster'

--- a/internal/pkg/template/templates/workloads/services/lb-web/cf.yml
+++ b/internal/pkg/template/templates/workloads/services/lb-web/cf.yml
@@ -169,62 +169,6 @@ Resources:
 
 {{- if .ALBEnabled}}
 {{include "alb" . | indent 2}}
-
-  CustomResourceRole:
-    Metadata:
-      'aws:copilot:description': 'An IAM role used by custom resources to describe your ECS service'
-    Type: AWS::IAM::Role
-    Properties:
-      AssumeRolePolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service:
-                - lambda.amazonaws.com
-            Action:
-              - sts:AssumeRole
-      Path: /
-      Policies:
-        - PolicyName: "DNSandACMAccess"
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-            - Effect: Allow
-              Action:
-                - elasticloadbalancing:DescribeRules
-              Resource: "*"
-        {{- if .Autoscaling }}
-        - PolicyName: "DelegateDesiredCountAccess"
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-              - Sid: ECS
-                Effect: Allow
-                Action:
-                  - ecs:DescribeServices
-                Resource: "*"
-                Condition: 
-                  ArnEquals: 
-                    'ecs:cluster':
-                      Fn::Sub:
-                        - arn:${AWS::Partition}:ecs:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}
-                        - ClusterName:
-                            Fn::ImportValue:
-                              !Sub '${AppName}-${EnvName}-ClusterId'
-              - Sid: ResourceGroups
-                Effect: Allow
-                Action:
-                  - resource-groups:GetResources
-                Resource: "*"
-              - Sid: Tags
-                Effect: Allow
-                Action:
-                  - "tag:GetResources"
-                Resource: "*"
-        {{- end}}
-      ManagedPolicyArns:
-        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
 {{- end}}
 
 {{- if .NLB}}

--- a/internal/pkg/template/templates/workloads/services/worker/cf.yml
+++ b/internal/pkg/template/templates/workloads/services/worker/cf.yml
@@ -53,52 +53,6 @@ Resources:
 {{include "taskrole" . | indent 2}}
 {{- if .Autoscaling }}
 {{include "autoscaling" . | indent 2}}
-  CustomResourceRole:
-    Metadata:
-      'aws:copilot:description': 'An IAM role used by custom resources to describe your ECS service'
-    Type: AWS::IAM::Role
-    Properties:
-      AssumeRolePolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          -
-            Effect: Allow
-            Principal:
-              Service:
-                - lambda.amazonaws.com
-            Action:
-              - sts:AssumeRole
-      Path: /
-      Policies:
-        - PolicyName: "DelegateDesiredCountAccess"
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-            - Sid: ECS
-              Effect: Allow
-              Action:
-                - ecs:DescribeServices
-              Resource: "*"
-              Condition: 
-                ArnEquals: 
-                  'ecs:cluster':
-                    Fn::Sub:
-                      - arn:${AWS::Partition}:ecs:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}
-                      - ClusterName:
-                          Fn::ImportValue:
-                            !Sub '${AppName}-${EnvName}-ClusterId'
-            - Sid: ResourceGroups
-              Effect: Allow
-              Action:
-                - resource-groups:GetResources
-              Resource: "*"
-            - Sid: Tags
-              Effect: Allow
-              Action:
-                - "tag:GetResources"
-              Resource: "*"
-      ManagedPolicyArns:
-        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
 {{- end}}
   Service:
     DependsOn:


### PR DESCRIPTION
Fixes #3571 by refactoring out the `CustomResourceRole` and instead creates a role for each lambda individually. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
