### PR TITLE
docs: code highlighting and spacing

### DIFF
--- a/site/content/docs/commands/app-delete.en.md
+++ b/site/content/docs/commands/app-delete.en.md
@@ -1,5 +1,5 @@
 # app delete
-```bash
+```console
 $ copilot app delete [flags]
 ```
 
@@ -9,13 +9,13 @@ $ copilot app delete [flags]
 
 ## What are the flags?
 
-```bash
+```
 -h, --help                          help for delete
     --yes                           Skips confirmation prompt.
 ```
 
 ## Examples
 Force delete the application.
-```bash
+```console
 $ copilot app delete --yes 
 ```

--- a/site/content/docs/commands/app-delete.ja.md
+++ b/site/content/docs/commands/app-delete.ja.md
@@ -1,5 +1,5 @@
 # app delete
-```bash
+```console
 $ copilot app delete [flags]
 ```
 
@@ -9,13 +9,13 @@ $ copilot app delete [flags]
 
 ## フラグ
 
-```bash
+```
 -h, --help                          help for delete
     --yes                           Skips confirmation prompt.
 ```
 
 ## 実行例
 Application を強制的に削除します。
-```bash
+```console
 $ copilot app delete --yes 
 ```

--- a/site/content/docs/commands/app-init.en.md
+++ b/site/content/docs/commands/app-init.en.md
@@ -1,5 +1,5 @@
 # app init
-```bash
+```console
 $ copilot app init [name] [flags]
 ```
 
@@ -12,7 +12,7 @@ Typically, you don't need to run `app init` (`init` does all the same work) unle
 
 ## What are the flags?
 Like all commands in the Copilot CLI, if you don't provide required flags, we'll prompt you for all the information we need to get you going. You can skip the prompts by providing information via flags:
-```bash
+```
       --domain string                  Optional. Your existing custom domain name.
   -h, --help                           help for init
       --resource-tags stringToString   Optional. Labels with a key and value separated by commas.
@@ -25,15 +25,15 @@ For example: `copilot app init --resource-tags department=MyDept,team=MyTeam`
 
 ## Examples
 Create a new application named "my-app".
-```bash
+```console
 $ copilot app init my-app
 ```
 Create a new application with an existing domain name in Amazon Route53.
-```bash
+```console
 $ copilot app init --domain example.com
 ```
 Create a new application with resource tags.
-```bash
+```console
 $ copilot app init --resource-tags department=MyDept,team=MyTeam
 ```
 ## What does it look like?

--- a/site/content/docs/commands/app-init.ja.md
+++ b/site/content/docs/commands/app-init.ja.md
@@ -1,5 +1,5 @@
 # app init
-```bash
+```console
 $ copilot app init [name] [flags]
 ```
 
@@ -14,7 +14,7 @@ $ copilot app init [name] [flags]
 ## フラグ
 Copilot CLI における全てのコマンドと同じ様に、必要なフラグを指定しなかった場合、必要な情報を全て入力する様に求められます。
 フラグを指定して情報を指定すると、プロンプトをスキップできます。
-```bash
+```
       --domain string                  Optional. Your existing custom domain name.
   -h, --help                           help for init
       --resource-tags stringToString   Optional. Labels with a key and value separated by commas.
@@ -29,15 +29,15 @@ Copilot CLI における全てのコマンドと同じ様に、必要なフラ�
 
 ## 実行例
 "my-app"という名前の新しい Application を作成します。
-```bash
+```console
 $ copilot app init my-app
 ```
 Route 53 に登録済みの既存ドメイン名を利用して新しい Application を作成します。
-```bash
+```console
 $ copilot app init --domain example.com
 ```
 リソースタグを指定して新しい Application を作成します。
-```bash
+```console
 $ copilot app init --resource-tags department=MyDept,team=MyTeam
 ```
 ## 出力例

--- a/site/content/docs/commands/app-ls.en.md
+++ b/site/content/docs/commands/app-ls.en.md
@@ -1,5 +1,5 @@
 # app ls
-```bash
+```console
 $ copilot app ls [flags]
 ```
 
@@ -9,13 +9,13 @@ $ copilot app ls [flags]
 
 ## What are the flags?
 
-```bash
+```
 -h, --help             help for ls
 ```
 
 ## Examples
 List all the applications in your account and region.
-```bash
+```console
 $ copilot app ls
 ```
 

--- a/site/content/docs/commands/app-ls.ja.md
+++ b/site/content/docs/commands/app-ls.ja.md
@@ -1,5 +1,5 @@
 # app ls
-```bash
+```console
 $ copilot app ls [flags]
 ```
 
@@ -9,13 +9,13 @@ $ copilot app ls [flags]
 
 ## フラグ
 
-```bash
+```
 -h, --help             help for ls
 ```
 
 ## 実行例
 AWS アカウント、リージョンにある全ての Application を一覧表示します。
-```bash
+```console
 $ copilot app ls
 ```
 

--- a/site/content/docs/commands/app-show.en.md
+++ b/site/content/docs/commands/app-show.en.md
@@ -1,5 +1,5 @@
 # app show
-```bash
+```console
 $ copilot app show [flags]
 ```
 
@@ -9,7 +9,7 @@ $ copilot app show [flags]
 
 ## What are the flags?
 
-```bash
+```
 -h, --help          help for show
     --json          Optional. Outputs in JSON format.
 -n, --name string   Name of the application.
@@ -17,7 +17,7 @@ $ copilot app show [flags]
 
 ## Examples
 Shows info about the application "my-app".
-```bash
+```console
 $ copilot app show -n my-app
 ```
 

--- a/site/content/docs/commands/app-show.ja.md
+++ b/site/content/docs/commands/app-show.ja.md
@@ -1,5 +1,5 @@
 # app show
-```bash
+```console
 $ copilot app show [flags]
 ```
 
@@ -9,7 +9,7 @@ $ copilot app show [flags]
 
 ## フラグ
 
-```bash
+```
 -h, --help          help for show
     --json          Optional. Outputs in JSON format.
 -n, --name string   Name of the application.
@@ -17,7 +17,7 @@ $ copilot app show [flags]
 
 ## 実行例
 "my-app"という Application に関する情報を出力します。
-```bash
+```console
 $ copilot app show -n my-app
 ```
 

--- a/site/content/docs/commands/app-upgrade.en.md
+++ b/site/content/docs/commands/app-upgrade.en.md
@@ -1,5 +1,5 @@
 # app upgrade
-```bash
+```console
 $ copilot app upgrade [flags]
 ```
 
@@ -9,13 +9,13 @@ $ copilot app upgrade [flags]
 
 ## What are the flags?
 
-```bash
+```
 -h, --help          help for upgrade
 -n, --name string   Name of the application.
 ```
 
 ## Examples
 Upgrade the application "my-app" to the latest version
-```bash
+```console
 $ copilot app upgrade -n my-app
 ```

--- a/site/content/docs/commands/app-upgrade.ja.md
+++ b/site/content/docs/commands/app-upgrade.ja.md
@@ -1,5 +1,5 @@
 # app upgrade
-```bash
+```console
 $ copilot app upgrade [flags]
 ```
 
@@ -9,13 +9,13 @@ $ copilot app upgrade [flags]
 
 ## フラグ
 
-```bash
+```
 -h, --help          help for upgrade
 -n, --name string   Name of the application.
 ```
 
 ## 実行例
 Application "my-app" を最新バージョンにアップグレードします。
-```bash
+```console
 $ copilot app upgrade -n my-app
 ```

--- a/site/content/docs/commands/completion.en.md
+++ b/site/content/docs/commands/completion.en.md
@@ -1,5 +1,5 @@
 # completion
-```
+```console
 $ copilot completion [shell] [flags]
 ```
 
@@ -9,30 +9,30 @@ $ copilot completion [shell] [flags]
 See the help menu for instructions on how to setup auto-completion for your respective shell.
 
 ## What are the flags?
-```bash
+```
 -h, --help   help for completion
 ```
 
 ## Examples
 Install zsh completion.
-```bash
+```console
 $ source <(copilot completion zsh)
 $ copilot completion zsh > "${fpath[1]}/_copilot" # to autoload on startup
 ```
 Install bash completion on macOS using homebrew.
-```bash
+```console
 $ brew install bash-completion   # if running 3.2
 $ brew install bash-completion@2 # if running Bash 4.1+
 $ copilot completion bash > /usr/local/etc/bash_completion.d
 ```
 Install bash completion on linux
-```bash
+```console
 $ source <(copilot completion bash)
 $ copilot completion bash > copilot.sh
 $ sudo mv copilot.sh /etc/bash_completion.d/copilot
 ```
 Install fish completion on linux
-```bash
+```console
 $ source <(copilot completion fish)
 $ copilot completion fish > ~/.config/fish/completions/copilot.fish
 ```

--- a/site/content/docs/commands/completion.ja.md
+++ b/site/content/docs/commands/completion.ja.md
@@ -1,5 +1,5 @@
 # completion
