### PR TITLE
chore(templates): Make all IAM policies have a consistent Version declaration and avoid the outdated 2008-10-17 policy language

### DIFF
--- a/e2e/multi-pipeline/s3template.yml
+++ b/e2e/multi-pipeline/s3template.yml
@@ -29,7 +29,7 @@ Resources:
     Type: AWS::S3::BucketPolicy
     Properties:
       PolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Sid: ForceHTTPS
             Effect: Deny
@@ -52,7 +52,7 @@ Resources:
         - Grants CRUD access to the S3 bucket ${Bucket}
         - { Bucket: !Ref e2epipelineaddonBucket }
       PolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Sid: S3ObjectActions
             Effect: Allow

--- a/e2e/sidecars/hello/addons/permissions.yaml
+++ b/e2e/sidecars/hello/addons/permissions.yaml
@@ -14,7 +14,7 @@ Resources:
     Type: AWS::IAM::ManagedPolicy
     Properties:
       PolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Action:

--- a/internal/pkg/addon/testdata/merge/first.yaml
+++ b/internal/pkg/addon/testdata/merge/first.yaml
@@ -53,7 +53,7 @@ Resources:
                 - Grants CRUD access to MyTable
                 - { Table: !Ref MyTable }
             PolicyDocument:
-                Version: 2012-10-17
+                Version: '2012-10-17'
                 Statement:
                     - Sid: DDBActions
                       Effect: Allow

--- a/internal/pkg/addon/testdata/merge/second.yaml
+++ b/internal/pkg/addon/testdata/merge/second.yaml
@@ -86,7 +86,7 @@ Resources:
           - Grants CRUD access to MyBucket
           - { Bucket: !Ref MyBucket }
         PolicyDocument:
-          Version: 2012-10-17
+          Version: '2012-10-17'
           Statement:
             - Sid: S3ObjectActions
               Effect: Allow

--- a/internal/pkg/addon/testdata/merge/wanted.yaml
+++ b/internal/pkg/addon/testdata/merge/wanted.yaml
@@ -72,7 +72,7 @@ Resources:
                 - Grants CRUD access to MyTable
                 - {Table: !Ref MyTable}
             PolicyDocument:
-                Version: 2012-10-17
+                Version: '2012-10-17'
                 Statement:
                     - Sid: DDBActions
                       Effect: Allow
@@ -115,7 +115,7 @@ Resources:
                 - Grants CRUD access to MyBucket
                 - {Bucket: !Ref MyBucket}
             PolicyDocument:
-                Version: 2012-10-17
+                Version: '2012-10-17'
                 Statement:
                     - Sid: S3ObjectActions
                       Effect: Allow

--- a/internal/pkg/addon/testdata/outputs/template.yml
+++ b/internal/pkg/addon/testdata/outputs/template.yml
@@ -56,7 +56,7 @@ Resources:
     Type: AWS::IAM::ManagedPolicy
     Properties:
       PolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Action:

--- a/internal/pkg/addon/testdata/storage/bucket.yml
+++ b/internal/pkg/addon/testdata/storage/bucket.yml
@@ -30,7 +30,7 @@ Resources:
     DeletionPolicy: Retain
     Properties:
       PolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Sid: ForceHTTPS
             Effect: Deny
@@ -53,7 +53,7 @@ Resources:
         - Grants CRUD access to the S3 bucket ${Bucket}
         - { Bucket: !Ref bucketBucket }
       PolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Sid: S3ObjectActions
             Effect: Allow

--- a/internal/pkg/addon/testdata/storage/ddb.yml
+++ b/internal/pkg/addon/testdata/storage/ddb.yml
@@ -47,7 +47,7 @@ Resources:
         - Grants CRUD access to the Dynamo DB table ${Table}
         - { Table: !Ref ddb }
       PolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Sid: DDBActions
             Effect: Allow

--- a/internal/pkg/aws/cloudformation/testdata/parse/lb-web-svc.yaml
+++ b/internal/pkg/aws/cloudformation/testdata/parse/lb-web-svc.yaml
@@ -57,6 +57,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-imported-certs-observability.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-imported-certs-observability.yml
@@ -481,7 +481,7 @@ Resources:
         Status: ENABLED
       Encrypted: true
       FileSystemPolicy:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Id: CopilotEFSPolicy
         Statement:
           - Sid: AllowIAMFromTaggedRoles

--- a/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/bb_template.yaml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/bb_template.yaml
@@ -12,7 +12,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -39,7 +39,7 @@ Resources:
     Properties:
       PolicyName: !Sub ${AWS::StackName}-CodeBuildPolicy
       PolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Action:
