### PR TITLE
chore: don't print internal alb dns name on `svc deploy`

### DIFF
--- a/internal/pkg/describe/uri.go
+++ b/internal/pkg/describe/uri.go
@@ -179,7 +179,7 @@ func (d *BackendServiceDescriber) URI(envName string) (URI, error) {
 				return URI{}, err
 			}
 			if !albURI.HTTPS && len(albURI.DNSNames) > 1 {
-				albURI, _ = albDescr.removeEnvDNSName(albURI)
+				albURI = albDescr.bestEffortRemoveEnvDNSName(albURI)
 			}
 			return URI{
 				URI:        english.OxfordWordSeries(albURI.strings(), "or"),
@@ -281,10 +281,10 @@ func (d *albDescriber) uri() (albURI, error) {
 	}, nil
 }
 
-func (d *albDescriber) removeEnvDNSName(albURI albURI) (albURI, error) {
+func (d *albDescriber) bestEffortRemoveEnvDNSName(albURI albURI) albURI {
 	envOutputs, err := d.envDescriber.Outputs()
 	if err != nil {
-		return albURI, fmt.Errorf("get stack outputs for environment %s: %w", d.env, err)
+		return albURI
 	}
 	lbDNSName := envOutputs[d.envDNSNameKey]
 	for i := range albURI.DNSNames {
@@ -293,7 +293,7 @@ func (d *albDescriber) removeEnvDNSName(albURI albURI) (albURI, error) {
 			break
 		}
 	}
-	return albURI, nil
+	return albURI
 }
 
 // URI returns the WebServiceURI to identify this service uniquely given an environment name.

--- a/internal/pkg/describe/uri.go
+++ b/internal/pkg/describe/uri.go
@@ -179,7 +179,6 @@ func (d *BackendServiceDescriber) URI(envName string) (URI, error) {
 				return URI{}, err
 			}
 			if !albURI.HTTPS && len(albURI.DNSNames) > 1 {
-				// filter out the default LB DNS Name
 				albURI, _ = albDescr.removeEnvDNSName(albURI)
 			}
 			return URI{

--- a/internal/pkg/describe/uri_test.go
+++ b/internal/pkg/describe/uri_test.go
@@ -364,7 +364,10 @@ func TestBackendServiceDescriber_URI(t *testing.T) {
 					}, nil),
 					m.ecsDescriber.EXPECT().ServiceStackResources().Return(resources, nil),
 					m.lbDescriber.EXPECT().ListenerRuleHostHeaders("mockRuleARN").
-						Return([]string{"jobs.test.phonetool.internal"}, nil),
+						Return([]string{"jobs.test.phonetool.internal", "1234.us-west-2.internal.aws.com"}, nil),
+					m.envDescriber.EXPECT().Outputs().Return(map[string]string{
+						envOutputInternalLoadBalancerDNSName: "1234.us-west-2.internal.aws.com",
+					}, nil),
 				)
 			},
 			wantedURI: "http://jobs.test.phonetool.internal/mySvc",


### PR DESCRIPTION
For backwards compatibility, we [set both the internal ALB DNS name and the "friendly" DNS name](https://github.com/aws/copilot-cli/blob/74d034755279b4d28b3c6f4b61c9a34aa2e6513b/internal/pkg/template/templates/workloads/partials/cf/http-listener.yml#L51-L58) that we generate as host headers for the service listener rule on internal ALBs. This change makes it so that we only show the friendly DNS name on `svc deploy`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
