### PR TITLE
test(e2e): reflect new environment workflow in all test suites

### DIFF
--- a/e2e/addons/addons_test.go
+++ b/e2e/addons/addons_test.go
@@ -44,7 +44,7 @@ var _ = Describe("addons flow", func() {
 		})
 	})
 
-	Context("when creating a new environment", func() {
+	Context("when adding a new environment", func() {
 		var (
 			testEnvInitErr error
 		)
@@ -57,8 +57,35 @@ var _ = Describe("addons flow", func() {
 			})
 		})
 
-		It("env init should succeed", func() {
+		It("should succeed", func() {
 			Expect(testEnvInitErr).NotTo(HaveOccurred())
+		})
+
+		It("should create environment manifest", func() {
+			Expect("./copilot/environments/test/manifest.yml").Should(BeAnExistingFile())
+		})
+
+		It("should show only bootstrap resources in env show", func() {
+			envShowOutput, envShowError := cli.EnvShow(&client.EnvShowRequest{
+				AppName: appName,
+				EnvName: "test",
+			})
+			Expect(envShowError).NotTo(HaveOccurred())
+			Expect(len(envShowOutput.Resources)).To(Equal(2)) // Contains only bootstrap resources - two IAM roles.
+		})
+	})
+
+	Context("when deploying the environment", func() {
+		var envDeployErr error
+		BeforeAll(func() {
+			_, envDeployErr = cli.EnvDeploy(&client.EnvDeployRequest{
+				AppName: appName,
+				Name:    "test",
+			})
+		})
+
+		It("should succeed", func() {
+			Expect(envDeployErr).NotTo(HaveOccurred())
 		})
 	})
 
@@ -262,6 +289,7 @@ var _ = Describe("addons flow", func() {
 			Expect("./copilot").Should(BeADirectory())
 			Expect("./copilot/hello/addons").Should(BeADirectory())
 			Expect("./copilot/hello/manifest.yml").Should(BeAnExistingFile())
+			Expect("./copilot/environments/test/manifest.yml").Should(BeAnExistingFile())
 			Expect("./copilot/.workspace").ShouldNot(BeAnExistingFile())
 
 			// Need to recreate the app for AfterSuite testing.

--- a/e2e/addons/addons_test.go
+++ b/e2e/addons/addons_test.go
@@ -60,19 +60,6 @@ var _ = Describe("addons flow", func() {
 		It("should succeed", func() {
 			Expect(testEnvInitErr).NotTo(HaveOccurred())
 		})
-
-		It("should create environment manifest", func() {
-			Expect("./copilot/environments/test/manifest.yml").Should(BeAnExistingFile())
-		})
-
-		It("should show only bootstrap resources in env show", func() {
-			envShowOutput, envShowError := cli.EnvShow(&client.EnvShowRequest{
-				AppName: appName,
-				EnvName: "test",
-			})
-			Expect(envShowError).NotTo(HaveOccurred())
-			Expect(len(envShowOutput.Resources)).To(Equal(2)) // Contains only bootstrap resources - two IAM roles.
-		})
 	})
 
 	Context("when deploying the environment", func() {

--- a/e2e/app-with-domain/app_with_domain_test.go
+++ b/e2e/app-with-domain/app_with_domain_test.go
@@ -102,34 +102,6 @@ var _ = Describe("App With Domain", func() {
 				Expect(err).NotTo(HaveOccurred())
 			}
 		})
-
-		It("should create environment manifests", func() {
-			Expect("./copilot/environments/test/manifest.yml").Should(BeAnExistingFile())
-			Expect("./copilot/environments/prod/manifest.yml").Should(BeAnExistingFile())
-		})
-
-		It("should show both environments in env ls", func() {
-			envList, envListError := cli.EnvList(appName)
-			Expect(envListError).NotTo(HaveOccurred())
-			Expect(len(envList.Envs)).To(Equal(2))
-		})
-
-		It("should show only bootstrap resources in env show", func() {
-			testEnvShowOutput, testEnvShowError := cli.EnvShow(&client.EnvShowRequest{
-				AppName: appName,
-				EnvName: "test",
-			})
-			prodEnvShowOutput, prodEnvShowError := cli.EnvShow(&client.EnvShowRequest{
-				AppName: appName,
-				EnvName: "prod",
-			})
-			Expect(testEnvShowError).NotTo(HaveOccurred())
-			Expect(prodEnvShowError).NotTo(HaveOccurred())
-
-			// Contains only bootstrap resources - two IAM roles.
-			Expect(len(testEnvShowOutput.Resources)).To(Equal(2))
-			Expect(len(prodEnvShowOutput.Resources)).To(Equal(2))
-		})
 	})
 
 	Context("when deploying the environments", func() {

--- a/e2e/app-with-domain/app_with_domain_test.go
+++ b/e2e/app-with-domain/app_with_domain_test.go
@@ -140,34 +140,22 @@ var _ = Describe("App With Domain", func() {
 			wg.Add(2)
 			go func() {
 				defer wg.Done()
-				for {
-					content, err := cli.EnvDeploy(&client.EnvDeployRequest{
-						AppName: appName,
-						Name:    "test",
-					})
-					if err == nil {
-						break
-					}
-					if !isStackSetOperationInProgress(content) {
-						fatalErrors <- err
-					}
-					time.Sleep(waitingInterval)
+				_, err := cli.EnvDeploy(&client.EnvDeployRequest{
+					AppName: appName,
+					Name:    "test",
+				})
+				if err != nil {
+					fatalErrors <- err
 				}
 			}()
 			go func() {
 				defer wg.Done()
-				for {
-					content, err := cli.EnvDeploy(&client.EnvDeployRequest{
-						AppName: appName,
-						Name:    "prod",
-					})
-					if err == nil {
-						break
-					}
-					if !isStackSetOperationInProgress(content) {
-						fatalErrors <- err
-					}
-					time.Sleep(waitingInterval)
+				_, err := cli.EnvDeploy(&client.EnvDeployRequest{
+					AppName: appName,
+					Name:    "prod",
+				})
+				if err != nil {
+					fatalErrors <- err
 				}
 			}()
 			go func() {

--- a/e2e/app-with-domain/app_with_domain_test.go
+++ b/e2e/app-with-domain/app_with_domain_test.go
@@ -48,10 +48,10 @@ var _ = Describe("App With Domain", func() {
 		})
 	})
 
-	Context("when creating new environments", func() {
+	Context("when adding new environments", func() {
 		fatalErrors := make(chan error)
 		wgDone := make(chan bool)
-		It("env init should succeed for creating test and prod environments", func() {
+		It("env init should succeed for adding test and prod environments", func() {
 			var wg sync.WaitGroup
 			wg.Add(2)
 			go func() {
@@ -80,6 +80,86 @@ var _ = Describe("App With Domain", func() {
 						EnvName: "prod",
 						Profile: prodEnvironmentProfile,
 						Prod:    false,
+					})
+					if err == nil {
+						break
+					}
+					if !isStackSetOperationInProgress(content) {
+						fatalErrors <- err
+					}
+					time.Sleep(waitingInterval)
+				}
+			}()
+			go func() {
+				wg.Wait()
+				close(wgDone)
+				close(fatalErrors)
+			}()
+
+			select {
+			case <-wgDone:
+			case err := <-fatalErrors:
+				Expect(err).NotTo(HaveOccurred())
+			}
+		})
+
+		It("should create environment manifests", func() {
+			Expect("./copilot/environments/test/manifest.yml").Should(BeAnExistingFile())
+			Expect("./copilot/environments/prod/manifest.yml").Should(BeAnExistingFile())
+		})
+
+		It("should show both environments in env ls", func() {
+			envList, envListError := cli.EnvList(appName)
+			Expect(envListError).NotTo(HaveOccurred())
+			Expect(len(envList.Envs)).To(Equal(2))
+		})
+
+		It("should show only bootstrap resources in env show", func() {
+			testEnvShowOutput, testEnvShowError := cli.EnvShow(&client.EnvShowRequest{
+				AppName: appName,
+				EnvName: "test",
+			})
+			prodEnvShowOutput, prodEnvShowError := cli.EnvShow(&client.EnvShowRequest{
+				AppName: appName,
+				EnvName: "prod",
+			})
+			Expect(testEnvShowError).NotTo(HaveOccurred())
+			Expect(prodEnvShowError).NotTo(HaveOccurred())
+
+			// Contains only bootstrap resources - two IAM roles.
+			Expect(len(testEnvShowOutput.Resources)).To(Equal(2))
+			Expect(len(prodEnvShowOutput.Resources)).To(Equal(2))
+		})
+	})
+
+	Context("when deploying the environments", func() {
+		fatalErrors := make(chan error)
+		wgDone := make(chan bool)
+		It("env deploy should succeed for deploying test and prod environments", func() {
+			var wg sync.WaitGroup
+			wg.Add(2)
+			go func() {
+				defer wg.Done()
+				for {
+					content, err := cli.EnvDeploy(&client.EnvDeployRequest{
+						AppName: appName,
+						Name:    "test",
+					})
+					if err == nil {
+						break
+					}
+					if !isStackSetOperationInProgress(content) {
+						fatalErrors <- err
+					}
+					time.Sleep(waitingInterval)
+				}
+			}()
+			go func() {
+				defer wg.Done()
+				for {
+					content, err := cli.EnvDeploy(&client.EnvDeployRequest{
+						AppName: appName,
+						Name:    "prod",
 					})
 					if err == nil {
 						break

--- a/e2e/exec/exec_test.go
+++ b/e2e/exec/exec_test.go
@@ -47,7 +47,7 @@ var _ = Describe("exec flow", func() {
 		})
 	})
 
-	Context("when creating a new environment", func() {
+	Context("when adding a new environment", func() {
 		var (
 			testEnvInitErr error
 		)
@@ -62,6 +62,33 @@ var _ = Describe("exec flow", func() {
 
 		It("env init should succeed", func() {
 			Expect(testEnvInitErr).NotTo(HaveOccurred())
+		})
+
+		It("should create environment manifest", func() {
+			Expect(fmt.Sprintf("./copilot/environments/%s/manifest.yml", envName)).Should(BeAnExistingFile())
+		})
+
+		It("should show only bootstrap resources in env show", func() {
+			envShowOutput, envShowError := cli.EnvShow(&client.EnvShowRequest{
+				AppName: appName,
+				EnvName: envName,
+			})
+			Expect(envShowError).NotTo(HaveOccurred())
+			Expect(len(envShowOutput.Resources)).To(Equal(2)) // Contains only bootstrap resources - two IAM roles.
+		})
+	})
+
+	Context("when deploying the environment", func() {
+		var envDeployErr error
+		BeforeAll(func() {
+			_, envDeployErr = cli.EnvDeploy(&client.EnvDeployRequest{
+				AppName: appName,
+				Name:    envName,
+			})
+		})
+
+		It("should succeed", func() {
+			Expect(envDeployErr).NotTo(HaveOccurred())
 		})
 	})
 

--- a/e2e/exec/exec_test.go
+++ b/e2e/exec/exec_test.go
@@ -63,19 +63,6 @@ var _ = Describe("exec flow", func() {
 		It("env init should succeed", func() {
 			Expect(testEnvInitErr).NotTo(HaveOccurred())
 		})
-
-		It("should create environment manifest", func() {
-			Expect(fmt.Sprintf("./copilot/environments/%s/manifest.yml", envName)).Should(BeAnExistingFile())
-		})
-
-		It("should show only bootstrap resources in env show", func() {
-			envShowOutput, envShowError := cli.EnvShow(&client.EnvShowRequest{
-				AppName: appName,
-				EnvName: envName,
-			})
-			Expect(envShowError).NotTo(HaveOccurred())
-			Expect(len(envShowOutput.Resources)).To(Equal(2)) // Contains only bootstrap resources - two IAM roles.
-		})
 	})
 
 	Context("when deploying the environment", func() {

--- a/e2e/internal/client/cli.go
+++ b/e2e/internal/client/cli.go
@@ -73,6 +73,12 @@ type EnvInitRequestVPCConfig struct {
 	PrivateSubnetCIDRs string
 }
 
+// EnvDeployRequest contains the parameters for calling copilot env deploy.
+type EnvDeployRequest struct {
+	AppName string
+	Name    string
+}
+
 // EnvShowRequest contains the parameters for calling copilot env show.
 type EnvShowRequest struct {
 	AppName string
@@ -594,6 +600,19 @@ func (cli *CLI) EnvInit(opts *EnvInitRequest) (string, error) {
 			"--override-az-names", opts.VPCConfig.AZs,
 			"--override-public-cidrs", opts.VPCConfig.PublicSubnetCIDRs,
 			"--override-private-cidrs", opts.VPCConfig.PrivateSubnetCIDRs)
+	}
+	return cli.exec(exec.Command(cli.path, commands...))
+}
+
+/*EnvDeploy runs:
+copilot env deploy
+	--name $n
+	--app $a
+*/
+func (cli *CLI) EnvDeploy(opts *EnvDeployRequest) (string, error) {
+	commands := []string{"env", "deploy",
+		"--name", opts.Name,
+		"--app", opts.AppName,
 	}
 	return cli.exec(exec.Command(cli.path, commands...))
 }

--- a/e2e/multi-pipeline/multi_pipeline_test.go
+++ b/e2e/multi-pipeline/multi_pipeline_test.go
@@ -121,28 +121,6 @@ var _ = Describe("pipeline flow", func() {
 				Expect(envs["test"].Account).NotTo(Equal(envs["prod"].Account))
 			}
 		})
-
-		It("should create environment manifests", func() {
-			Expect("./copilot/environments/test/manifest.yml").Should(BeAnExistingFile())
-			Expect("./copilot/environments/prod/manifest.yml").Should(BeAnExistingFile())
-		})
-
-		It("should show only bootstrap resources in env show", func() {
-			testEnvShowOutput, testEnvShowError := copilot.EnvShow(&client.EnvShowRequest{
-				AppName: appName,
-				EnvName: "test",
-			})
-			prodEnvShowOutput, prodEnvShowError := copilot.EnvShow(&client.EnvShowRequest{
-				AppName: appName,
-				EnvName: "prod",
-			})
-			Expect(testEnvShowError).NotTo(HaveOccurred())
-			Expect(prodEnvShowError).NotTo(HaveOccurred())
-
-			// Contains only bootstrap resources - two IAM roles.
-			Expect(len(testEnvShowOutput.Resources)).To(Equal(2))
-			Expect(len(prodEnvShowOutput.Resources)).To(Equal(2))
-		})
 	})
 
 	Context("when deploying the environments", func() {

--- a/e2e/multi-pipeline/multi_pipeline_test.go
+++ b/e2e/multi-pipeline/multi_pipeline_test.go
@@ -82,7 +82,7 @@ var _ = Describe("pipeline flow", func() {
 		})
 	})
 
-	Context("when creating a new environment", func() {
+	Context("when adding a new environment", func() {
 		It("test env init should succeed", func() {
 			_, err := copilot.EnvInit(&client.EnvInitRequest{
 				AppName: appName,
@@ -99,6 +99,7 @@ var _ = Describe("pipeline flow", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 		})
+
 		It("env ls should list both envs", func() {
 			out, err := copilot.EnvList(appName)
 			Expect(err).NotTo(HaveOccurred())
@@ -119,6 +120,45 @@ var _ = Describe("pipeline flow", func() {
 				Expect(envs["test"].Region).NotTo(Equal(envs["prod"].Region))
 				Expect(envs["test"].Account).NotTo(Equal(envs["prod"].Account))
 			}
+		})
+
+		It("should create environment manifests", func() {
+			Expect("./copilot/environments/test/manifest.yml").Should(BeAnExistingFile())
+			Expect("./copilot/environments/prod/manifest.yml").Should(BeAnExistingFile())
+		})
+
+		It("should show only bootstrap resources in env show", func() {
+			testEnvShowOutput, testEnvShowError := copilot.EnvShow(&client.EnvShowRequest{
+				AppName: appName,
+				EnvName: "test",
+			})
+			prodEnvShowOutput, prodEnvShowError := copilot.EnvShow(&client.EnvShowRequest{
+				AppName: appName,
+				EnvName: "prod",
+			})
+			Expect(testEnvShowError).NotTo(HaveOccurred())
+			Expect(prodEnvShowError).NotTo(HaveOccurred())
+
+			// Contains only bootstrap resources - two IAM roles.
+			Expect(len(testEnvShowOutput.Resources)).To(Equal(2))
+			Expect(len(prodEnvShowOutput.Resources)).To(Equal(2))
+		})
+	})
+
+	Context("when deploying the environments", func() {
+		It("test env deploy should succeed", func() {
+			_, err := copilot.EnvDeploy(&client.EnvDeployRequest{
+				AppName: appName,
+				Name:    "test",
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+		It("prod env deploy should succeed", func() {
+			_, err := copilot.EnvDeploy(&client.EnvDeployRequest{
+				AppName: appName,
+				Name:    "prod",
+			})
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 

--- a/e2e/multi-svc-app/multi_svc_app_test.go
+++ b/e2e/multi-svc-app/multi_svc_app_test.go
@@ -62,19 +62,6 @@ var _ = Describe("Multiple Service App", func() {
 		It("env init should succeed", func() {
 			Expect(testEnvInitErr).NotTo(HaveOccurred())
 		})
-
-		It("should create environment manifest", func() {
-			Expect("./copilot/environments/test/manifest.yml").Should(BeAnExistingFile())
-		})
-
-		It("should show only bootstrap resources in env show", func() {
-			envShowOutput, envShowError := cli.EnvShow(&client.EnvShowRequest{
-				AppName: appName,
-				EnvName: "test",
-			})
-			Expect(envShowError).NotTo(HaveOccurred())
-			Expect(len(envShowOutput.Resources)).To(Equal(2)) // Contains only bootstrap resources - two IAM roles.
-		})
 	})
 
 	Context("when deploying the environment", func() {

--- a/e2e/multi-svc-app/multi_svc_app_test.go
+++ b/e2e/multi-svc-app/multi_svc_app_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Multiple Service App", func() {
 		})
 	})
 
-	Context("when creating a new environment", func() {
+	Context("when adding a new environment", func() {
 		var (
 			testEnvInitErr error
 		)
@@ -61,6 +61,33 @@ var _ = Describe("Multiple Service App", func() {
 
 		It("env init should succeed", func() {
 			Expect(testEnvInitErr).NotTo(HaveOccurred())
+		})
+
+		It("should create environment manifest", func() {
+			Expect("./copilot/environments/test/manifest.yml").Should(BeAnExistingFile())
+		})
+
+		It("should show only bootstrap resources in env show", func() {
+			envShowOutput, envShowError := cli.EnvShow(&client.EnvShowRequest{
+				AppName: appName,
+				EnvName: "test",
+			})
+			Expect(envShowError).NotTo(HaveOccurred())
+			Expect(len(envShowOutput.Resources)).To(Equal(2)) // Contains only bootstrap resources - two IAM roles.
+		})
+	})
+
+	Context("when deploying the environment", func() {
+		var envDeployErr error
+		BeforeAll(func() {
+			_, envDeployErr = cli.EnvDeploy(&client.EnvDeployRequest{
+				AppName: appName,
+				Name:    "test",
+			})
+		})
+
+		It("should succeed", func() {
+			Expect(envDeployErr).NotTo(HaveOccurred())
 		})
 	})
 

--- a/e2e/pipeline/pipeline_test.go
+++ b/e2e/pipeline/pipeline_test.go
@@ -68,7 +68,7 @@ var _ = Describe("pipeline flow", func() {
 		})
 	})
 
-	Context("when creating a new environment", func() {
+	Context("when adding a new environment", func() {
 		It("test env init should succeed", func() {
 			_, err := copilot.EnvInit(&client.EnvInitRequest{
 				AppName: appName,
@@ -100,6 +100,48 @@ var _ = Describe("pipeline flow", func() {
 
 			Expect(envs["test"]).NotTo(BeNil())
 			Expect(envs["prod"]).NotTo(BeNil())
+		})
+		It("should create environment manifest", func() {
+			Expect("./copilot/environments/test/manifest.yml").Should(BeAnExistingFile())
+			Expect("./copilot/environments/prod/manifest.yml").Should(BeAnExistingFile())
+		})
+		It("should show only bootstrap resources in env show", func() {
+			testEnvShowOutput, testEnvShowError := copilot.EnvShow(&client.EnvShowRequest{
+				AppName: appName,
+				EnvName: "test",
+			})
+			prodEnvShowOutput, prodEnvShowError := copilot.EnvShow(&client.EnvShowRequest{
+				AppName: appName,
+				EnvName: "prod",
+			})
+			Expect(testEnvShowError).NotTo(HaveOccurred())
+			Expect(prodEnvShowError).NotTo(HaveOccurred())
+
+			Expect(testEnvShowOutput.Environment.Name).To(Equal("test"))
+			Expect(testEnvShowOutput.Environment.App).To(Equal(appName))
+			Expect(prodEnvShowOutput.Environment.Name).To(Equal("prod"))
+			Expect(prodEnvShowOutput.Environment.App).To(Equal(appName))
+
+			// Contains only bootstrap resources - two IAM roles.
+			Expect(len(testEnvShowOutput.Resources)).To(Equal(2))
+			Expect(len(prodEnvShowOutput.Resources)).To(Equal(2))
+		})
+	})
+
+	Context("when deploying the environments", func() {
+		It("test env deploy should succeed", func() {
+			_, err := copilot.EnvDeploy(&client.EnvDeployRequest{
+				AppName: appName,
+				Name:    "test",
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+		It("prod env deploy should succeed", func() {
+			_, err := copilot.EnvDeploy(&client.EnvDeployRequest{
+				AppName: appName,
+				Name:    "prod",
+			})
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 

--- a/e2e/pipeline/pipeline_test.go
+++ b/e2e/pipeline/pipeline_test.go
@@ -101,31 +101,6 @@ var _ = Describe("pipeline flow", func() {
 			Expect(envs["test"]).NotTo(BeNil())
 			Expect(envs["prod"]).NotTo(BeNil())
 		})
-		It("should create environment manifest", func() {
-			Expect("./copilot/environments/test/manifest.yml").Should(BeAnExistingFile())
-			Expect("./copilot/environments/prod/manifest.yml").Should(BeAnExistingFile())
-		})
-		It("should show only bootstrap resources in env show", func() {
-			testEnvShowOutput, testEnvShowError := copilot.EnvShow(&client.EnvShowRequest{
-				AppName: appName,
-				EnvName: "test",
-			})
-			prodEnvShowOutput, prodEnvShowError := copilot.EnvShow(&client.EnvShowRequest{
-				AppName: appName,
-				EnvName: "prod",
-			})
-			Expect(testEnvShowError).NotTo(HaveOccurred())
-			Expect(prodEnvShowError).NotTo(HaveOccurred())
-
-			Expect(testEnvShowOutput.Environment.Name).To(Equal("test"))
-			Expect(testEnvShowOutput.Environment.App).To(Equal(appName))
-			Expect(prodEnvShowOutput.Environment.Name).To(Equal("prod"))
-			Expect(prodEnvShowOutput.Environment.App).To(Equal(appName))
-
-			// Contains only bootstrap resources - two IAM roles.
-			Expect(len(testEnvShowOutput.Resources)).To(Equal(2))
-			Expect(len(prodEnvShowOutput.Resources)).To(Equal(2))
-		})
 	})
 
 	Context("when deploying the environments", func() {

--- a/e2e/sidecars/sidecars_test.go
+++ b/e2e/sidecars/sidecars_test.go
@@ -112,19 +112,6 @@ var _ = Describe("sidecars flow", func() {
 		It("env init should succeed", func() {
 			Expect(testEnvInitErr).NotTo(HaveOccurred())
 		})
-
-		It("should create environment manifest", func() {
-			Expect("./copilot/environments/test/manifest.yml").Should(BeAnExistingFile())
-		})
-
-		It("should show only bootstrap resources in env show", func() {
-			envShowOutput, envShowError := cli.EnvShow(&client.EnvShowRequest{
-				AppName: appName,
-				EnvName: "test",
-			})
-			Expect(envShowError).NotTo(HaveOccurred())
-			Expect(len(envShowOutput.Resources)).To(Equal(2)) // Contains only bootstrap resources - two IAM roles.
-		})
 	})
 
 	Context("when deploying the environment", func() {

--- a/e2e/sidecars/sidecars_test.go
+++ b/e2e/sidecars/sidecars_test.go
@@ -96,7 +96,7 @@ var _ = Describe("sidecars flow", func() {
 		})
 	})
 
-	Context("when creating a new environment", func() {
+	Context("when adding a new environment", func() {
 		var (
 			testEnvInitErr error
 		)
@@ -111,6 +111,33 @@ var _ = Describe("sidecars flow", func() {
 
 		It("env init should succeed", func() {
 			Expect(testEnvInitErr).NotTo(HaveOccurred())
+		})
+
+		It("should create environment manifest", func() {
+			Expect("./copilot/environments/test/manifest.yml").Should(BeAnExistingFile())
+		})
+
+		It("should show only bootstrap resources in env show", func() {
+			envShowOutput, envShowError := cli.EnvShow(&client.EnvShowRequest{
+				AppName: appName,
+				EnvName: "test",
+			})
+			Expect(envShowError).NotTo(HaveOccurred())
+			Expect(len(envShowOutput.Resources)).To(Equal(2)) // Contains only bootstrap resources - two IAM roles.
+		})
+	})
+
+	Context("when deploying the environment", func() {
+		var envDeployErr error
+		BeforeAll(func() {
+			_, envDeployErr = cli.EnvDeploy(&client.EnvDeployRequest{
+				AppName: appName,
+				Name:    "test",
+			})
+		})
+
+		It("should succeed", func() {
+			Expect(envDeployErr).NotTo(HaveOccurred())
 		})
 	})
 

--- a/e2e/task/task_test.go
+++ b/e2e/task/task_test.go
@@ -4,8 +4,6 @@
 package task
 
 import (
-	"fmt"
-
 	"github.com/aws/copilot-cli/e2e/internal/client"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -40,19 +38,6 @@ var _ = Describe("Task", func() {
 
 		It("env init should succeed", func() {
 			Expect(err).NotTo(HaveOccurred())
-		})
-
-		It("should create environment manifest", func() {
-			Expect(fmt.Sprintf("./copilot/environments/%s/manifest.yml", envName)).Should(BeAnExistingFile())
-		})
-
-		It("should show only bootstrap resources in env show", func() {
-			envShowOutput, envShowError := cli.EnvShow(&client.EnvShowRequest{
-				AppName: appName,
-				EnvName: envName,
-			})
-			Expect(envShowError).NotTo(HaveOccurred())
-			Expect(len(envShowOutput.Resources)).To(Equal(2)) // Contains only bootstrap resources - two IAM roles.
 		})
 	})
 

--- a/e2e/worker/worker_test.go
+++ b/e2e/worker/worker_test.go
@@ -46,19 +46,6 @@ var _ = Describe("Worker Service E2E Test", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 		})
-
-		It("should create environment manifest", func() {
-			Expect(fmt.Sprintf("./copilot/environments/%s/manifest.yml", envName)).Should(BeAnExistingFile())
-		})
-
-		It("should show only bootstrap resources in env show", func() {
-			envShowOutput, envShowError := cli.EnvShow(&client.EnvShowRequest{
-				AppName: appName,
-				EnvName: envName,
-			})
-			Expect(envShowError).NotTo(HaveOccurred())
-			Expect(len(envShowOutput.Resources)).To(Equal(2)) // Contains only bootstrap resources - two IAM roles.
-		})
 	})
 
 	Context("when deploying the environment", func() {

--- a/e2e/worker/worker_test.go
+++ b/e2e/worker/worker_test.go
@@ -37,12 +37,35 @@ var _ = Describe("Worker Service E2E Test", func() {
 		})
 	})
 
-	Context("create an environment", func() {
+	Context("add an environment", func() {
 		It("env init should succeed", func() {
 			_, err := cli.EnvInit(&client.EnvInitRequest{
 				AppName: appName,
 				EnvName: envName,
 				Profile: "default",
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should create environment manifest", func() {
+			Expect(fmt.Sprintf("./copilot/environments/%s/manifest.yml", envName)).Should(BeAnExistingFile())
+		})
+
+		It("should show only bootstrap resources in env show", func() {
+			envShowOutput, envShowError := cli.EnvShow(&client.EnvShowRequest{
+				AppName: appName,
+				EnvName: envName,
+			})
+			Expect(envShowError).NotTo(HaveOccurred())
+			Expect(len(envShowOutput.Resources)).To(Equal(2)) // Contains only bootstrap resources - two IAM roles.
+		})
+	})
+
+	Context("when deploying the environment", func() {
+		It("env deploy should succeed", func() {
+			_, err := cli.EnvDeploy(&client.EnvDeployRequest{
+				AppName: appName,
+				Name:    envName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 		})


### PR DESCRIPTION


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
