### PR TITLE
chore(templates): trigger env controller when there is an alias change

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/lb_network_web_service_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/lb_network_web_service_integration_test.go
@@ -24,9 +24,6 @@ import (
 
 const (
 	nlbSvcManifestPath = "svc-nlb-manifest.yml"
-
-	nlbCustomDomainPath  = "custom-resources/nlb-custom-domain.js"
-	nlbCertValidatorPath = "custom-resources/nlb-cert-validator.js"
 )
 
 func TestNetworkLoadBalancedWebService_Template(t *testing.T) {

--- a/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-basic-manifest.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-basic-manifest.yml
@@ -1120,7 +1120,7 @@ Outputs:
     Export:
       Name: !Sub ${AWS::StackName}-SubDomain
   EnabledFeatures:
-    Value: !Sub '${ALBWorkloads},${InternalALBWorkloads},${EFSWorkloads},${NATWorkloads}'
+    Value: !Sub '${ALBWorkloads},${InternalALBWorkloads},${EFSWorkloads},${NATWorkloads},${Aliases}'
     Description: Required output to force the stack to update if mutating feature params, like ALBWorkloads, does not change the template.
   ManagedFileSystemID:
     Condition: CreateEFS

--- a/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-imported-certs-observability.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-imported-certs-observability.yml
@@ -994,7 +994,7 @@ Outputs:
     Export:
       Name: !Sub ${AWS::StackName}-CFNExecutionRoleARN
   EnabledFeatures:
-    Value: !Sub '${ALBWorkloads},${InternalALBWorkloads},${EFSWorkloads},${NATWorkloads}'
+    Value: !Sub '${ALBWorkloads},${InternalALBWorkloads},${EFSWorkloads},${NATWorkloads},${Aliases}'
     Description: Required output to force the stack to update if mutating feature params, like ALBWorkloads, does not change the template.
   ManagedFileSystemID:
     Condition: CreateEFS

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/https-path-alias-template.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/https-path-alias-template.yml
@@ -310,7 +310,7 @@ Resources:
       RulePath: !Ref RulePath
       ListenerArn: !GetAtt EnvControllerAction.InternalHTTPSListenerArn
   
-  HTTPRulePriorityAction:
+  HTTPRuleWithDomainPriorityAction:
     Metadata:
       'aws:copilot:description': 'A custom resource assigning priority for HTTP listener rules'
     Type: Custom::RulePriorityFunction
@@ -345,7 +345,7 @@ Resources:
               - - !Sub "/${RulePath}"
                 - !Sub "/${RulePath}/*"
       ListenerArn: !GetAtt EnvControllerAction.InternalHTTPListenerArn
-      Priority: !GetAtt HTTPRulePriorityAction.Priority # Same priority as HTTPS Listener
+      Priority: !GetAtt HTTPRuleWithDomainPriorityAction.Priority # Same priority as HTTPS Listener
   HTTPSListenerRule:
     Metadata:
       'aws:copilot:description': 'An HTTPS listener rule for forwarding HTTPS traffic to your tasks'
@@ -424,6 +424,7 @@ Resources:
     Properties:
       ServiceToken: !GetAtt EnvControllerFunction.Arn
       Workload: !Ref WorkloadName
+      Aliases: ["example.com", "foobar.com", "*.foobar.com"]
       EnvStack: !Sub '${AppName}-${EnvName}'
       Parameters: [InternalALBWorkloads]
   EnvControllerFunction:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-grpc-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-grpc-test.stack.yml
@@ -350,6 +350,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
     Properties:
       ServiceToken: !GetAtt EnvControllerFunction.Arn
       Workload: !Ref WorkloadName
+      Aliases: ["example.com"]
       EnvStack: !Sub '${AppName}-${EnvName}'
       Parameters: [ALBWorkloads, Aliases]
   EnvControllerFunction:
@@ -508,7 +509,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       RulePath: !Ref RulePath
       ListenerArn: !GetAtt EnvControllerAction.HTTPSListenerArn
   
-  HTTPRulePriorityAction:
+  HTTPRuleWithDomainPriorityAction:
     Metadata:
       'aws:copilot:description': 'A custom resource assigning priority for HTTP listener rules'
     Type: Custom::RulePriorityFunction
@@ -543,7 +544,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
               - - !Sub "/${RulePath}"
                 - !Sub "/${RulePath}/*"
       ListenerArn: !GetAtt EnvControllerAction.HTTPListenerArn
-      Priority: !GetAtt HTTPRulePriorityAction.Priority # Same priority as HTTPS Listener
+      Priority: !GetAtt HTTPRuleWithDomainPriorityAction.Priority # Same priority as HTTPS Listener
   HTTPSListenerRule:
     Metadata:
       'aws:copilot:description': 'An HTTPS listener rule for forwarding HTTPS traffic to your tasks'

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-dev.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-dev.stack.yml
@@ -410,7 +410,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       RulePath: !Ref RulePath
       ListenerArn: !GetAtt EnvControllerAction.HTTPSListenerArn
   
-  HTTPRulePriorityAction:
+  HTTPRuleWithDomainPriorityAction:
     Metadata:
       'aws:copilot:description': 'A custom resource assigning priority for HTTP listener rules'
     Type: Custom::RulePriorityFunction
@@ -449,7 +449,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
               - - !Sub "/${RulePath}"
                 - !Sub "/${RulePath}/*"
       ListenerArn: !GetAtt EnvControllerAction.HTTPListenerArn
-      Priority: !GetAtt HTTPRulePriorityAction.Priority # Same priority as HTTPS Listener
+      Priority: !GetAtt HTTPRuleWithDomainPriorityAction.Priority
   HTTPSListenerRule:
     Metadata:
       'aws:copilot:description': 'An HTTPS listener rule for forwarding HTTPS traffic to your tasks'

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-prod.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-prod.stack.yml
@@ -433,6 +433,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
     Properties:
       ServiceToken: !GetAtt EnvControllerFunction.Arn
       Workload: !Ref WorkloadName
+      Aliases: ["example.com"]
       EnvStack: !Sub '${AppName}-${EnvName}'
       Parameters: [ALBWorkloads, Aliases]
   EnvControllerFunction:
@@ -595,7 +596,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       RulePath: !Ref RulePath
       ListenerArn: !GetAtt EnvControllerAction.HTTPSListenerArn
   
-  HTTPRulePriorityAction:
+  HTTPRuleWithDomainPriorityAction:
     Metadata:
       'aws:copilot:description': 'A custom resource assigning priority for HTTP listener rules'
     Type: Custom::RulePriorityFunction
@@ -630,7 +631,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
               - - !Sub "/${RulePath}"
                 - !Sub "/${RulePath}/*"
       ListenerArn: !GetAtt EnvControllerAction.HTTPListenerArn
-      Priority: !GetAtt HTTPRulePriorityAction.Priority # Same priority as HTTPS Listener
+      Priority: !GetAtt HTTPRuleWithDomainPriorityAction.Priority
   HTTPSListenerRule:
     Metadata:
       'aws:copilot:description': 'An HTTPS listener rule for forwarding HTTPS traffic to your tasks'

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-staging.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-staging.stack.yml
@@ -239,6 +239,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
     Properties:
       ServiceToken: !GetAtt EnvControllerFunction.Arn
       Workload: !Ref WorkloadName
+      Aliases: ["example.com"]
       EnvStack: !Sub '${AppName}-${EnvName}'
       Parameters: [ALBWorkloads, Aliases]
   EnvControllerFunction:
@@ -411,7 +412,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       RulePath: !Ref RulePath
       ListenerArn: !GetAtt EnvControllerAction.HTTPSListenerArn
   
-  HTTPRulePriorityAction:
+  HTTPRuleWithDomainPriorityAction:
     Metadata:
       'aws:copilot:description': 'A custom resource assigning priority for HTTP listener rules'
     Type: Custom::RulePriorityFunction
@@ -446,7 +447,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
               - - !Sub "/${RulePath}"
                 - !Sub "/${RulePath}/*"
       ListenerArn: !GetAtt EnvControllerAction.HTTPListenerArn
-      Priority: !GetAtt HTTPRulePriorityAction.Priority # Same priority as HTTPS Listener
+      Priority: !GetAtt HTTPRuleWithDomainPriorityAction.Priority
   HTTPSListenerRule:
     Metadata:
       'aws:copilot:description': 'An HTTPS listener rule for forwarding HTTPS traffic to your tasks'

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-test.stack.yml
@@ -350,6 +350,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
     Properties:
       ServiceToken: !GetAtt EnvControllerFunction.Arn
       Workload: !Ref WorkloadName
+      Aliases: ["example.com"]
       EnvStack: !Sub '${AppName}-${EnvName}'
       Parameters: [ALBWorkloads, Aliases]
   EnvControllerFunction:
@@ -507,7 +508,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       RulePath: !Ref RulePath
       ListenerArn: !GetAtt EnvControllerAction.HTTPSListenerArn
   
-  HTTPRulePriorityAction:
+  HTTPRuleWithDomainPriorityAction:
     Metadata:
       'aws:copilot:description': 'A custom resource assigning priority for HTTP listener rules'
     Type: Custom::RulePriorityFunction
@@ -542,7 +543,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
               - - !Sub "/${RulePath}"
                 - !Sub "/${RulePath}/*"
       ListenerArn: !GetAtt EnvControllerAction.HTTPListenerArn
-      Priority: !GetAtt HTTPRulePriorityAction.Priority # Same priority as HTTPS Listener
+      Priority: !GetAtt HTTPRuleWithDomainPriorityAction.Priority
   HTTPSListenerRule:
     Metadata:
       'aws:copilot:description': 'An HTTPS listener rule for forwarding HTTPS traffic to your tasks'

--- a/internal/pkg/template/templates/environment/cf.yml
+++ b/internal/pkg/template/templates/environment/cf.yml
@@ -634,7 +634,7 @@ Outputs:
       Name: !Sub ${AWS::StackName}-SubDomain
 {{- end}}
   EnabledFeatures:
-    Value: !Sub '${ALBWorkloads},${InternalALBWorkloads},${EFSWorkloads},${NATWorkloads}'
+    Value: !Sub '${ALBWorkloads},${InternalALBWorkloads},${EFSWorkloads},${NATWorkloads},${Aliases}'
     Description: Required output to force the stack to update if mutating feature params, like ALBWorkloads, does not change the template.
   ManagedFileSystemID:
     Condition: CreateEFS

--- a/internal/pkg/template/templates/workloads/partials/cf/env-controller.yml
+++ b/internal/pkg/template/templates/workloads/partials/cf/env-controller.yml
@@ -5,7 +5,7 @@ EnvControllerAction:
   Properties:
     ServiceToken: !GetAtt EnvControllerFunction.Arn
     Workload: !Ref WorkloadName
-{{- if and (not .UseImportedCerts) (.Aliases)}}
+{{- if .Aliases}}
     Aliases: {{ fmtSlice (quoteSlice .Aliases) }}
 {{- end}}
     EnvStack: !Sub '${AppName}-${EnvName}'

--- a/internal/pkg/template/templates/workloads/partials/cf/https-listener.yml
+++ b/internal/pkg/template/templates/workloads/partials/cf/https-listener.yml
@@ -58,7 +58,7 @@ HTTPSRulePriorityAction:
     ListenerArn: !GetAtt EnvControllerAction.HTTPSListenerArn
     {{- end}}
 
-HTTPRulePriorityAction:
+HTTPRuleWithDomainPriorityAction:
   Metadata:
     'aws:copilot:description': 'A custom resource assigning priority for HTTP listener rules'
   Type: Custom::RulePriorityFunction
@@ -115,7 +115,7 @@ HTTPListenerRuleWithDomain:
     {{- else}}
     ListenerArn: !GetAtt EnvControllerAction.HTTPListenerArn
     {{- end}}
-    Priority: !GetAtt HTTPRulePriorityAction.Priority
+    Priority: !GetAtt HTTPRuleWithDomainPriorityAction.Priority
 
 HTTPSListenerRule:
   Metadata:


### PR DESCRIPTION
In addition to the title, also renaming the logical ID of the HTTP rule priority action that is used for `HTTPListenerRuleWithDomain`. This listener rule shouldn't share the same priority action as `HTTPListenerRule`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
