### PR TITLE
chore: Disable render_test on Windows

### DIFF
--- a/internal/pkg/term/progress/render_test.go
+++ b/internal/pkg/term/progress/render_test.go
@@ -142,9 +142,7 @@ func TestRender(t *testing.T) {
 		wanted.WriteString("hi\n")
 		c.Show()
 
-		//require.Equal(t, wanted.String(), actual.String(), "expected the content printed to match")
-
-		panic("a \"" + actual.String() + "\" w\"" + wanted.String() + "\"")
+		require.Equal(t, wanted.String(), actual.String(), "expected the content printed to match")
 	})
 
 }

--- a/internal/pkg/term/progress/render_test.go
+++ b/internal/pkg/term/progress/render_test.go
@@ -1,3 +1,11 @@
+//go:build !windows
+
+// This test is not compatible with Windows because it makes POSIX-centric assumptions about terminal output.
+//
+// On Windows, these terminal features involve system calls instead of writing escape sequences, which means
+// that this test case doesn't actually test what it's trying to do on Windows and instead just makes a bunch
+// of invalid system calls, in addition to having intermittent timing issues.
+
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
@@ -134,7 +142,9 @@ func TestRender(t *testing.T) {
 		wanted.WriteString("hi\n")
 		c.Show()
 
-		require.Equal(t, wanted.String(), actual.String(), "expected the content printed to match")
+		//require.Equal(t, wanted.String(), actual.String(), "expected the content printed to match")
+
+		panic("a \"" + actual.String() + "\" w\"" + wanted.String() + "\"")
 	})
 
 }


### PR DESCRIPTION
Addresses https://github.com/aws/copilot-cli/issues/3806 on Windows, there's been no confirmation of the issue on Linux or macOS.

> This test is not compatible with Windows because it makes POSIX-centric assumptions about terminal output.
>
> On Windows, these terminal features involve system calls instead of writing escape sequences, which means
> that this test case doesn't actually test what it's trying to do on Windows and instead just makes a bunch
> of invalid system calls, in addition to having intermittent timing issues.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
