### PR TITLE
chore(cli): let `env init` deploys only bootstrap resources

### DIFF
--- a/internal/pkg/cli/env_init.go
+++ b/internal/pkg/cli/env_init.go
@@ -655,29 +655,6 @@ To recreate the environment, please run:
 	return nil
 }
 
-func (o *initEnvOpts) importVPCConfig() *config.ImportVPC {
-	if o.defaultConfig || !o.importVPC.isSet() {
-		return nil
-	}
-	return &config.ImportVPC{
-		ID:               o.importVPC.ID,
-		PrivateSubnetIDs: o.importVPC.PrivateSubnetIDs,
-		PublicSubnetIDs:  o.importVPC.PublicSubnetIDs,
-	}
-}
-
-func (o *initEnvOpts) adjustVPCConfig() *config.AdjustVPC {
-	if o.defaultConfig || !o.adjustVPC.isSet() {
-		return nil
-	}
-	return &config.AdjustVPC{
-		CIDR:               o.adjustVPC.CIDR.String(),
-		AZs:                o.adjustVPC.AZs,
-		PrivateSubnetCIDRs: o.adjustVPC.PrivateSubnetCIDRs,
-		PublicSubnetCIDRs:  o.adjustVPC.PublicSubnetCIDRs,
-	}
-}
-
 func (o *initEnvOpts) deployEnv(app *config.Application,
 	artifactBucketARN, artifactBucketKeyARN string) error {
 	caller, err := o.identity.Get()

--- a/internal/pkg/cli/env_init.go
+++ b/internal/pkg/cli/env_init.go
@@ -130,12 +130,6 @@ type telemetryVars struct {
 	EnableContainerInsights bool
 }
 
-func (v telemetryVars) toConfig() *config.Telemetry {
-	return &config.Telemetry{
-		EnableContainerInsights: v.EnableContainerInsights,
-	}
-}
-
 type initEnvVars struct {
 	appName       string
 	name          string // Name for the environment.
@@ -146,7 +140,7 @@ type initEnvVars struct {
 	importVPC          importVPCVars // Existing VPC resources to use instead of creating new ones.
 	adjustVPC          adjustVPCVars // Configure parameters for VPC resources generated while initializing an environment.
 	telemetry          telemetryVars // Configure observability and monitoring settings.
-	importCerts        []string      // Addtional existing ACM certificates to use.
+	importCerts        []string      // Additional existing ACM certificates to use.
 	internalALBSubnets []string      // Subnets to be used for internal ALB placement.
 	allowVPCIngress    bool          // True means the env stack will create ingress to the internal ALB from ports 80/443.
 
@@ -315,17 +309,6 @@ func (o *initEnvOpts) Execute() error {
 		return fmt.Errorf("get environment struct for %s: %w", o.name, err)
 	}
 	env.Prod = o.isProduction
-	customizedEnv := config.CustomizeEnv{
-		ImportVPC:                   o.importVPCConfig(),
-		VPCConfig:                   o.adjustVPCConfig(),
-		ImportCertARNs:              o.importCerts,
-		InternalALBSubnets:          o.internalALBSubnets,
-		EnableInternalALBVPCIngress: o.allowVPCIngress,
-	}
-	if !customizedEnv.IsEmpty() {
-		env.CustomConfig = &customizedEnv
-	}
-	env.Telemetry = o.telemetry.toConfig()
 
 	// 6. Store the environment in SSM.
 	if err := o.store.CreateEnvironment(env); err != nil {

--- a/internal/pkg/cli/env_init_test.go
+++ b/internal/pkg/cli/env_init_test.go
@@ -1072,9 +1072,6 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 					Name:      "test",
 					AccountID: "1234",
 					Region:    "mars-1",
-					Telemetry: &config.Telemetry{
-						EnableContainerInsights: true,
-					},
 				}).Return(nil)
 			},
 			expectIdentity: func(m *mocks.MockidentityService) {
@@ -1117,9 +1114,6 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 					Name:      "test",
 					AccountID: "1234",
 					Region:    "mars-1",
-					Telemetry: &config.Telemetry{
-						EnableContainerInsights: false,
-					},
 				}).Return(nil)
 			},
 			expectIdentity: func(m *mocks.MockidentityService) {
@@ -1187,9 +1181,6 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 					Name:      "test",
 					AccountID: "4567",
 					Region:    "us-west-2",
-					Telemetry: &config.Telemetry{
-						EnableContainerInsights: false,
-					},
 				}).Return(nil)
 			},
 			expectIdentity: func(m *mocks.MockidentityService) {

--- a/internal/pkg/cli/env_init_test.go
+++ b/internal/pkg/cli/env_init_test.go
@@ -901,54 +901,45 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 	}
 }
 
