### PR TITLE
chore: add subnet placement condition in env cfn template

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/env.go
+++ b/internal/pkg/deploy/cloudformation/stack/env.go
@@ -102,10 +102,10 @@ func (e *EnvStackConfig) Template() (string, error) {
 		ArtifactBucketARN:      e.in.ArtifactBucketARN,
 		ArtifactBucketKeyARN:   e.in.ArtifactBucketKeyARN,
 
-		ImportCertARNs:     e.importCertARNs(),
-		VPCConfig:          e.vpcConfig(),
-		InternalALBSubnets: e.internalALBSubnets(),
-		Telemetry:          e.telemetryConfig(),
+		ImportCertARNs:           e.importCertARNs(),
+		VPCConfig:                e.vpcConfig(),
+		CustomInternalALBSubnets: e.internalALBSubnets(),
+		Telemetry:                e.telemetryConfig(),
 
 		Version:       e.in.Version,
 		LatestVersion: deploy.LatestEnvTemplateVersion,

--- a/internal/pkg/deploy/cloudformation/stack/env.go
+++ b/internal/pkg/deploy/cloudformation/stack/env.go
@@ -102,9 +102,10 @@ func (e *EnvStackConfig) Template() (string, error) {
 		ArtifactBucketARN:      e.in.ArtifactBucketARN,
 		ArtifactBucketKeyARN:   e.in.ArtifactBucketKeyARN,
 
-		ImportCertARNs: e.importCertARNs(),
-		VPCConfig:      e.vpcConfig(),
-		Telemetry:      e.telemetryConfig(),
+		ImportCertARNs:     e.importCertARNs(),
+		VPCConfig:          e.vpcConfig(),
+		InternalALBSubnets: e.internalALBSubnets(),
+		Telemetry:          e.telemetryConfig(),
 
 		Version:       e.in.Version,
 		LatestVersion: deploy.LatestEnvTemplateVersion,
@@ -194,6 +195,15 @@ func (e *EnvStackConfig) importCertARNs() []string {
 	}
 	// Fallthrough to SSM config.
 	return e.in.ImportCertARNs
+}
+
+func (e *EnvStackConfig) internalALBSubnets() []string {
+	// If a manifest is present, it is the only place we look.
+	if e.in.Mft != nil {
+		return e.in.Mft.HTTPConfig.Private.Subnets
+	}
+	// Fallthrough to SSM config.
+	return e.in.InternalALBSubnets
 }
 
 // Parameters returns the parameters to be passed into an environment CloudFormation template.

--- a/internal/pkg/deploy/deploy.go
+++ b/internal/pkg/deploy/deploy.go
@@ -307,7 +307,7 @@ func (s *Store) IsServiceDeployed(appName string, envName string, svcName string
 	return s.isWorkloadDeployed(appName, envName, svcName)
 }
 
-// IsJobDeployed returnds whether a job is deployed in an environment or not by checking for a state machine.
+// IsJobDeployed returns whether a job is deployed in an environment or not by checking for a state machine.
 func (s *Store) IsJobDeployed(appName, envName, jobName string) (bool, error) {
 	return s.isWorkloadDeployed(appName, envName, jobName)
 }

--- a/internal/pkg/deploy/env.go
+++ b/internal/pkg/deploy/env.go
@@ -32,6 +32,7 @@ type CreateEnvironmentInput struct {
 	ImportVPCConfig      *config.ImportVPC // Optional configuration if users have an existing VPC.
 	AdjustVPCConfig      *config.AdjustVPC // Optional configuration if users want to override default VPC configuration.
 	ImportCertARNs       []string          // Optional configuration if users want to import certificates.
+	InternalALBSubnets   []string          // Optional configuration if users want to specify internal ALB placement.
 	Telemetry            *config.Telemetry // Optional observability and monitoring configuration.
 	Mft                  *manifest.Environment
 

--- a/internal/pkg/manifest/env.go
+++ b/internal/pkg/manifest/env.go
@@ -132,9 +132,15 @@ func (o environmentObservability) IsEmpty() bool {
 }
 
 type environmentHTTPConfig struct {
-	Public publicHTTPConfig `yaml:"public,omitempty"`
+	Public  publicHTTPConfig  `yaml:"public,omitempty"`
+	Private privateHTTPConfig `yaml:"private,omitempty"`
 }
 
 type publicHTTPConfig struct {
+	Certificates []string `yaml:"certificates,omitempty"`
+}
+
+type privateHTTPConfig struct {
+	Subnets      []string `yaml:"subnets,omitempty"`
 	Certificates []string `yaml:"certificates,omitempty"`
 }

--- a/internal/pkg/manifest/validate_env.go
+++ b/internal/pkg/manifest/validate_env.go
@@ -173,7 +173,7 @@ func (cfg environmentHTTPConfig) Validate() error {
 	if err := cfg.Public.Validate(); err != nil {
 		return fmt.Errorf(`validate "public": %w`, err)
 	}
-	if err := o.Private.Validate(); err != nil {
+	if err := cfg.Private.Validate(); err != nil {
 		return fmt.Errorf(`validate "private": %w`, err)
 	}
 	return nil

--- a/internal/pkg/manifest/validate_env.go
+++ b/internal/pkg/manifest/validate_env.go
@@ -33,6 +33,9 @@ func (e EnvironmentConfig) Validate() error {
 	if err := e.Observability.Validate(); err != nil {
 		return fmt.Errorf(`validate "observability": %w`, err)
 	}
+	if err := e.HTTPConfig.Validate(); err != nil {
+		return fmt.Errorf(`validate "http config": %w`, err)
+	}
 	return nil
 }
 
@@ -180,7 +183,7 @@ func (o environmentHTTPConfig) Validate() error {
 func (o publicHTTPConfig) Validate() error {
 	for idx, certARN := range o.Certificates {
 		if _, err := arn.Parse(certARN); err != nil {
-			return fmt.Errorf(`validate "certificates[%d]": %w`, idx, err)
+			return fmt.Errorf(`parse "certificates[%d]": %w`, idx, err)
 		}
 	}
 	return nil
@@ -190,7 +193,7 @@ func (o publicHTTPConfig) Validate() error {
 func (o privateHTTPConfig) Validate() error {
 	for idx, certARN := range o.Certificates {
 		if _, err := arn.Parse(certARN); err != nil {
-			return fmt.Errorf(`validate "certificates[%d]": %w`, idx, err)
+			return fmt.Errorf(`parse "certificates[%d]": %w`, idx, err)
 		}
 	}
 	return nil

--- a/internal/pkg/manifest/validate_env.go
+++ b/internal/pkg/manifest/validate_env.go
@@ -170,11 +170,24 @@ func (o environmentHTTPConfig) Validate() error {
 	if err := o.Public.Validate(); err != nil {
 		return fmt.Errorf(`validate "public": %w`, err)
 	}
+	if err := o.Private.Validate(); err != nil {
+		return fmt.Errorf(`validate "private": %w`, err)
+	}
 	return nil
 }
 
 // Validate returns nil if publicHTTPConfig is configured correctly.
 func (o publicHTTPConfig) Validate() error {
+	for idx, certARN := range o.Certificates {
+		if _, err := arn.Parse(certARN); err != nil {
+			return fmt.Errorf(`validate "certificates[%d]": %w`, idx, err)
+		}
+	}
+	return nil
+}
+
+// Validate returns nil if privateHTTPConfig is configured correctly.
+func (o privateHTTPConfig) Validate() error {
 	for idx, certARN := range o.Certificates {
 		if _, err := arn.Parse(certARN); err != nil {
 			return fmt.Errorf(`validate "certificates[%d]": %w`, idx, err)

--- a/internal/pkg/manifest/validate_env_test.go
+++ b/internal/pkg/manifest/validate_env_test.go
@@ -518,7 +518,7 @@ func TestEnvironmentHTTPConfig_Validate(t *testing.T) {
 		in                   environmentHTTPConfig
 		wantedErrorMsgPrefix string
 	}{
-		"malformed certificates": {
+		"malformed public certificate": {
 			in: environmentHTTPConfig{
 				Public: publicHTTPConfig{
 					Certificates: []string{"arn:aws:weird-little-arn"},
@@ -526,9 +526,24 @@ func TestEnvironmentHTTPConfig_Validate(t *testing.T) {
 			},
 			wantedErrorMsgPrefix: `validate "certificates[0]": `,
 		},
-		"success": {
+		"malformed private certificate": {
+			in: environmentHTTPConfig{
+				Private: privateHTTPConfig{
+					Certificates: []string{"arn:aws:weird-little-arn"},
+				},
+			},
+			wantedErrorMsgPrefix: `validate "certificates[0]": `,
+		},
+		"success with public cert": {
 			in: environmentHTTPConfig{
 				Public: publicHTTPConfig{
+					Certificates: []string{"arn:aws:acm:us-east-1:1111111:certificate/look-like-a-good-arn"},
+				},
+			},
+		},
+		"success with private cert": {
+			in: environmentHTTPConfig{
+				Private: privateHTTPConfig{
 					Certificates: []string{"arn:aws:acm:us-east-1:1111111:certificate/look-like-a-good-arn"},
 				},
 			},

--- a/internal/pkg/manifest/validate_env_test.go
+++ b/internal/pkg/manifest/validate_env_test.go
@@ -524,7 +524,7 @@ func TestEnvironmentHTTPConfig_Validate(t *testing.T) {
 					Certificates: []string{"arn:aws:weird-little-arn"},
 				},
 			},
-			wantedErrorMsgPrefix: `validate "certificates[0]": `,
+			wantedErrorMsgPrefix: `parse "certificates[0]": `,
 		},
 		"malformed private certificate": {
 			in: environmentHTTPConfig{
@@ -532,7 +532,7 @@ func TestEnvironmentHTTPConfig_Validate(t *testing.T) {
 					Certificates: []string{"arn:aws:weird-little-arn"},
 				},
 			},
-			wantedErrorMsgPrefix: `validate "certificates[0]": `,
+			wantedErrorMsgPrefix: `parse "certificates[0]": `,
 		},
 		"success with public cert": {
 			in: environmentHTTPConfig{

--- a/internal/pkg/template/env.go
+++ b/internal/pkg/template/env.go
@@ -41,9 +41,10 @@ type EnvOpts struct {
 	ArtifactBucketARN         string
 	ArtifactBucketKeyARN      string
 
-	VPCConfig      VPCConfig
-	ImportCertARNs []string
-	Telemetry      *Telemetry
+	VPCConfig          VPCConfig
+	ImportCertARNs     []string
+	InternalALBSubnets []string
+	Telemetry          *Telemetry
 
 	LatestVersion string
 	Manifest      string // Serialized manifest used to render the environment template.

--- a/internal/pkg/template/env.go
+++ b/internal/pkg/template/env.go
@@ -41,10 +41,10 @@ type EnvOpts struct {
 	ArtifactBucketARN         string
 	ArtifactBucketKeyARN      string
 
-	VPCConfig          VPCConfig
-	ImportCertARNs     []string
-	InternalALBSubnets []string
-	Telemetry          *Telemetry
+	VPCConfig                VPCConfig
+	ImportCertARNs           []string
+	CustomInternalALBSubnets []string
+	Telemetry                *Telemetry
 
 	LatestVersion string
 	Manifest      string // Serialized manifest used to render the environment template.

--- a/internal/pkg/template/template.go
+++ b/internal/pkg/template/template.go
@@ -130,7 +130,7 @@ func (t *Template) UploadRequestDrivenWebServiceCustomResources(upload s3.Compre
 	return t.uploadCustomResources(upload, rdWkldCustomResourceFiles)
 }
 
-// UploadLoadBalancedWebServiceNLBCustomResources uploads the network load-balanced web service custom resource scripts.
+// UploadNetworkLoadBalancedWebServiceCustomResources uploads the network load-balanced web service custom resource scripts.
 func (t *Template) UploadNetworkLoadBalancedWebServiceCustomResources(upload s3.CompressAndUploadFunc) (map[string]string, error) {
 	return t.uploadCustomResources(upload, nlbWkldCustomResourceFiles)
 }

--- a/internal/pkg/template/templates/environment/cf.yml
+++ b/internal/pkg/template/templates/environment/cf.yml
@@ -195,7 +195,9 @@ Resources:
     Properties:
       Scheme: internal
       SecurityGroups: [ !GetAtt InternalLoadBalancerSecurityGroup.GroupId ]
-{{- if .VPCConfig.Imported}}
+{{- if .InternalALBSubnets}}
+      Subnets: [ {{range $subnet := .InternalALBSubnets}}{{$subnet}}, {{end}} ]
+{{- else if .VPCConfig.Imported}}
       Subnets: [ {{range $id := .VPCConfig.Imported.PrivateSubnetIDs}}{{$id}}, {{end}} ]
 {{- else}}
       Subnets: [ {{range $ind, $cidr := .VPCConfig.Managed.PrivateSubnetCIDRs}}!Ref PrivateSubnet{{inc $ind}}, {{end}} ]

--- a/internal/pkg/template/templates/environment/cf.yml
+++ b/internal/pkg/template/templates/environment/cf.yml
@@ -195,8 +195,8 @@ Resources:
     Properties:
       Scheme: internal
       SecurityGroups: [ !GetAtt InternalLoadBalancerSecurityGroup.GroupId ]
-{{- if .InternalALBSubnets}}
-      Subnets: [ {{range $subnet := .InternalALBSubnets}}{{$subnet}}, {{end}} ]
+{{- if .CustomInternalALBSubnets}}
+      Subnets: [ {{range $subnet := .CustomInternalALBSubnets}}{{$subnet}}, {{end}} ]
 {{- else if .VPCConfig.Imported}}
       Subnets: [ {{range $id := .VPCConfig.Imported.PrivateSubnetIDs}}{{$id}}, {{end}} ]
 {{- else}}


### PR DESCRIPTION
If subnets are indicated for internal ALB placement, instruct accordingly in the CFN template. `cli` package changes to come.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
