### PR TITLE
chore: fix e2e test by populating `prod` info back to SSM parameter

### DIFF
--- a/internal/pkg/cli/env_init.go
+++ b/internal/pkg/cli/env_init.go
@@ -320,6 +320,7 @@ func (o *initEnvOpts) Execute() error {
 	if err != nil {
 		return fmt.Errorf("get environment struct for %s: %w", o.name, err)
 	}
+	env.Prod = o.isProduction
 	customizedEnv := config.CustomizeEnv{
 		ImportVPC:      o.importVPCConfig(),
 		VPCConfig:      o.adjustVPCConfig(),


### PR DESCRIPTION


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
