### PR TITLE
test: enable running a single e2e test with `e2e-dryrun` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,16 @@ e2e: build-e2e
 	@echo "Running E2E Tests" &&\
 	docker run --privileged -v ${HOME}/.aws:/home/.aws -e "HOME=/home" copilot/e2e:latest
 
+.PHONY: e2e-dryrun
+e2e-dryrun: build # Sample command "make e2e-dryrun test=multi-env-app" to run the test suit under "e2e/multi-env-app"
+	@echo "Install ginkgo"
+	go install github.com/onsi/ginkgo/ginkgo@latest
+	@echo "Setup credentials"
+	./scripts/e2e-dryrun-creds.sh
+	@echo "Run the $(test) test"
+	cd e2e/$(test) && DRYRUN=true ginkgo -v -r
+	cd -
+
 .PHONY: tools
 tools:
 	@echo "Installing custom resource dependencies" &&\

--- a/e2e/internal/client/cli.go
+++ b/e2e/internal/client/cli.go
@@ -244,6 +244,9 @@ func NewCLI() (*CLI, error) {
 	// with test data and files. Since this is going to run
 	// from Docker, the binary will be located in the root bin.
 	cliPath := filepath.Join("/", "bin", "copilot")
+	if os.Getenv("DRYRUN") == "true" {
+		cliPath = filepath.Join("..", "..", "bin", "local", "copilot")
+	}
 	if _, err := os.Stat(cliPath); err != nil {
 		return nil, err
 	}

--- a/e2e/multi-env-app/multi_env_test.go
+++ b/e2e/multi-env-app/multi_env_test.go
@@ -6,6 +6,7 @@ package multi_env_app_test
 import (
 	"fmt"
 	"net/http"
+	"os"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -93,9 +94,11 @@ var _ = Describe("Multiple Env App", func() {
 			Expect(envs["prod"].Prod).To(BeTrue())
 
 			// Make sure, for the sake of coverage, these are cross account,
-			// cross region environments.
-			Expect(envs["test"].Region).NotTo(Equal(envs["prod"].Region))
-			Expect(envs["test"].Account).NotTo(Equal(envs["prod"].Account))
+			// cross region environments if we're not doing a dryrun.
+			if os.Getenv("DRYRUN") != "true" {
+				Expect(envs["test"].Region).NotTo(Equal(envs["prod"].Region))
+				Expect(envs["test"].Account).NotTo(Equal(envs["prod"].Account))
+			}
 		})
 	})
 
@@ -241,8 +244,10 @@ var _ = Describe("Multiple Env App", func() {
 			Expect(envs["test"].Prod).To(BeFalse())
 			Expect(envs["prod"]).NotTo(BeNil())
 			Expect(envs["prod"].Prod).To(BeTrue())
-			Expect(envs["test"].Region).NotTo(Equal(envs["prod"].Region))
-			Expect(envs["test"].Account).NotTo(Equal(envs["prod"].Account))
+			if os.Getenv("DRYRUN") != "true" {
+				Expect(envs["test"].Region).NotTo(Equal(envs["prod"].Region))
+				Expect(envs["test"].Account).NotTo(Equal(envs["prod"].Account))
+			}
 			Expect(envs["test"].ExecutionRole).NotTo(Equal(envs["prod"].ExecutionRole))
 			Expect(envs["test"].ManagerRole).NotTo(Equal(envs["prod"].ExecutionRole))
 		})

--- a/e2e/multi-pipeline/multi_pipeline_test.go
+++ b/e2e/multi-pipeline/multi_pipeline_test.go
@@ -112,8 +112,13 @@ var _ = Describe("pipeline flow", func() {
 
 			Expect(envs["test"]).NotTo(BeNil())
 			Expect(envs["prod"]).NotTo(BeNil())
-			Expect(envs["test"].Region).NotTo(Equal(envs["prod"].Region))
-			Expect(envs["test"].Account).NotTo(Equal(envs["prod"].Account))
+
+			// Make sure, for the sake of coverage, these are cross account,
+			// cross region environments if we're not doing a dryrun.
+			if os.Getenv("DRYRUN") != "true" {
+				Expect(envs["test"].Region).NotTo(Equal(envs["prod"].Region))
+				Expect(envs["test"].Account).NotTo(Equal(envs["prod"].Account))
+			}
 		})
 	})
 

--- a/scripts/e2e-dryrun-creds.sh
+++ b/scripts/e2e-dryrun-creds.sh
@@ -1,0 +1,19 @@
+#! /usr/bin/env python3
+import subprocess
+
+cmd = subprocess.run(['aws', 'configure', 'list-profiles'], stdout=subprocess.PIPE)
+profiles = cmd.stdout.decode('utf-8').split('\n')
+
+for e2eprofile in ['e2etestenv', 'e2eprodenv']:
+  if e2eprofile in profiles:
+    continue
+  print(f'Profile [{e2eprofile}] is required but does not exist. Copying your [default] access key id and secret key...')
+  cmd = subprocess.run(['aws', 'configure', 'get', 'default.region'], stdout=subprocess.PIPE)
+  region = cmd.stdout.decode('utf-8').strip()
+  cmd = subprocess.run(['aws', 'configure', 'get', 'default.aws_access_key_id'], stdout=subprocess.PIPE)
+  access_key = cmd.stdout.decode('utf-8').strip()
+  cmd = subprocess.run(['aws', 'configure', 'get', 'default.aws_secret_access_key'], stdout=subprocess.PIPE)
+  secret = cmd.stdout.decode('utf-8').strip()
+  subprocess.run(['aws', 'configure', 'set', 'region', region, '--profile', e2eprofile])
+  subprocess.run(['aws', 'configure', 'set', 'aws_access_key_id', access_key, '--profile', e2eprofile])
+  subprocess.run(['aws', 'configure', 'set', 'aws_secret_access_key', secret, '--profile', e2eprofile])


### PR DESCRIPTION
You can now run a single e2e test in your AWS account with:
```
make e2e-dryrun test=<the test suit name>
```
For example, `make e2e-dryrun test=multi-env-app`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
