### PR TITLE
chore: allow non-http svcs in env w/ cert(s)

### DIFF
--- a/internal/pkg/cli/deploy/deploy.go
+++ b/internal/pkg/cli/deploy/deploy.go
@@ -944,7 +944,6 @@ func (d *backendSvcDeployer) stackConfiguration(in *StackRuntimeConfiguration) (
 	if err != nil {
 		return nil, err
 	}
-
 	if err := d.validateALBRuntime(); err != nil {
 		return nil, err
 	}
@@ -1211,6 +1210,8 @@ func validateAppVersionForAlias(appName string, appVersionGetter versionGetter) 
 
 func (d *backendSvcDeployer) validateALBRuntime() error {
 	switch {
+	case d.backendMft.RoutingRule.IsEmpty():
+		return nil
 	case d.backendMft.RoutingRule.Alias.IsEmpty() && d.env.HasImportedCerts():
 		return &errSvcWithNoALBAliasDeployingToEnvWithImportedCerts{
 			name:    d.name,

--- a/internal/pkg/cli/deploy/deploy.go
+++ b/internal/pkg/cli/deploy/deploy.go
@@ -1209,9 +1209,10 @@ func validateAppVersionForAlias(appName string, appVersionGetter versionGetter) 
 }
 
 func (d *backendSvcDeployer) validateALBRuntime() error {
-	switch {
-	case d.backendMft.RoutingRule.IsEmpty():
+	if d.backendMft.RoutingRule.IsEmpty() {
 		return nil
+	}
+	switch {
 	case d.backendMft.RoutingRule.Alias.IsEmpty() && d.env.HasImportedCerts():
 		return &errSvcWithNoALBAliasDeployingToEnvWithImportedCerts{
 			name:    d.name,

--- a/internal/pkg/cli/deploy/deploy_test.go
+++ b/internal/pkg/cli/deploy/deploy_test.go
@@ -1211,11 +1211,32 @@ func TestBackendSvcDeployer_stackConfiguration(t *testing.T) {
 					ImportCertARNs: []string{"mockCertARN"},
 				},
 			},
-			Manifest: &manifest.BackendService{},
+			Manifest: &manifest.BackendService{
+				BackendServiceConfig: manifest.BackendServiceConfig{
+					RoutingRule: manifest.RoutingRuleConfiguration{
+						Path: aws.String("/"),
+					},
+				},
+			},
 			setupMocks: func(m *deployMocks) {
 				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return(mockAppName+".local", nil)
 			},
 			expectedErr: `cannot deploy service mock-svc without http.alias to environment mock-env with certificate imported`,
+		},
+		"success if env has imported certs but alb not configured": {
+			App: &config.Application{
+				Name: mockAppName,
+			},
+			Env: &config.Environment{
+				Name: mockEnvName,
+				CustomConfig: &config.CustomizeEnv{
+					ImportCertARNs: []string{"mockCertARN"},
+				},
+			},
+			Manifest: &manifest.BackendService{},
+			setupMocks: func(m *deployMocks) {
+				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return(mockAppName+".local", nil)
+			},
 		},
 	}
 


### PR DESCRIPTION
In an environment with imported certs, not all backend services should have to be associated with the internal load balancer. This limits the alias-cert validation to backend services with `http` specified.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
