### PR TITLE
fix: stackset AdminRole should assume the ExecRole

### DIFF
--- a/internal/pkg/template/templates/app/app.yml
+++ b/internal/pkg/template/templates/app/app.yml
@@ -50,7 +50,7 @@ Resources:
                 Action:
                   - sts:AssumeRole
                 Resource:
-                  - !Sub 'arn:${AWS::Partition}:iam::*:role/${AdminRoleName}'
+                  - !Sub 'arn:${AWS::Partition}:iam::*:role/${ExecutionRoleName}'
   ExecutionRole:
     Type: AWS::IAM::Role
     Properties:


### PR DESCRIPTION
We had a typo in the stackset IAM roles for the past 3 years :scream:. 
However, there was no impact for the customer because all
stack set instances are created within the same AWS account.

Since the `ExecutionRole` allows `sts:AssumeRole` to the
`AdministrationRole` and both roles live in the same IAM account (see
https://serverfault.com/questions/944254/aws-iam-assumerole-within-same-account/1021603#1021603)
the `AdministrationRole` could always assume the `ExecutionRole`.

Although this bug has no impact, we should fix it because it's confusing
to read that the `AdministrationRole` can assume itself when it should
be `ExecutionRole` instead.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