@@ -137,7 +137,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -151,7 +151,7 @@ Resources:
     Properties:
       PolicyName: !Sub ${AWS::StackName}-CodepipelinePolicy
       PolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Action:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/cc_template.yaml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/cc_template.yaml
@@ -7,7 +7,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -34,7 +34,7 @@ Resources:
     Properties:
       PolicyName: !Sub ${AWS::StackName}-CodeBuildPolicy
       PolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Action:
@@ -132,7 +132,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -146,7 +146,7 @@ Resources:
     Properties:
       PolicyName: !Sub ${AWS::StackName}-CodepipelinePolicy
       PolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Action:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/gh_template.yaml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/gh_template.yaml
@@ -12,7 +12,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -39,7 +39,7 @@ Resources:
     Properties:
       PolicyName: !Sub ${AWS::StackName}-CodeBuildPolicy
       PolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Action:
@@ -133,7 +133,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -147,7 +147,7 @@ Resources:
     Properties:
       PolicyName: !Sub ${AWS::StackName}-CodepipelinePolicy
       PolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Action:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/ghv1_template.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/ghv1_template.yml
@@ -7,7 +7,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -34,7 +34,7 @@ Resources:
     Properties:
       PolicyName: !Sub ${AWS::StackName}-CodeBuildPolicy
       PolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Action:
@@ -128,7 +128,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -142,7 +142,7 @@ Resources:
     Properties:
       PolicyName: !Sub ${AWS::StackName}-CodepipelinePolicy
       PolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Action:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/stacklocal/autoscaling-svc-cf.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/stacklocal/autoscaling-svc-cf.yml
@@ -4,6 +4,7 @@
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/http-autoscaling-template.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/http-autoscaling-template.yml
@@ -130,7 +130,7 @@ Resources:
               ],
             ]
           PolicyDocument:
-            Version: "2012-10-17"
+            Version: '2012-10-17'
             Statement:
               - Effect: "Allow"
                 Action:
@@ -173,7 +173,7 @@ Resources:
                 ],
               ]
             PolicyDocument:
-              Version: "2012-10-17"
+              Version: '2012-10-17'
               Statement:
                 - Effect: "Allow"
                   Action:
@@ -214,7 +214,7 @@ Resources:
       Policies:
         - PolicyName: "DenyIAMExceptTaggedRoles"
           PolicyDocument:
-            Version: "2012-10-17"
+            Version: '2012-10-17'
             Statement:
               - Effect: "Deny"
                 Action: "iam:*"
@@ -229,7 +229,7 @@ Resources:
                     "iam:ResourceTag/copilot-environment": !Sub "${EnvName}"
         - PolicyName: "ExecuteCommand"
           PolicyDocument:
-            Version: "2012-10-17"
+            Version: '2012-10-17'
             Statement:
               - Effect: "Allow"
                 Action:
@@ -298,7 +298,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -312,7 +312,7 @@ Resources:
       Policies:
         - PolicyName: "DelegateDesiredCountAccess"
           PolicyDocument:
-            Version: "2012-10-17"
+            Version: '2012-10-17'
             Statement:
               - Sid: ECS
                 Effect: Allow
@@ -469,7 +469,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -483,7 +483,7 @@ Resources:
       Policies:
         - PolicyName: "RulePriorityGeneratorAccess"
           PolicyDocument:
-            Version: "2012-10-17"
+            Version: '2012-10-17'
             Statement:
               - Effect: Allow
                 Action:
@@ -577,7 +577,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -589,7 +589,7 @@ Resources:
       Policies:
         - PolicyName: "EnvControllerStackUpdate"
           PolicyDocument:
-            Version: "2012-10-17"
+            Version: '2012-10-17'
             Statement:
               - Effect: Allow
                 Action:
@@ -602,7 +602,7 @@ Resources:
                     "cloudformation:ResourceTag/copilot-environment": !Sub "${EnvName}"
         - PolicyName: "EnvControllerRolePass"
           PolicyDocument:
-            Version: "2012-10-17"
+            Version: '2012-10-17'
             Statement:
               - Effect: Allow
                 Action:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/http-autoscaling-template.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/http-autoscaling-template.yml
@@ -110,6 +110,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -204,6 +205,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -340,6 +342,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/http-full-config-template.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/http-full-config-template.yml
@@ -110,6 +110,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -204,6 +205,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/http-full-config-template.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/http-full-config-template.yml
@@ -130,7 +130,7 @@ Resources:
               ],
             ]
           PolicyDocument:
