### PR TITLE
chore: make windows bin md5 sum file name match others

### DIFF
--- a/.release/buildspec_integ.yml
+++ b/.release/buildspec_integ.yml
@@ -36,7 +36,7 @@ phases:
             do
                 bn="$(basename $artifact)"
                 echo "bn: $bn"
-                md5FileName="${{bn%.exe}}.md5"
+                md5FileName="${{bn}}.md5"
                 echo "md5FileName: $md5FileName"
                 aws s3api put-object-tagging --bucket $NEUTRAL_BUILD_RELEASE_BUCKET_NAME \
                 --key "$md5FileName" \

--- a/.release/buildspec_stage.yml
+++ b/.release/buildspec_stage.yml
@@ -22,7 +22,7 @@ phases:
       - |
         for artifact in `cat ./$GIT_COMMIT_ID.manifest`
         do
-            md5FileName="${artifact%.exe}"
+            md5FileName="${artifact}"
             md5sum $artifact | sed 's/ .*//' > "$md5FileName.md5"
             echo "Generated m5d for $artifact: $(cat $md5FileName.md5)"
             aws s3 cp $artifact "s3://$STAGE_BUCKET/$artifact" || exit 1


### PR DESCRIPTION
All of the other md5 sums of our output resources are named `filename.md5` except for windows, which has `.exe` stripped off the filename. We don't strip off the `.exe` for the signature files (`.asc`) on windows, so this makes the windows md5 sum match the windows signature file and the rest (linux & mac) of the resources.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