-```
+```console
 $ copilot completion [shell] [flags]
 ```
 
@@ -9,30 +9,30 @@ $ copilot completion [shell] [flags]
 それぞれのシェルで自動補完を設定する方法については、ヘルプメニューを参照してください。
 
 ## フラグ
-```bash
+```
 -h, --help   help for completion
 ```
 
 ## 例
 zsh の補完をインストールします。
-```bash
+```console
 $ source <(copilot completion zsh)
 $ copilot completion zsh > "${fpath[1]}/_copilot" # to autoload on startup
 ```
 bash の補完を homebrew を使って macOS にインストールします。
-```bash
+```console
 $ brew install bash-completion   # if running 3.2
 $ brew install bash-completion@2 # if running Bash 4.1+
 $ copilot completion bash > /usr/local/etc/bash_completion.d
 ```
 bash の補完を Linux にインストールします。
-```bash
+```console
 $ source <(copilot completion bash)
 $ copilot completion bash > copilot.sh
 $ sudo mv copilot.sh /etc/bash_completion.d/copilot
 ```
 fish の補完を Linux にインストールします。
-```bash
+```console
 $ source <(copilot completion fish)
 $ copilot completion fish > ~/.config/fish/completions/copilot.fish
 ```

--- a/site/content/docs/commands/deploy.en.md
+++ b/site/content/docs/commands/deploy.en.md
@@ -1,5 +1,5 @@
 # copilot deploy
-```
+```console
 $ copilot deploy
 ```
 
@@ -15,7 +15,7 @@ This command is used to run either [`copilot svc deploy`](../commands/svc-deploy
 
 ## What are the flags?
 
-```bash
+```
   -a, --app string                     Name of the application.
   -e, --env string                     Name of the environment.
       --force                          Optional. Force a new service deployment using the existing image.
@@ -38,11 +38,11 @@ rollback of the stack via the AWS console or AWS CLI before the next deployment.
 ## Examples
 
 Deploys a service named "frontend" to a "test" environment.
-```bash
+```console
  $ copilot deploy --name frontend --env test
 ```
 
 Deploys a job named "mailer" with additional resource tags to a "prod" environment.
-```bash
+```console
 $ copilot deploy -n mailer -e prod --resource-tags source/revision=bb133e7,deployment/initiator=manual
 ```

--- a/site/content/docs/commands/deploy.ja.md
+++ b/site/content/docs/commands/deploy.ja.md
@@ -1,5 +1,5 @@
 # copilot deploy
-```
+```console
 $ copilot deploy
 ```
 
@@ -16,7 +16,7 @@ $ copilot deploy
 
 ## フラグ
 
-```bash
+```
   -a, --app string                     Name of the application.
   -e, --env string                     Name of the environment.
       --force                          Optional. Force a new service deployment using the existing image.
@@ -38,11 +38,11 @@ $ copilot deploy
 ## 実行例
 
 "frontend"という名前の Service を "test" Environment にデプロイします。
-```bash
+```console
  $ copilot deploy --name frontend --env test
 ```
 
 "mailer"という名前の Job を、追加のリソースタグを付加して、"prod" Environment にデプロイします。
-```bash
+```console
 $ copilot deploy -n mailer -e prod --resource-tags source/revision=bb133e7,deployment/initiator=manual
 ```

--- a/site/content/docs/commands/docs.en.md
+++ b/site/content/docs/commands/docs.en.md
@@ -1,5 +1,5 @@
 # docs
-```bash
+```console
 $ copilot docs [flags]
 ```
 
@@ -9,6 +9,6 @@ $ copilot docs [flags]
 
 ## What are the flags?
 
-```bash
+```
   -h, --help         help for docs
 ```

--- a/site/content/docs/commands/docs.ja.md
+++ b/site/content/docs/commands/docs.ja.md
@@ -1,5 +1,5 @@
 # docs
-```bash
+```console
 $ copilot docs [flags]
 ```
 
@@ -9,6 +9,6 @@ $ copilot docs [flags]
 
 ## フラグ 
 
-```bash
+```
   -h, --help         help for docs
 ```

--- a/site/content/docs/commands/env-delete.en.md
+++ b/site/content/docs/commands/env-delete.en.md
@@ -1,5 +1,5 @@
 # env delete
-```bash
+```console
 $ copilot env delete [flags]
 ```
 
@@ -18,10 +18,10 @@ After you answer the questions, you should see that the AWS CloudFormation stack
 
 ## Examples
 Delete the "test" environment.
-```bash
+```console
 $ copilot env delete --name test 
 ```
 Delete the "test" environment without prompting.
-```bash
+```console
 $ copilot env delete --name test --yes
 ```

--- a/site/content/docs/commands/env-delete.ja.md
+++ b/site/content/docs/commands/env-delete.ja.md
@@ -1,5 +1,5 @@
 # env delete
-```bash
+```console
 $ copilot env delete [flags]
 ```
 
@@ -18,10 +18,10 @@ $ copilot env delete [flags]
 
 ## 実行例
 "test" Environment を削除します。
-```bash
+```console
 $ copilot env delete --name test 
 ```
 "test" Environment をプロンプトなしで削除します。
-```bash
+```console
 $ copilot env delete --name test --yes
 ```

--- a/site/content/docs/commands/env-init.en.md
+++ b/site/content/docs/commands/env-init.en.md
@@ -1,5 +1,5 @@
 # env init
-```bash
+```console
 $ copilot env init [flags]
 ```
 
@@ -49,17 +49,17 @@ Telemetry Flags
 
 ## Examples
 Creates a test environment using your "default" AWS profile and default configuration.
-```bash
+```console
 $ copilot env init --name test --profile default --default-config
 ```
 
 Creates a prod-iad environment using your "prod-admin" AWS profile and enables CloudWatch Container Insights.
-```bash
+```console
 $ copilot env init --name prod-iad --profile prod-admin --container-insights
 ```
 
 Creates an environment with imported VPC resources.
-```bash
+```console
 $ copilot env init --import-vpc-id vpc-099c32d2b98cdcf47 \
   --import-public-subnets subnet-013e8b691862966cf,subnet-014661ebb7ab8681a \
   --import-private-subnets subnet-055fafef48fb3c547,subnet-00c9e76f288363e7f \
@@ -68,7 +68,7 @@ $ copilot env init --import-vpc-id vpc-099c32d2b98cdcf47 \
 
 Creates an environment with overridden CIDRs and AZs.
 
-```bash
+```console
 $ copilot env init --override-vpc-cidr 10.1.0.0/16 \
   --override-az-names us-west-2b,us-west-2c \
   --override-public-cidrs 10.1.0.0/24,10.1.1.0/24 \

--- a/site/content/docs/commands/env-init.ja.md
+++ b/site/content/docs/commands/env-init.ja.md
@@ -1,5 +1,5 @@
 # env init
-```bash
+```console
 $ copilot env init [flags]
 ```
 
@@ -44,17 +44,17 @@ Telemetry Flags
 
 ## 実行例
 AWS プロファイルの "default" 利用し、デフォルト設定を使用して test Environment を作成します。
-```bash
+```console
 $ copilot env init --name test --profile default --default-config
 ```
 
 AWS プロファイルの "prod-admin" を利用して prod-iad Environment を作成し、 CloudWatch Container Insights　を有効化します。
-```bash
+```console
 $ copilot env init --name prod-iad --profile prod-admin --container-insights 
 ```
 
 VPC リソースをインポートして Environment を作成します。
-```bash
+```console
 $ copilot env init --import-vpc-id vpc-099c32d2b98cdcf47 \
   --import-public-subnets subnet-013e8b691862966cf,subnet-014661ebb7ab8681a \
   --import-private-subnets subnet-055fafef48fb3c547,subnet-00c9e76f288363e7f
@@ -62,7 +62,7 @@ $ copilot env init --import-vpc-id vpc-099c32d2b98cdcf47 \
 
 CIDR と AZ を上書きして、Environment を作成します。
 
-```bash
+```console
 $ copilot env init --override-vpc-cidr 10.1.0.0/16 \
   --override-az-names us-west-2b,us-west-2c \
   --override-public-cidrs 10.1.0.0/24,10.1.1.0/24 \

--- a/site/content/docs/commands/env-ls.en.md
+++ b/site/content/docs/commands/env-ls.en.md
@@ -1,5 +1,5 @@
 # env ls
-```bash
+```console
 $ copilot env ls [flags]
 ```
 
@@ -7,7 +7,7 @@ $ copilot env ls [flags]
 `copilot env ls` lists all the environments in your application.
 
 ## What are the flags?
-```bash
+```
 -h, --help          help for ls
     --json          Optional. Outputs in JSON format.
 -a, --app string    Name of the application.
@@ -16,7 +16,7 @@ You can use the `--json` flag if you'd like to programmatically parse the result
 
 ## Examples
 Lists all the environments for the frontend application.
-```bash
+```console
 $ copilot env ls -a frontend
 ```
 

--- a/site/content/docs/commands/env-ls.ja.md
+++ b/site/content/docs/commands/env-ls.ja.md
@@ -1,5 +1,5 @@
 # env ls