-            Version: "2012-10-17"
+            Version: '2012-10-17'
             Statement:
               - Effect: "Allow"
                 Action:
@@ -173,7 +173,7 @@ Resources:
                 ],
               ]
             PolicyDocument:
-              Version: "2012-10-17"
+              Version: '2012-10-17'
               Statement:
                 - Effect: "Allow"
                   Action:
@@ -214,7 +214,7 @@ Resources:
       Policies:
         - PolicyName: "DenyIAMExceptTaggedRoles"
           PolicyDocument:
-            Version: "2012-10-17"
+            Version: '2012-10-17'
             Statement:
               - Effect: "Deny"
                 Action: "iam:*"
@@ -229,7 +229,7 @@ Resources:
                     "iam:ResourceTag/copilot-environment": !Sub "${EnvName}"
         - PolicyName: "ExecuteCommand"
           PolicyDocument:
-            Version: "2012-10-17"
+            Version: '2012-10-17'
             Statement:
               - Effect: "Allow"
                 Action:
@@ -354,7 +354,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -368,7 +368,7 @@ Resources:
       Policies:
         - PolicyName: "RulePriorityGeneratorAccess"
           PolicyDocument:
-            Version: "2012-10-17"
+            Version: '2012-10-17'
             Statement:
               - Effect: Allow
                 Action:
@@ -466,7 +466,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -478,7 +478,7 @@ Resources:
       Policies:
         - PolicyName: "EnvControllerStackUpdate"
           PolicyDocument:
-            Version: "2012-10-17"
+            Version: '2012-10-17'
             Statement:
               - Effect: Allow
                 Action:
@@ -491,7 +491,7 @@ Resources:
                     "cloudformation:ResourceTag/copilot-environment": !Sub "${EnvName}"
         - PolicyName: "EnvControllerRolePass"
           PolicyDocument:
-            Version: "2012-10-17"
+            Version: '2012-10-17'
             Statement:
               - Effect: Allow
                 Action:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/http-only-path-template.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/http-only-path-template.yml
@@ -110,6 +110,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -204,6 +205,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/http-only-path-template.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/http-only-path-template.yml
@@ -130,7 +130,7 @@ Resources:
               ],
             ]
           PolicyDocument:
-            Version: "2012-10-17"
+            Version: '2012-10-17'
             Statement:
               - Effect: "Allow"
                 Action:
@@ -173,7 +173,7 @@ Resources:
                 ],
               ]
             PolicyDocument:
-              Version: "2012-10-17"
+              Version: '2012-10-17'
               Statement:
                 - Effect: "Allow"
                   Action:
@@ -214,7 +214,7 @@ Resources:
       Policies:
         - PolicyName: "DenyIAMExceptTaggedRoles"
           PolicyDocument:
-            Version: "2012-10-17"
+            Version: '2012-10-17'
             Statement:
               - Effect: "Deny"
                 Action: "iam:*"
@@ -229,7 +229,7 @@ Resources:
                     "iam:ResourceTag/copilot-environment": !Sub "${EnvName}"
         - PolicyName: "ExecuteCommand"
           PolicyDocument:
-            Version: "2012-10-17"
+            Version: '2012-10-17'
             Statement:
               - Effect: "Allow"
                 Action:
@@ -347,7 +347,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -361,7 +361,7 @@ Resources:
       Policies:
         - PolicyName: "RulePriorityGeneratorAccess"
           PolicyDocument:
-            Version: "2012-10-17"
+            Version: '2012-10-17'
             Statement:
               - Effect: Allow
                 Action:
@@ -455,7 +455,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -467,7 +467,7 @@ Resources:
       Policies:
         - PolicyName: "EnvControllerStackUpdate"
           PolicyDocument:
-            Version: "2012-10-17"
+            Version: '2012-10-17'
             Statement:
               - Effect: Allow
                 Action:
@@ -480,7 +480,7 @@ Resources:
                     "cloudformation:ResourceTag/copilot-environment": !Sub "${EnvName}"
         - PolicyName: "EnvControllerRolePass"
           PolicyDocument:
-            Version: "2012-10-17"
+            Version: '2012-10-17'
             Statement:
               - Effect: Allow
                 Action:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/https-path-alias-template.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/https-path-alias-template.yml
@@ -250,7 +250,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -264,7 +264,7 @@ Resources:
       Policies:
         - PolicyName: "RulePriorityGeneratorAccess"
           PolicyDocument:
-            Version: "2012-10-17"
+            Version: '2012-10-17'
             Statement:
               - Effect: Allow
                 Action:
