### PR TITLE
fix: Add quotes for env-vars and secrets for `task run --generate-cmd`

### DIFF
--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -617,7 +617,7 @@ type publicIPGetter interface {
 }
 
 type cliStringer interface {
-	CLIString() string
+	CLIString() (string, error)
 }
 
 type secretPutter interface {

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -696,7 +696,11 @@ func (o *runTaskOpts) generateCommand() error {
 	if err != nil {
 		return err
 	}
-	log.Infoln(command.CLIString())
+	cliString, err := command.CLIString()
+	if err != nil {
+		return err
+	}
+	log.Infoln(cliString)
 	return nil
 }
 

--- a/internal/pkg/ecs/run_task_request.go
+++ b/internal/pkg/ecs/run_task_request.go
@@ -299,6 +299,9 @@ func fmtStringMapToString(m map[string]string) (string, error) {
 
 	// Then for shell escaping, wrap the entire argument in single quotes
 	// and escape any internal single quotes.
-	final = strings.ReplaceAll(final, `'`, `'\''`)
-	return `'` + final + `'`, nil
+	return shellQuote(final), nil
+}
+
+func shellQuote(s string) string {
+	return `'` + strings.ReplaceAll(s, `'`, `'\''`) + `'`
 }

--- a/internal/pkg/ecs/run_task_request_test.go
+++ b/internal/pkg/ecs/run_task_request_test.go
@@ -431,8 +431,8 @@ func TestRunTaskRequest_CLIString(t *testing.T) {
 				"--image beautiful-image",
 				"--entrypoint \"enter here\"",
 				"--command \"do not enter here\"",
-				`--env-vars '"enter=no","kidding=yes"'`,
-				`--secrets '"truth=go-ask-the-wise"'`,
+				`--env-vars 'enter=no,kidding=yes'`,
+				`--secrets 'truth=go-ask-the-wise'`,
 				"--security-groups sg-1,sg-2",
 				fmt.Sprintf("--app %s", testApp),
 				fmt.Sprintf("--env %s", testEnv),
@@ -455,15 +455,15 @@ func TestRunTaskRequest_fmtStringMapToString(t *testing.T) {
 	}{
 		"with internal commas": {
 			in:     map[string]string{"a": "1,2,3", "b": "2"},
-			wanted: `'"a=1,2,3","b=2"'`,
+			wanted: `'"a=1,2,3",b=2'`,
 		},
 		"with internal quotes": {
 			in:     map[string]string{"name": `john "nickname" doe`, "single": "single 'quote'"},
-			wanted: `'"name=john ""nickname"" doe","single=single '\''quote'\''"'`,
+			wanted: `'"name=john ""nickname"" doe",single=single '\''quote'\'''`,
 		},
 		"with internal equals sign": {
 			in:     map[string]string{"a": "4=2+2=4", "b": "b"},
-			wanted: `'"a=4=2+2=4","b=b"'`,
+			wanted: `'a=4=2+2=4,b=b'`,
 		},
 		"with a json env var": {
 			in:     map[string]string{"myval": `{"key1":"val1","key2":5}`},

--- a/internal/pkg/ecs/run_task_request_test.go
+++ b/internal/pkg/ecs/run_task_request_test.go
@@ -442,7 +442,8 @@ func TestRunTaskRequest_CLIString(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			got := tc.in.CLIString()
+			got, err := tc.in.CLIString()
+			require.Nil(t, err)
 			require.Equal(t, tc.wanted, got)
 		})
 	}
@@ -473,7 +474,8 @@ func TestRunTaskRequest_fmtStringMapToString(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			got := fmtStringMapToString(tc.in)
+			got, err := fmtStringMapToString(tc.in)
+			require.Nil(t, err)
 			require.Equal(t, tc.wanted, got)
 		})
 	}