-```bash
+```console
 $ copilot env ls [flags]
 ```
 
@@ -7,7 +7,7 @@ $ copilot env ls [flags]
 `copilot env ls` は、Application 内の全ての Environment を一覧表示します。
 
 ## フラグ
-```bash
+```
 -h, --help          help for ls
     --json          Optional. Outputs in JSON format.
 -a, --app string    Name of the application.
@@ -16,7 +16,7 @@ $ copilot env ls [flags]
 
 ## 実行例
 frontend Application の全ての Environment を一覧表示します。
-```bash
+```console
 $ copilot env ls -a frontend
 ```
 

--- a/site/content/docs/commands/env-show.en.md
+++ b/site/content/docs/commands/env-show.en.md
@@ -1,5 +1,5 @@
 # env show
-```bash
+```console
 $ copilot env show [flags]
 ```
 
@@ -14,7 +14,7 @@ $ copilot env show [flags]
 You can optionally pass in a `--resources` flag which will include the AWS resources associated specifically with the environment. 
 
 ## What are the flags?
-```bash
+```
 -a, --app string    Name of the application.
 -h, --help          help for show
     --json          Optional. Outputs in JSON format.
@@ -25,6 +25,6 @@ You can use the `--json` flag if you'd like to programmatically parse the result
 
 ## Examples
 Shows info about the environment "test".
-```bash
+```console
 $ copilot env show -n test
 ```

--- a/site/content/docs/commands/env-show.ja.md
+++ b/site/content/docs/commands/env-show.ja.md
@@ -1,5 +1,5 @@
 # env show
-```bash
+```console
 $ copilot env show [flags]
 ```
 
@@ -14,7 +14,7 @@ $ copilot env show [flags]
 オプションで `--resources` フラグを付けると Environment に関連する AWS リソースが表示されます。
 
 ## フラグ
-```bash
+```
 -a, --app string    Name of the application.
 -h, --help          help for show
     --json          Optional. Outputs in JSON format.
@@ -25,6 +25,6 @@ $ copilot env show [flags]
 
 ## 実行例
 "test" Environment に関する情報を表示します。
-```bash
+```console
 $ copilot env show -n test
 ```

--- a/site/content/docs/commands/init.en.md
+++ b/site/content/docs/commands/init.en.md
@@ -1,5 +1,5 @@
 # init
-```bash
+```console
 $ copilot init
 ```
 
@@ -14,7 +14,7 @@ If you have an existing app, and want to add another service or job to that app,
 
 Like all commands in the Copilot CLI, if you don't provide required flags, we'll prompt you for all the information we need to get you going. You can skip the prompts by providing information via flags:
 
-```sh
+```
   -a, --app string          Name of the application.
       --deploy              Deploy your service or job to a "test" environment.
   -d, --dockerfile string   Path to the Dockerfile.

--- a/site/content/docs/commands/init.ja.md
+++ b/site/content/docs/commands/init.ja.md
@@ -1,5 +1,5 @@
 # init
-```bash
+```console
 $ copilot init
 ```
 
@@ -14,7 +14,7 @@ $ copilot init
 
 Copilot CLI の全てのコマンドと同様に、必要なフラグを指定しない場合は、アプリの実行に必要な情報をすべて入力するように求められます。フラグを介して情報を提供することで、プロンプトをスキップできます。
 
-```sh
+```
   -a, --app string          Name of the application.
       --deploy              Deploy your service or job to a "test" environment.
   -d, --dockerfile string   Path to the Dockerfile.

--- a/site/content/docs/commands/job-delete.en.md
+++ b/site/content/docs/commands/job-delete.en.md
@@ -1,5 +1,5 @@
 # job delete
-```bash
+```console
 $ copilot job delete [flags]
 ```
 
@@ -9,7 +9,7 @@ $ copilot job delete [flags]
 
 ## What are the flags?
 
-```bash
+```
   -a, --app string    Name of the application.
   -e, --env string    Name of the environment.
   -h, --help          help for delete
@@ -20,21 +20,21 @@ $ copilot job delete [flags]
 ## Examples
 
 Delete the "report-generator" job from the my-app application.
-```bash
+```console
 $ copilot job delete --name report-generator --app my-app
 ```
 
 Delete the "report-generator" job from just the prod environment.
-```bash
+```console
 $ copilot job delete --name report-generator --env prod
 ```
 
 Delete the "report-generator" job from the my-app application from outside of the workspace.
-```bash
+```console
 $ copilot job delete --name report-generator --app my-app
 ```
 
 Delete the "report-generator" job without the confirmation prompt.
-```bash
+```console
 $ copilot job delete --name report-generator --yes
 ```

--- a/site/content/docs/commands/job-delete.ja.md
+++ b/site/content/docs/commands/job-delete.ja.md
@@ -1,5 +1,5 @@
 # job delete
-```bash
+```console
 $ copilot job delete [flags]
 ```
 
@@ -9,7 +9,7 @@ $ copilot job delete [flags]
 
 ## フラグ
 
-```bash
+```
   -a, --app string    Name of the application.
   -e, --env string    Name of the environment.
   -h, --help          help for delete
@@ -20,16 +20,16 @@ $ copilot job delete [flags]
 ## 実行例
 
 "report-generator" Job を "my-app" Application から削除します。このコマンドはワークスペースの外からでも実行できます。
-```bash
+```console
 $ copilot job delete --name report-generator --app my-app
 ```
 
 "report-generator" Job を "prod" Environment からのみ削除します。
-```bash
+```console
 $ copilot job delete --name report-generator --env prod
 ```
 
 確認をプロンプトに表示せず "report-generator" Job を削除します。
-```bash
+```console
 $ copilot job delete --name report-generator --yes
 ```

--- a/site/content/docs/commands/job-deploy.en.md
+++ b/site/content/docs/commands/job-deploy.en.md
@@ -1,5 +1,5 @@
 # job deploy
-```bash
+```console
 $ copilot job deploy
 ```
 
@@ -17,7 +17,7 @@ The steps involved in `job deploy` are:
 
 ## What are the flags?
 
-```bash
+```
   -a, --app string                     Name of the application.
   -e, --env string                     Name of the environment.
   -h, --help                           help for deploy
@@ -39,11 +39,11 @@ rollback of the stack via the AWS console or AWS CLI before the next deployment.
 ## Examples
 
 Deploys a job named "report-gen" to a "test" environment.
-```bash
+```console
 $ copilot job deploy --name report-gen --env test
 ```
 
 Deploys a job with additional resource tags.
-```bash
+```console
 $ copilot job deploy --resource-tags source/revision=bb133e7,deployment/initiator=manual`
 ```

--- a/site/content/docs/commands/job-deploy.ja.md
+++ b/site/content/docs/commands/job-deploy.ja.md
@@ -1,5 +1,5 @@
 # job deploy
-```bash
+```console
 $ copilot job deploy
 ```
 
@@ -17,7 +17,7 @@ $ copilot job deploy
 
 ## フラグ
 
-```bash
+```
   -a, --app string                     Name of the application.
   -e, --env string                     Name of the environment.
   -h, --help                           help for deploy
@@ -38,11 +38,11 @@ $ copilot job deploy
 ## 実行例
 
 "report-gen" という Job を "test" Environment にデプロイします。
-```bash
+```console
 $ copilot job deploy --name report-gen --env test
 ```
 
 追加のリソースタグを付与して Job をデプロイします。
-```bash
+```console
 $ copilot job deploy --resource-tags source/revision=bb133e7,deployment/initiator=manual`
 ```

--- a/site/content/docs/commands/job-init.en.md
+++ b/site/content/docs/commands/job-init.en.md
@@ -1,5 +1,5 @@
 # job init
-```bash
+```console
 $ copilot job init
 ```
 
@@ -13,7 +13,7 @@ After that, if you already have an environment set up, you can run `copilot job 
 
 ## What are the flags?
 
-```bash
+```
   -a, --app string          Name of the application.
   -d, --dockerfile string   Path to the Dockerfile.
                             Mutually exclusive with -i, --image.
@@ -36,10 +36,10 @@ After that, if you already have an environment set up, you can run `copilot job 
 ## Examples
 
  Creates a "reaper" scheduled task to run once per day.
-```bash
+```console
 $ copilot job init --name reaper --dockerfile ./frontend/Dockerfile --schedule "@daily"
 ```
 Creates a "report-generator" scheduled task with retries.
-```bash
+```console
 $ copilot job init --name report-generator --schedule "@monthly" --retries 3 --timeout 900s
 ```

--- a/site/content/docs/commands/job-init.ja.md
+++ b/site/content/docs/commands/job-init.ja.md
@@ -1,5 +1,5 @@
 # job init
-```bash
+```console
 $ copilot job init
 ```
 
@@ -13,7 +13,7 @@ $ copilot job init
 
 ## フラグ
 
-```bash
+```
   -a, --app string          Name of the application.
   -d, --dockerfile string   Path to the Dockerfile.
                             Mutually exclusive with -i, --image.
@@ -36,10 +36,10 @@ $ copilot job init
 ## 実行例
 
 1 日 1 回実行される "reaper" という名前のスケジュールされたタスクを作成します。
-```bash
+```console
 $ copilot job init --name reaper --dockerfile ./frontend/Dockerfile --schedule "@daily"
 ```
 リトライ回数を指定した "report-generator" という名前のスケジュールされたタスクを作成します。