@@ -433,7 +433,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/https-path-alias-template.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/https-path-alias-template.yml
@@ -100,6 +100,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -166,6 +167,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/simple-template.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/simple-template.yml
@@ -97,6 +97,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -191,6 +192,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/simple-template.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/simple-template.yml
@@ -117,7 +117,7 @@ Resources:
               ],
             ]
           PolicyDocument:
-            Version: "2012-10-17"
+            Version: '2012-10-17'
             Statement:
               - Effect: "Allow"
                 Action:
@@ -160,7 +160,7 @@ Resources:
                 ],
               ]
             PolicyDocument:
-              Version: "2012-10-17"
+              Version: '2012-10-17'
               Statement:
                 - Effect: "Allow"
                   Action:
@@ -201,7 +201,7 @@ Resources:
       Policies:
         - PolicyName: "DenyIAMExceptTaggedRoles"
           PolicyDocument:
-            Version: "2012-10-17"
+            Version: '2012-10-17'
             Statement:
               - Effect: "Deny"
                 Action: "iam:*"
@@ -216,7 +216,7 @@ Resources:
                     "iam:ResourceTag/copilot-environment": !Sub "${EnvName}"
         - PolicyName: "ExecuteCommand"
           PolicyDocument:
-            Version: "2012-10-17"
+            Version: '2012-10-17'
             Statement:
               - Effect: "Allow"
                 Action:
@@ -332,7 +332,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -344,7 +344,7 @@ Resources:
       Policies:
         - PolicyName: "EnvControllerStackUpdate"
           PolicyDocument:
-            Version: "2012-10-17"
+            Version: '2012-10-17'
             Statement:
               - Effect: Allow
                 Action:
@@ -357,7 +357,7 @@ Resources:
                     "cloudformation:ResourceTag/copilot-environment": !Sub "${EnvName}"
         - PolicyName: "EnvControllerRolePass"
           PolicyDocument:
-            Version: "2012-10-17"
+            Version: '2012-10-17'
             Statement:
               - Effect: Allow
                 Action:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/job-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/job-test.stack.yml
@@ -213,6 +213,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -278,6 +279,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -334,6 +336,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
+        Version: '2012-10-17'
         Statement:
         - Effect: Allow
           Principal:
@@ -342,6 +345,7 @@ Resources:
       Policies:
       - PolicyName: EventRulePolicy
         PolicyDocument:
+          Version: '2012-10-17'
           Statement:
           - Effect: Allow
             Action: states:StartExecution
@@ -433,6 +437,7 @@ Resources:
       Policies:
       - PolicyName: StateMachine
         PolicyDocument:
+          Version: '2012-10-17'
           Statement:
           - Effect: Allow
             Action: iam:PassRole

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/job-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/job-test.stack.yml
@@ -72,7 +72,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           -
             Effect: Allow
@@ -428,7 +428,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
         - Effect: Allow
           Principal:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/rdws-prod.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/rdws-prod.stack.yml
@@ -65,7 +65,7 @@ Resources:
     Condition: NeedsAccessRole
     Properties:
       AssumeRolePolicyDocument:
-        Version: '2008-10-17'
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -82,6 +82,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/rdws-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/rdws-test.stack.yml
@@ -65,7 +65,7 @@ Resources:
     Condition: NeedsAccessRole
     Properties:
       AssumeRolePolicyDocument:
-        Version: '2008-10-17'
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -82,6 +82,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/rdws-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/rdws-test.stack.yml
@@ -228,7 +228,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           -
             Effect: Allow

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-grpc-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-grpc-test.stack.yml
@@ -263,7 +263,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -369,7 +369,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -479,7 +479,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -493,7 +493,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Policies:
         - PolicyName: "RulePriorityGeneratorAccess"
           PolicyDocument:
-            Version: "2012-10-17"
+            Version: '2012-10-17'
             Statement:
               - Effect: Allow
                 Action:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-grpc-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-grpc-test.stack.yml
@@ -117,6 +117,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -183,6 +184,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -305,6 +307,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-dev.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-dev.stack.yml
@@ -247,7 +247,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -363,7 +363,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -377,7 +377,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Policies:
         - PolicyName: "RulePriorityGeneratorAccess"
           PolicyDocument:
-            Version: "2012-10-17"
+            Version: '2012-10-17'
             Statement:
               - Effect: Allow
                 Action:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-dev.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-dev.stack.yml