+type initEnvExecuteMocks struct {
+	store             *mocks.Mockstore
+	deployer          *mocks.Mockdeployer
+	identity          *mocks.MockidentityService
+	progress          *mocks.Mockprogress
+	iam               *mocks.MockroleManager
+	cfn               *mocks.MockstackExistChecker
+	appCFN            *mocks.MockappResourcesGetter
+	resourcesUploader *mocks.MockcustomResourcesUploader
+}
+
 func TestInitEnvOpts_Execute(t *testing.T) {
 	testCases := map[string]struct {
 		enableContainerInsights bool
-
-		expectStore             func(m *mocks.Mockstore)
-		expectDeployer          func(m *mocks.Mockdeployer)
-		expectIdentity          func(m *mocks.MockidentityService)
-		expectProgress          func(m *mocks.Mockprogress)
-		expectIAM               func(m *mocks.MockroleManager)
-		expectCFN               func(m *mocks.MockstackExistChecker)
-		expectAppCFN            func(m *mocks.MockappResourcesGetter)
-		expectResourcesUploader func(m *mocks.MockcustomResourcesUploader)
-
-		wantedErrorS string
+		setupMocks              func(m *initEnvExecuteMocks)
+		wantedErrorS            string
 	}{
 		"returns app exists error": {
-			expectStore: func(m *mocks.Mockstore) {
-				m.EXPECT().GetApplication("phonetool").Return(nil, errors.New("some error"))
+			setupMocks: func(m *initEnvExecuteMocks) {
+				m.store.EXPECT().GetApplication("phonetool").Return(nil, errors.New("some error"))
 			},
-
 			wantedErrorS: "some error",
 		},
 		"returns identity get error": {
-			expectStore: func(m *mocks.Mockstore) {
-				m.EXPECT().GetApplication("phonetool").Return(&config.Application{Name: "phonetool"}, nil)
-			},
-			expectIdentity: func(m *mocks.MockidentityService) {
-				m.EXPECT().Get().Return(identity.Caller{}, errors.New("some identity error"))
+			setupMocks: func(m *initEnvExecuteMocks) {
+				m.store.EXPECT().GetApplication("phonetool").Return(&config.Application{Name: "phonetool"}, nil)
+				m.identity.EXPECT().Get().Return(identity.Caller{}, errors.New("some identity error"))
 			},
 			wantedErrorS: "get identity: some identity error",
 		},
 		"failed to create stack set instance": {
-			expectStore: func(m *mocks.Mockstore) {
-				m.EXPECT().CreateEnvironment(gomock.Any()).Times(0)
-				m.EXPECT().GetApplication("phonetool").Return(&config.Application{Name: "phonetool"}, nil)
-			},
-			expectIdentity: func(m *mocks.MockidentityService) {
-				m.EXPECT().Get().Return(identity.Caller{RootUserARN: "some arn", Account: "1234"}, nil)
-			},
-			expectIAM: func(m *mocks.MockroleManager) {
-				m.EXPECT().CreateECSServiceLinkedRole().Return(nil)
-			},
-			expectProgress: func(m *mocks.Mockprogress) {
-				m.EXPECT().Start(fmt.Sprintf(fmtAddEnvToAppStart, "1234", "us-west-2", "phonetool"))
-				m.EXPECT().Stop(log.Serrorf(fmtAddEnvToAppFailed, "1234", "us-west-2", "phonetool"))
-			},
-			expectDeployer: func(m *mocks.Mockdeployer) {
-				m.EXPECT().AddEnvToApp(&deploycfn.AddEnvToAppOpts{
+			setupMocks: func(m *initEnvExecuteMocks) {
+				m.store.EXPECT().CreateEnvironment(gomock.Any()).Times(0)
+				m.store.EXPECT().GetApplication("phonetool").Return(&config.Application{Name: "phonetool"}, nil)
+				m.identity.EXPECT().Get().Return(identity.Caller{RootUserARN: "some arn", Account: "1234"}, nil)
+				m.iam.EXPECT().CreateECSServiceLinkedRole().Return(nil)
+				m.progress.EXPECT().Start(fmt.Sprintf(fmtAddEnvToAppStart, "1234", "us-west-2", "phonetool"))
+				m.progress.EXPECT().Stop(log.Serrorf(fmtAddEnvToAppFailed, "1234", "us-west-2", "phonetool"))
+				m.deployer.EXPECT().AddEnvToApp(&deploycfn.AddEnvToAppOpts{
 					App:          &config.Application{Name: "phonetool"},
 					EnvName:      "test",
 					EnvAccountID: "1234",
@@ -958,64 +949,42 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 			wantedErrorS: "deploy env test to application phonetool: some cfn error",
 		},
 		"errors cannot get app resources by region": {
-			expectStore: func(m *mocks.Mockstore) {
-				m.EXPECT().GetApplication("phonetool").Return(&config.Application{Name: "phonetool"}, nil)
-			},
-			expectProgress: func(m *mocks.Mockprogress) {
-				m.EXPECT().Start(fmt.Sprintf(fmtAddEnvToAppStart, "1234", "us-west-2", "phonetool"))
-				m.EXPECT().Stop(log.Ssuccessf(fmtAddEnvToAppComplete, "1234", "us-west-2", "phonetool"))
-			},
-			expectIdentity: func(m *mocks.MockidentityService) {
-				m.EXPECT().Get().Return(identity.Caller{RootUserARN: "some arn", Account: "1234"}, nil)
-			},
-			expectIAM: func(m *mocks.MockroleManager) {
-				m.EXPECT().CreateECSServiceLinkedRole().Return(nil)
-			},
-			expectDeployer: func(m *mocks.Mockdeployer) {
-				m.EXPECT().AddEnvToApp(gomock.Any()).Return(nil)
-			},
-			expectAppCFN: func(m *mocks.MockappResourcesGetter) {
-				m.EXPECT().GetAppResourcesByRegion(&config.Application{Name: "phonetool"}, "us-west-2").
+			setupMocks: func(m *initEnvExecuteMocks) {
+				m.store.EXPECT().GetApplication("phonetool").Return(&config.Application{Name: "phonetool"}, nil)
+				m.identity.EXPECT().Get().Return(identity.Caller{RootUserARN: "some arn", Account: "1234"}, nil)
+				m.iam.EXPECT().CreateECSServiceLinkedRole().Return(nil)
+				m.progress.EXPECT().Start(fmt.Sprintf(fmtAddEnvToAppStart, "1234", "us-west-2", "phonetool"))
+				m.progress.EXPECT().Stop(log.Ssuccessf(fmtAddEnvToAppComplete, "1234", "us-west-2", "phonetool"))
+				m.deployer.EXPECT().AddEnvToApp(gomock.Any()).Return(nil)
+				m.appCFN.EXPECT().GetAppResourcesByRegion(&config.Application{Name: "phonetool"}, "us-west-2").
 					Return(nil, errors.New("some error"))
 			},
 			wantedErrorS: "get app resources: some error",
 		},
 		"deletes retained IAM roles if environment stack fails creation": {
-			expectStore: func(m *mocks.Mockstore) {
-				m.EXPECT().GetApplication("phonetool").Return(&config.Application{Name: "phonetool"}, nil)
-			},
-			expectProgress: func(m *mocks.Mockprogress) {
-				m.EXPECT().Start(fmt.Sprintf(fmtAddEnvToAppStart, "1234", "us-west-2", "phonetool"))
-				m.EXPECT().Stop(log.Ssuccessf(fmtAddEnvToAppComplete, "1234", "us-west-2", "phonetool"))
-			},
-			expectIdentity: func(m *mocks.MockidentityService) {
-				m.EXPECT().Get().Return(identity.Caller{RootUserARN: "some arn", Account: "1234"}, nil).Times(2)
-			},
-			expectIAM: func(m *mocks.MockroleManager) {
+			setupMocks: func(m *initEnvExecuteMocks) {
+				m.store.EXPECT().GetApplication("phonetool").Return(&config.Application{Name: "phonetool"}, nil)
+				m.progress.EXPECT().Start(fmt.Sprintf(fmtAddEnvToAppStart, "1234", "us-west-2", "phonetool"))
+				m.progress.EXPECT().Stop(log.Ssuccessf(fmtAddEnvToAppComplete, "1234", "us-west-2", "phonetool"))
+				m.identity.EXPECT().Get().Return(identity.Caller{RootUserARN: "some arn", Account: "1234"}, nil).Times(2)
 				gomock.InOrder(
-					m.EXPECT().CreateECSServiceLinkedRole().Return(nil),
+					m.iam.EXPECT().CreateECSServiceLinkedRole().Return(nil),
 					// Skip deleting non-existing roles.
-					m.EXPECT().ListRoleTags(gomock.Eq("phonetool-test-CFNExecutionRole")).Return(nil, errors.New("does not exist")),
-					m.EXPECT().ListRoleTags(gomock.Eq("phonetool-test-EnvManagerRole")).Return(nil, errors.New("does not exist")),
+					m.iam.EXPECT().ListRoleTags(gomock.Eq("phonetool-test-CFNExecutionRole")).Return(nil, errors.New("does not exist")),
+					m.iam.EXPECT().ListRoleTags(gomock.Eq("phonetool-test-EnvManagerRole")).Return(nil, errors.New("does not exist")),
 
 					// Cleanup after created roles.
-					m.EXPECT().ListRoleTags(gomock.Eq("phonetool-test-CFNExecutionRole")).Return(map[string]string{
+					m.iam.EXPECT().ListRoleTags(gomock.Eq("phonetool-test-CFNExecutionRole")).Return(map[string]string{
 						"copilot-application": "phonetool",
 						"copilot-environment": "test",
 					}, nil),
-					m.EXPECT().DeleteRole(gomock.Eq("phonetool-test-CFNExecutionRole")).Return(nil),
-					m.EXPECT().ListRoleTags(gomock.Eq("phonetool-test-EnvManagerRole")).Return(nil, errors.New("does not exist")),
+					m.iam.EXPECT().DeleteRole(gomock.Eq("phonetool-test-CFNExecutionRole")).Return(nil),
+					m.iam.EXPECT().ListRoleTags(gomock.Eq("phonetool-test-EnvManagerRole")).Return(nil, errors.New("does not exist")),
 				)
-			},
-			expectCFN: func(m *mocks.MockstackExistChecker) {
-				m.EXPECT().Exists("phonetool-test").Return(false, nil)
-			},
-			expectDeployer: func(m *mocks.Mockdeployer) {
-				m.EXPECT().AddEnvToApp(gomock.Any()).Return(nil)
-				m.EXPECT().CreateAndRenderEnvironment(gomock.Any(), gomock.Any()).Return(errors.New("some deploy error"))
-			},
-			expectAppCFN: func(m *mocks.MockappResourcesGetter) {
-				m.EXPECT().GetAppResourcesByRegion(&config.Application{Name: "phonetool"}, "us-west-2").
+				m.cfn.EXPECT().Exists("phonetool-test").Return(false, nil)
+				m.deployer.EXPECT().AddEnvToApp(gomock.Any()).Return(nil)
+				m.deployer.EXPECT().CreateAndRenderEnvironment(gomock.Any(), gomock.Any()).Return(errors.New("some deploy error"))
+				m.appCFN.EXPECT().GetAppResourcesByRegion(&config.Application{Name: "phonetool"}, "us-west-2").
 					Return(&stack.AppRegionalResources{
 						S3Bucket: "mockBucket",
 					}, nil)
@@ -1023,39 +992,27 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 			wantedErrorS: "some deploy error",
 		},
 		"returns error from CreateEnvironment": {
-			expectStore: func(m *mocks.Mockstore) {
-				m.EXPECT().GetApplication("phonetool").Return(&config.Application{
+			setupMocks: func(m *initEnvExecuteMocks) {
+				m.store.EXPECT().GetApplication("phonetool").Return(&config.Application{
 					Name: "phonetool",
 				}, nil)
-				m.EXPECT().CreateEnvironment(gomock.Any()).Return(errors.New("some create error"))
-			},
-			expectIdentity: func(m *mocks.MockidentityService) {
-				m.EXPECT().Get().Return(identity.Caller{RootUserARN: "some arn", Account: "1234"}, nil).Times(2)
-			},
-			expectIAM: func(m *mocks.MockroleManager) {
-				m.EXPECT().CreateECSServiceLinkedRole().Return(nil)
-				m.EXPECT().ListRoleTags(gomock.Any()).
+				m.store.EXPECT().CreateEnvironment(gomock.Any()).Return(errors.New("some create error"))
+				m.identity.EXPECT().Get().Return(identity.Caller{RootUserARN: "some arn", Account: "1234"}, nil).Times(2)
+				m.iam.EXPECT().CreateECSServiceLinkedRole().Return(nil)
+				m.iam.EXPECT().ListRoleTags(gomock.Any()).
 					Return(nil, errors.New("does not exist")).AnyTimes()
-			},
-			expectCFN: func(m *mocks.MockstackExistChecker) {
-				m.EXPECT().Exists("phonetool-test").Return(false, nil)
-			},
-			expectProgress: func(m *mocks.Mockprogress) {
-				m.EXPECT().Start(fmt.Sprintf(fmtAddEnvToAppStart, "1234", "us-west-2", "phonetool"))
-				m.EXPECT().Stop(log.Ssuccessf(fmtAddEnvToAppComplete, "1234", "us-west-2", "phonetool"))
-			},
-			expectDeployer: func(m *mocks.Mockdeployer) {
-				m.EXPECT().CreateAndRenderEnvironment(gomock.Any(), gomock.Any()).Return(nil)
-				m.EXPECT().GetEnvironment("phonetool", "test").Return(&config.Environment{
+				m.cfn.EXPECT().Exists("phonetool-test").Return(false, nil)
+				m.progress.EXPECT().Start(fmt.Sprintf(fmtAddEnvToAppStart, "1234", "us-west-2", "phonetool"))
+				m.progress.EXPECT().Stop(log.Ssuccessf(fmtAddEnvToAppComplete, "1234", "us-west-2", "phonetool"))
+				m.deployer.EXPECT().CreateAndRenderEnvironment(gomock.Any(), gomock.Any()).Return(nil)
+				m.deployer.EXPECT().GetEnvironment("phonetool", "test").Return(&config.Environment{
 					App:       "phonetool",
 					Name:      "test",
 					AccountID: "1234",
 					Region:    "mars-1",
 				}, nil)
-				m.EXPECT().AddEnvToApp(gomock.Any()).Return(nil)
-			},
-			expectAppCFN: func(m *mocks.MockappResourcesGetter) {
-				m.EXPECT().GetAppResourcesByRegion(&config.Application{Name: "phonetool"}, "us-west-2").
+				m.deployer.EXPECT().AddEnvToApp(gomock.Any()).Return(nil)
+				m.appCFN.EXPECT().GetAppResourcesByRegion(&config.Application{Name: "phonetool"}, "us-west-2").
 					Return(&stack.AppRegionalResources{
 						S3Bucket: "mockBucket",
 					}, nil)
@@ -1065,74 +1022,52 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 		"success": {
 			enableContainerInsights: true,
 
-			expectStore: func(m *mocks.Mockstore) {
-				m.EXPECT().GetApplication("phonetool").Return(&config.Application{Name: "phonetool"}, nil)
-				m.EXPECT().CreateEnvironment(&config.Environment{
+			setupMocks: func(m *initEnvExecuteMocks) {
+				m.store.EXPECT().GetApplication("phonetool").Return(&config.Application{Name: "phonetool"}, nil)
+				m.store.EXPECT().CreateEnvironment(&config.Environment{
 					App:       "phonetool",
 					Name:      "test",
 					AccountID: "1234",
 					Region:    "mars-1",
 				}).Return(nil)
-			},
-			expectIdentity: func(m *mocks.MockidentityService) {
-				m.EXPECT().Get().Return(identity.Caller{RootUserARN: "some arn", Account: "1234"}, nil).Times(2)
-			},
-			expectIAM: func(m *mocks.MockroleManager) {
-				m.EXPECT().CreateECSServiceLinkedRole().Return(nil)
-				m.EXPECT().ListRoleTags(gomock.Eq("phonetool-test-CFNExecutionRole")).Return(nil, errors.New("does not exist"))
-				m.EXPECT().ListRoleTags(gomock.Eq("phonetool-test-EnvManagerRole")).Return(nil, errors.New("does not exist"))
-			},
-			expectCFN: func(m *mocks.MockstackExistChecker) {
-				m.EXPECT().Exists("phonetool-test").Return(false, nil)
-			},
-			expectProgress: func(m *mocks.Mockprogress) {
-				m.EXPECT().Start(fmt.Sprintf(fmtAddEnvToAppStart, "1234", "us-west-2", "phonetool"))
-				m.EXPECT().Stop(log.Ssuccessf(fmtAddEnvToAppComplete, "1234", "us-west-2", "phonetool"))
-			},
-			expectDeployer: func(m *mocks.Mockdeployer) {
-				m.EXPECT().CreateAndRenderEnvironment(gomock.Any(), gomock.Any()).Return(nil)
-				m.EXPECT().GetEnvironment("phonetool", "test").Return(&config.Environment{
+				m.identity.EXPECT().Get().Return(identity.Caller{RootUserARN: "some arn", Account: "1234"}, nil).Times(2)
+				m.iam.EXPECT().CreateECSServiceLinkedRole().Return(nil)
+				m.iam.EXPECT().ListRoleTags(gomock.Eq("phonetool-test-CFNExecutionRole")).Return(nil, errors.New("does not exist"))
+				m.iam.EXPECT().ListRoleTags(gomock.Eq("phonetool-test-EnvManagerRole")).Return(nil, errors.New("does not exist"))
+				m.cfn.EXPECT().Exists("phonetool-test").Return(false, nil)
+				m.progress.EXPECT().Start(fmt.Sprintf(fmtAddEnvToAppStart, "1234", "us-west-2", "phonetool"))
+				m.progress.EXPECT().Stop(log.Ssuccessf(fmtAddEnvToAppComplete, "1234", "us-west-2", "phonetool"))
+				m.deployer.EXPECT().CreateAndRenderEnvironment(gomock.Any(), gomock.Any()).Return(nil)
+				m.deployer.EXPECT().GetEnvironment("phonetool", "test").Return(&config.Environment{
 					AccountID: "1234",
 					Region:    "mars-1",
 					Name:      "test",
 					App:       "phonetool",
 				}, nil)
-				m.EXPECT().AddEnvToApp(gomock.Any()).Return(nil)
-			},
-			expectAppCFN: func(m *mocks.MockappResourcesGetter) {
-				m.EXPECT().GetAppResourcesByRegion(&config.Application{Name: "phonetool"}, "us-west-2").
+				m.deployer.EXPECT().AddEnvToApp(gomock.Any()).Return(nil)
+				m.appCFN.EXPECT().GetAppResourcesByRegion(&config.Application{Name: "phonetool"}, "us-west-2").
 					Return(&stack.AppRegionalResources{
 						S3Bucket: "mockBucket",
 					}, nil)
 			},
 		},
 		"skips creating stack if environment stack already exists": {
-			expectStore: func(m *mocks.Mockstore) {
-				m.EXPECT().GetApplication("phonetool").Return(&config.Application{Name: "phonetool"}, nil)
-				m.EXPECT().CreateEnvironment(&config.Environment{
+			setupMocks: func(m *initEnvExecuteMocks) {
+				m.store.EXPECT().GetApplication("phonetool").Return(&config.Application{Name: "phonetool"}, nil)
+				m.store.EXPECT().CreateEnvironment(&config.Environment{
 					App:       "phonetool",
 					Name:      "test",
 					AccountID: "1234",
 					Region:    "mars-1",
 				}).Return(nil)
-			},
-			expectIdentity: func(m *mocks.MockidentityService) {
-				m.EXPECT().Get().Return(identity.Caller{RootUserARN: "some arn", Account: "1234"}, nil).Times(2)
-			},
-			expectIAM: func(m *mocks.MockroleManager) {
-				m.EXPECT().CreateECSServiceLinkedRole().Return(nil)
+				m.identity.EXPECT().Get().Return(identity.Caller{RootUserARN: "some arn", Account: "1234"}, nil).Times(2)
+				m.iam.EXPECT().CreateECSServiceLinkedRole().Return(nil)
 				// Don't attempt to delete any roles since an environment stack already exists.
-				m.EXPECT().ListRoleTags(gomock.Any()).Times(0)
-			},
-			expectCFN: func(m *mocks.MockstackExistChecker) {
-				m.EXPECT().Exists("phonetool-test").Return(true, nil)
-			},
-			expectProgress: func(m *mocks.Mockprogress) {
-				m.EXPECT().Start(fmt.Sprintf(fmtAddEnvToAppStart, "1234", "us-west-2", "phonetool"))
-				m.EXPECT().Stop(log.Ssuccessf(fmtAddEnvToAppComplete, "1234", "us-west-2", "phonetool"))
-			},
-			expectDeployer: func(m *mocks.Mockdeployer) {
-				m.EXPECT().CreateAndRenderEnvironment(gomock.Any(), &deploy.CreateEnvironmentInput{
+				m.iam.EXPECT().ListRoleTags(gomock.Any()).Times(0)
+				m.cfn.EXPECT().Exists("phonetool-test").Return(true, nil)
+				m.progress.EXPECT().Start(fmt.Sprintf(fmtAddEnvToAppStart, "1234", "us-west-2", "phonetool"))
+				m.progress.EXPECT().Stop(log.Ssuccessf(fmtAddEnvToAppComplete, "1234", "us-west-2", "phonetool"))
+				m.deployer.EXPECT().CreateAndRenderEnvironment(gomock.Any(), &deploy.CreateEnvironmentInput{
 					Name: "test",
 					App: deploy.AppInformation{
 						Name:                "phonetool",
@@ -1141,16 +1076,14 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 					ArtifactBucketARN:    "arn:aws:s3:::mockBucket",
 					ArtifactBucketKeyARN: "mockKMS",
 				}).Return(&cloudformation.ErrStackAlreadyExists{})
-				m.EXPECT().GetEnvironment("phonetool", "test").Return(&config.Environment{
+				m.deployer.EXPECT().GetEnvironment("phonetool", "test").Return(&config.Environment{
 					AccountID: "1234",
 					Region:    "mars-1",
 					Name:      "test",
 					App:       "phonetool",
 				}, nil)
-				m.EXPECT().AddEnvToApp(gomock.Any()).Return(nil)
-			},
-			expectAppCFN: func(m *mocks.MockappResourcesGetter) {
-				m.EXPECT().GetAppResourcesByRegion(&config.Application{Name: "phonetool"}, "us-west-2").
+				m.deployer.EXPECT().AddEnvToApp(gomock.Any()).Return(nil)
+				m.appCFN.EXPECT().GetAppResourcesByRegion(&config.Application{Name: "phonetool"}, "us-west-2").
 					Return(&stack.AppRegionalResources{
 						S3Bucket:  "mockBucket",
 						KMSKeyARN: "mockKMS",
@@ -1158,61 +1091,44 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 			},
 		},
 		"failed to delegate DNS (app has Domain and env and apps are different)": {
-			expectStore: func(m *mocks.Mockstore) {
-				m.EXPECT().GetApplication("phonetool").Return(&config.Application{Name: "phonetool", AccountID: "1234", Domain: "amazon.com"}, nil)
-			},
-			expectIdentity: func(m *mocks.MockidentityService) {
-				m.EXPECT().Get().Return(identity.Caller{RootUserARN: "some arn", Account: "4567"}, nil).Times(1)
-			},
-			expectProgress: func(m *mocks.Mockprogress) {
-				m.EXPECT().Start(fmt.Sprintf(fmtDNSDelegationStart, "4567"))
-				m.EXPECT().Stop(log.Serrorf(fmtDNSDelegationFailed, "4567"))
-			},
-			expectDeployer: func(m *mocks.Mockdeployer) {
-				m.EXPECT().DelegateDNSPermissions(gomock.Any(), "4567").Return(errors.New("some error"))
+			setupMocks: func(m *initEnvExecuteMocks) {
+				m.store.EXPECT().GetApplication("phonetool").Return(&config.Application{Name: "phonetool", AccountID: "1234", Domain: "amazon.com"}, nil)
+				m.identity.EXPECT().Get().Return(identity.Caller{RootUserARN: "some arn", Account: "4567"}, nil).Times(1)
+				m.progress.EXPECT().Start(fmt.Sprintf(fmtDNSDelegationStart, "4567"))
+				m.progress.EXPECT().Stop(log.Serrorf(fmtDNSDelegationFailed, "4567"))
+				m.deployer.EXPECT().DelegateDNSPermissions(gomock.Any(), "4567").Return(errors.New("some error"))
+
 			},
 			wantedErrorS: "granting DNS permissions: some error",
 		},
 		"success with DNS Delegation (app has Domain and env and app are different)": {
-			expectStore: func(m *mocks.Mockstore) {
-				m.EXPECT().GetApplication("phonetool").Return(&config.Application{Name: "phonetool", AccountID: "1234", Domain: "amazon.com"}, nil)
-				m.EXPECT().CreateEnvironment(&config.Environment{
+			setupMocks: func(m *initEnvExecuteMocks) {
+				m.store.EXPECT().GetApplication("phonetool").Return(&config.Application{Name: "phonetool", AccountID: "1234", Domain: "amazon.com"}, nil)
+				m.store.EXPECT().CreateEnvironment(&config.Environment{
 					App:       "phonetool",
 					Name:      "test",
 					AccountID: "4567",
 					Region:    "us-west-2",
 				}).Return(nil)
-			},
-			expectIdentity: func(m *mocks.MockidentityService) {
-				m.EXPECT().Get().Return(identity.Caller{RootUserARN: "some arn", Account: "4567"}, nil).Times(2)
-			},
-			expectIAM: func(m *mocks.MockroleManager) {
-				m.EXPECT().CreateECSServiceLinkedRole().Return(nil)
-				m.EXPECT().ListRoleTags(gomock.Any()).
+				m.identity.EXPECT().Get().Return(identity.Caller{RootUserARN: "some arn", Account: "4567"}, nil).Times(2)
+				m.iam.EXPECT().CreateECSServiceLinkedRole().Return(nil)
+				m.iam.EXPECT().ListRoleTags(gomock.Any()).
 					Return(nil, errors.New("does not exist")).AnyTimes()
-			},
-			expectCFN: func(m *mocks.MockstackExistChecker) {
-				m.EXPECT().Exists("phonetool-test").Return(false, nil)
-			},
-			expectProgress: func(m *mocks.Mockprogress) {
-				m.EXPECT().Start(fmt.Sprintf(fmtDNSDelegationStart, "4567"))
-				m.EXPECT().Stop(log.Ssuccessf(fmtDNSDelegationComplete, "4567"))
-				m.EXPECT().Start(fmt.Sprintf(fmtAddEnvToAppStart, "4567", "us-west-2", "phonetool"))
-				m.EXPECT().Stop(log.Ssuccessf(fmtAddEnvToAppComplete, "4567", "us-west-2", "phonetool"))
-			},
-			expectDeployer: func(m *mocks.Mockdeployer) {
-				m.EXPECT().DelegateDNSPermissions(gomock.Any(), "4567").Return(nil)
-				m.EXPECT().CreateAndRenderEnvironment(gomock.Any(), gomock.Any()).Return(nil)
-				m.EXPECT().GetEnvironment("phonetool", "test").Return(&config.Environment{
+				m.cfn.EXPECT().Exists("phonetool-test").Return(false, nil)
+				m.progress.EXPECT().Start(fmt.Sprintf(fmtDNSDelegationStart, "4567"))
+				m.progress.EXPECT().Stop(log.Ssuccessf(fmtDNSDelegationComplete, "4567"))
+				m.progress.EXPECT().Start(fmt.Sprintf(fmtAddEnvToAppStart, "4567", "us-west-2", "phonetool"))
+				m.progress.EXPECT().Stop(log.Ssuccessf(fmtAddEnvToAppComplete, "4567", "us-west-2", "phonetool"))
+				m.deployer.EXPECT().DelegateDNSPermissions(gomock.Any(), "4567").Return(nil)
+				m.deployer.EXPECT().CreateAndRenderEnvironment(gomock.Any(), gomock.Any()).Return(nil)
+				m.deployer.EXPECT().GetEnvironment("phonetool", "test").Return(&config.Environment{
 					AccountID: "4567",
 					Region:    "us-west-2",
 					Name:      "test",
 					App:       "phonetool",
 				}, nil)
-				m.EXPECT().AddEnvToApp(gomock.Any()).Return(nil)
-			},
-			expectAppCFN: func(m *mocks.MockappResourcesGetter) {
-				m.EXPECT().GetAppResourcesByRegion(&config.Application{
+				m.deployer.EXPECT().AddEnvToApp(gomock.Any()).Return(nil)
+				m.appCFN.EXPECT().GetAppResourcesByRegion(&config.Application{
 					Name:      "phonetool",
 					AccountID: "1234",
 					Domain:    "amazon.com",
@@ -1230,40 +1146,17 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
-			mockStore := mocks.NewMockstore(ctrl)
-			mockDeployer := mocks.NewMockdeployer(ctrl)
-			mockIdentity := mocks.NewMockidentityService(ctrl)
-			mockProgress := mocks.NewMockprogress(ctrl)
-			mockAppCFN := mocks.NewMockappResourcesGetter(ctrl)
-			mockIAM := mocks.NewMockroleManager(ctrl)
-			mockCFN := mocks.NewMockstackExistChecker(ctrl)
-			mockResourcesUploader := mocks.NewMockcustomResourcesUploader(ctrl)
-			mockUploader := mocks.NewMockuploader(ctrl)
-			if tc.expectStore != nil {
-				tc.expectStore(mockStore)
+			m := &initEnvExecuteMocks{
+				store:             mocks.NewMockstore(ctrl),
+				deployer:          mocks.NewMockdeployer(ctrl),
+				identity:          mocks.NewMockidentityService(ctrl),
+				progress:          mocks.NewMockprogress(ctrl),
+				iam:               mocks.NewMockroleManager(ctrl),
+				cfn:               mocks.NewMockstackExistChecker(ctrl),
+				appCFN:            mocks.NewMockappResourcesGetter(ctrl),
+				resourcesUploader: mocks.NewMockcustomResourcesUploader(ctrl),
 			}
-			if tc.expectDeployer != nil {
-				tc.expectDeployer(mockDeployer)
-			}
-			if tc.expectIdentity != nil {
-				tc.expectIdentity(mockIdentity)
-			}
-			if tc.expectIAM != nil {
-				tc.expectIAM(mockIAM)
-			}
-			if tc.expectCFN != nil {
-				tc.expectCFN(mockCFN)
-			}
-			if tc.expectProgress != nil {
-				tc.expectProgress(mockProgress)
-			}
-			if tc.expectAppCFN != nil {
-				tc.expectAppCFN(mockAppCFN)
-			}
-			if tc.expectResourcesUploader != nil {
-				tc.expectResourcesUploader(mockResourcesUploader)
-			}
-
+			tc.setupMocks(m)
 			provider := sessions.ImmutableProvider()
 			sess, _ := provider.DefaultWithRegion("us-west-2")
 
@@ -1275,19 +1168,19 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 						EnableContainerInsights: tc.enableContainerInsights,
 					},
 				},
-				store:       mockStore,
-				envDeployer: mockDeployer,
-				appDeployer: mockDeployer,
-				identity:    mockIdentity,
-				envIdentity: mockIdentity,
-				iam:         mockIAM,
-				cfn:         mockCFN,
-				prog:        mockProgress,
+				store:       m.store,
+				envDeployer: m.deployer,
+				appDeployer: m.deployer,
+				identity:    m.identity,
+				envIdentity: m.identity,
+				iam:         m.iam,
+				cfn:         m.cfn,
+				prog:        m.progress,
 				sess:        sess,
-				appCFN:      mockAppCFN,
-				uploader:    mockResourcesUploader,
+				appCFN:      m.appCFN,
+				uploader:    m.resourcesUploader,
 				newS3: func(region string) (uploader, error) {
-					return mockUploader, nil
+					return mocks.NewMockuploader(ctrl), nil
 				},
 			}
 

--- a/internal/pkg/cli/env_init_test.go
+++ b/internal/pkg/cli/env_init_test.go
@@ -980,34 +980,6 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 			},
 			wantedErrorS: "get app resources: some error",
 		},
-		"errors cannot read env lambdas": {
-			expectStore: func(m *mocks.Mockstore) {
-				m.EXPECT().GetApplication("phonetool").Return(&config.Application{Name: "phonetool"}, nil)
-			},
-			expectProgress: func(m *mocks.Mockprogress) {
-				m.EXPECT().Start(fmt.Sprintf(fmtAddEnvToAppStart, "1234", "us-west-2", "phonetool"))
-				m.EXPECT().Stop(log.Ssuccessf(fmtAddEnvToAppComplete, "1234", "us-west-2", "phonetool"))
-			},
-			expectIdentity: func(m *mocks.MockidentityService) {
-				m.EXPECT().Get().Return(identity.Caller{RootUserARN: "some arn", Account: "1234"}, nil)
-			},
-			expectIAM: func(m *mocks.MockroleManager) {
-				m.EXPECT().CreateECSServiceLinkedRole().Return(nil)
-			},
-			expectDeployer: func(m *mocks.Mockdeployer) {
-				m.EXPECT().AddEnvToApp(gomock.Any()).Return(nil)
-			},
-			expectAppCFN: func(m *mocks.MockappResourcesGetter) {
-				m.EXPECT().GetAppResourcesByRegion(&config.Application{Name: "phonetool"}, "us-west-2").
-					Return(&stack.AppRegionalResources{
-						S3Bucket: "mockBucket",
-					}, nil)
-			},
-			expectResourcesUploader: func(m *mocks.MockcustomResourcesUploader) {
-				m.EXPECT().UploadEnvironmentCustomResources(gomock.Any()).Return(nil, fmt.Errorf("some error"))
-			},
-			wantedErrorS: "upload custom resources to bucket mockBucket: some error",
-		},
 		"deletes retained IAM roles if environment stack fails creation": {
 			expectStore: func(m *mocks.Mockstore) {
 				m.EXPECT().GetApplication("phonetool").Return(&config.Application{Name: "phonetool"}, nil)
@@ -1048,9 +1020,6 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 						S3Bucket: "mockBucket",
 					}, nil)
 			},
-			expectResourcesUploader: func(m *mocks.MockcustomResourcesUploader) {
-				m.EXPECT().UploadEnvironmentCustomResources(gomock.Any()).Return(nil, nil)
-			},
 			wantedErrorS: "some deploy error",
 		},
 		"returns error from CreateEnvironment": {
@@ -1090,9 +1059,6 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 					Return(&stack.AppRegionalResources{
 						S3Bucket: "mockBucket",
 					}, nil)
-			},
-			expectResourcesUploader: func(m *mocks.MockcustomResourcesUploader) {
-				m.EXPECT().UploadEnvironmentCustomResources(gomock.Any()).Return(nil, nil)
 			},
 			wantedErrorS: "store environment: some create error",
 		},
@@ -1142,9 +1108,6 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 						S3Bucket: "mockBucket",
 					}, nil)
 			},
-			expectResourcesUploader: func(m *mocks.MockcustomResourcesUploader) {
-				m.EXPECT().UploadEnvironmentCustomResources(gomock.Any()).Return(nil, nil)
-			},
 		},
 		"skips creating stack if environment stack already exists": {
 			expectStore: func(m *mocks.Mockstore) {
@@ -1181,11 +1144,6 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 						Name:                "phonetool",
 						AccountPrincipalARN: "some arn",
 					},
-					CustomResourcesURLs: map[string]string{"mockCustomResource": "mockURL"},
-					Telemetry: &config.Telemetry{
-						EnableContainerInsights: false,
-					},
-					Version:              deploy.LatestEnvTemplateVersion,
 					ArtifactBucketARN:    "arn:aws:s3:::mockBucket",
 					ArtifactBucketKeyARN: "mockKMS",
 				}).Return(&cloudformation.ErrStackAlreadyExists{})
@@ -1203,9 +1161,6 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 						S3Bucket:  "mockBucket",
 						KMSKeyARN: "mockKMS",
 					}, nil)
-			},
-			expectResourcesUploader: func(m *mocks.MockcustomResourcesUploader) {
-				m.EXPECT().UploadEnvironmentCustomResources(gomock.Any()).Return(map[string]string{"mockCustomResource": "mockURL"}, nil)
 			},
 		},
 		"failed to delegate DNS (app has Domain and env and apps are different)": {
@@ -1274,9 +1229,6 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 					Return(&stack.AppRegionalResources{
 						S3Bucket: "mockBucket",
 					}, nil)
-			},
-			expectResourcesUploader: func(m *mocks.MockcustomResourcesUploader) {
-				m.EXPECT().UploadEnvironmentCustomResources(gomock.Any()).Return(nil, nil)
 			},
 		},
 	}

--- a/internal/pkg/config/env.go
+++ b/internal/pkg/config/env.go
@@ -15,16 +15,18 @@ import (
 
 // Environment represents a deployment environment in an application.
 type Environment struct {
-	App              string        `json:"app"`                    // Name of the app this environment belongs to.
-	Name             string        `json:"name"`                   // Name of the environment, must be unique within a App.
-	Region           string        `json:"region"`                 // Name of the region this environment is stored in.
-	AccountID        string        `json:"accountID"`              // Account ID of the account this environment is stored in.
-	Prod             bool          `json:"prod"`                   // Deprecated. Whether or not this environment is a production environment.
-	RegistryURL      string        `json:"registryURL"`            // URL For ECR Registry for this environment.
-	ExecutionRoleARN string        `json:"executionRoleARN"`       // ARN used by CloudFormation to make modification to the environment stack.
-	ManagerRoleARN   string        `json:"managerRoleARN"`         // ARN for the manager role assumed to manipulate the environment and its services.
-	CustomConfig     *CustomizeEnv `json:"customConfig,omitempty"` // Custom environment configuration by users.
-	Telemetry        *Telemetry    `json:"telemetry,omitempty"`    // Optional environment telemetry features.
+	App              string `json:"app"`              // Name of the app this environment belongs to.
+	Name             string `json:"name"`             // Name of the environment, must be unique within a App.
+	Region           string `json:"region"`           // Name of the region this environment is stored in.
+	AccountID        string `json:"accountID"`        // Account ID of the account this environment is stored in.
+	Prod             bool   `json:"prod"`             // Deprecated. Whether or not this environment is a production environment.
+	RegistryURL      string `json:"registryURL"`      // URL For ECR Registry for this environment.
+	ExecutionRoleARN string `json:"executionRoleARN"` // ARN used by CloudFormation to make modification to the environment stack.
+	ManagerRoleARN   string `json:"managerRoleARN"`   // ARN for the manager role assumed to manipulate the environment and its services.
+
+	// Fields that store user configuration is no longer updated, but kept for retrofitting purpose.
+	CustomConfig *CustomizeEnv `json:"customConfig,omitempty"` // Custom environment configuration by users.
+	Telemetry    *Telemetry    `json:"telemetry,omitempty"`    // Optional environment telemetry features.
 }
 
 // CustomizeEnv represents the custom environment config.

--- a/internal/pkg/config/env.go
+++ b/internal/pkg/config/env.go
@@ -25,8 +25,8 @@ type Environment struct {
 	ManagerRoleARN   string `json:"managerRoleARN"`   // ARN for the manager role assumed to manipulate the environment and its services.
 
 	// Fields that store user configuration is no longer updated, but kept for retrofitting purpose.
-	CustomConfig *CustomizeEnv `json:"customConfig,omitempty"` // Custom environment configuration by users.
-	Telemetry    *Telemetry    `json:"telemetry,omitempty"`    // Optional environment telemetry features.
+	CustomConfig *CustomizeEnv `json:"customConfig,omitempty"` // Deprecated. Custom environment configuration by users. This configuration is now available in the env manifest.
+	Telemetry    *Telemetry    `json:"telemetry,omitempty"`    // Deprecated. Optional environment telemetry features. This configuration is now available in the env manifest.
 }
 
 // CustomizeEnv represents the custom environment config.

--- a/internal/pkg/deploy/env.go
+++ b/internal/pkg/deploy/env.go
@@ -22,14 +22,18 @@ type CreateEnvironmentInput struct {
 	// The version of the environment template to create the stack. If empty, creates the legacy stack.
 	Version string
 
+	// Application regional configurations.
 	App                  AppInformation    // Information about the application that the environment belongs to, include app name, DNS name, the principal ARN of the account.
 	Name                 string            // Name of the environment, must be unique within an application.
 	AdditionalTags       map[string]string // AdditionalTags are labels applied to resources under the application.
 	ArtifactBucketARN    string            // ARN of the regional application bucket.
 	ArtifactBucketKeyARN string            // ARN of the KMS key used to encrypt the contents in the regional application bucket.
-	CustomResourcesURLs  map[string]string // Deprecated: Remove this in favor of LambdaURLs. Environment custom resource script S3 object URLs.
-	LambdaURLs           map[string]string // TODO(efekarakus): rename this field to CustomResourcesURLs when we can swap the implementation.
 
+	// Runtime configurations.
+	CustomResourcesURLs map[string]string // Deprecated: Remove this in favor of LambdaURLs. Environment custom resource script S3 object URLs.
+	LambdaURLs          map[string]string // TODO(efekarakus): rename this field to CustomResourcesURLs when we can swap the implementation.
+
+	// User inputs.
 	ImportVPCConfig    *config.ImportVPC // Optional configuration if users have an existing VPC.
 	AdjustVPCConfig    *config.AdjustVPC // Optional configuration if users want to override default VPC configuration.
 	ImportCertARNs     []string          // Optional configuration if users want to import certificates.

--- a/internal/pkg/manifest/env.go
+++ b/internal/pkg/manifest/env.go
@@ -29,16 +29,16 @@ type Environment struct {
 
 // EnvironmentProps contains properties for creating a new environment manifest.
 type EnvironmentProps struct {
-	Name          string
-	CustomizedEnv *config.CustomizeEnv
-	Telemetry     *config.Telemetry
+	Name         string
+	CustomConfig *config.CustomizeEnv
+	Telemetry    *config.Telemetry
 }
 
 // NewEnvironment creates a new environment manifest object.
 func NewEnvironment(props *EnvironmentProps) *Environment {
 	return FromEnvConfig(&config.Environment{
 		Name:         props.Name,
-		CustomConfig: props.CustomizedEnv,
+		CustomConfig: props.CustomConfig,
 		Telemetry:    props.Telemetry,
 	}, template.New())
 }

--- a/internal/pkg/manifest/env_test.go
+++ b/internal/pkg/manifest/env_test.go
@@ -452,7 +452,7 @@ func TestEnvironment_MarshalBinary(t *testing.T) {
 		"fully configured with customized vpc resources": {
 			inProps: EnvironmentProps{
 				Name: "test",
-				CustomizedEnv: &config.CustomizeEnv{
+				CustomConfig: &config.CustomizeEnv{
 					VPCConfig: &config.AdjustVPC{
 						CIDR:               "mock-cidr-0",
 						AZs:                []string{"mock-az-1", "mock-az-2"},
@@ -471,7 +471,7 @@ func TestEnvironment_MarshalBinary(t *testing.T) {
 		"fully configured with imported vpc resources": {
 			inProps: EnvironmentProps{
 				Name: "test",
-				CustomizedEnv: &config.CustomizeEnv{
+				CustomConfig: &config.CustomizeEnv{
 					ImportVPC: &config.ImportVPC{
 						ID:               "mock-vpc-id",
 						PublicSubnetIDs:  []string{"mock-subnet-id-1", "mock-subnet-id-2"},

--- a/internal/pkg/manifest/testdata/environment-adjust-vpc.yml
+++ b/internal/pkg/manifest/testdata/environment-adjust-vpc.yml
@@ -3,8 +3,8 @@
 #  https://aws.github.io/copilot-cli/docs/manifest/environment/
 
 # Your environment name will be used in naming your resources like VPC, cluster, etc.
-Name: test
-Type: Environment
+name: test
+type: Environment
 
 # Import your own VPC and subnets or configure how they should be created.
 network:

--- a/internal/pkg/manifest/testdata/environment-default.yml
+++ b/internal/pkg/manifest/testdata/environment-default.yml
@@ -3,8 +3,8 @@
 #  https://aws.github.io/copilot-cli/docs/manifest/environment/
 
 # Your environment name will be used in naming your resources like VPC, cluster, etc.
-Name: test
-Type: Environment
+name: test
+type: Environment
 
 # Import your own VPC and subnets or configure how they should be created.
 # network:

--- a/internal/pkg/manifest/testdata/environment-import-vpc.yml
+++ b/internal/pkg/manifest/testdata/environment-import-vpc.yml
@@ -3,8 +3,8 @@
 #  https://aws.github.io/copilot-cli/docs/manifest/environment/
 
 # Your environment name will be used in naming your resources like VPC, cluster, etc.
-Name: test
-Type: Environment
+name: test
+type: Environment
 
 # Import your own VPC and subnets or configure how they should be created.
 network:

--- a/internal/pkg/template/templates/environment/manifest.yml
+++ b/internal/pkg/template/templates/environment/manifest.yml
@@ -3,8 +3,8 @@
 #  https://aws.github.io/copilot-cli/docs/manifest/environment/
 
 # Your environment name will be used in naming your resources like VPC, cluster, etc.
-Name: {{.Name}}
-Type: {{.Type}}
+name: {{.Name}}
+type: {{.Type}}
 
 # Import your own VPC and subnets or configure how they should be created.
 {{- if .Network.VPC.IsEmpty}}


### PR DESCRIPTION
This PR modifies `env init`'s behaviors:
1. It deploys environment stack with bootstrap resources only (currently, it means `CFNExecutionRole` and `EnvManagerRole`). Other environment resources such as VPC are deployed in `env deploy`, not `env init`.
2. SSM parameter no longer contains information about user customization to the environment, such as `importVPC` and `adjustVPC`; instead, it only contains basic information about the app and env, and the bootstrap resources.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