-```bash
+```console
 $ copilot job init --name report-generator --schedule "@monthly" --retries 3 --timeout 900s
 ```

--- a/site/content/docs/commands/job-ls.en.md
+++ b/site/content/docs/commands/job-ls.en.md
@@ -1,5 +1,5 @@
 # job ls
-```bash
+```console
 $ copilot job ls
 ```
 
@@ -9,7 +9,7 @@ $ copilot job ls
 
 ## What are the flags?
 
-```bash
+```
   -a, --app string   Name of the application.
   -h, --help         help for ls
       --json         Optional. Outputs in JSON format.
@@ -19,6 +19,6 @@ $ copilot job ls
 ## Example
 
 Lists all the jobs for the "myapp" application.
-```bash
+```console
 $ copilot job ls --app myapp
 ```

--- a/site/content/docs/commands/job-ls.ja.md
+++ b/site/content/docs/commands/job-ls.ja.md
@@ -1,5 +1,5 @@
 # job ls
-```bash
+```console
 $ copilot job ls
 ```
 
@@ -9,7 +9,7 @@ $ copilot job ls
 
 ## フラグ
 
-```bash
+```
   -a, --app string   Name of the application.
   -h, --help         help for ls
       --json         Optional. Outputs in JSON format.
@@ -19,6 +19,6 @@ $ copilot job ls
 ## 実行例
 
 "myapp" Application に含まれる全ての Job を一覧表示します。
-```bash
+```console
 $ copilot job ls --app myapp
 ```

--- a/site/content/docs/commands/job-package.en.md
+++ b/site/content/docs/commands/job-package.en.md
@@ -1,5 +1,5 @@
 # job package
-```bash
+```console
 $ copilot job package
 ```
 
@@ -9,7 +9,7 @@ $ copilot job package
 
 ## What are the flags?
 
-```bash
+```
   -a, --app string          Name of the application.
   -e, --env string          Name of the environment.
   -h, --help                help for package
@@ -24,13 +24,13 @@ $ copilot job package
 
 Prints the CloudFormation template for the "report-generator" job parametrized for the "test" environment.
 
-```bash
+```console
 $ copilot job package -n report-generator -e test
 ```
 
 Writes the CloudFormation stack and configuration to an "infrastructure/" sub-directory instead of printing.
 
-```bash
+```console
 $ copilot job package -n report-generator -e test --output-dir ./infrastructure
 $ ls ./infrastructure
   report-generator-test.stack.yml      report-generator-test.params.yml

--- a/site/content/docs/commands/job-package.ja.md
+++ b/site/content/docs/commands/job-package.ja.md
@@ -1,5 +1,5 @@
 # job package 
-```bash
+```console
 $ copilot job package
 ```
 
@@ -9,7 +9,7 @@ $ copilot job package
 
 ## フラグ
 
-```bash
+```
   -a, --app string          Name of the application.
   -e, --env string          Name of the environment.
   -h, --help                help for package
@@ -24,13 +24,13 @@ $ copilot job package
 
 "report-generator" Job を作成する CloudFormation テンプレートを、"test" Environment にデプロイする形で出力します。
  
-```bash
+```console
 $ copilot job package -n report-generator -e test
 ```
 
 CloudFormation テンプレートと設定を "infrastructure/" ディレクトリ以下に書き出します。
   
-```bash
+```console
 $ copilot job package -n report-generator -e test --output-dir ./infrastructure
 $ ls ./infrastructure
   report-generator-test.stack.yml      report-generator-test.params.yml

--- a/site/content/docs/commands/pipeline-delete.en.md
+++ b/site/content/docs/commands/pipeline-delete.en.md
@@ -1,5 +1,5 @@
 # pipeline delete
-```bash
+```console
 $ copilot pipeline delete [flags]
 ```
 
@@ -7,7 +7,7 @@ $ copilot pipeline delete [flags]
 `copilot pipeline delete` deletes the pipeline associated with your workspace.
 
 ## What are the flags?
-```bash
+```
 -a, --app             Name of the application.
     --delete-secret   Deletes AWS Secrets Manager secret associated with a pipeline source repository.
 -h, --help            help for delete
@@ -17,6 +17,6 @@ $ copilot pipeline delete [flags]
 
 ## Examples
 Delete the pipeline associated with your workspace.
-```bash
+```console
 $ copilot pipeline delete
 ```

--- a/site/content/docs/commands/pipeline-delete.ja.md
+++ b/site/content/docs/commands/pipeline-delete.ja.md
@@ -1,5 +1,5 @@
 # pipeline delete
-```bash
+```console
 $ copilot pipeline delete [flags]
 ```
 
@@ -7,7 +7,7 @@ $ copilot pipeline delete [flags]
 `copilot pipeline delete` は、ワークスペースに紐付いている Pipeline を削除します。
 
 ## フラグ
-```bash
+```
 -a, --app             Name of the application.
     --delete-secret   Deletes AWS Secrets Manager secret associated with a pipeline source repository.
 -h, --help            help for delete
@@ -17,6 +17,6 @@ $ copilot pipeline delete [flags]
 
 ## 実行例
 ワークスペースに紐付いている Pipeline を削除します。
-```bash
+```console
 $ copilot pipeline delete
 ```

--- a/site/content/docs/commands/pipeline-deploy.en.md
+++ b/site/content/docs/commands/pipeline-deploy.en.md
@@ -1,5 +1,5 @@
 # pipeline deploy
-```bash
+```console
 $ copilot pipeline deploy [flags]
 ```
 
@@ -7,7 +7,7 @@ $ copilot pipeline deploy [flags]
 `copilot pipeline deploy` deploys a pipeline for the services in your workspace, using the environments associated with the application from a pipeline manifest.
 
 ## What are the flags?
-```bash
+```
 -a, --app string    Name of the application.
 -h, --help          help for deploy
 -n, --name string   Name of the pipeline.
@@ -16,6 +16,6 @@ $ copilot pipeline deploy [flags]
 
 ## Examples
 Deploys a pipeline for the services and jobs in your workspace.
-```bash
+```console
 $ copilot pipeline deploy
 ```

--- a/site/content/docs/commands/pipeline-deploy.ja.md
+++ b/site/content/docs/commands/pipeline-deploy.ja.md
@@ -1,5 +1,5 @@
 # pipeline deploy
-```bash
+```console
 $ copilot pipeline deploy [flags]
 ```
 
@@ -7,7 +7,7 @@ $ copilot pipeline deploy [flags]
 `copilot pipeline deploy` は、ワークスペース内の全ての Service に対する Pipeline をデプロイします。Pipeline 用 Manifest にて Application と紐付けられた Environment 群を利用します。
 
 ## フラグ
-```bash
+```
 -a, --app string    Name of the application.
 -h, --help          help for deploy
 -n, --name string   Name of the pipeline.
@@ -16,6 +16,6 @@ $ copilot pipeline deploy [flags]
 
 ## 実行例
 ワークスペース内の Service 群と Job 群に対する Pipeline をデプロイします。
-```bash
+```console
 $ copilot pipeline deploy
 ```

--- a/site/content/docs/commands/pipeline-init.en.md
+++ b/site/content/docs/commands/pipeline-init.en.md
@@ -1,5 +1,5 @@
 # pipeline init
-```bash
+```console
 $ copilot pipeline init [flags]
 ```
 
@@ -7,7 +7,7 @@ $ copilot pipeline init [flags]
 `copilot pipeline init` creates a pipeline manifest for the services in your workspace, using the environments associated with the application.
 
 ## What are the flags?
-```bash
+```
 -a, --app string             Name of the application.
 -e, --environments strings   Environments to add to the pipeline.
 -b, --git-branch string      Branch used to trigger your pipeline.
@@ -18,7 +18,7 @@ $ copilot pipeline init [flags]
 
 ## Examples
 Create a pipeline for the services in your workspace.
-```bash
+```console
 $ copilot pipeline init \
 --name frontend-main \
 --url https://github.com/gitHubUserName/frontend.git \

--- a/site/content/docs/commands/pipeline-init.ja.md
+++ b/site/content/docs/commands/pipeline-init.ja.md
@@ -1,5 +1,5 @@
 # pipeline init
-```bash
+```console
 $ copilot pipeline init [flags]
 ```
 
@@ -7,7 +7,7 @@ $ copilot pipeline init [flags]
 `copilot pipeline init` は、ワークスペース内の全ての Service をデプロイする Pipeline 用の Manifest を作成します。この Manifest では Application に関連づけられた Environment がデプロイターゲットとなります。
 
 ## フラグ
-```bash
+```
 -a, --app string             Name of the application.
 -e, --environments strings   Environments to add to the pipeline.
 -b, --git-branch string      Branch used to trigger your pipeline.
@@ -18,7 +18,7 @@ $ copilot pipeline init [flags]
 
 ## 実行例
 ワークスペース内の全ての Service をデプロイする Pipeline 用の Manifest を作成します。
-```bash
+```console
 $ copilot pipeline init \
 --name frontend-main \
 --url https://github.com/gitHubUserName/frontend.git \

--- a/site/content/docs/commands/pipeline-ls.en.md
+++ b/site/content/docs/commands/pipeline-ls.en.md
@@ -1,5 +1,5 @@
 # pipeline ls
-```bash
+```console
 $ copilot pipeline ls [flags]
 ```
 
