### PR TITLE
fix(templates): default path should have lowest priority for HTTPS

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/https-path-alias-template.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/https-path-alias-template.yml
@@ -399,7 +399,11 @@ Resources:
               - - !Sub "/${RulePath}"
                 - !Sub "/${RulePath}/*"
       ListenerArn: !GetAtt EnvControllerAction.HTTPListenerArn
-      Priority: !GetAtt HTTPSRulePriorityAction.Priority # Same priority as HTTPS Listener
+      Priority:
+        !If
+          - IsDefaultRootPath
+          - 50000 # This is the max rule priority. Since this rule evaluates true for everything, we make sure it is last
+          - !GetAtt HTTPSRulePriorityAction.Priority
   HTTPSListenerRule:
     Metadata:
       "aws:copilot:description": "An HTTPS listener rule for forwarding HTTPS traffic to your tasks"
@@ -420,7 +424,11 @@ Resources:
               - - !Sub "/${RulePath}"
                 - !Sub "/${RulePath}/*"
       ListenerArn: !GetAtt EnvControllerAction.HTTPSListenerArn
-      Priority: !GetAtt HTTPSRulePriorityAction.Priority
+      Priority:
+        !If
+          - IsDefaultRootPath
+          - 50000 # This is the max rule priority. Since this rule evaluates true for everything, we make sure it is last
+          - !GetAtt HTTPSRulePriorityAction.Priority
   AddonsStack:
     Metadata:
       "aws:copilot:description": "An Addons CloudFormation Stack for your additional AWS resources"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-grpc-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-grpc-test.stack.yml
@@ -529,7 +529,11 @@ Resources: # If a bucket URL is specified, that means the template exists.
               - - !Sub "/${RulePath}"
                 - !Sub "/${RulePath}/*"
       ListenerArn: !GetAtt EnvControllerAction.HTTPListenerArn
-      Priority: !GetAtt HTTPSRulePriorityAction.Priority # Same priority as HTTPS Listener
+      Priority:
+        !If
+          - IsDefaultRootPath
+          - 50000 # This is the max rule priority. Since this rule evaluates true for everything, we make sure it is last
+          - !GetAtt HTTPSRulePriorityAction.Priority # Same priority as HTTPS Listener
   HTTPSListenerRule:
     Metadata:
       'aws:copilot:description': 'An HTTPS listener rule for forwarding HTTPS traffic to your tasks'
@@ -550,7 +554,11 @@ Resources: # If a bucket URL is specified, that means the template exists.
               - - !Sub "/${RulePath}"
                 - !Sub "/${RulePath}/*"
       ListenerArn: !GetAtt EnvControllerAction.HTTPSListenerArn
-      Priority: !GetAtt HTTPSRulePriorityAction.Priority
+      Priority:
+        !If
+          - IsDefaultRootPath
+          - 50000 # This is the max rule priority. Since this rule evaluates true for everything, we make sure it is last
+          - !GetAtt HTTPSRulePriorityAction.Priority
   AddonsStack:
     Metadata:
       'aws:copilot:description': 'An Addons CloudFormation Stack for your additional AWS resources'

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-dev.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-dev.stack.yml
@@ -436,7 +436,11 @@ Resources: # If a bucket URL is specified, that means the template exists.
               - - !Sub "/${RulePath}"
                 - !Sub "/${RulePath}/*"
       ListenerArn: !GetAtt EnvControllerAction.HTTPListenerArn
-      Priority: !GetAtt HTTPSRulePriorityAction.Priority # Same priority as HTTPS Listener
+      Priority:
+        !If
+          - IsDefaultRootPath
+          - 50000 # This is the max rule priority. Since this rule evaluates true for everything, we make sure it is last
+          - !GetAtt HTTPSRulePriorityAction.Priority
   HTTPSListenerRule:
     Metadata:
       'aws:copilot:description': 'An HTTPS listener rule for forwarding HTTPS traffic to your tasks'
@@ -461,7 +465,11 @@ Resources: # If a bucket URL is specified, that means the template exists.
               - - !Sub "/${RulePath}"
                 - !Sub "/${RulePath}/*"
       ListenerArn: !GetAtt EnvControllerAction.HTTPSListenerArn
-      Priority: !GetAtt HTTPSRulePriorityAction.Priority
+      Priority:
+        !If
+          - IsDefaultRootPath
+          - 50000 # This is the max rule priority. Since this rule evaluates true for everything, we make sure it is last
+          - !GetAtt HTTPSRulePriorityAction.Priority
   PublicNetworkLoadBalancer:
     Metadata:
       'aws:copilot:description': 'A Network Load Balancer to distribute public traffic to your service'

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-prod.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-prod.stack.yml
@@ -592,7 +592,11 @@ Resources: # If a bucket URL is specified, that means the template exists.
               - - !Sub "/${RulePath}"
                 - !Sub "/${RulePath}/*"
       ListenerArn: !GetAtt EnvControllerAction.HTTPListenerArn
-      Priority: !GetAtt HTTPSRulePriorityAction.Priority # Same priority as HTTPS Listener
+      Priority:
+        !If
+          - IsDefaultRootPath
+          - 50000 # This is the max rule priority. Since this rule evaluates true for everything, we make sure it is last
+          - !GetAtt HTTPSRulePriorityAction.Priority
   HTTPSListenerRule:
     Metadata:
       'aws:copilot:description': 'An HTTPS listener rule for forwarding HTTPS traffic to your tasks'
