### PR TITLE
chore: reduce chance of copying invalid character in secret to copilot manifest

### DIFF
--- a/internal/pkg/cli/secret_init.go
+++ b/internal/pkg/cli/secret_init.go
@@ -416,7 +416,7 @@ func (o *secretInitOpts) RecommendActions() error {
 	}
 
 	log.Infoln("You can refer to these secrets from your manifest file by editing the `secrets` section.")
-	log.Infoln(color.HighlightCode(secretsManifestExample))
+	log.Infoln(color.HighlightCodeBlock(secretsManifestExample))
 	return nil
 }
 


### PR DESCRIPTION
New printout:

```
You can refer to these secrets from your manifest file by editing the `secrets` section.
<three backticks>
secrets:
    TEST_SECRET_THREE: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/TEST_SECRET_THREE
<three backticks>
```

Issue: #3446

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