@@ -7,7 +7,7 @@ $ copilot pipeline ls [flags]
 `copilot pipeline ls` lists all the deployed pipelines in an application.
 
 ## What are the flags?
-```bash
+```
 -a, --app string   Name of the application.
 -h, --help         help for ls
     --json         Optional. Outputs in JSON format.
@@ -16,6 +16,6 @@ $ copilot pipeline ls [flags]
 
 ## Examples
 Lists all the pipelines for the "phonetool" application.
-```bash
+```console
 $ copilot pipeline ls -a phonetool
 ```

--- a/site/content/docs/commands/pipeline-ls.ja.md
+++ b/site/content/docs/commands/pipeline-ls.ja.md
@@ -1,5 +1,5 @@
 # pipeline ls
-```bash
+```console
 $ copilot pipeline ls [flags]
 ```
 
@@ -7,7 +7,7 @@ $ copilot pipeline ls [flags]
 `copilot pipeline ls` は、Application にデプロイされた全ての Pipeline を一覧表示します。
 
 ## フラグ
-```bash
+```
 -a, --app string   Name of the application.
 -h, --help         help for ls
     --json         Optional. Outputs in JSON format.
@@ -17,6 +17,6 @@ $ copilot pipeline ls [flags]
 ## 実行例
 Application "phonetool" のすべての Pipeline を一覧表示します。
 
-```bash
+```console
 $ copilot pipeline ls -a phonetool
 ```

--- a/site/content/docs/commands/pipeline-show.en.md
+++ b/site/content/docs/commands/pipeline-show.en.md
@@ -1,5 +1,5 @@
 # pipeline show
-```bash
+```console
 $ copilot pipeline show [flags]
 ```
 
@@ -7,7 +7,7 @@ $ copilot pipeline show [flags]
 `copilot pipeline show` shows configuration information about a deployed pipeline for an application, including the account, region, and stages.
 
 ## What are the flags?
-```bash
+```
 -a, --app string    Name of the application.
 -h, --help          help for show
     --json          Optional. Outputs in JSON format.
@@ -17,7 +17,7 @@ $ copilot pipeline show [flags]
 
 ## Examples
 Shows info, including resources, about the pipeline "myrepo-mybranch."
-```bash
+```console
 $ copilot pipeline show --name myrepo-mybranch --resources
 ```
 

--- a/site/content/docs/commands/pipeline-show.ja.md
+++ b/site/content/docs/commands/pipeline-show.ja.md
@@ -1,5 +1,5 @@
 # pipeline show
-```bash
+```console
 $ copilot pipeline show [flags]
 ```
 
@@ -7,7 +7,7 @@ $ copilot pipeline show [flags]
 `copilot pipeline show` は、Application にデプロイされた Pipeline の構成情報 (アカウント、リージョン、ステージなど) を表示します。
 
 ## フラグ
-```bash
+```
 -a, --app string    Name of the application.
 -h, --help          help for show
     --json          Optional. Outputs in JSON format.
@@ -17,7 +17,7 @@ $ copilot pipeline show [flags]
 
 ## 実行例
 Pipeline "myapp-mybranch" に関する情報をリソース情報を含めて表示します。
-```bash
+```console
 $ copilot pipeline show --name myrepo-mybranch --resources
 ```
 

--- a/site/content/docs/commands/pipeline-status.en.md
+++ b/site/content/docs/commands/pipeline-status.en.md
@@ -1,5 +1,5 @@
 # pipeline status
-```bash
+```console
 $ copilot pipeline status [flags]
 ```
 
@@ -7,7 +7,7 @@ $ copilot pipeline status [flags]
 `copilot pipeline status` shows the status of the stages in a deployed pipeline.
 
 ## What are the flags?
-```bash
+```
 -a, --app string    Name of the application.
 -h, --help          help for status
     --json          Optional. Outputs in JSON format.
@@ -16,7 +16,7 @@ $ copilot pipeline status [flags]
 
 ## Examples
 Shows status of the pipeline "my-repo-my-branch".
-```bash
+```console
 $ copilot pipeline status -n my-repo-my-branch
 ```
 

--- a/site/content/docs/commands/pipeline-status.ja.md
+++ b/site/content/docs/commands/pipeline-status.ja.md
@@ -1,5 +1,5 @@
 # pipeline status
-```bash
+```console
 $ copilot pipeline status [flags]
 ```
 
@@ -7,7 +7,7 @@ $ copilot pipeline status [flags]
 `copilot pipeline status` では、デプロイされた Pipeline のステージの状態を表示します。
 
 ## フラグ
-```bash
+```
 -a, --app string    Name of the application.
 -h, --help          help for status
     --json          Optional. Outputs in JSON format.
@@ -16,7 +16,7 @@ $ copilot pipeline status [flags]
 
 ## 実行例
 Pipeline "my-repo-my-branch" の状態を表示します。
-```bash
+```console
 $ copilot pipeline status -n my-repo-my-branch
 ```
 

--- a/site/content/docs/commands/secret-init.en.md
+++ b/site/content/docs/commands/secret-init.en.md
@@ -1,5 +1,5 @@
 # secret init
-```
+```console
 $ copilot secret init
 ```
 
@@ -25,16 +25,16 @@ A secret can have different values in each of your existing environments, and is
 ```
 ## How can I use it?
 Create a secret with prompts. You will be prompted for the name of the secret, and its values in each of your existing environments.
-```
+```console
 $ copilot secret init
 ```
 
 Create a secret named `db_password` in multiple environments. You will be prompted for the `db_password`'s values you want for each of your existing environments.
-```
+```console
 $ copilot secret init --name db_password
 ```
 Create secrets from `input.yml`. For the format of the YAML file, please see <a href="#secret-init-cli-input-yaml">below</a>.
-```
+```console
 $ copilot secret init --cli-input-yaml input.yml
 ```
 

--- a/site/content/docs/commands/secret-init.ja.md
+++ b/site/content/docs/commands/secret-init.ja.md
@@ -1,5 +1,5 @@
 # secret init
-```
+```console
 $ copilot secret init
 ```
 
@@ -25,16 +25,16 @@ $ copilot secret init
 ```
 ## 使用例
 インタラクティブにシークレットを作成します。コマンドを実行すると、シークレットの名前、そして各 Environment ごとの値を尋ねられます。
-```
+```console
 $ copilot secret init
 ```
 
 `db_password` という名前のシークレットを複数の Environment に作成します。コマンドを実行すると、各 Environment ごとの `db_password` の値を尋ねられます。
-```
+```console
 $ copilot secret init --name db_password
 ```
 `input.yml` からシークレットを作成します。YAML ファイルのフォーマットは<a href="#secret-init-cli-input-yaml">ページ下部</a>をご覧ください。
-```
+```console
 $ copilot secret init --cli-input-yaml input.yml
 ```
 

--- a/site/content/docs/commands/storage-init.en.md
+++ b/site/content/docs/commands/storage-init.en.md
@@ -1,5 +1,5 @@
 # storage init
-```bash
+```console
 $ copilot storage init
 ```
 ## What does it do?
@@ -8,7 +8,7 @@ $ copilot storage init
 After running this command, the CLI creates an `addons` subdirectory inside your `copilot/service` directory if it does not exist. When you run `copilot svc deploy`, your newly initialized storage resource is created in the environment you're deploying to. By default, only the service you specify during `storage init` will have access to that storage resource.
 
 ## What are the flags?
-```bash
+```
 Required Flags
   -n, --name string           Name of the storage resource to create.
   -t, --storage-type string   Type of storage to add. Must be one of:
@@ -34,18 +34,18 @@ Aurora Serverless Flags
 ## How can I use it? 
 Create an S3 bucket named "my-bucket" attached to the "frontend" service.
 
-```
+```console
 $ copilot storage init -n my-bucket -t S3 -w frontend
 ```
 Create a basic DynamoDB table named "my-table" attached to the "frontend" service with a sort key specified.
 
-```
+```console
 $ copilot storage init -n my-table -t DynamoDB -w frontend --partition-key Email:S --sort-key UserId:N --no-lsi
 ```
 
 Create a DynamoDB table with multiple alternate sort keys.
 
-```
+```console
 $ copilot storage init \
   -n my-table -t DynamoDB -w frontend \
   --partition-key Email:S \
@@ -55,7 +55,7 @@ $ copilot storage init \
 ```
 
 Create an RDS Aurora Serverless cluster using PostgreSQL as the database engine.
-```
+```console
 $ copilot storage init \
   -n my-cluster -t Aurora -w frontend --engine PostgreSQL
 ```