@@ -613,7 +617,11 @@ Resources: # If a bucket URL is specified, that means the template exists.
               - - !Sub "/${RulePath}"
                 - !Sub "/${RulePath}/*"
       ListenerArn: !GetAtt EnvControllerAction.HTTPSListenerArn
-      Priority: !GetAtt HTTPSRulePriorityAction.Priority
+      Priority:
+        !If
+          - IsDefaultRootPath
+          - 50000 # This is the max rule priority. Since this rule evaluates true for everything, we make sure it is last
+          - !GetAtt HTTPSRulePriorityAction.Priority
   AddonsStack:
     Metadata:
       'aws:copilot:description': 'An Addons CloudFormation Stack for your additional AWS resources'

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-staging.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-staging.stack.yml
@@ -420,7 +420,11 @@ Resources: # If a bucket URL is specified, that means the template exists.
               - - !Sub "/${RulePath}"
                 - !Sub "/${RulePath}/*"
       ListenerArn: !GetAtt EnvControllerAction.HTTPListenerArn
-      Priority: !GetAtt HTTPSRulePriorityAction.Priority # Same priority as HTTPS Listener
+      Priority:
+        !If
+          - IsDefaultRootPath
+          - 50000 # This is the max rule priority. Since this rule evaluates true for everything, we make sure it is last
+          - !GetAtt HTTPSRulePriorityAction.Priority
   HTTPSListenerRule:
     Metadata:
       'aws:copilot:description': 'An HTTPS listener rule for forwarding HTTPS traffic to your tasks'
@@ -441,7 +445,11 @@ Resources: # If a bucket URL is specified, that means the template exists.
               - - !Sub "/${RulePath}"
                 - !Sub "/${RulePath}/*"
       ListenerArn: !GetAtt EnvControllerAction.HTTPSListenerArn
-      Priority: !GetAtt HTTPSRulePriorityAction.Priority
+      Priority:
+        !If
+          - IsDefaultRootPath
+          - 50000 # This is the max rule priority. Since this rule evaluates true for everything, we make sure it is last
+          - !GetAtt HTTPSRulePriorityAction.Priority
   AddonsStack:
     Metadata:
       'aws:copilot:description': 'An Addons CloudFormation Stack for your additional AWS resources'

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-test.stack.yml
@@ -528,7 +528,11 @@ Resources: # If a bucket URL is specified, that means the template exists.
               - - !Sub "/${RulePath}"
                 - !Sub "/${RulePath}/*"
       ListenerArn: !GetAtt EnvControllerAction.HTTPListenerArn
-      Priority: !GetAtt HTTPSRulePriorityAction.Priority # Same priority as HTTPS Listener
+      Priority:
+        !If
+          - IsDefaultRootPath
+          - 50000 # This is the max rule priority. Since this rule evaluates true for everything, we make sure it is last
+          - !GetAtt HTTPSRulePriorityAction.Priority
   HTTPSListenerRule:
     Metadata:
       'aws:copilot:description': 'An HTTPS listener rule for forwarding HTTPS traffic to your tasks'
@@ -549,7 +553,11 @@ Resources: # If a bucket URL is specified, that means the template exists.
               - - !Sub "/${RulePath}"
                 - !Sub "/${RulePath}/*"
       ListenerArn: !GetAtt EnvControllerAction.HTTPSListenerArn
-      Priority: !GetAtt HTTPSRulePriorityAction.Priority
+      Priority:
+        !If
+          - IsDefaultRootPath
+          - 50000 # This is the max rule priority. Since this rule evaluates true for everything, we make sure it is last
+          - !GetAtt HTTPSRulePriorityAction.Priority
   AddonsStack:
     Metadata:
       'aws:copilot:description': 'An Addons CloudFormation Stack for your additional AWS resources'

--- a/internal/pkg/template/templates/workloads/partials/cf/https-listener.yml
+++ b/internal/pkg/template/templates/workloads/partials/cf/https-listener.yml
@@ -70,7 +70,11 @@ HTTPListenerRuleWithDomain:
                 - !Sub "/${RulePath}"
                 - !Sub "/${RulePath}/*"
     ListenerArn: !GetAtt EnvControllerAction.HTTPListenerArn
-    Priority: !GetAtt HTTPSRulePriorityAction.Priority # Same priority as HTTPS Listener
+    Priority:
+      !If
+        - IsDefaultRootPath
+        - 50000 # This is the max rule priority. Since this rule evaluates true for everything, we make sure it is last
+        - !GetAtt HTTPSRulePriorityAction.Priority # Same priority as HTTPS Listener
 
 HTTPSListenerRule:
   Metadata:
@@ -114,4 +118,8 @@ HTTPSListenerRule:
                 - !Sub "/${RulePath}"
                 - !Sub "/${RulePath}/*"
     ListenerArn: !GetAtt EnvControllerAction.HTTPSListenerArn
-    Priority: !GetAtt HTTPSRulePriorityAction.Priority
+    Priority:
+      !If
+        - IsDefaultRootPath
+        - 50000 # This is the max rule priority. Since this rule evaluates true for everything, we make sure it is last
+        - !GetAtt HTTPSRulePriorityAction.Priority


### PR DESCRIPTION
<!-- Provide summary of changes -->
Currently, for an app with domain, if an LBWS uses the default path that matches everything, all the upcoming LBWS will not get routed for any traffic because of the routing priority. An workaround before this PR would be deploying them in a specific order.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