@@ -114,6 +114,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -180,6 +181,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-prod.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-prod.stack.yml
@@ -255,7 +255,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -424,7 +424,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -491,7 +491,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-prod.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-prod.stack.yml
@@ -122,6 +122,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -188,6 +189,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-test.stack.yml
@@ -236,7 +236,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -434,7 +434,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-test.stack.yml
@@ -103,6 +103,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -169,6 +170,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-prod.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-prod.stack.yml
@@ -203,6 +203,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -266,6 +267,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -388,6 +390,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-prod.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-prod.stack.yml
@@ -346,7 +346,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -452,7 +452,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -566,7 +566,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       'aws:copilot:description': "An IAM Role to describe load balancer rules for assigning a priority"
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -580,7 +580,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Policies:
         - PolicyName: "RulePriorityGeneratorAccess"
           PolicyDocument:
-            Version: "2012-10-17"
+            Version: '2012-10-17'
             Statement:
               - Effect: Allow
                 Action:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-staging.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-staging.stack.yml
@@ -117,6 +117,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -183,6 +184,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-staging.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-staging.stack.yml
@@ -258,7 +258,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -369,7 +369,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -383,7 +383,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Policies:
         - PolicyName: "RulePriorityGeneratorAccess"
           PolicyDocument:
-            Version: "2012-10-17"
+            Version: '2012-10-17'
             Statement:
               - Effect: Allow
                 Action:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-test.stack.yml
@@ -263,7 +263,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -369,7 +369,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -478,7 +478,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -492,7 +492,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Policies:
         - PolicyName: "RulePriorityGeneratorAccess"
           PolicyDocument:
-            Version: "2012-10-17"
+            Version: '2012-10-17'
             Statement:
               - Effect: Allow
                 Action:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-test.stack.yml
@@ -117,6 +117,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -183,6 +184,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -305,6 +307,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/windows-svc-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/windows-svc-test.stack.yml
@@ -241,7 +241,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -349,7 +349,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -363,7 +363,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Policies:
         - PolicyName: "RulePriorityGeneratorAccess"
           PolicyDocument:
-            Version: "2012-10-17"
+            Version: '2012-10-17'
             Statement:
               - Effect: Allow
                 Action:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/windows-svc-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/windows-svc-test.stack.yml
@@ -108,6 +108,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -174,6 +175,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/worker-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/worker-test.stack.yml
@@ -297,7 +297,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -405,7 +405,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -617,7 +617,7 @@ Resources:
     Properties:
       Queues: [!Ref 'DeadLetterQueue']
       PolicyDocument:
-        Version: "2012-10-17"
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -761,7 +761,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/worker-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/worker-test.stack.yml
@@ -162,6 +162,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -225,6 +226,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -339,6 +341,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:

--- a/internal/pkg/template/templates/addons/aurora/rdws/cf.yml
+++ b/internal/pkg/template/templates/addons/aurora/rdws/cf.yml
@@ -96,7 +96,7 @@ Resources:
         - Grants read access to the ${Secret} secret
         - { Secret: !Ref {{logicalIDSafe .ClusterName}}AuroraSecret }
       PolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Sid: SecretActions
             Effect: Allow

--- a/internal/pkg/template/templates/addons/ddb/cf.yml
+++ b/internal/pkg/template/templates/addons/ddb/cf.yml
@@ -43,7 +43,7 @@ Resources:
         - Grants CRUD access to the Dynamo DB table ${Table}
         - { Table: !Ref {{logicalIDSafe .Name}} }
       PolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Sid: DDBActions
             Effect: Allow

--- a/internal/pkg/template/templates/addons/s3/cf.yml
+++ b/internal/pkg/template/templates/addons/s3/cf.yml
@@ -30,7 +30,7 @@ Resources:
     DeletionPolicy: Retain
     Properties:
       PolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Sid: ForceHTTPS
             Effect: Deny
@@ -53,7 +53,7 @@ Resources:
         - Grants CRUD access to the S3 bucket ${Bucket}
         - { Bucket: !Ref {{logicalIDSafe .Name}}Bucket }
       PolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Sid: S3ObjectActions
             Effect: Allow

--- a/internal/pkg/template/templates/app/app.yml
+++ b/internal/pkg/template/templates/app/app.yml
@@ -33,7 +33,7 @@ Resources:
     Properties:
       RoleName: !Ref AdminRoleName
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -44,7 +44,7 @@ Resources:
       Policies:
         - PolicyName: AssumeRole-AWSCloudFormationStackSetExecutionRole
           PolicyDocument:
-            Version: 2012-10-17
+            Version: '2012-10-17'
             Statement:
               - Effect: Allow
                 Action:
@@ -56,7 +56,7 @@ Resources:
     Properties:
       RoleName: !Ref ExecutionRoleName
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -67,7 +67,7 @@ Resources:
       Policies:
       - PolicyName: ExecutionRolePolicy
         PolicyDocument:
-          Version: "2012-10-17"
+          Version: '2012-10-17'
           Statement:
               - Sid: StackSetRequiredPermissions
                 Effect: Allow
@@ -109,7 +109,7 @@ Resources:
     Properties:
       RoleName: !Ref DNSDelegationRoleName
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -128,7 +128,7 @@ Resources:
       Policies:
       - PolicyName: DNSDelegationPolicy
         PolicyDocument:
-          Version: "2012-10-17"
+          Version: '2012-10-17'
           Statement:
               - Sid: HostedZoneReadRecords
                 Effect: Allow

--- a/internal/pkg/template/templates/app/cf.yml
+++ b/internal/pkg/template/templates/app/cf.yml
@@ -19,7 +19,7 @@ Resources:
     Properties:
       EnableKeyRotation: true
       KeyPolicy:
-        Version: "2012-10-17"
+        Version: '2012-10-17'
         Id: !Ref AWS::StackName
         Statement:
           -

--- a/internal/pkg/template/templates/app/cf.yml
+++ b/internal/pkg/template/templates/app/cf.yml
@@ -95,7 +95,7 @@ Resources:
           Key: {{$svcTag}}
           Value: {{$service}}
       RepositoryPolicyText:
-        Version: '2008-10-17'
+        Version: '2012-10-17'
         Statement:
         - Sid: AllowPushPull
           Effect: Allow

--- a/internal/pkg/template/templates/app/cf.yml
+++ b/internal/pkg/template/templates/app/cf.yml
@@ -63,6 +63,7 @@ Resources:
     Properties:
       Bucket: !Ref PipelineBuiltArtifactBucket
       PolicyDocument:
+        Version: '2012-10-17'
         Statement:
           -
             Action:

--- a/internal/pkg/template/templates/cicd/pipeline_cfn.yml
+++ b/internal/pkg/template/templates/cicd/pipeline_cfn.yml
@@ -16,7 +16,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -45,7 +45,7 @@ Resources:
     Properties:
       PolicyName: !Sub ${AWS::StackName}-CodeBuildPolicy
       PolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Action:
@@ -162,7 +162,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -176,7 +176,7 @@ Resources:
     Properties:
       PolicyName: !Sub ${AWS::StackName}-CodepipelinePolicy
       PolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Action:

--- a/internal/pkg/template/templates/environment/cf.yml
+++ b/internal/pkg/template/templates/environment/cf.yml
@@ -385,7 +385,7 @@ Resources:
         Status: ENABLED
       Encrypted: true
       FileSystemPolicy:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Id: CopilotEFSPolicy
         Statement:
           - Sid: AllowIAMFromTaggedRoles

--- a/internal/pkg/template/templates/environment/partials/custom-resources-role.yml
+++ b/internal/pkg/template/templates/environment/partials/custom-resources-role.yml
@@ -6,7 +6,7 @@ CustomResourceRole:
   Condition: DelegateDNS
   Properties:
     AssumeRolePolicyDocument:
-      Version: 2012-10-17
+      Version: '2012-10-17'
       Statement:
         -
           Effect: Allow

--- a/internal/pkg/template/templates/task/cf.yml
+++ b/internal/pkg/template/templates/task/cf.yml
@@ -82,6 +82,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
@@ -150,6 +151,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:

--- a/internal/pkg/template/templates/task/cf.yml
+++ b/internal/pkg/template/templates/task/cf.yml
@@ -183,7 +183,7 @@ Resources:
     Properties:
       RepositoryName: !Join ["-", ["copilot", !Ref TaskName]]
       RepositoryPolicyText:
-        Version: '2008-10-17'
+        Version: '2012-10-17'
         Statement:
           - Sid: AllowPushPull
             Effect: Allow

--- a/internal/pkg/template/templates/workloads/partials/cf/accessrole.yml
+++ b/internal/pkg/template/templates/workloads/partials/cf/accessrole.yml
@@ -5,7 +5,7 @@ AccessRole:
   Condition: NeedsAccessRole
   Properties:
     AssumeRolePolicyDocument:
-      Version: '2008-10-17'
+      Version: '2012-10-17'
       Statement:
         - Effect: Allow
           Principal:

--- a/internal/pkg/template/templates/workloads/partials/cf/alb.yml
+++ b/internal/pkg/template/templates/workloads/partials/cf/alb.yml
@@ -58,7 +58,7 @@ RulePriorityFunctionRole:
   Type: AWS::IAM::Role
   Properties:
     AssumeRolePolicyDocument:
-      Version: 2012-10-17
+      Version: '2012-10-17'
       Statement:
         - Effect: Allow
           Principal:
@@ -72,7 +72,7 @@ RulePriorityFunctionRole:
     Policies:
       - PolicyName: "RulePriorityGeneratorAccess"
         PolicyDocument:
-          Version: "2012-10-17"
+          Version: '2012-10-17'
           Statement:
             - Effect: Allow
               Action:

--- a/internal/pkg/template/templates/workloads/partials/cf/autoscaling.yml
+++ b/internal/pkg/template/templates/workloads/partials/cf/autoscaling.yml
@@ -34,7 +34,7 @@ DynamicDesiredCountFunctionRole:
   Type: AWS::IAM::Role
   Properties:
     AssumeRolePolicyDocument:
-      Version: 2012-10-17
+      Version: '2012-10-17'
       Statement:
         - Effect: Allow
           Principal:
@@ -202,7 +202,7 @@ BacklogPerTaskCalculatorRole:
   Type: AWS::IAM::Role
   Properties:
     AssumeRolePolicyDocument:
-      Version: 2012-10-17
+      Version: '2012-10-17'
       Statement:
         - Effect: Allow
           Principal:

--- a/internal/pkg/template/templates/workloads/partials/cf/autoscaling.yml
+++ b/internal/pkg/template/templates/workloads/partials/cf/autoscaling.yml
@@ -80,6 +80,7 @@ AutoScalingRole:
   Type: AWS::IAM::Role
   Properties:
     AssumeRolePolicyDocument:
+      Version: '2012-10-17'
       Statement:
         - Effect: Allow
           Principal:

--- a/internal/pkg/template/templates/workloads/partials/cf/env-controller.yml
+++ b/internal/pkg/template/templates/workloads/partials/cf/env-controller.yml
@@ -31,7 +31,7 @@ EnvControllerRole:
   Type: AWS::IAM::Role
   Properties:
     AssumeRolePolicyDocument:
-      Version: 2012-10-17
+      Version: '2012-10-17'
       Statement:
         -
           Effect: Allow

--- a/internal/pkg/template/templates/workloads/partials/cf/eventrule.yml
+++ b/internal/pkg/template/templates/workloads/partials/cf/eventrule.yml
@@ -18,6 +18,7 @@ RuleRole:
   Type: AWS::IAM::Role
   Properties:
     AssumeRolePolicyDocument:
+      Version: '2012-10-17'
       Statement:
       - Effect: Allow
         Principal:
@@ -26,6 +27,7 @@ RuleRole:
     Policies:
     - PolicyName: EventRulePolicy
       PolicyDocument:
+        Version: '2012-10-17'
         Statement:
         - Effect: Allow
           Action: states:StartExecution

--- a/internal/pkg/template/templates/workloads/partials/cf/executionrole.yml
+++ b/internal/pkg/template/templates/workloads/partials/cf/executionrole.yml
@@ -4,6 +4,7 @@ ExecutionRole:
   Type: AWS::IAM::Role
   Properties:
     AssumeRolePolicyDocument:
+      Version: '2012-10-17'
       Statement:
         - Effect: Allow
           Principal:

--- a/internal/pkg/template/templates/workloads/partials/cf/instancerole.yml
+++ b/internal/pkg/template/templates/workloads/partials/cf/instancerole.yml
@@ -12,6 +12,7 @@ InstanceRole:
     {{- end}}
   {{- end}}
     AssumeRolePolicyDocument:
+      Version: '2012-10-17'
       Statement:
         - Effect: Allow
           Principal:

--- a/internal/pkg/template/templates/workloads/partials/cf/nlb.yml
+++ b/internal/pkg/template/templates/workloads/partials/cf/nlb.yml
@@ -153,7 +153,7 @@ NLBCustomDomainRole:
   Type: AWS::IAM::Role
   Properties:
     AssumeRolePolicyDocument:
-      Version: 2012-10-17
+      Version: '2012-10-17'
       Statement:
         -
           Effect: Allow
@@ -230,7 +230,7 @@ NLBCertValidatorRole:
   Type: AWS::IAM::Role
   Properties:
     AssumeRolePolicyDocument:
-      Version: 2012-10-17
+      Version: '2012-10-17'
       Statement:
         -
           Effect: Allow