@@ -64,7 +64,7 @@ $ copilot storage init \
 Copilot writes a Cloudformation template specifying the S3 bucket or DDB table to the `addons` dir. When you run `copilot svc deploy`, the CLI merges this template with all the other templates in the addons directory to create a nested stack associated with your service. This nested stack describes all the additional resources you've associated with that service and is deployed wherever your service is deployed. 
 
 This means that after running
-```
+```console
 $ copilot storage init -n bucket -t S3 -w fe
 $ copilot svc deploy -n fe -e test
 $ copilot svc deploy -n fe -e prod

--- a/site/content/docs/commands/storage-init.ja.md
+++ b/site/content/docs/commands/storage-init.ja.md
@@ -1,5 +1,5 @@
 # storage init
-```bash
+```console
 $ copilot storage init
 ```
 ## コマンドの概要
@@ -8,7 +8,7 @@ $ copilot storage init
 このコマンドを実行すると、CLI は `copilot/service` ディレクトリ内に、`addons` サブディレクトリが存在しなければ作成します。`copilot svc deploy` を実行すると、新規に初期化されたストレージリソースが、デプロイ先の環境に作成されます。デフォルトでは、`storage init` で指定したサービスのみが、そのストレージリソースにアクセスできます。
 
 ## フラグ
-```bash
+```
 Required Flags
   -n, --name string           Name of the storage resource to create.
   -t, --storage-type string   Type of storage to add. Must be one of:
@@ -33,17 +33,17 @@ Aurora Serverless Flags
 
 ## 使用例
 "frontend" Service に "my-bucket" という名前の S3 バケットを作成します。
-```
+```console
 $ copilot storage init -n my-bucket -t S3 -w frontend
 ```
 
 "frontend" Service にアタッチされた "my-table" という名前の基本的な DynamoDB テーブルを、ソートキーを指定して作成します。
-```
+```console
 $ copilot storage init -n my-table -t DynamoDB -w frontend --partition-key Email:S --sort-key UserId:N --no-lsi
 ```
 
 複数の代替ソートキーを持つ DynamoDB テーブルを作成します。
-```
+```console
 $ copilot storage init \
   -n my-table -t DynamoDB -w frontend \
   --partition-key Email:S \
@@ -53,7 +53,7 @@ $ copilot storage init \
 ```
 
 データベースエンジンに PostgreSQL を使用して、RDS Aurora Serverless クラスタを作成します。
-```
+```console
 $ copilot storage init \
   -n my-cluster -t Aurora -w frontend --engine PostgreSQL
 ```
@@ -62,7 +62,7 @@ $ copilot storage init \
 Copilotは、S3 バケットや DDB テーブルを指定した CloudFormation テンプレートを `addons` ディレクトリに格納します。`copilot svc deploy` を実行すると、CLI はこのテンプレートを addons ディレクトリ内の他のすべてのテンプレートとマージして、Service に関連付けられたネストされた (入れ子になった) スタックを作成します。このネストされたスタックには、その Service に関連付けられたすべての追加リソースが記述されており、その Service がデプロイできる場所ではどこにでもデプロイ可能です。
 
 これは、実行後に、
-```
+```console
 $ copilot storage init -n bucket -t S3 -w fe
 $ copilot svc deploy -n fe -e test
 $ copilot svc deploy -n fe -e prod

--- a/site/content/docs/commands/svc-delete.en.md
+++ b/site/content/docs/commands/svc-delete.en.md
@@ -1,5 +1,5 @@
 # svc delete
-```bash
+```console
 $ copilot svc delete [flags]
 ```
 
@@ -9,7 +9,7 @@ $ copilot svc delete [flags]
 
 ## What are the flags?
 
-```bash
+```
   -e, --env string    Name of the environment.
   -h, --help          help for delete
   -n, --name string   Name of the service.
@@ -18,6 +18,6 @@ $ copilot svc delete [flags]
 
 ## Examples
 Force delete the application with environments "test" and "prod".
-```bash
+```console
 $ copilot svc delete --name test --yes
 ```

--- a/site/content/docs/commands/svc-delete.ja.md
+++ b/site/content/docs/commands/svc-delete.ja.md
@@ -1,5 +1,5 @@
 # svc delete
-```bash
+```console
 $ copilot svc delete [flags]
 ```
 
@@ -9,7 +9,7 @@ $ copilot svc delete [flags]
 
 ## フラグ
 
-```bash
+```
   -e, --env string    Name of the environment.
   -h, --help          help for delete
   -n, --name string   Name of the service.
@@ -18,6 +18,6 @@ $ copilot svc delete [flags]
 
 ## 実行例
 "test" アプリケーションを全ての Environment から強制的に削除します。
-```bash
+```console
 $ copilot svc delete --name test --yes
 ```

--- a/site/content/docs/commands/svc-deploy.en.md
+++ b/site/content/docs/commands/svc-deploy.en.md
@@ -1,5 +1,5 @@
 # svc deploy
-```bash
+```console
 $ copilot svc deploy
 ```
 
@@ -17,7 +17,7 @@ The steps involved in service deploy are:
 
 ## What are the flags?
 
-```bash
+```
   -a, --app string                     Name of the application.
   -e, --env string                     Name of the environment.
       --force                          Optional. Force a new service deployment using the existing image.

--- a/site/content/docs/commands/svc-deploy.ja.md
+++ b/site/content/docs/commands/svc-deploy.ja.md
@@ -1,5 +1,5 @@
 # svc deploy
-```bash
+```console
 $ copilot svc deploy
 ```
 
@@ -17,7 +17,7 @@ Service デプロイの手順は以下の通りです。
 
 ## フラグ
 
-```bash
+```
   -a, --app string                     Name of the application.
   -e, --env string                     Name of the environment.
       --force                          Optional. Force a new service deployment using the existing image.

--- a/site/content/docs/commands/svc-exec.en.md
+++ b/site/content/docs/commands/svc-exec.en.md
@@ -1,5 +1,5 @@
 # svc exec
-```
+```console
 $ copilot svc exec
 ```
 
@@ -22,13 +22,13 @@ $ copilot svc exec
 
 Start an interactive bash session with a task part of the "frontend" service.
 
-```bash
+```console
 $ copilot svc exec -a my-app -e test -n frontend
 ```
 
 Runs the 'ls' command in the task prefixed with ID "8c38184" within the "backend" service.
 
-```bash
+```console
 $ copilot svc exec -a my-app -e test --name backend --task-id 8c38184 --command "ls"
 ```
 

--- a/site/content/docs/commands/svc-exec.ja.md
+++ b/site/content/docs/commands/svc-exec.ja.md
@@ -1,5 +1,5 @@
 # svc exec
-```
+```console
 $ copilot svc exec
 ```
 
@@ -22,13 +22,13 @@ $ copilot svc exec
 
 "frontend" Service のタスクにインタラクティブなセッションを開始します。
 
-```bash
+```console
 $ copilot svc exec -a my-app -e test -n frontend
 ```
 
 "backend" Service 内の ID "8c38184" から始まるタスクで 'ls' コマンドを実行します。
 
-```bash
+```console
 $ copilot svc exec -a my-app -e test --name backend --task-id 8c38184 --command "ls"
 ```
 

--- a/site/content/docs/commands/svc-init.en.md
+++ b/site/content/docs/commands/svc-init.en.md
@@ -1,5 +1,5 @@
 # svc init
-```bash
+```console
 $ copilot svc init
 ```
 
@@ -13,7 +13,7 @@ After that, if you already have an environment set up, you can run `copilot depl
 
 ## What are the flags?
 
-```bash
+```
 Flags
   -a, --app string          Name of the application.
   -d, --dockerfile string   Path to the Dockerfile.

--- a/site/content/docs/commands/svc-init.ja.md
+++ b/site/content/docs/commands/svc-init.ja.md
@@ -1,5 +1,5 @@
 # svc init
-```bash
+```console
 $ copilot svc init
 ```
 
@@ -15,7 +15,7 @@ $ copilot svc init
 
 ## フラグ
 
-```bash
+```
 Flags
   -a, --app string          Name of the application.
   -d, --dockerfile string   Path to the Dockerfile.

--- a/site/content/docs/commands/svc-logs.en.md
+++ b/site/content/docs/commands/svc-logs.en.md
@@ -1,5 +1,5 @@
 # svc logs
-```bash
+```console
 $ copilot svc logs
 ```
 
@@ -9,7 +9,7 @@ $ copilot svc logs
 
 ## What are the flags?
 
-```bash
+```
   -a, --app string          Name of the application.
       --end-time string     Optional. Only return logs before a specific date (RFC3339).
                             Defaults to all logs. Only one of end-time / follow may be used.
@@ -30,18 +30,18 @@ $ copilot svc logs
 
 Displays logs of the service "my-svc" in environment "test".
 
-```bash
+```console
 $ copilot svc logs -n my-svc -e test
 ```
 
 Displays logs in the last hour.
 
-```bash
+```console
 $ copilot svc logs --since 1h
 ```
 
 Displays logs from 2006-01-02T15:04:05 to 2006-01-02T15:05:05.
 
-```bash
+```console
 $ copilot svc logs --start-time 2006-01-02T15:04:05+00:00 --end-time 2006-01-02T15:05:05+00:00
 ```

