### PR TITLE
chore(cli): let `env init` writes an environment manifest

### DIFF
--- a/internal/pkg/cli/env_init.go
+++ b/internal/pkg/cli/env_init.go
@@ -333,6 +333,11 @@ func (o *initEnvOpts) Execute() error {
 
 // RecommendActions returns follow-up actions the user can take after successfully executing the command.
 func (o *initEnvOpts) RecommendActions() error {
+	logRecommendedActions([]string{
+		fmt.Sprintf("Update your manifest %s to change the defaults.", color.HighlightResource(o.mftPath)),
+		fmt.Sprintf("Run %s to deploy your environment.",
+			color.HighlightCode(fmt.Sprintf("copilot env deploy --name %s", o.name))),
+	})
 	return nil
 }
 

--- a/internal/pkg/cli/env_init.go
+++ b/internal/pkg/cli/env_init.go
@@ -326,7 +326,7 @@ func (o *initEnvOpts) Execute() error {
 	if err := o.store.CreateEnvironment(env); err != nil {
 		return fmt.Errorf("store environment: %w", err)
 	}
-	log.Successf("Created environment %s in region %s under application %s.\n",
+	log.Successf("Provisioned bootstrap resources for environment %s in region %s under application %s.\n",
 		color.HighlightUserInput(env.Name), color.Emphasize(env.Region), color.HighlightUserInput(env.App))
 	return nil
 }
@@ -735,7 +735,7 @@ func (o *initEnvOpts) addToStackset(opts *deploycfn.AddEnvToAppOpts) error {
 	o.prog.Start(fmt.Sprintf(fmtAddEnvToAppStart, color.Emphasize(opts.EnvAccountID), color.Emphasize(opts.EnvRegion), color.HighlightUserInput(o.appName)))
 	if err := o.appDeployer.AddEnvToApp(opts); err != nil {
 		o.prog.Stop(log.Serrorf(fmtAddEnvToAppFailed, color.Emphasize(opts.EnvAccountID), color.Emphasize(opts.EnvRegion), color.HighlightUserInput(o.appName)))
-		return fmt.Errorf("deploy env %s to application %s: %w", opts.EnvName, opts.App.Name, err)
+		return fmt.Errorf("add env %s to application %s: %w", opts.EnvName, opts.App.Name, err)
 	}
 	o.prog.Stop(log.Ssuccessf(fmtAddEnvToAppComplete, color.Emphasize(opts.EnvAccountID), color.Emphasize(opts.EnvRegion), color.HighlightUserInput(o.appName)))
 

--- a/internal/pkg/cli/env_init.go
+++ b/internal/pkg/cli/env_init.go
@@ -200,7 +200,7 @@ func newInitEnvOpts(vars initEnvVars) (*initEnvOpts, error) {
 
 	ws, err := workspace.New()
 	if err != nil {
-		return nil, fmt.Errorf("workspace cannot be created: %w", err)
+		return nil, fmt.Errorf("create workspace: %w", err)
 	}
 	return &initEnvOpts{
 		initEnvVars:  vars,

--- a/internal/pkg/cli/env_init.go
+++ b/internal/pkg/cli/env_init.go
@@ -41,8 +41,6 @@ import (
 )
 
 const (
-	envInitAppNameHelpPrompt = "An environment will be created in the selected application."
-
 	envInitNamePrompt              = "What is your environment's name?"
 	envInitNameHelpPrompt          = "A unique identifier for an environment (e.g. dev, test, prod)."
 	envInitDefaultEnvConfirmPrompt = `Would you like to use the default configuration for a new environment?
@@ -79,7 +77,6 @@ https://aws.github.io/copilot-cli/docs/credentials/#environment-credentials`
 )
 
 var (
-	envInitAppNamePrompt                  = fmt.Sprintf("In which %s would you like to create the environment?", color.Emphasize("application"))
 	envInitDefaultConfigSelectOption      = "Yes, use default."
 	envInitAdjustEnvResourcesSelectOption = "Yes, but I'd like configure the default resources (CIDR ranges, AZs)."
 	envInitImportEnvResourcesSelectOption = "No, I'd like to import existing resources (VPC, subnets)."

--- a/internal/pkg/cli/env_init_test.go
+++ b/internal/pkg/cli/env_init_test.go
@@ -999,7 +999,7 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 					EnvRegion:    "us-west-2",
 				}).Return(errors.New("some cfn error"))
 			},
-			wantedErrorS: "deploy env test to application phonetool: some cfn error",
+			wantedErrorS: "add env test to application phonetool: some cfn error",
 		},
 		"errors cannot get app resources by region": {
 			setupMocks: func(m *initEnvExecuteMocks) {

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -237,6 +237,10 @@ type manifestReader interface {
 	ReadWorkloadManifest(name string) (workspace.WorkloadManifest, error)
 }
 
+type environmentManifestWriter interface {
+	WriteEnvironmentManifest(encoding.BinaryMarshaler, string) (string, error)
+}
+
 type workspacePathGetter interface {
 	Path() (string, error)
 }

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -2239,6 +2239,44 @@ func (mr *MockmanifestReaderMockRecorder) ReadWorkloadManifest(name interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadWorkloadManifest", reflect.TypeOf((*MockmanifestReader)(nil).ReadWorkloadManifest), name)
 }
 
+// MockenvironmentManifestWriter is a mock of environmentManifestWriter interface.
+type MockenvironmentManifestWriter struct {
+	ctrl     *gomock.Controller
+	recorder *MockenvironmentManifestWriterMockRecorder
+}
+
+// MockenvironmentManifestWriterMockRecorder is the mock recorder for MockenvironmentManifestWriter.
+type MockenvironmentManifestWriterMockRecorder struct {
+	mock *MockenvironmentManifestWriter
+}
+
+// NewMockenvironmentManifestWriter creates a new mock instance.
+func NewMockenvironmentManifestWriter(ctrl *gomock.Controller) *MockenvironmentManifestWriter {
+	mock := &MockenvironmentManifestWriter{ctrl: ctrl}
+	mock.recorder = &MockenvironmentManifestWriterMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockenvironmentManifestWriter) EXPECT() *MockenvironmentManifestWriterMockRecorder {
+	return m.recorder
+}
+
+// WriteEnvironmentManifest mocks base method.
+func (m *MockenvironmentManifestWriter) WriteEnvironmentManifest(arg0 encoding.BinaryMarshaler, arg1 string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WriteEnvironmentManifest", arg0, arg1)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WriteEnvironmentManifest indicates an expected call of WriteEnvironmentManifest.
+func (mr *MockenvironmentManifestWriterMockRecorder) WriteEnvironmentManifest(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteEnvironmentManifest", reflect.TypeOf((*MockenvironmentManifestWriter)(nil).WriteEnvironmentManifest), arg0, arg1)
+}
+
 // MockworkspacePathGetter is a mock of workspacePathGetter interface.
 type MockworkspacePathGetter struct {
 	ctrl     *gomock.Controller

--- a/internal/pkg/workspace/workspace.go
+++ b/internal/pkg/workspace/workspace.go
@@ -392,6 +392,16 @@ func (ws *Workspace) WritePipelineManifest(marshaler encoding.BinaryMarshaler, n
 	return ws.write(data, pipelinesDirName, name, manifestFileName)
 }
 
+// WriteEnvironmentManifest writes the environment manifest under the copilot/environments/{name}/ directory.
+// If successful returns the full path of the file, otherwise returns an empty string and the error.
+func (ws *Workspace) WriteEnvironmentManifest(marshaler encoding.BinaryMarshaler, name string) (string, error) {
+	data, err := marshaler.MarshalBinary()
+	if err != nil {
+		return "", fmt.Errorf("marshal environment manifest to binary: %w", err)
+	}
+	return ws.write(data, environmentsDirName, name, manifestFileName)
+}
+
 // DeleteWorkspaceFile removes the .workspace file under copilot/ directory.
 // This will be called during app delete, we do not want to delete any other generated files.
 func (ws *Workspace) DeleteWorkspaceFile() error {


### PR DESCRIPTION
Lets `env init` writes an initial environment manifest to `/copilot/environments/<env_name>/manifest.yml`, given user inputs (either from prompts or flags).

NOTE: depends on #3724. Marked "WIP" until #3724 is merged.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
