### PR TITLE
ci: update golangci-lint to v1.46.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.45.2
+          version: v1.46.2
           args: --timeout 5m0s
 
   license:

--- a/internal/pkg/cli/deploy/svc_test.go
+++ b/internal/pkg/cli/deploy/svc_test.go
@@ -931,7 +931,6 @@ func TestWorkloadDeployer_DeployWorkload(t *testing.T) {
 type deployRDSvcMocks struct {
 	mockVersionGetter  *mocks.MockversionGetter
 	mockEndpointGetter *mocks.MockendpointGetter
-	mockUploader       *mocks.MockcustomResourcesUploader
 }
 
 func TestSvcDeployOpts_rdWebServiceStackConfiguration(t *testing.T) {

--- a/internal/pkg/cli/env_deploy.go
+++ b/internal/pkg/cli/env_deploy.go
@@ -22,9 +22,8 @@ import (
 )
 
 type deployEnvVars struct {
-	appName      string
-	name         string
-	isProduction bool
+	appName string
+	name    string
 }
 
 type deployEnvOpts struct {

--- a/internal/pkg/cli/svc_package.go
+++ b/internal/pkg/cli/svc_package.go
@@ -413,7 +413,7 @@ func (o *packageSvcOpts) getTargetEnv() (*config.Environment, error) {
 
 // RecommendActions suggests recommended actions before the packaged template is used for deployment.
 func (o *packageSvcOpts) RecommendActions() error {
-	return validateManifestCompatibilityWithEnv(o.appliedManifest.(manifest.WorkloadManifest), o.envName, o.envFeaturesDescriber)
+	return validateManifestCompatibilityWithEnv(o.appliedManifest, o.envName, o.envFeaturesDescriber)
 }
 
 func contains(s string, items []string) bool {

--- a/internal/pkg/cli/svc_package.go
+++ b/internal/pkg/cli/svc_package.go
@@ -80,7 +80,6 @@ type packageSvcOpts struct {
 	targetApp       *config.Application
 	targetEnv       *config.Environment
 	appliedManifest manifest.WorkloadManifest
-	rawManifest     []byte
 	rootUserARN     string
 }
 

--- a/internal/pkg/deploy/pipeline.go
+++ b/internal/pkg/deploy/pipeline.go
@@ -590,7 +590,7 @@ func (stg *PipelineStage) Deployments() ([]DeployAction, error) {
 
 func (stg *PipelineStage) buildDeploymentsGraph() *graph.Graph[string] {
 	var names []string
-	for name, _ := range stg.deployments {
+	for name := range stg.deployments {
 		names = append(names, name)
 	}
 	digraph := graph.New(names...)

--- a/internal/pkg/manifest/http.go
+++ b/internal/pkg/manifest/http.go
@@ -23,10 +23,6 @@ func (r *RoutingRuleConfigOrBool) Disabled() bool {
 	return r.Enabled != nil && !aws.BoolValue(r.Enabled)
 }
 
-func (r *RoutingRuleConfigOrBool) isEmpty() bool {
-	return r.Enabled == nil && r.RoutingRuleConfiguration.IsEmpty()
-}
-
 // UnmarshalYAML implements the yaml(v3) interface. It allows https routing rule to be specified as a
 // bool or a struct alternately.
 func (r *RoutingRuleConfigOrBool) UnmarshalYAML(value *yaml.Node) error {
@@ -97,10 +93,6 @@ func ipNetP(s string) *IPNet {
 type AdvancedAlias struct {
 	Alias      *string `yaml:"name"`
 	HostedZone *string `yaml:"hosted_zone"`
-}
-
-func (a *AdvancedAlias) isEmpty() bool {
-	return a.Alias == nil && a.HostedZone == nil
 }
 
 // Alias is a custom type which supports unmarshaling "http.alias" yaml which

--- a/internal/pkg/manifest/validate.go
+++ b/internal/pkg/manifest/validate.go
@@ -458,7 +458,7 @@ func (p Pipeline) Validate() error {
 // Validate returns nil if deployments are configured correctly.
 func (d Deployments) Validate() error {
 	names := make(map[string]bool)
-	for name, _ := range d {
+	for name := range d {
 		names[name] = true
 	}
 

--- a/internal/pkg/template/env_local_integration_test.go
+++ b/internal/pkg/template/env_local_integration_test.go
@@ -33,7 +33,7 @@ func TestEnv_AvailableEnvFeatures(t *testing.T) {
 	for _, f := range AvailableEnvFeatures() {
 		featuresSet[f] = exists
 	}
-	for paramName, _ := range tmpl.Params {
+	for paramName := range tmpl.Params {
 		if !strings.HasSuffix(paramName, "Workloads") {
 			continue
 		}

--- a/internal/pkg/term/selector/selector.go
+++ b/internal/pkg/term/selector/selector.go
@@ -181,15 +181,13 @@ type ConfigSelector struct {
 // LocalWorkloadSelector is an application and environment selector, but can also choose a service from the workspace.
 type LocalWorkloadSelector struct {
 	*ConfigSelector
-	ws      workspaceRetriever
-	appName string
+	ws workspaceRetriever
 }
 
 // LocalEnvironmentSelector is an application and environment selector, but can also choose an environment from the workspace.
 type LocalEnvironmentSelector struct {
 	*AppEnvSelector
-	ws      workspaceRetriever
-	appName string
+	ws workspaceRetriever
 }
 
 // WorkspaceSelector selects from local workspace.


### PR DESCRIPTION
<!-- Provide summary of changes -->

This re-enables the "staticcheck" lint that was disabled due to upgrading to Go 1.18.

structcheck is still disabled since it has not been upgraded to support Go 1.18 in golangci-lint. See https://github.com/golangci/golangci-lint/issues/2649 for more details.

This PR also fixes some of the lint issues that were missed in the past few months.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
