### PR TITLE
chore(cli): allow `--internal-alb-subnet` flag to be used independently

### DIFF
--- a/internal/pkg/cli/env_init.go
+++ b/internal/pkg/cli/env_init.go
@@ -371,7 +371,7 @@ func (o *initEnvOpts) validateCustomizedResources() error {
 	if (o.importVPC.isSet() || o.adjustVPC.isSet()) && o.defaultConfig {
 		return fmt.Errorf("cannot import or configure vpc if --%s is set", defaultConfigFlag)
 	}
-	if o.internalALBSubnets != nil && !o.importVPC.isSet() {
+	if o.internalALBSubnets != nil && (o.adjustVPC.isSet() || o.defaultConfig) {
 		log.Error(`To specify internal ALB subnet placement, you must import existing resources, including subnets.
 For default config without subnet placement specification, Copilot will place the internal ALB in the generated private subnets.`)
 		return fmt.Errorf("subnets '%s' specified for internal ALB placement, but those subnets are not imported", strings.Join(o.internalALBSubnets, ", "))


### PR DESCRIPTION
This tiny change reverts the logic that allows users to specify subnets for internal ALB placement without importing subnets WITH FLAGS. If the `--internal-alb-subnets` flag is used and no `--override` or `--default-config` flags are used, rather than erroring out, we should proceed to prompt for env vpc resource imports.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