--- a/site/content/docs/commands/svc-logs.ja.md
+++ b/site/content/docs/commands/svc-logs.ja.md
@@ -1,5 +1,5 @@
 # svc logs
-```bash
+```console
 $ copilot svc logs
 ```
 
@@ -9,7 +9,7 @@ $ copilot svc logs
 
 ## フラグ
 
-```bash
+```
   -a, --app string          Name of the application.
       --end-time string     Optional. Only return logs before a specific date (RFC3339).
                             Defaults to all logs. Only one of end-time / follow may be used.
@@ -30,18 +30,18 @@ $ copilot svc logs
 
 "test" Environment の "my-svc" Service のログを表示します。
 
-```bash
+```console
 $ copilot svc logs -n my-svc -e test
 ```
 
 過去 1 時間のログを表示します。
 
-```bash
+```console
 $ copilot svc logs --since 1h
 ```
 
 2006-01-02T15:04:05 から 2006-01-02T15:05:05 までのログを表示します。
 
-```bash
+```console
 $ copilot svc logs --start-time 2006-01-02T15:04:05+00:00 --end-time 2006-01-02T15:05:05+00:00
 ```

--- a/site/content/docs/commands/svc-ls.en.md
+++ b/site/content/docs/commands/svc-ls.en.md
@@ -1,5 +1,5 @@
 # svc ls
-```bash
+```console
 $ copilot svc ls
 ```
 
@@ -9,7 +9,7 @@ $ copilot svc ls
 
 ## What are the flags?
 
-```bash
+```
   -a, --app string   Name of the application.
   -h, --help         help for ls
       --json         Optional. Outputs in JSON format.

--- a/site/content/docs/commands/svc-ls.ja.md
+++ b/site/content/docs/commands/svc-ls.ja.md
@@ -1,5 +1,5 @@
 # svc ls
-```bash
+```console
 $ copilot svc ls
 ```
 
@@ -9,7 +9,7 @@ $ copilot svc ls
 
 ## フラグ
 
-```bash
+```
   -a, --app string   Name of the application.
   -h, --help         help for ls
       --json         Optional. Outputs in JSON format.

--- a/site/content/docs/commands/svc-package.en.md
+++ b/site/content/docs/commands/svc-package.en.md
@@ -1,5 +1,5 @@
 # svc package
-```bash
+```console
 $ copilot svc package
 ```
 
@@ -9,7 +9,7 @@ $ copilot svc package
 
 ## What are the flags?
 
-```bash
+```
   -a, --app string          Name of the application.
   -e, --env string          Name of the environment.
   -h, --help                help for package
@@ -24,7 +24,7 @@ $ copilot svc package
 
 Write the CloudFormation stack and configuration to a "infrastructure/" sub-directory instead of printing.
 
-```bash
+```console
 $ copilot svc package -n frontend -e test --output-dir ./infrastructure
 $ ls ./infrastructure
 frontend.stack.yml      frontend-test.config.yml

--- a/site/content/docs/commands/svc-package.ja.md
+++ b/site/content/docs/commands/svc-package.ja.md
@@ -1,5 +1,5 @@
 # svc package 
-```bash
+```console
 $ copilot svc package
 ```
 
@@ -9,7 +9,7 @@ $ copilot svc package
 
 ## フラグ
 
-```bash
+```
   -a, --app string          Name of the application.
   -e, --env string          Name of the environment.
   -h, --help                help for package
@@ -24,7 +24,7 @@ $ copilot svc package
 
 CloudFormaiton スタックと設定を表示する代わりに、"infrastructure/" サブディレクトリへ書き込みます。
 
-```bash
+```console
 $ copilot svc package -n frontend -e test --output-dir ./infrastructure
 $ ls ./infrastructure
 frontend.stack.yml      frontend-test.config.yml

--- a/site/content/docs/commands/svc-pause.en.md
+++ b/site/content/docs/commands/svc-pause.en.md
@@ -1,5 +1,5 @@
 # svc pause
-```bash
+```console
 $ copilot svc pause [flags]
 ```
 
@@ -12,7 +12,7 @@ $ copilot svc pause [flags]
 
 ## What are the flags?
 
-```bash
+```
   -a, --app string    Name of the application.
   -e, --env string    Name of the environment.
   -h, --help          help for pause
@@ -22,6 +22,6 @@ $ copilot svc pause [flags]
 
 ## Examples
 Pause running App Runner service "my-svc".
-```
+```console
 $ copilot svc pause -n my-svc
 ```

--- a/site/content/docs/commands/svc-pause.ja.md
+++ b/site/content/docs/commands/svc-pause.ja.md
@@ -1,5 +1,5 @@
 # svc pause
-```bash
+```console
 $ copilot svc pause [flags]
 ```
 
@@ -12,7 +12,7 @@ $ copilot svc pause [flags]
 
 ## フラグ
 
-```bash
+```
   -a, --app string    Name of the application.
   -e, --env string    Name of the environment.
   -h, --help          help for pause
@@ -23,6 +23,6 @@ $ copilot svc pause [flags]
 ## 実行例
 
 実行中の App Runner サービス、"my-svc" を一時停止します。
-```
+```console
 $ copilot svc pause -n my-svc
 ```

--- a/site/content/docs/commands/svc-resume.en.md
+++ b/site/content/docs/commands/svc-resume.en.md
@@ -1,5 +1,5 @@
 # svc resume
-```bash
+```console
 $ copilot svc resume [flags]
 ```
 
@@ -12,7 +12,7 @@ $ copilot svc resume [flags]
 
 ## What are the flags?
 
-```bash
+```
   -a, --app string    Name of the application.
   -e, --env string    Name of the environment.
   -h, --help          help for resume
@@ -21,6 +21,6 @@ $ copilot svc resume [flags]
 
 ## Examples
 Resume paused App Runner service "my-svc".
-```
+```console
 $ copilot svc resume -n my-svc
 ```

--- a/site/content/docs/commands/svc-resume.ja.md
+++ b/site/content/docs/commands/svc-resume.ja.md
@@ -1,5 +1,5 @@
 # svc resume
-```bash
+```console
 $ copilot svc resume [flags]
 ```
 
@@ -12,7 +12,7 @@ $ copilot svc resume [flags]
 
 ## フラグ
 
-```bash
+```
   -a, --app string    Name of the application.
   -e, --env string    Name of the environment.
   -h, --help          help for resume
@@ -22,6 +22,6 @@ $ copilot svc resume [flags]
 ## 実行例
 
 一時停止中の App Runner サービス、"my-svc" を再開します。
-```
+```console
 $ copilot svc resume -n my-svc
 ```

--- a/site/content/docs/commands/svc-show.en.md
+++ b/site/content/docs/commands/svc-show.en.md
@@ -1,5 +1,5 @@
 # svc show
-```bash
+```console
 $ copilot svc show
 ```
 
@@ -9,7 +9,7 @@ $ copilot svc show
 
 ## What are the flags?
 
-```bash
+```
   -a, --app string    Name of the application.
   -h, --help          help for show
       --json          Optional. Outputs in JSON format.

--- a/site/content/docs/commands/svc-show.ja.md
+++ b/site/content/docs/commands/svc-show.ja.md
@@ -1,5 +1,5 @@
 # svc show
-```bash
+```console
 $ copilot svc show
 ```
 
@@ -9,7 +9,7 @@ $ copilot svc show
 
 ## フラグ
 
-```bash
+```
   -a, --app string    Name of the application.
   -h, --help          help for show
       --json          Optional. Outputs in JSON format.

--- a/site/content/docs/commands/svc-status.en.md
+++ b/site/content/docs/commands/svc-status.en.md
@@ -1,5 +1,5 @@
 # svc status
-```
+```console
 $ copilot svc status
 ```
 

--- a/site/content/docs/commands/svc-status.ja.md
+++ b/site/content/docs/commands/svc-status.ja.md
@@ -1,5 +1,5 @@
 # svc status
-```
+```console
 $ copilot svc status
 ```
 

--- a/site/content/docs/commands/task-delete.en.md
+++ b/site/content/docs/commands/task-delete.en.md
@@ -1,5 +1,5 @@
 # task delete
-```
+```console
 $ copilot task delete
 ```
 
@@ -21,16 +21,16 @@ $ copilot task delete
 ```
 ## Example
 Delete the "test" task from the default cluster.
-```
+```console
 $ copilot task delete --name test --default
 ```
 
 Delete the "db-migrate" task from the prod environment.
-```
+```console
 $ copilot task delete --name db-migrate --env prod
 ```
 
 Delete the "test" task without confirmation prompt.
-```
+```console
 $ copilot task delete --name test --yes
 ```

--- a/site/content/docs/commands/task-delete.ja.md
+++ b/site/content/docs/commands/task-delete.ja.md
@@ -1,5 +1,5 @@
 # task delete
-```
+```console
 $ copilot task delete
 ```
 
@@ -21,16 +21,16 @@ $ copilot task delete
 ```
 ## 実行例
 デフォルトのクラスターから、"test" タスクを削除します。
-```
+```console
 $ copilot task delete --name test --default
 ```
 
 prod Environment から、"db-migrate" タスクを削除します。
