### PR TITLE
refactor(template): separate HTTPConfigs for public and private load balancers

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/env.go
+++ b/internal/pkg/deploy/cloudformation/stack/env.go
@@ -96,19 +96,16 @@ func (e *EnvStackConfig) Template() (string, error) {
 		forceUpdateID = id.String()
 	}
 	content, err := e.parser.ParseEnv(&template.EnvOpts{
-		AppName:                       e.in.App.Name,
-		EnvName:                       e.in.Name,
-		CustomResources:               crs,
-		ArtifactBucketARN:             e.in.ArtifactBucketARN,
-		ArtifactBucketKeyARN:          e.in.ArtifactBucketKeyARN,
-		PublicFacingCIDRPrefixListIDs: e.in.CIDRPrefixListIDs,
-		PublicImportedCertARNs:        e.importPublicCertARNs(),
-		PrivateImportedCertARNs:       e.importPrivateCertARNs(),
-		VPCConfig:                     e.vpcConfig(),
-		CustomInternalALBSubnets:      e.internalALBSubnets(),
-		AllowVPCIngress:               aws.BoolValue(e.in.Mft.HTTPConfig.Private.SecurityGroupsConfig.Ingress.VPCIngress),
-		Telemetry:                     e.telemetryConfig(),
-		CDNConfig:                     e.cdnConfig(),
+		AppName:              e.in.App.Name,
+		EnvName:              e.in.Name,
+		CustomResources:      crs,
+		ArtifactBucketARN:    e.in.ArtifactBucketARN,
+		ArtifactBucketKeyARN: e.in.ArtifactBucketKeyARN,
+		VPCConfig:            e.vpcConfig(),
+		PublicHTTPConfig:     e.publicHTTPConfig(),
+		PrivateHTTPConfig:    e.privateHTTPConfig(),
+		Telemetry:            e.telemetryConfig(),
+		CDNConfig:            e.cdnConfig(),
 
 		Version:            e.in.Version,
 		LatestVersion:      deploy.LatestEnvTemplateVersion,
@@ -354,10 +351,25 @@ func (e *EnvStackConfig) cdnConfig() *template.CDNConfig {
 	return nil // no-op - return &template.CDNConfig{} when feature is ready
 }
 
+func (e *EnvStackConfig) publicHTTPConfig() template.HTTPConfig {
+	return template.HTTPConfig{
+		CIDRPrefixListIDs: e.in.CIDRPrefixListIDs,
+		ImportedCertARNs:  e.importPublicCertARNs(),
+	}
+}
+
+func (e *EnvStackConfig) privateHTTPConfig() template.HTTPConfig {
+	return template.HTTPConfig{
+		ImportedCertARNs: e.importPrivateCertARNs(),
+		CustomALBSubnets: e.internalALBSubnets(),
+	}
+}
+
 func (e *EnvStackConfig) vpcConfig() template.VPCConfig {
 	return template.VPCConfig{
-		Imported: e.importVPC(),
-		Managed:  e.managedVPC(),
+		Imported:        e.importVPC(),
+		Managed:         e.managedVPC(),
+		AllowVPCIngress: aws.BoolValue(e.in.Mft.HTTPConfig.Private.SecurityGroupsConfig.Ingress.VPCIngress),
 	}
 }
 

--- a/internal/pkg/template/env.go
+++ b/internal/pkg/template/env.go
@@ -105,27 +105,31 @@ type EnvOpts struct {
 	ArtifactBucketARN    string
 	ArtifactBucketKeyARN string
 
-	VPCConfig                     VPCConfig
-	PublicFacingCIDRPrefixListIDs []string
-	PublicImportedCertARNs        []string
-	PrivateImportedCertARNs       []string
-	CustomInternalALBSubnets      []string
-	AllowVPCIngress               bool
-	Telemetry                     *Telemetry
-
-	CDNConfig *CDNConfig // If nil, no cdn is to be used
+	VPCConfig         VPCConfig
+	PublicHTTPConfig  HTTPConfig
+	PrivateHTTPConfig HTTPConfig
+	Telemetry         *Telemetry
+	CDNConfig         *CDNConfig
 
 	LatestVersion      string
 	SerializedManifest string // Serialized manifest used to render the environment template.
 	ForceUpdateID      string
 }
 
+// HTTPConfig represents configuration for a Load Balancer.
+type HTTPConfig struct {
+	CIDRPrefixListIDs []string
+	ImportedCertARNs  []string
+	CustomALBSubnets  []string
+}
+
 // CDNConfig represents a Content Delivery Network deployed by CloudFront.
 type CDNConfig struct{}
 
 type VPCConfig struct {
-	Imported *ImportVPC // If not-nil, use the imported VPC resources instead of the Managed VPC.
-	Managed  ManagedVPC
+	Imported        *ImportVPC // If not-nil, use the imported VPC resources instead of the Managed VPC.
+	Managed         ManagedVPC
+	AllowVPCIngress bool
 }
 
 // ImportVPC holds the fields to import VPC resources.

--- a/internal/pkg/template/templates/environment/cf.yml
+++ b/internal/pkg/template/templates/environment/cf.yml
@@ -105,8 +105,8 @@ Resources:
     Properties:
       GroupDescription: HTTP access to the public facing load balancer
       SecurityGroupIngress:
-        {{- if .PublicFacingCIDRPrefixListIDs}}
-        {{- range $id := .PublicFacingCIDRPrefixListIDs}}
+        {{- if .PublicHTTPConfig.CIDRPrefixListIDs}}
+        {{- range $id := .PublicHTTPConfig.CIDRPrefixListIDs}}
         - SourcePrefixListId: {{$id}}
           Description: Allow ingress from prefix list {{$id}} on port 80
           FromPort: 80
@@ -136,8 +136,8 @@ Resources:
     Properties:
       GroupDescription: HTTPS access to the public facing load balancer
       SecurityGroupIngress:
-        {{- if .PublicFacingCIDRPrefixListIDs}}
-        {{- range $id := .PublicFacingCIDRPrefixListIDs}}
+        {{- if .PublicHTTPConfig.CIDRPrefixListIDs}}
+        {{- range $id := .PublicHTTPConfig.CIDRPrefixListIDs}}
         - SourcePrefixListId: {{$id}}
           Description: Allow ingress from prefix list {{$id}} on port 443
           FromPort: 443
@@ -228,7 +228,7 @@ Resources:
       GroupId: !Ref InternalLoadBalancerSecurityGroup
       IpProtocol: -1
       SourceSecurityGroupId: !Ref EnvironmentSecurityGroup
-{{- if .AllowVPCIngress }}
+{{- if .VPCConfig.AllowVPCIngress }}
   InternalLoadBalancerSecurityGroupIngressFromHttp:
     Metadata:
       'aws:copilot:description': 'An inbound rule to the internal load balancer security group for port 80 within the VPC'
@@ -310,8 +310,8 @@ Resources:
     Condition: ExportHTTPSListener
     Properties:
       Certificates:
-{{- if .PublicImportedCertARNs}}
-        - CertificateArn: {{index .PublicImportedCertARNs 0}}
+{{- if .PublicHTTPConfig.ImportedCertARNs}}
+        - CertificateArn: {{index .PublicHTTPConfig.ImportedCertARNs 0}}
 {{- else}}
         - CertificateArn: !Ref HTTPSCert
 {{- end}}
@@ -321,7 +321,7 @@ Resources:
       LoadBalancerArn: !Ref PublicLoadBalancer
       Port: 443
       Protocol: HTTPS
-{{- range $ind, $arn := .PublicImportedCertARNs}}
+{{- range $ind, $arn := .PublicHTTPConfig.ImportedCertARNs}}
 {{- if gt $ind 0}}
   HTTPSImportCertificate{{inc $ind}}:
     Type: AWS::ElasticLoadBalancingV2::ListenerCertificate
@@ -340,8 +340,8 @@ Resources:
     Properties:
       Scheme: internal
       SecurityGroups: [ !GetAtt InternalLoadBalancerSecurityGroup.GroupId ]
-{{- if .CustomInternalALBSubnets}}
-      Subnets: {{fmtSlice .CustomInternalALBSubnets}}
+{{- if .PrivateHTTPConfig.CustomALBSubnets}}
+      Subnets: {{fmtSlice .PrivateHTTPConfig.CustomALBSubnets}}
 {{- else if .VPCConfig.Imported}}
       Subnets: {{fmtSlice .VPCConfig.Imported.PrivateSubnetIDs}}
 {{- else}}
@@ -387,9 +387,9 @@ Resources:
     Type: AWS::ElasticLoadBalancingV2::Listener
     Condition: ExportInternalHTTPSListener
     Properties:
-{{- if .PrivateImportedCertARNs}}
+{{- if .PrivateHTTPConfig.ImportedCertARNs}}
       Certificates:
-        - CertificateArn: {{index .PrivateImportedCertARNs 0}}
+        - CertificateArn: {{index .PrivateHTTPConfig.ImportedCertARNs 0}}
 {{- end}}
       DefaultActions:
         - TargetGroupArn: !Ref DefaultInternalHTTPTargetGroup
@@ -397,7 +397,7 @@ Resources:
       LoadBalancerArn: !Ref InternalLoadBalancer
       Port: 443
       Protocol: HTTPS
-{{- range $ind, $arn := .PrivateImportedCertARNs}}
+{{- range $ind, $arn := .PrivateHTTPConfig.ImportedCertARNs}}
 {{- if gt $ind 0}}
   InternalHTTPSImportCertificate{{inc $ind}}:
     Type: AWS::ElasticLoadBalancingV2::ListenerCertificate
@@ -408,7 +408,7 @@ Resources:
         - CertificateArn: {{$arn}}
 {{- end}}
 {{- end}}
-  {{- if not .PrivateImportedCertARNs}}
+  {{- if not .PrivateHTTPConfig.ImportedCertARNs}}
   InternalWorkloadsHostedZone:
     Metadata:
       'aws:copilot:description': 'A hosted zone named {{.EnvName}}.{{.AppName}}.internal for backends behind a private load balancer'
@@ -508,7 +508,7 @@ Resources:
         - !Ref EFSSecurityGroup
 {{- end}}
 {{- end}}
-{{- if not .PublicImportedCertARNs}}
+{{- if not .PublicHTTPConfig.ImportedCertARNs}}
 {{include "custom-resources-role" . | indent 2}}
   EnvironmentHostedZone:
     Metadata:
@@ -625,7 +625,7 @@ Outputs:
     Value: !GetAtt InternalLoadBalancer.CanonicalHostedZoneID
     Export:
       Name: !Sub ${AWS::StackName}-InternalLoadBalancerCanonicalHostedZoneID
-  {{- if not .PrivateImportedCertARNs}}
+  {{- if not .PrivateHTTPConfig.ImportedCertARNs}}
   InternalWorkloadsHostedZone:
     Condition: CreateInternalALB
     Value: !GetAtt InternalWorkloadsHostedZone.Id
@@ -666,7 +666,7 @@ Outputs:
     Description: The role to be assumed by the Cloudformation service when it deploys application infrastructure.
     Export:
       Name: !Sub ${AWS::StackName}-CFNExecutionRoleARN
-{{- if not .PublicImportedCertARNs}}
+{{- if not .PublicHTTPConfig.ImportedCertARNs}}
   EnvironmentHostedZone:
     Condition: DelegateDNS
     Value: !Ref EnvironmentHostedZone

--- a/internal/pkg/template/templates/environment/partials/environment-manager-role.yml
+++ b/internal/pkg/template/templates/environment/partials/environment-manager-role.yml
@@ -19,17 +19,17 @@ EnvironmentManagerRole:
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
-{{- if or .PublicImportedCertARNs .PrivateImportedCertARNs}}
+{{- if or .PublicHTTPConfig.ImportedCertARNs .PrivateHTTPConfig.ImportedCertARNs}}
         - Sid: ImportedCertificates
           Effect: Allow
           Action: [
             acm:DescribeCertificate
           ]
           Resource:
-{{- range $arn := .PublicImportedCertARNs}}
+{{- range $arn := .PublicHTTPConfig.ImportedCertARNs}}
           - "{{$arn}}"
 {{- end}}
-{{- range $arn := .PrivateImportedCertARNs}}
+{{- range $arn := .PrivateHTTPConfig.ImportedCertARNs}}
           - "{{$arn}}"
 {{- end}}
 {{- end}}


### PR DESCRIPTION
<!-- Provide summary of changes -->
Refactors `EnvOpts` struct to have a public and private `HTTPConfig` which holds information closer to how it's represented in the manifest.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
