### PR TITLE
docs: fix flag description, verb tense, manifest key

### DIFF
--- a/internal/pkg/cli/flag.go
+++ b/internal/pkg/cli/flag.go
@@ -205,13 +205,15 @@ const (
 	profileFlagDescription    = "Name of the profile."
 	yesFlagDescription        = "Skips confirmation prompt."
 	execYesFlagDescription    = "Optional. Whether to update the Session Manager Plugin."
-	jsonFlagDescription       = "Optional. Outputs in JSON format."
+	jsonFlagDescription       = "Optional. Output in JSON format."
 	forceFlagDescription      = "Optional. Force a new service deployment using the existing image."
 	noRollbackFlagDescription = `Optional. Disable automatic stack 
 rollback in case of deployment failure.
 We do not recommend using this flag for a
 production environment.`
 	manifestFlagDescription = "Optional. Output the manifest file used for the deployment."
+	svcManifestFlagDescription = `Optional. Name of the environment in which the service was deployed;
+output the manifest file used for that deployment.`
 
 	imageTagFlagDescription     = `Optional. The container image tag.`
 	resourceTagsFlagDescription = `Optional. Labels with a key and value separated by commas.

--- a/internal/pkg/cli/svc_show.go
+++ b/internal/pkg/cli/svc_show.go
@@ -245,7 +245,7 @@ func buildSvcShowCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&vars.svcName, nameFlag, nameFlagShort, "", svcFlagDescription)
 	cmd.Flags().BoolVar(&vars.shouldOutputJSON, jsonFlag, false, jsonFlagDescription)
 	cmd.Flags().BoolVar(&vars.shouldOutputResources, resourcesFlag, false, svcResourcesFlagDescription)
-	cmd.Flags().StringVar(&vars.outputManifestForEnv, manifestFlag, "", manifestFlagDescription)
+	cmd.Flags().StringVar(&vars.outputManifestForEnv, manifestFlag, "", svcManifestFlagDescription)
 
 	cmd.MarkFlagsMutuallyExclusive(jsonFlag, manifestFlag)
 	cmd.MarkFlagsMutuallyExclusive(resourcesFlag, manifestFlag)

--- a/site/content/docs/commands/app-show.en.md
+++ b/site/content/docs/commands/app-show.en.md
@@ -11,7 +11,7 @@ $ copilot app show [flags]
 
 ```
 -h, --help          help for show
-    --json          Optional. Outputs in JSON format.
+    --json          Optional. Output in JSON format.
 -n, --name string   Name of the application.
 ```
 

--- a/site/content/docs/commands/app-show.ja.md
+++ b/site/content/docs/commands/app-show.ja.md
@@ -11,7 +11,7 @@ $ copilot app show [flags]
 
 ```
 -h, --help          help for show
-    --json          Optional. Outputs in JSON format.
+    --json          Optional. Output in JSON format.
 -n, --name string   Name of the application.
 ```
 

--- a/site/content/docs/commands/env-ls.en.md
+++ b/site/content/docs/commands/env-ls.en.md
@@ -9,7 +9,7 @@ $ copilot env ls [flags]
 ## What are the flags?
 ```
 -h, --help          help for ls
-    --json          Optional. Outputs in JSON format.
+    --json          Optional. Output in JSON format.
 -a, --app string    Name of the application.
 ```
 You can use the `--json` flag if you'd like to programmatically parse the results.

--- a/site/content/docs/commands/env-ls.ja.md
+++ b/site/content/docs/commands/env-ls.ja.md
@@ -9,7 +9,7 @@ $ copilot env ls [flags]
 ## フラグ
 ```
 -h, --help          help for ls
-    --json          Optional. Outputs in JSON format.
+    --json          Optional. Output in JSON format.
 -a, --app string    Name of the application.
 ```
 結果をプログラムでパースしたい場合 `--json` フラグを利用することができます。

--- a/site/content/docs/commands/env-show.en.md
+++ b/site/content/docs/commands/env-show.en.md
@@ -17,7 +17,8 @@ You can optionally pass in a `--resources` flag which will include the AWS resou
 ```
 -a, --app string    Name of the application.
 -h, --help          help for show
-    --json          Optional. Outputs in JSON format.
+    --json          Optional. Output in JSON format.
+    --manifest      Optional. Output the manifest file used for the deployment.
 -n, --name string   Name of the environment.
     --resources     Optional. Show the resources in your environment.
 ```

--- a/site/content/docs/commands/env-show.ja.md
+++ b/site/content/docs/commands/env-show.ja.md
@@ -17,7 +17,7 @@ $ copilot env show [flags]
 ```
 -a, --app string    Name of the application.
 -h, --help          help for show
-    --json          Optional. Outputs in JSON format.
+    --json          Optional. Output in JSON format.
 -n, --name string   Name of the environment.
     --resources     Optional. Show the resources in your environment.
 ```

--- a/site/content/docs/commands/job-ls.en.md
+++ b/site/content/docs/commands/job-ls.en.md
@@ -12,7 +12,7 @@ $ copilot job ls
 ```
   -a, --app string   Name of the application.
   -h, --help         help for ls
-      --json         Optional. Outputs in JSON format.
+      --json         Optional. Output in JSON format.
       --local        Only show jobs in the workspace.
 ```
 

--- a/site/content/docs/commands/job-ls.ja.md
+++ b/site/content/docs/commands/job-ls.ja.md
@@ -12,7 +12,7 @@ $ copilot job ls
 ```
   -a, --app string   Name of the application.
   -h, --help         help for ls
-      --json         Optional. Outputs in JSON format.
+      --json         Optional. Output in JSON format.
       --local        Only show jobs in the workspace.
 ```
 

--- a/site/content/docs/commands/pipeline-ls.en.md
+++ b/site/content/docs/commands/pipeline-ls.en.md
@@ -10,7 +10,7 @@ $ copilot pipeline ls [flags]
 ```
 -a, --app string   Name of the application.
 -h, --help         help for ls
-    --json         Optional. Outputs in JSON format.
+    --json         Optional. Output in JSON format.
     --local        Only show pipelines in the workspace.
 ```
 

--- a/site/content/docs/commands/pipeline-ls.ja.md
+++ b/site/content/docs/commands/pipeline-ls.ja.md
@@ -10,7 +10,7 @@ $ copilot pipeline ls [flags]
 ```
 -a, --app string   Name of the application.
 -h, --help         help for ls
-    --json         Optional. Outputs in JSON format.
+    --json         Optional. Output in JSON format.
     --local        Only show pipelines in the workspace.
 ```
 

--- a/site/content/docs/commands/pipeline-show.en.md
+++ b/site/content/docs/commands/pipeline-show.en.md
@@ -10,7 +10,7 @@ $ copilot pipeline show [flags]
 ```
 -a, --app string    Name of the application.
 -h, --help          help for show
-    --json          Optional. Outputs in JSON format.
+    --json          Optional. Output in JSON format.
 -n, --name string   Name of the pipeline.
     --resources     Optional. Show the resources in your pipeline.
 ```

--- a/site/content/docs/commands/pipeline-show.ja.md
+++ b/site/content/docs/commands/pipeline-show.ja.md
@@ -10,7 +10,7 @@ $ copilot pipeline show [flags]
 ```
 -a, --app string    Name of the application.
 -h, --help          help for show
-    --json          Optional. Outputs in JSON format.
+    --json          Optional. Output in JSON format.
 -n, --name string   Name of the pipeline.
     --resources     Optional. Show the resources in your pipeline.
 ```

--- a/site/content/docs/commands/pipeline-status.en.md
+++ b/site/content/docs/commands/pipeline-status.en.md
@@ -10,7 +10,7 @@ $ copilot pipeline status [flags]
 ```
 -a, --app string    Name of the application.
 -h, --help          help for status
-    --json          Optional. Outputs in JSON format.
+    --json          Optional. Output in JSON format.
 -n, --name string   Name of the pipeline.
 ```
 

--- a/site/content/docs/commands/pipeline-status.ja.md
+++ b/site/content/docs/commands/pipeline-status.ja.md
@@ -10,7 +10,7 @@ $ copilot pipeline status [flags]
 ```
 -a, --app string    Name of the application.
 -h, --help          help for status
-    --json          Optional. Outputs in JSON format.
+    --json          Optional. Output in JSON format.
 -n, --name string   Name of the pipeline.
 ```
 

--- a/site/content/docs/commands/svc-logs.en.md
+++ b/site/content/docs/commands/svc-logs.en.md
@@ -16,7 +16,7 @@ $ copilot svc logs
   -e, --env string          Name of the environment.
       --follow              Optional. Specifies if the logs should be streamed.
   -h, --help                help for logs
-      --json                Optional. Outputs in JSON format.
+      --json                Optional. Output in JSON format.
       --limit int           Optional. The maximum number of log events returned. (default 10)
   -n, --name string         Name of the service.
       --since duration      Optional. Only return logs newer than a relative duration like 5s, 2m, or 3h.

--- a/site/content/docs/commands/svc-logs.ja.md
+++ b/site/content/docs/commands/svc-logs.ja.md
@@ -16,7 +16,7 @@ $ copilot svc logs
   -e, --env string          Name of the environment.
       --follow              Optional. Specifies if the logs should be streamed.
   -h, --help                help for logs
-      --json                Optional. Outputs in JSON format.
+      --json                Optional. Output in JSON format.
       --limit int           Optional. The maximum number of log events returned. (default 10)
   -n, --name string         Name of the service.
       --since duration      Optional. Only return logs newer than a relative duration like 5s, 2m, or 3h.

--- a/site/content/docs/commands/svc-ls.en.md
+++ b/site/content/docs/commands/svc-ls.en.md
@@ -12,7 +12,7 @@ $ copilot svc ls
 ```
   -a, --app string   Name of the application.
   -h, --help         help for ls
-      --json         Optional. Outputs in JSON format.
+      --json         Optional. Output in JSON format.
       --local        Only show services in the workspace.
 ```
 

--- a/site/content/docs/commands/svc-ls.ja.md
+++ b/site/content/docs/commands/svc-ls.ja.md
@@ -12,7 +12,7 @@ $ copilot svc ls
 ```
   -a, --app string   Name of the application.
   -h, --help         help for ls
-      --json         Optional. Outputs in JSON format.
+      --json         Optional. Output in JSON format.
       --local        Only show services in the workspace.
 ```
 

--- a/site/content/docs/commands/svc-show.en.md
+++ b/site/content/docs/commands/svc-show.en.md
@@ -10,11 +10,13 @@ $ copilot svc show
 ## What are the flags?
 
 ```
-  -a, --app string    Name of the application.
-  -h, --help          help for show
-      --json          Optional. Outputs in JSON format.
-  -n, --name string   Name of the service.
-      --resources     Optional. Show the resources in your service.
+  -a, --app string        Name of the application.
+  -h, --help              help for show
+      --json              Optional. Output in JSON format.
+      --manifest string   Optional. Name of the environment in which the service was deployed;
+                          output the manifest file used for that deployment.
+  -n, --name string       Name of the service.
+      --resources         Optional. Show the resources in your service.
 ```
 
 ## What does it look like?

--- a/site/content/docs/commands/svc-show.ja.md
+++ b/site/content/docs/commands/svc-show.ja.md
@@ -12,7 +12,7 @@ $ copilot svc show
 ```
   -a, --app string    Name of the application.
   -h, --help          help for show
-      --json          Optional. Outputs in JSON format.
+      --json          Optional. Output in JSON format.
   -n, --name string   Name of the service.
       --resources     Optional. Show the resources in your service.
 ```

--- a/site/content/docs/commands/svc-status.en.md
+++ b/site/content/docs/commands/svc-status.en.md
@@ -11,7 +11,7 @@ $ copilot svc status
   -a, --app string    Name of the application.
   -e, --env string    Name of the environment.
   -h, --help          help for status
-      --json          Optional. Outputs in JSON format.
+      --json          Optional. Output in JSON format.
   -n, --name string   Name of the service.
 ```
 

--- a/site/content/docs/commands/svc-status.ja.md
+++ b/site/content/docs/commands/svc-status.ja.md
@@ -11,7 +11,7 @@ $ copilot svc status
   -a, --app string    Name of the application.
   -e, --env string    Name of the environment.
   -h, --help          help for status
-      --json          Optional. Outputs in JSON format.
+      --json          Optional. Output in JSON format.
   -n, --name string   Name of the service.
 ```
 

--- a/site/content/docs/developing/sidecars.en.md
+++ b/site/content/docs/developing/sidecars.en.md
@@ -38,7 +38,7 @@ http:
   path: 'api'
   healthcheck: '/api/health-check'
   # Target container for Load Balancer is our sidecar 'nginx', instead of the service container.
-  targetContainer: 'nginx'
+  target_container: 'nginx'
 
 cpu: 256
 memory: 512


### PR DESCRIPTION
This PR adds a separate help menu description for `--manifest` for `svc show`, as it wasn't clear that the env name needed to follow the flag for that command.

Also fixed the verb tense for that flag description as well as `--json`; changed affected docs pages. Will try to make the rest consistent at a later date.

Also fixed the `target_container` key name in a sample app on the "Sidecars" page.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