--- a/internal/pkg/template/templates/workloads/partials/cf/state-machine.yml
+++ b/internal/pkg/template/templates/workloads/partials/cf/state-machine.yml
@@ -50,7 +50,7 @@ StateMachineRole:
   Type: AWS::IAM::Role
   Properties:
     AssumeRolePolicyDocument:
-      Version: 2012-10-17
+      Version: '2012-10-17'
       Statement:
       - Effect: Allow
         Principal:

--- a/internal/pkg/template/templates/workloads/partials/cf/state-machine.yml
+++ b/internal/pkg/template/templates/workloads/partials/cf/state-machine.yml
@@ -59,6 +59,7 @@ StateMachineRole:
     Policies:
     - PolicyName: StateMachine
       PolicyDocument:
+        Version: '2012-10-17'
         Statement:
         - Effect: Allow
           Action: iam:PassRole

--- a/internal/pkg/template/templates/workloads/partials/cf/subscribe.yml
+++ b/internal/pkg/template/templates/workloads/partials/cf/subscribe.yml
@@ -96,7 +96,7 @@ DeadLetterPolicy:
   Properties:
     Queues: [!Ref 'DeadLetterQueue']
     PolicyDocument:
-      Version: "2012-10-17"
+      Version: '2012-10-17'
       Statement:
         - Effect: Allow
           Principal:
@@ -193,7 +193,7 @@ QueuePolicy:
   Properties:
     Queues: [!Ref '{{logicalIDSafe $topic.Service}}{{logicalIDSafe $topic.Name}}DeadLetterQueue']
     PolicyDocument:
-      Version: "2012-10-17"
+      Version: '2012-10-17'
       Statement:
         - Effect: Allow
           Principal:

--- a/internal/pkg/template/templates/workloads/partials/cf/taskrole.yml
+++ b/internal/pkg/template/templates/workloads/partials/cf/taskrole.yml
@@ -6,6 +6,7 @@ TaskRole:
     ManagedPolicyArns:{{range $managedPolicy := .NestedStack.PolicyOutputs}}
       - Fn::GetAtt: [{{$stackName}}, Outputs.{{$managedPolicy}}]{{end}}{{end}}{{end}}
     AssumeRolePolicyDocument:
+      Version: '2012-10-17'
       Statement:
         - Effect: Allow
           Principal:

--- a/internal/pkg/template/templates/workloads/services/rd-web/cf.yml
+++ b/internal/pkg/template/templates/workloads/services/rd-web/cf.yml
@@ -190,7 +190,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           -
             Effect: Allow

--- a/site/content/docs/developing/additional-aws-resources.en.md
+++ b/site/content/docs/developing/additional-aws-resources.en.md
@@ -81,7 +81,7 @@ Resources:
     Type: AWS::IAM::ManagedPolicy
     Properties:
       PolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Sid: DDBActions
             Effect: Allow

--- a/site/content/docs/developing/additional-aws-resources.ja.md
+++ b/site/content/docs/developing/additional-aws-resources.ja.md
@@ -82,7 +82,7 @@ Resources:
     Type: AWS::IAM::ManagedPolicy
     Properties:
       PolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Sid: DDBActions
             Effect: Allow

--- a/site/content/docs/developing/sidecars.en.md
+++ b/site/content/docs/developing/sidecars.en.md
@@ -121,7 +121,7 @@ Resources:
     Type: AWS::IAM::ManagedPolicy
     Properties:
       PolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Sid: CopyOfAWSXRayDaemonWriteAccess
             Effect: Allow
@@ -193,7 +193,7 @@ Resources:
     Type: AWS::IAM::ManagedPolicy
     Properties:
       PolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
         - Effect: Allow
           Action:

--- a/site/content/docs/developing/sidecars.ja.md
+++ b/site/content/docs/developing/sidecars.ja.md
@@ -118,7 +118,7 @@ Resources:
     Type: AWS::IAM::ManagedPolicy
     Properties:
       PolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Sid: CopyOfAWSXRayDaemonWriteAccess
             Effect: Allow
@@ -189,7 +189,7 @@ Resources:
     Type: AWS::IAM::ManagedPolicy
     Properties:
       PolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
         - Effect: Allow
           Action:


### PR DESCRIPTION
This ensures that our CloudFormation templates use the 2012-10-17 IAM policy version.

Since 2008-10-17 is the default policy version, this also adds the Version key to the policies that were missing it.

Based on https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_version.html, the 2008-10-17 policy should not be used for new policies.

This should not change any behavior, but is likely good practice. Since customers might use Copilot's generated CloudFormation templates as a reference, we want to make sure our generated templates follow best practices recommended by other AWS services.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
