### PR TITLE
chore: Document "PipelineBucket" misnomer to avoid confusion

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/app.go
+++ b/internal/pkg/deploy/cloudformation/stack/app.go
@@ -44,7 +44,7 @@ type AppStackConfig struct {
 type AppRegionalResources struct {
 	Region         string            // The region these resources are in.
 	KMSKeyARN      string            // A KMS Key ARN for encrypting Pipeline artifacts.
-	S3Bucket       string            // S3 bucket for Pipeline artifacts.
+	S3Bucket       string            // A bucket used for any Copilot artifacts that must be stored in S3 (pipelines, env files, etc)
 	RepositoryURLs map[string]string // The image repository URLs by service name.
 }
 
@@ -54,13 +54,16 @@ const (
 	appAdminRoleParamName         = "AdminRoleName"
 	appExecutionRoleParamName     = "ExecutionRoleName"
 	appDNSDelegationRoleParamName = "DNSDelegationRoleName"
-	appOutputKMSKey               = "KMSKeyARN"
-	appOutputS3Bucket             = "PipelineBucket"
-	appOutputECRRepoPrefix        = "ECRRepo"
-	appDNSDelegatedAccountsKey    = "AppDNSDelegatedAccounts"
-	appDomainNameKey              = "AppDomainName"
-	appDomainHostedZoneIDKey      = "AppDomainHostedZoneID"
-	appNameKey                    = "AppName"
+	// Linked to AppRegionalResources.KMSKeyARN
+	appOutputKMSKey = "KMSKeyARN"
+	// Linked to AppRegionalResources.S3Bucket
+	appOutputS3Bucket = "PipelineBucket"
+	// Linked to AppRegionalResources.RepositoryURLs
+	appOutputECRRepoPrefix     = "ECRRepo"
+	appDNSDelegatedAccountsKey = "AppDNSDelegatedAccounts"
+	appDomainNameKey           = "AppDomainName"
+	appDomainHostedZoneIDKey   = "AppDomainHostedZoneID"
+	appNameKey                 = "AppName"
 
 	// arn:${partition}:iam::${account}:role/${roleName}
 	fmtStackSetAdminRoleARN = "arn:%s:iam::%s:role/%s"

--- a/internal/pkg/deploy/cloudformation/stack/app.go
+++ b/internal/pkg/deploy/cloudformation/stack/app.go
@@ -44,7 +44,7 @@ type AppStackConfig struct {
 type AppRegionalResources struct {
 	Region         string            // The region these resources are in.
 	KMSKeyARN      string            // A KMS Key ARN for encrypting Pipeline artifacts.
-	S3Bucket       string            // A bucket used for any Copilot artifacts that must be stored in S3 (pipelines, env files, etc)
+	S3Bucket       string            // A bucket used for any Copilot artifacts that must be stored in S3 (pipelines, env files, etc).
 	RepositoryURLs map[string]string // The image repository URLs by service name.
 }
 
@@ -54,16 +54,13 @@ const (
 	appAdminRoleParamName         = "AdminRoleName"
 	appExecutionRoleParamName     = "ExecutionRoleName"
 	appDNSDelegationRoleParamName = "DNSDelegationRoleName"
-	// Linked to AppRegionalResources.KMSKeyARN
-	appOutputKMSKey = "KMSKeyARN"
-	// Linked to AppRegionalResources.S3Bucket
-	appOutputS3Bucket = "PipelineBucket"
-	// Linked to AppRegionalResources.RepositoryURLs
-	appOutputECRRepoPrefix     = "ECRRepo"
-	appDNSDelegatedAccountsKey = "AppDNSDelegatedAccounts"
-	appDomainNameKey           = "AppDomainName"
-	appDomainHostedZoneIDKey   = "AppDomainHostedZoneID"
-	appNameKey                 = "AppName"
+	appOutputKMSKey               = "KMSKeyARN"      // Linked to AppRegionalResources.KMSKeyARN.
+	appOutputS3Bucket             = "PipelineBucket" // Linked to AppRegionalResources.S3Bucket.
+	appOutputECRRepoPrefix        = "ECRRepo"        // Linked to AppRegionalResources.RepositoryURLs.
+	appDNSDelegatedAccountsKey    = "AppDNSDelegatedAccounts"
+	appDomainNameKey              = "AppDomainName"
+	appDomainHostedZoneIDKey      = "AppDomainHostedZoneID"
+	appNameKey                    = "AppName"
 
 	// arn:${partition}:iam::${account}:role/${roleName}
 	fmtStackSetAdminRoleARN = "arn:%s:iam::%s:role/%s"

--- a/internal/pkg/deploy/cloudformation/stack/app.go
+++ b/internal/pkg/deploy/cloudformation/stack/app.go
@@ -54,9 +54,9 @@ const (
 	appAdminRoleParamName         = "AdminRoleName"
 	appExecutionRoleParamName     = "ExecutionRoleName"
 	appDNSDelegationRoleParamName = "DNSDelegationRoleName"
-	appOutputKMSKey               = "KMSKeyARN"      // Linked to AppRegionalResources.KMSKeyARN.
-	appOutputS3Bucket             = "PipelineBucket" // Linked to AppRegionalResources.S3Bucket.
-	appOutputECRRepoPrefix        = "ECRRepo"        // Linked to AppRegionalResources.RepositoryURLs.
+	appOutputKMSKey               = "KMSKeyARN"      // Name of the CloudFormation Output that holds the KMS Key ARN to encrypt artifact buckets.
+	appOutputS3Bucket             = "PipelineBucket" // Name of the CloudFormation Output that holds the Artifact Bucket ARN for any artifacts that must be stored in S3.
+	appOutputECRRepoPrefix        = "ECRRepo"        // Name of the CloudFormation Output that holds the ECR image repository URL for each service.
 	appDNSDelegatedAccountsKey    = "AppDNSDelegatedAccounts"
 	appDomainNameKey              = "AppDomainName"
 	appDomainHostedZoneIDKey      = "AppDomainHostedZoneID"

--- a/internal/pkg/deploy/cloudformation/stack/app.go
+++ b/internal/pkg/deploy/cloudformation/stack/app.go
@@ -55,8 +55,8 @@ const (
 	appExecutionRoleParamName     = "ExecutionRoleName"
 	appDNSDelegationRoleParamName = "DNSDelegationRoleName"
 	appOutputKMSKey               = "KMSKeyARN"      // Name of the CloudFormation Output that holds the KMS Key ARN to encrypt artifact buckets.
-	appOutputS3Bucket             = "PipelineBucket" // Name of the CloudFormation Output that holds the Artifact Bucket ARN for any artifacts that must be stored in S3.
-	appOutputECRRepoPrefix        = "ECRRepo"        // Name of the CloudFormation Output that holds the ECR image repository URL for each service.
+	appOutputS3Bucket             = "PipelineBucket" // Name of the CloudFormation Output that holds the Artifact Bucket name.
+	appOutputECRRepoPrefix        = "ECRRepo"        // Prefix of the CloudFormation Output name that holds the ECR image repository ARN for each service.
 	appDNSDelegatedAccountsKey    = "AppDNSDelegatedAccounts"
 	appDomainNameKey              = "AppDomainName"
 	appDomainHostedZoneIDKey      = "AppDomainHostedZoneID"

--- a/internal/pkg/template/templates/app/cf.yml
+++ b/internal/pkg/template/templates/app/cf.yml
@@ -119,7 +119,7 @@ Outputs:
     Export:
       Name: {{$app}}-ArtifactKey
   PipelineBucket:
-    Description: Bucket used for CodePipeline to stage resources in.
+    Description: "A bucket used for any Copilot artifacts that must be stored in S3 (pipelines, env files, etc)"
     Value: !Ref PipelineBuiltArtifactBucket
 {{- range $service := $services}} 
   ECRRepo{{logicalIDSafe $service}}:

--- a/internal/pkg/template/templates/app/cf.yml
+++ b/internal/pkg/template/templates/app/cf.yml
@@ -119,7 +119,7 @@ Outputs:
     Export:
       Name: {{$app}}-ArtifactKey
   PipelineBucket:
-    Description: "A bucket used for any Copilot artifacts that must be stored in S3 (pipelines, env files, etc)"
+    Description: "A bucket used for any Copilot artifacts that must be stored in S3 (pipelines, env files, etc)."
     Value: !Ref PipelineBuiltArtifactBucket
 {{- range $service := $services}} 
   ECRRepo{{logicalIDSafe $service}}:


### PR DESCRIPTION
<!-- Provide summary of changes -->

I spent a bit too much time reading code & templates not realizing that PipelineBucket was a sort of a misnomer. This change aims to make sure that others reading the code are able to see that it is used for all things that Copilot uploads to S3.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
