### PR TITLE
chore(displayPath): do not call Getwd for already-relative paths

### DIFF
--- a/internal/pkg/cli/cli.go
+++ b/internal/pkg/cli/cli.go
@@ -146,9 +146,13 @@ func quoteStringSlice(in []string) []string {
 // This path should not be stored in configuration files or used in any way except
 // for being displayed to the user.
 func displayPath(target string) string {
+	if !filepath.IsAbs(target) {
+		return filepath.Clean(target)
+	}
+
 	base, err := os.Getwd()
 
-	if err != nil || !filepath.IsAbs(target) {
+	if err != nil {
 		return filepath.Clean(target)
 	}
 

--- a/internal/pkg/cli/cli.go
+++ b/internal/pkg/cli/cli.go
@@ -151,7 +151,6 @@ func displayPath(target string) string {
 	}
 
 	base, err := os.Getwd()
-
 	if err != nil {
 		return filepath.Clean(target)
 	}

--- a/internal/pkg/initialize/workload.go
+++ b/internal/pkg/initialize/workload.go
@@ -389,7 +389,6 @@ func displayPath(target string) string {
 	}
 
 	base, err := os.Getwd()
-
 	if err != nil {
 		return filepath.Clean(target)
 	}

--- a/internal/pkg/initialize/workload.go
+++ b/internal/pkg/initialize/workload.go
@@ -384,9 +384,13 @@ func newWorkerServiceManifest(i *ServiceProps) (*manifest.WorkerService, error) 
 
 // Copy of cli.displayPath
 func displayPath(target string) string {
+	if !filepath.IsAbs(target) {
+		return filepath.Clean(target)
+	}
+
 	base, err := os.Getwd()
 
-	if err != nil || !filepath.IsAbs(target) {
+	if err != nil {
 		return filepath.Clean(target)
 	}
 


### PR DESCRIPTION
<!-- Provide summary of changes -->

This was a comment from #3740 that got missed due to the automatic merge.

https://github.com/aws/copilot-cli/pull/3740#discussion_r932768730

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
