### PR TITLE
chore(aws): add function for ec2 api to retrieve prefix lists

### DIFF
--- a/internal/pkg/aws/ec2/ec2.go
+++ b/internal/pkg/aws/ec2/ec2.go
@@ -14,8 +14,9 @@ import (
 )
 
 const (
-	defaultForAZFilterName  = "default-for-az"
-	internetGatewayIDPrefix = "igw-"
+	defaultForAZFilterName   = "default-for-az"
+	internetGatewayIDPrefix  = "igw-"
+	cloudFrontPrefixListName = "com.amazonaws.global.cloudfront.origin-facing"
 
 	// TagFilterName is the filter name format for tag filters
 	TagFilterName = "tag:%s"
@@ -439,8 +440,8 @@ func (idx *routeTableIndex) IsPublicSubnet(subnetID string) bool {
 	return idx.mainTable.HasIGW()
 }
 
-// ManagedPrefixListId returns the PrefixListId of a prefix list queried by name.
-func (c *EC2) ManagedPrefixListId(prefixListName string) (*string, error) {
+// managedPrefixListId returns the DescribeManagedPrefixListsOutput of a query by name.
+func (c *EC2) managedPrefixList(prefixListName string) (*ec2.DescribeManagedPrefixListsOutput, error) {
 	prefixListOutput, err := c.client.DescribeManagedPrefixLists(&ec2.DescribeManagedPrefixListsInput{
 		Filters: []*ec2.Filter{
 			{
@@ -454,17 +455,28 @@ func (c *EC2) ManagedPrefixListId(prefixListName string) (*string, error) {
 		return nil, fmt.Errorf("describe managed prefix list with name %s: %w", prefixListName, err)
 	}
 
+	return prefixListOutput, nil
+}
+
+// CloudFrontManagedPrefixListId returns the PrefixListId of the associated cloudfront prefix list as a *string.
+func (c *EC2) CloudFrontManagedPrefixListId() (*string, error) {
+	prefixListsOutput, err := c.managedPrefixList(cloudFrontPrefixListName)
+
+	if err != nil {
+		return nil, err
+	}
+
 	var ids []*string
-	for _, v := range prefixListOutput.PrefixLists {
+	for _, v := range prefixListsOutput.PrefixLists {
 		ids = append(ids, v.PrefixListId)
 	}
 
 	if len(ids) == 0 {
-		return nil, fmt.Errorf("cannot find any prefix list with name: %s", prefixListName)
+		return nil, fmt.Errorf("cannot find any prefix list with name: %s", cloudFrontPrefixListName)
 	}
 
 	if len(ids) > 1 {
-		return nil, fmt.Errorf("found more than one prefix list with the name %s: %v", prefixListName, ids)
+		return nil, fmt.Errorf("found more than one prefix list with the name %s: %v", cloudFrontPrefixListName, ids)
 	}
 
 	return ids[0], nil

--- a/internal/pkg/aws/ec2/ec2.go
+++ b/internal/pkg/aws/ec2/ec2.go
@@ -451,20 +451,21 @@ func (c *EC2) ManagedPrefixListId(prefixListName string) (*string, error) {
 	})
 
 	if err != nil {
-		return nil, fmt.Errorf("query returned error: %w", err)
+		return nil, fmt.Errorf("describe managed prefix list with name %s: %w", prefixListName, err)
 	}
 
-	if len(prefixListOutput.PrefixLists) == 0 {
+	var ids []*string
+	for _, v := range prefixListOutput.PrefixLists {
+		ids = append(ids, v.PrefixListId)
+	}
+
+	if len(ids) == 0 {
 		return nil, fmt.Errorf("cannot find any prefix list with name: %s", prefixListName)
 	}
 
-	if len(prefixListOutput.PrefixLists) > 1 {
-		var ids []*string
-		for _, v := range prefixListOutput.PrefixLists {
-			ids = append(ids, v.PrefixListId)
-		}
+	if len(ids) > 1 {
 		return nil, fmt.Errorf("found more than one prefix list with the name %s: %v", prefixListName, ids)
 	}
 
-	return prefixListOutput.PrefixLists[0].PrefixListId, nil
+	return ids[0], nil
 }

--- a/internal/pkg/aws/ec2/ec2.go
+++ b/internal/pkg/aws/ec2/ec2.go
@@ -440,7 +440,7 @@ func (idx *routeTableIndex) IsPublicSubnet(subnetID string) bool {
 	return idx.mainTable.HasIGW()
 }
 
-// managedPrefixListId returns the DescribeManagedPrefixListsOutput of a query by name.
+// managedPrefixList returns the DescribeManagedPrefixListsOutput of a query by name.
 func (c *EC2) managedPrefixList(prefixListName string) (*ec2.DescribeManagedPrefixListsOutput, error) {
 	prefixListOutput, err := c.client.DescribeManagedPrefixLists(&ec2.DescribeManagedPrefixListsInput{
 		Filters: []*ec2.Filter{
@@ -458,8 +458,8 @@ func (c *EC2) managedPrefixList(prefixListName string) (*ec2.DescribeManagedPref
 	return prefixListOutput, nil
 }
 
-// CloudFrontManagedPrefixListId returns the PrefixListId of the associated cloudfront prefix list as a *string.
-func (c *EC2) CloudFrontManagedPrefixListId() (*string, error) {
+// CloudFrontManagedPrefixListID returns the PrefixListId of the associated cloudfront prefix list as a *string.
+func (c *EC2) CloudFrontManagedPrefixListID() (*string, error) {
 	prefixListsOutput, err := c.managedPrefixList(cloudFrontPrefixListName)
 
 	if err != nil {

--- a/internal/pkg/aws/ec2/ec2_test.go
+++ b/internal/pkg/aws/ec2/ec2_test.go
@@ -270,7 +270,7 @@ func TestEC2_GetManagedPrefixListId(t *testing.T) {
 			mockEC2Client: func(m *mocks.Mockapi) {
 				m.EXPECT().DescribeManagedPrefixLists(gomock.Any()).Return(nil, mockError)
 			},
-			wantedError: fmt.Errorf("query returned error: some error"),
+			wantedError: fmt.Errorf("describe managed prefix list with name %s: %w", mockPrefixListName, mockError),
 		},
 		"query returns no prefix list ids": {
 			mockEC2Client: func(m *mocks.Mockapi) {

--- a/internal/pkg/aws/ec2/ec2_test.go
+++ b/internal/pkg/aws/ec2/ec2_test.go
@@ -245,9 +245,87 @@ func TestEC2_ListAZs(t *testing.T) {
 	}
 }
 
-func TestEC2_GetManagedPrefixListId(t *testing.T) {
+func TestEC2_managedPrefixList(t *testing.T) {
 	const (
 		mockPrefixListName = "mockName"
+		mockPrefixListId   = "mockId"
+		mockNextToken      = "mockNextToken"
+	)
+	mockError := errors.New("some error")
+	mockFilter := []*ec2.Filter{
+		{
+			Name:   aws.String("prefix-list-name"),
+			Values: aws.StringSlice([]string{mockPrefixListName}),
+		},
+	}
+	mockPrefixList := []*ec2.ManagedPrefixList{
+		{
+			PrefixListId: aws.String(mockPrefixListId),
+		},
+	}
+
+	testCases := map[string]struct {
+		mockEC2Client func(m *mocks.Mockapi)
+
+		wantedError          error
+		wantedErrorMsgPrefix string
+		wantedList           *ec2.DescribeManagedPrefixListsOutput
+	}{
+		"query returns error": {
+			mockEC2Client: func(m *mocks.Mockapi) {
+				m.EXPECT().DescribeManagedPrefixLists(gomock.Any()).Return(nil, mockError)
+			},
+			wantedError: fmt.Errorf("describe managed prefix list with name %s: %w", mockPrefixListName, mockError),
+		},
+		"query returns succesfully": {
+			mockEC2Client: func(m *mocks.Mockapi) {
+				m.EXPECT().DescribeManagedPrefixLists(&ec2.DescribeManagedPrefixListsInput{
+					Filters: mockFilter,
+				}).Return(&ec2.DescribeManagedPrefixListsOutput{
+					NextToken: aws.String(mockNextToken),
+					PrefixLists: []*ec2.ManagedPrefixList{
+						{
+							PrefixListId: aws.String(mockPrefixListId),
+						},
+					},
+				}, nil)
+			},
+			wantedList: &ec2.DescribeManagedPrefixListsOutput{
+				NextToken:   aws.String(mockNextToken),
+				PrefixLists: mockPrefixList,
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+
+			mockAPI := mocks.NewMockapi(ctrl)
+			tc.mockEC2Client(mockAPI)
+
+			ec2Client := EC2{
+				client: mockAPI,
+			}
+
+			output, err := ec2Client.managedPrefixList(mockPrefixListName)
+			if tc.wantedError != nil {
+				require.EqualError(t, tc.wantedError, err.Error())
+			} else if tc.wantedErrorMsgPrefix != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.wantedErrorMsgPrefix)
+				return
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.wantedList, output, "managed prefix lists output must be equal")
+			}
+		})
+	}
+}
+
+func TestEC2_CloudFrontManagedPrefixListId(t *testing.T) {
+	const (
+		mockPrefixListName = cloudFrontPrefixListName
 		mockPrefixListId   = "mockId"
 		mockNextToken      = "mockNextToken"
 	)
@@ -329,7 +407,7 @@ func TestEC2_GetManagedPrefixListId(t *testing.T) {
 				client: mockAPI,
 			}
 
-			id, err := ec2Client.ManagedPrefixListId(mockPrefixListName)
+			id, err := ec2Client.CloudFrontManagedPrefixListId()
 			if tc.wantedError != nil {
 				require.EqualError(t, tc.wantedError, err.Error())
 			} else if tc.wantedErrorMsgPrefix != "" {

--- a/internal/pkg/aws/ec2/ec2_test.go
+++ b/internal/pkg/aws/ec2/ec2_test.go
@@ -407,7 +407,7 @@ func TestEC2_CloudFrontManagedPrefixListId(t *testing.T) {
 				client: mockAPI,
 			}
 
-			id, err := ec2Client.CloudFrontManagedPrefixListId()
+			id, err := ec2Client.CloudFrontManagedPrefixListID()
 			if tc.wantedError != nil {
 				require.EqualError(t, tc.wantedError, err.Error())
 			} else if tc.wantedErrorMsgPrefix != "" {

--- a/internal/pkg/aws/ec2/mocks/mock_ec2.go
+++ b/internal/pkg/aws/ec2/mocks/mock_ec2.go
@@ -49,6 +49,21 @@ func (mr *MockapiMockRecorder) DescribeAvailabilityZones(input interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAvailabilityZones", reflect.TypeOf((*Mockapi)(nil).DescribeAvailabilityZones), input)
 }
 
+// DescribeManagedPrefixLists mocks base method.
+func (m *Mockapi) DescribeManagedPrefixLists(input *ec2.DescribeManagedPrefixListsInput) (*ec2.DescribeManagedPrefixListsOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeManagedPrefixLists", input)
+	ret0, _ := ret[0].(*ec2.DescribeManagedPrefixListsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeManagedPrefixLists indicates an expected call of DescribeManagedPrefixLists.
+func (mr *MockapiMockRecorder) DescribeManagedPrefixLists(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeManagedPrefixLists", reflect.TypeOf((*Mockapi)(nil).DescribeManagedPrefixLists), input)
+}
+
 // DescribeNetworkInterfaces mocks base method.
 func (m *Mockapi) DescribeNetworkInterfaces(input *ec2.DescribeNetworkInterfacesInput) (*ec2.DescribeNetworkInterfacesOutput, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
<!-- Provide summary of changes -->
Add a function to retrieve aws managed prefix list ID queried by name. This will allow Copilot to retrieve prefix lists to set security group ingress to only allow traffic from CloudFront.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->
Related #3701

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