-```
+```console
 $ copilot task delete --name db-migrate --env prod
 ```
 
 確認のプロンプトを表示せずに、"test" タスクを削除します。
-```
+```console
 $ copilot task delete --name test --yes
 ```

--- a/site/content/docs/commands/task-exec.en.md
+++ b/site/content/docs/commands/task-exec.en.md
@@ -1,5 +1,5 @@
 # task exec
-```
+```console
 $ copilot task exec
 ```
 
@@ -22,19 +22,19 @@ $ copilot task exec
 
 Start an interactive bash session with a task in task group "db-migrate" in the "test" environment under the current workspace.
 
-```bash
+```console
 $ copilot task exec -e test -n db-migrate
 ```
 
 Runs the 'cat progress.csv' command in the task prefixed with ID "1848c38" part of the "db-migrate" task group.
 
-```bash
+```console
 $ copilot task exec --name db-migrate --task-id 1848c38 --command "cat progress.csv"
 ```
 
 Start an interactive bash session with a task prefixed with ID "38c3818" in the default cluster.
 
-```bash
+```console
 $ copilot task exec --default --task-id 38c3818
 ```
 

--- a/site/content/docs/commands/task-exec.ja.md
+++ b/site/content/docs/commands/task-exec.ja.md
@@ -1,5 +1,5 @@
 # task exec
-```
+```console
 $ copilot task exec
 ```
 
@@ -22,19 +22,19 @@ $ copilot task exec
 
 現在のワークスペース配下の "test" Environment で、タスクグループ "db-migrate" 内のタスクへ対話型の bash セッションを開始します。
 
-```bash
+```console
 $ copilot task exec -e test -n db-migrate
 ```
 
 タスクグループ "db-migrate" 内の、ID "1848c38" のプレフィックスを持つタスクで 'cat progress.csv' コマンドを実行します。
 
-```bash
+```console
 $ copilot task exec --name db-migrate --task-id 1848c38 --command "cat progress.csv"
 ```
 
 デフォルトクラスター内で動作する、ID "38c3818" のプレフィックスを持つタスクへ対話型の bash セッションを開始します。
 
-```bash
+```console
 $ copilot task exec --default --task-id 38c3818
 ```
 

--- a/site/content/docs/commands/task-run.en.md
+++ b/site/content/docs/commands/task-run.en.md
@@ -1,5 +1,5 @@
 # task run
-```
+```console
 $ copilot task run
 ```
 
@@ -77,36 +77,36 @@ Utility Flags
 ## Examples
 Run a task using your local Dockerfile and display log streams after the task is running. 
 You will be prompted to specify an environment for the tasks to run in.
-```
+```console
 $ copilot task run --follow
 ```
 
 Run a task named "db-migrate" in the "test" environment under the current workspace.
-```
+```console
 $ copilot task run -n db-migrate --env test --follow
 ```
 
 Run 4 tasks with 2GB memory, an existing image, and a custom task role.
-```
+```console
 $ copilot task run --count 4 --memory 2048 --image=rds-migrate --task-role migrate-role --follow
 ```
 
 Run a task with environment variables.
-```
+```console
 $ copilot task run --env-vars name=myName,user=myUser
 ```
 
 Run a task using the current workspace with specific subnets and security groups.
-```
+```console
 $ copilot task run --subnets subnet-123,subnet-456 --security-groups sg-123,sg-456
 ```
 
 Run a task with a command.
-```
+```console
 $ copilot task run --command "python migrate-script.py"
 ```
 
 Run a Windows task with the minimum cpu and memory values.
-```
+```console
 $ copilot task run --platform-os WINDOWS_SERVER_2019_CORE --platform-arch X86_64 --cpu 1024 --memory 2048
 ```

--- a/site/content/docs/commands/task-run.ja.md
+++ b/site/content/docs/commands/task-run.ja.md
@@ -1,5 +1,5 @@
 # task run
-```
+```console
 $ copilot task run
 ```
 
@@ -77,36 +77,36 @@ Utility Flags
 ## 実行例
 ローカルの Dockerfile を使用してタスクを実行し、タスクの実行後はログストリームを表示します。
 コマンド実行後には質問が表示されますので、タスクを実行する Environment を指定します。
-```
+```console
 $ copilot task run --follow
 ```
 
 現在のワークスペース配下の "test" Environment で、"db-migrate" という名前のタスクを実行します。
-```
+```console
 $ copilot task run -n db-migrate --env test --follow
 ```
 
 2GB のメモリ、既存のイメージ、およびカスタムタスクロールを使用して 4 つのタスクを実行します。
-```
+```console
 $ copilot task run --count 4 --memory 2048 --image=rds-migrate --task-role migrate-role --follow
 ```
 
 環境変数を使用してタスクを実行します。
-```
+```console
 $ copilot task run --env-vars name=myName,user=myUser
 ```
 
 指定したサブネットとセキュリティグループを使用して、現在のワークスペース配下でタスクを実行します。
-```
+```console
 $ copilot task run --subnets subnet-123,subnet-456 --security-groups sg-123,sg-456
 ```
 
 コマンドを指定してタスクを実行します。
-```
+```console
 $ copilot task run --command "python migrate-script.py"
 ```
 
 Windows タスクを最小のCPUとメモリで実行します。 
-```
+```console
 $ copilot task run --platform-os WINDOWS_SERVER_2019_CORE --platform-arch X86_64 --cpu 1024 --memory 2048
 ```

--- a/site/content/docs/commands/version.en.md
+++ b/site/content/docs/commands/version.en.md
@@ -1,5 +1,5 @@
 # version
-```
+```console
 $ copilot version [flags]
 ```
 
@@ -7,6 +7,6 @@ $ copilot version [flags]
 `copilot version` prints the version of the CLI along with the target operating system it was built for.
 
 ## What are the flags?
-```bash
+```
 -h, --help   help for version
 ```

--- a/site/content/docs/commands/version.ja.md
+++ b/site/content/docs/commands/version.ja.md
@@ -1,5 +1,5 @@
 # version
-```
+```console
 $ copilot version [flags]
 ```
 
@@ -7,6 +7,6 @@ $ copilot version [flags]
 `copilot version` Copilot CLI のバージョンと、ビルドのターゲットオペレーティングシステムを表示します。
 
 ## フラグ
-```bash
+```
 -h, --help   help for version
 ```

--- a/site/content/docs/developing/taskdef-overrides.en.md
+++ b/site/content/docs/developing/taskdef-overrides.en.md
@@ -17,7 +17,7 @@ taskdef_overrides:
 - path: ContainerDefinitions[0].Cpu
   value: 512
 - path: ContainerDefinitions[0].Memory
-   value: 1024
+  value: 1024
 ```
 
 Each rule is applied sequentially to the CloudFormation template. The resulting CloudFormation template becomes the target of the next rule. Evaluation continues until all rules are successfully applied or an error is encountered.
@@ -61,7 +61,7 @@ taskdef_overrides:
 taskdef_overrides:
   - path: "ContainerDefinitions[0].PortMappings[-].ContainerPort"
     value: 2056
-  // PortMappings[1] gets the port mapping added by the previous rule, since by default Copilot creates a port mapping.
+  # PortMappings[1] gets the port mapping added by the previous rule, since by default Copilot creates a port mapping.
   - path: "ContainerDefinitions[0].PortMappings[1].Protocol"
     value: "udp"
 ```

--- a/site/content/docs/developing/taskdef-overrides.ja.md
+++ b/site/content/docs/developing/taskdef-overrides.ja.md
@@ -18,7 +18,7 @@ taskdef_overrides:
 - path: ContainerDefinitions[0].Cpu
   value: 512
 - path: ContainerDefinitions[0].Memory
-   value: 1024
+  value: 1024
 ```
 
 それぞれのルールは CloudFormation テンプレートに順次適用されます。結果として得られた CloudFormation テンプレートが次のルールの対象となります。すべてのルールが正常に適用されるか、エラーが発生するまで評価が続けられます。
@@ -62,7 +62,7 @@ taskdef_overrides:
 taskdef_overrides:
   - path: "ContainerDefinitions[0].PortMappings[-].ContainerPort"
     value: 2056
-  // Copilot はデフォルトでポートマッピングを作成するため、PortMappings[1] とすることで、上記ルールで追加されたポートマッピングを取得します。
+  # Copilot はデフォルトでポートマッピングを作成するため、PortMappings[1] とすることで、上記ルールで追加されたポートマッピングを取得します。
   - path: "ContainerDefinitions[0].PortMappings[1].Protocol"
     value: "udp"
 ```


### PR DESCRIPTION
`taskdef-overrides.md` has different changes (spacing) than the rest that are fixing/removing code highlighting.

Current:
![Screen Shot 2022-06-10 at 16 13 22](https://user-images.githubusercontent.com/10566468/173161505-ffef9592-b072-4a0d-b312-64a7f62f6ed2.png)


New:
![Screen Shot 2022-06-10 at 16 13 28](https://user-images.githubusercontent.com/10566468/173161547-e34f01c8-72af-4bcc-84f6-1a4b77258034.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
