### PR TITLE
chore(deploy): use customresource pkg to UploadArtifacts 

### DIFF
--- a/internal/pkg/cli/deploy/deploy.go
+++ b/internal/pkg/cli/deploy/deploy.go
@@ -1017,7 +1017,7 @@ func (d *lbWebSvcDeployer) stackConfiguration(in *StackRuntimeConfiguration) (*s
 	if err := d.validateALBRuntime(); err != nil {
 		return nil, err
 	}
-	if err := d.validateNLBWSRuntime(); err != nil {
+	if err := d.validateNLBRuntime(); err != nil {
 		return nil, err
 	}
 	var opts []stack.LoadBalancedWebServiceOption
@@ -1374,7 +1374,7 @@ func (d *lbWebSvcDeployer) validateALBRuntime() error {
 	return fmt.Errorf("cannot specify http.alias when application is not associated with a domain and env %s doesn't import one or more certificates", d.env.Name)
 }
 
-func (d *lbWebSvcDeployer) validateNLBWSRuntime() error {
+func (d *lbWebSvcDeployer) validateNLBRuntime() error {
 	if d.lbMft.NLBConfig.Aliases.IsEmpty() {
 		return nil
 	}

--- a/internal/pkg/cli/deploy/deploy.go
+++ b/internal/pkg/cli/deploy/deploy.go
@@ -1014,7 +1014,7 @@ func (d *lbWebSvcDeployer) stackConfiguration(in *StackRuntimeConfiguration) (*s
 	if err != nil {
 		return nil, err
 	}
-	if err := d.validateALBWSRuntime(); err != nil {
+	if err := d.validateALBRuntime(); err != nil {
 		return nil, err
 	}
 	if err := d.validateNLBWSRuntime(); err != nil {
@@ -1343,7 +1343,7 @@ func (d *backendSvcDeployer) validateALBRuntime() error {
 	return nil
 }
 
-func (d *lbWebSvcDeployer) validateALBWSRuntime() error {
+func (d *lbWebSvcDeployer) validateALBRuntime() error {
 	if d.lbMft.RoutingRule.Alias.IsEmpty() {
 		if d.env.HasImportedCerts() {
 			return &errSvcWithNoALBAliasDeployingToEnvWithImportedCerts{

--- a/internal/pkg/cli/deploy/deploy.go
+++ b/internal/pkg/cli/deploy/deploy.go
@@ -528,28 +528,6 @@ type Options struct {
 }
 
 // UploadArtifacts uploads the deployment artifacts such as the container image, custom resources, addons and env files.
-func (d *workloadDeployer) UploadArtifacts() (*UploadArtifactsOutput, error) {
-	imageDigest, err := d.uploadContainerImage(d.imageBuilderPusher)
-	if err != nil {
-		return nil, err
-	}
-	s3Artifacts, err := d.uploadArtifactsToS3(&uploadArtifactsToS3Input{
-		fs:        d.fs,
-		uploader:  d.s3Client,
-		templater: d.templater,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return &UploadArtifactsOutput{
-		ImageDigest: imageDigest,
-		EnvFileARN:  s3Artifacts.envFileARN,
-		AddonsURL:   s3Artifacts.addonsURL,
-	}, nil
-}
-
-// UploadArtifacts uploads the deployment artifacts such as the container image, custom resources, addons and env files.
 func (d *lbWebSvcDeployer) UploadArtifacts() (*UploadArtifactsOutput, error) {
 	return d.uploadArtifacts(d.customResources)
 }

--- a/internal/pkg/cli/deploy/deploy.go
+++ b/internal/pkg/cli/deploy/deploy.go
@@ -295,8 +295,8 @@ type lbWebSvcDeployer struct {
 	lbMft                  *manifest.LoadBalancedWebService
 }
 
-// NewLBDeployer is the constructor for lbWebSvcDeployer.
-func NewLBDeployer(in *WorkloadDeployerInput) (*lbWebSvcDeployer, error) {
+// NewLBWSDeployer is the constructor for lbWebSvcDeployer.
+func NewLBWSDeployer(in *WorkloadDeployerInput) (*lbWebSvcDeployer, error) {
 	svcDeployer, err := newSvcDeployer(in)
 	if err != nil {
 		return nil, err

--- a/internal/pkg/cli/deploy/deploy.go
+++ b/internal/pkg/cli/deploy/deploy.go
@@ -1368,7 +1368,7 @@ func (d *lbWebSvcDeployer) validateALBRuntime() error {
 			logAppVersionOutdatedError(aws.StringValue(d.lbMft.Name))
 			return err
 		}
-		return validateLBSvcAlias(d.lbMft.RoutingRule.Alias, d.app, d.env.Name)
+		return validateLBWSAlias(d.lbMft.RoutingRule.Alias, d.app, d.env.Name)
 	}
 	log.Errorf(ecsALBAliasUsedWithoutDomainFriendlyText)
 	return fmt.Errorf("cannot specify http.alias when application is not associated with a domain and env %s doesn't import one or more certificates", d.env.Name)
@@ -1389,10 +1389,10 @@ func (d *lbWebSvcDeployer) validateNLBRuntime() error {
 		logAppVersionOutdatedError(aws.StringValue(d.lbMft.Name))
 		return err
 	}
-	return validateLBSvcAlias(d.lbMft.NLBConfig.Aliases, d.app, d.env.Name)
+	return validateLBWSAlias(d.lbMft.NLBConfig.Aliases, d.app, d.env.Name)
 }
 
-func validateLBSvcAlias(aliases manifest.Alias, app *config.Application, envName string) error {
+func validateLBWSAlias(aliases manifest.Alias, app *config.Application, envName string) error {
 	if aliases.IsEmpty() {
 		return nil
 	}

--- a/internal/pkg/cli/deploy/deploy_test.go
+++ b/internal/pkg/cli/deploy/deploy_test.go
@@ -181,6 +181,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 					svcDeployer: &svcDeployer{
 						workloadDeployer: deployer,
 					},
+					customResources: customresource.LBWS,
 				}
 			},
 		},
@@ -206,6 +207,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 					svcDeployer: &svcDeployer{
 						workloadDeployer: deployer,
 					},
+					customResources: customresource.Backend,
 				}
 			},
 		},
@@ -231,6 +233,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 					svcDeployer: &svcDeployer{
 						workloadDeployer: deployer,
 					},
+					customResources: customresource.Worker,
 				}
 			},
 		},
@@ -256,6 +259,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 					svcDeployer: &svcDeployer{
 						workloadDeployer: deployer,
 					},
+					customResources: customresource.RDWS,
 				}
 			},
 		},
@@ -279,6 +283,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 			mockServiceDeployer: func(deployer *workloadDeployer) artifactsUploader {
 				return &jobDeployer{
 					workloadDeployer: deployer,
+					customResources:  customresource.ScheduledJob,
 				}
 			},
 		},

--- a/internal/pkg/cli/deploy/deploy_test.go
+++ b/internal/pkg/cli/deploy/deploy_test.go
@@ -124,7 +124,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 		inRegion                    string
 		inUploadCustomResourcesFlag bool
 
-		mock                func(m *deployMocks)
+		mock                func(t *testing.T, m *deployMocks)
 		mockServiceDeployer func(deployer *workloadDeployer) artifactsUploader
 
 		wantAddonsURL     string
@@ -135,7 +135,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 	}{
 		"error if failed to build and push image": {
 			inBuildRequired: true,
-			mock: func(m *deployMocks) {
+			mock: func(t *testing.T, m *deployMocks) {
 				m.mockImageBuilderPusher.EXPECT().BuildAndPush(gomock.Any(), &dockerengine.BuildArguments{
 					Dockerfile: "mockDockerfile",
 					Context:    "mockContext",
@@ -147,7 +147,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 		},
 		"build and push image successfully": {
 			inBuildRequired: true,
-			mock: func(m *deployMocks) {
+			mock: func(t *testing.T, m *deployMocks) {
 				m.mockImageBuilderPusher.EXPECT().BuildAndPush(gomock.Any(), &dockerengine.BuildArguments{
 					Dockerfile: "mockDockerfile",
 					Context:    "mockContext",
@@ -162,7 +162,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 		},
 		"should retrieve Load Balanced Web Service custom resource URLs": {
 			inUploadCustomResourcesFlag: true,
-			mock: func(m *deployMocks) {
+			mock: func(t *testing.T, m *deployMocks) {
 				// Ignore addon uploads.
 				m.mockTemplater.EXPECT().Template().Return("", &addon.ErrAddonsNotFound{})
 
@@ -189,7 +189,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 		},
 		"should retrieve Backend Service custom resource URLs": {
 			inUploadCustomResourcesFlag: true,
-			mock: func(m *deployMocks) {
+			mock: func(t *testing.T, m *deployMocks) {
 				// Ignore addon uploads.
 				m.mockTemplater.EXPECT().Template().Return("", &addon.ErrAddonsNotFound{})
 
@@ -216,7 +216,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 		},
 		"should retrieve Worker Service custom resource URLs": {
 			inUploadCustomResourcesFlag: true,
-			mock: func(m *deployMocks) {
+			mock: func(t *testing.T, m *deployMocks) {
 				// Ignore addon uploads.
 				m.mockTemplater.EXPECT().Template().Return("", &addon.ErrAddonsNotFound{})
 
@@ -243,7 +243,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 		},
 		"should retrieve Request-Driven Web Service custom resource URLs": {
 			inUploadCustomResourcesFlag: true,
-			mock: func(m *deployMocks) {
+			mock: func(t *testing.T, m *deployMocks) {
 				// Ignore addon uploads.
 				m.mockTemplater.EXPECT().Template().Return("", &addon.ErrAddonsNotFound{})
 
@@ -270,7 +270,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 		},
 		"should retrieve Scheduled Job custom resource URLs": {
 			inUploadCustomResourcesFlag: true,
-			mock: func(m *deployMocks) {
+			mock: func(t *testing.T, m *deployMocks) {
 				// Ignore addon uploads.
 				m.mockTemplater.EXPECT().Template().Return("", &addon.ErrAddonsNotFound{})
 
@@ -295,7 +295,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 		},
 		"error if fail to read env file": {
 			inEnvFile: mockEnvFile,
-			mock: func(m *deployMocks) {
+			mock: func(t *testing.T, m *deployMocks) {
 				m.mockFileReader.EXPECT().ReadFile(filepath.Join(mockWorkspacePath, mockEnvFile)).
 					Return(nil, mockError)
 			},
@@ -303,7 +303,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 		},
 		"error if fail to put env file to s3 bucket": {
 			inEnvFile: mockEnvFile,
-			mock: func(m *deployMocks) {
+			mock: func(t *testing.T, m *deployMocks) {
 				m.mockFileReader.EXPECT().ReadFile(filepath.Join(mockWorkspacePath, mockEnvFile)).Return([]byte{}, nil)
 				m.mockUploader.EXPECT().Upload(mockS3Bucket, mockEnvFilePath, gomock.Any()).
 					Return("", mockError)
@@ -312,7 +312,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 		},
 		"error if fail to parse s3 url": {
 			inEnvFile: mockEnvFile,
-			mock: func(m *deployMocks) {
+			mock: func(t *testing.T, m *deployMocks) {
 				m.mockFileReader.EXPECT().ReadFile(filepath.Join(mockWorkspacePath, mockEnvFile)).Return([]byte{}, nil)
 				m.mockUploader.EXPECT().Upload(mockS3Bucket, mockEnvFilePath, gomock.Any()).
 					Return(mockBadEnvFileS3URL, nil)
@@ -323,7 +323,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 		"error if fail to find the partition": {
 			inEnvFile: mockEnvFile,
 			inRegion:  "sun-south-0",
-			mock: func(m *deployMocks) {
+			mock: func(t *testing.T, m *deployMocks) {
 				m.mockFileReader.EXPECT().ReadFile(filepath.Join(mockWorkspacePath, mockEnvFile)).Return([]byte{}, nil)
 				m.mockUploader.EXPECT().Upload(mockS3Bucket, mockEnvFilePath, gomock.Any()).
 					Return(mockEnvFileS3URL, nil)
@@ -333,7 +333,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 		"should push addons template to S3 bucket": {
 			inEnvFile: mockEnvFile,
 			inRegion:  "us-west-2",
-			mock: func(m *deployMocks) {
+			mock: func(t *testing.T, m *deployMocks) {
 				m.mockFileReader.EXPECT().ReadFile(filepath.Join(mockWorkspacePath, mockEnvFile)).Return([]byte{}, nil)
 				m.mockUploader.EXPECT().Upload(mockS3Bucket, mockEnvFilePath, gomock.Any()).
 					Return(mockEnvFileS3URL, nil)
@@ -347,7 +347,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 		},
 		"should return error if fail to upload to S3 bucket": {
 			inRegion: "us-west-2",
-			mock: func(m *deployMocks) {
+			mock: func(t *testing.T, m *deployMocks) {
 				m.mockTemplater.EXPECT().Template().Return("some data", nil)
 				m.mockUploader.EXPECT().Upload(mockS3Bucket, mockAddonPath, gomock.Any()).
 					Return("", mockError)
@@ -356,14 +356,14 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 			wantErr: fmt.Errorf("put addons artifact to bucket mockBucket: some error"),
 		},
 		"should return empty url if the service doesn't have any addons and env files": {
-			mock: func(m *deployMocks) {
+			mock: func(t *testing.T, m *deployMocks) {
 				m.mockTemplater.EXPECT().Template().Return("", &addon.ErrAddonsNotFound{
 					WlName: "mockWkld",
 				})
 			},
 		},
 		"should fail if addons cannot be retrieved from workspace": {
-			mock: func(m *deployMocks) {
+			mock: func(t *testing.T, m *deployMocks) {
 				m.mockTemplater.EXPECT().Template().Return("", mockError)
 			},
 			wantErr: fmt.Errorf("retrieve addons template: %w", mockError),
@@ -381,7 +381,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 				mockImageBuilderPusher: mocks.NewMockimageBuilderPusher(ctrl),
 				mockFileReader:         mocks.NewMockfileReader(ctrl),
 			}
-			tc.mock(m)
+			tc.mock(t, m)
 
 			wkldDeployer := &workloadDeployer{
 				name: mockName,

--- a/internal/pkg/cli/deploy/deploy_test.go
+++ b/internal/pkg/cli/deploy/deploy_test.go
@@ -177,7 +177,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 				}).Times(len(crs))
 			},
 			mockServiceDeployer: func(deployer *workloadDeployer) artifactsUploader {
-				return &lbSvcDeployer{
+				return &lbWebSvcDeployer{
 					svcDeployer: &svcDeployer{
 						workloadDeployer: deployer,
 					},
@@ -839,7 +839,7 @@ func TestWorkloadDeployer_DeployWorkload(t *testing.T) {
 			}
 			tc.mock(m)
 
-			deployer := lbSvcDeployer{
+			deployer := lbWebSvcDeployer{
 				svcDeployer: &svcDeployer{
 					workloadDeployer: &workloadDeployer{
 						name:           mockName,

--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -118,7 +118,7 @@ func newSvcDeployer(o *deploySvcOpts) (workloadDeployer, error) {
 	}
 	switch t := o.appliedManifest.(type) {
 	case *manifest.LoadBalancedWebService:
-		deployer, err = clideploy.NewLBDeployer(&in)
+		deployer, err = clideploy.NewLBWSDeployer(&in)
 	case *manifest.BackendService:
 		deployer, err = clideploy.NewBackendDeployer(&in)
 	case *manifest.RequestDrivenWebService:

--- a/internal/pkg/cli/svc_package.go
+++ b/internal/pkg/cli/svc_package.go
@@ -137,7 +137,7 @@ func newWkldTplGenerator(o *packageSvcOpts) (workloadTemplateGenerator, error) {
 	}
 	switch t := o.appliedManifest.(type) {
 	case *manifest.LoadBalancedWebService:
-		deployer, err = clideploy.NewLBDeployer(&in)
+		deployer, err = clideploy.NewLBWSDeployer(&in)
 	case *manifest.BackendService:
 		deployer, err = clideploy.NewBackendDeployer(&in)
 	case *manifest.RequestDrivenWebService:


### PR DESCRIPTION
We call the new `customresource` path only behind a feature flag so that we donot upload these lambda functions for now.

Also refactors to rename receivers for LBWS deployers and validation method names.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