--- a/internal/pkg/ecs/run_task_request_test.go
+++ b/internal/pkg/ecs/run_task_request_test.go
@@ -431,8 +431,8 @@ func TestRunTaskRequest_CLIString(t *testing.T) {
 				"--image beautiful-image",
 				"--entrypoint \"enter here\"",
 				"--command \"do not enter here\"",
-				"--env-vars enter=\"no\",kidding=\"yes\"",
-				"--secrets truth=\"go-ask-the-wise\"",
+				`--env-vars '"enter=no","kidding=yes"'`,
+				`--secrets '"truth=go-ask-the-wise"'`,
 				"--security-groups sg-1,sg-2",
 				fmt.Sprintf("--app %s", testApp),
 				fmt.Sprintf("--env %s", testEnv),
@@ -443,6 +443,37 @@ func TestRunTaskRequest_CLIString(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			got := tc.in.CLIString()
+			require.Equal(t, tc.wanted, got)
+		})
+	}
+}
+
+func TestRunTaskRequest_fmtStringMapToString(t *testing.T) {
+	testCases := map[string]struct {
+		in     map[string]string
+		wanted string
+	}{
+		"with internal commas": {
+			in:     map[string]string{"a": "1,2,3", "b": "2"},
+			wanted: `'"a=1,2,3","b=2"'`,
+		},
+		"with internal quotes": {
+			in:     map[string]string{"name": `john "nickname" doe`, "single": "single 'quote'"},
+			wanted: `'"name=john ""nickname"" doe","single=single '\''quote'\''"'`,
+		},
+		"with internal equals sign": {
+			in:     map[string]string{"a": "4=2+2=4", "b": "b"},
+			wanted: `'"a=4=2+2=4","b=b"'`,
+		},
+		"with a json env var": {
+			in:     map[string]string{"myval": `{"key1":"val1","key2":5}`},
+			wanted: `'"myval={""key1"":""val1"",""key2"":5}"'`,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got := fmtStringMapToString(tc.in)
 			require.Equal(t, tc.wanted, got)
 		})
 	}

--- a/internal/pkg/template/templates/task/cf.yml
+++ b/internal/pkg/template/templates/task/cf.yml
@@ -57,14 +57,14 @@ Resources:
           Name: !Ref TaskName{{if .EnvVars}}
           Environment:{{range $name, $value := .EnvVars}}
           - Name: {{$name}}
-            Value: {{$value}}{{end}}{{end}}
+            Value: {{$value | printf "%q"}}{{end}}{{end}}
           {{- if or .SSMParamSecrets .SecretsManagerSecrets}}
           Secrets:{{range $name, $valueFrom := .SSMParamSecrets}}
           - Name: {{$name}}
-            ValueFrom: {{$valueFrom}}{{end}}
+            ValueFrom: {{$valueFrom | printf "%q"}}{{end}}
           {{- range $name, $valueFrom := .SecretsManagerSecrets}}
           - Name: {{$name}}
-            ValueFrom: {{$valueFrom}}{{end}}
+            ValueFrom: {{$valueFrom | printf "%q"}}{{end}}
           {{- end}}
       Family: !Join ['-', ["copilot", !Ref TaskName]]
       RuntimePlatform: !If [HasCustomPlatform, {OperatingSystemFamily: !Ref OS, CpuArchitecture: !Ref Arch}, !Ref "AWS::NoValue"]


### PR DESCRIPTION
fix quoting of env vars and secrets in `task run --generate-cmd` output. also quote them in the generated yaml cf template.

Fixes #3683

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.

A couple comments on this:

1. I had to go further than the solution we originally talked about @efekarakus -- once I started testing the fix against our actual app, I realized it didn't fully fix our use case which is having JSON env var values. We need to do further shell escaping/quoting to get JSON passed back in to copilot correctly. I decided maybe wrapping the entire option in single quotes is best?
2. This shell escaping is necessarily shell specific. I tested this in sh, bash, zsh, fish, it works fine there, but I don't know of any reasonable way to guarantee escaping across all common shells. I know copilot supports windows as well, I don't know much about windows shells, is this likely to work there? If not I'm not sure what the fix might be.