### PR TITLE
chore: e2e app runner `svc logs` fix

### DIFF
--- a/internal/pkg/logging/workload.go
+++ b/internal/pkg/logging/workload.go
@@ -173,7 +173,9 @@ func (s *WorkloadClient) WriteLogEvents(opts WriteLogEventsOpts) error {
 		LogStreamLimit:      opts.LogStreamLimit,
 	}
 
-	logEventsOpts.LogStreamPrefixFilters = s.logStreams(opts.TaskIDs)
+	if opts.TaskIDs != nil {
+		logEventsOpts.LogStreamPrefixFilters = s.logStreams(opts.TaskIDs)
+	}
 
 	for {
 		logEventsOutput, err := s.eventsGetter.LogEvents(logEventsOpts)

--- a/internal/pkg/logging/workload.go
+++ b/internal/pkg/logging/workload.go
@@ -173,7 +173,7 @@ func (s *WorkloadClient) WriteLogEvents(opts WriteLogEventsOpts) error {
 		LogStreamLimit:      opts.LogStreamLimit,
 	}
 
-	if opts.TaskIDs != nil {
+	if s.logStreamNamePrefix != "" {
 		logEventsOpts.LogStreamPrefixFilters = s.logStreams(opts.TaskIDs)
 	}
 

--- a/internal/pkg/logging/workload.go
+++ b/internal/pkg/logging/workload.go
@@ -173,6 +173,8 @@ func (s *WorkloadClient) WriteLogEvents(opts WriteLogEventsOpts) error {
 		LogStreamLimit:      opts.LogStreamLimit,
 	}
 
+	// TODO: there should be a separate logging client for ECS services
+	// and App Runner services. This `if` check is only ever true for ECS services.
 	if s.logStreamNamePrefix != "" {
 		logEventsOpts.LogStreamPrefixFilters = s.logStreams(opts.TaskIDs)
 	}


### PR DESCRIPTION
Fixes an e2e test failure caused by filtering app runner log streams to have to begin with `copilot/`, but they don't 😊 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
