### PR TITLE
refactor(cloudformation): move fileWriter from methods to struct field

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ site-local:
 
 .PHONY: gen-mocks
 gen-mocks: tools
-	GOBIN=${GOBIN} go install github.com/golang/mock/mockgen
+	GOBIN=${GOBIN} go install github.com/golang/mock/mockgen@latest
 	# TODO: make this more extensible?
 	${GOBIN}/mockgen -package=mocks -destination=./internal/pkg/aws/sessions/mocks/mock_sessions.go -source=./internal/pkg/aws/sessions/sessions.go
 	${GOBIN}/mockgen -package=mocks -destination=./internal/pkg/cli/mocks/mock_rg.go -source=./internal/pkg/cli/env_delete.go resourceGetter

--- a/internal/pkg/cli/deploy/env_test.go
+++ b/internal/pkg/cli/deploy/env_test.go
@@ -293,7 +293,7 @@ func TestEnvDeployer_DeployEnvironment(t *testing.T) {
 				m.envDeployer.EXPECT().EnvironmentParameters(gomock.Any(), gomock.Any()).Return(nil, nil)
 				m.envDeployer.EXPECT().ForceUpdateOutputID(gomock.Any(), gomock.Any()).Return("", nil)
 				m.prefixListGetter.EXPECT().CloudFrontManagedPrefixListID().Return("mockPrefixListID", nil).Times(0)
-				m.envDeployer.EXPECT().UpdateAndRenderEnvironment(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+				m.envDeployer.EXPECT().UpdateAndRenderEnvironment(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			},
 			inManifest: nil,
 		},
@@ -324,7 +324,7 @@ func TestEnvDeployer_DeployEnvironment(t *testing.T) {
 				m.prefixListGetter.EXPECT().CloudFrontManagedPrefixListID().Return("mockPrefixListID", nil).Times(0)
 				m.envDeployer.EXPECT().EnvironmentParameters(gomock.Any(), gomock.Any()).Return(nil, nil)
 				m.envDeployer.EXPECT().ForceUpdateOutputID(gomock.Any(), gomock.Any()).Return("", nil)
-				m.envDeployer.EXPECT().UpdateAndRenderEnvironment(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("some error"))
+				m.envDeployer.EXPECT().UpdateAndRenderEnvironment(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("some error"))
 			},
 			wantedError: errors.New("some error"),
 		},
@@ -336,7 +336,7 @@ func TestEnvDeployer_DeployEnvironment(t *testing.T) {
 				m.prefixListGetter.EXPECT().CloudFrontManagedPrefixListID().Return("mockPrefixListID", nil).Times(0)
 				m.envDeployer.EXPECT().EnvironmentParameters(gomock.Any(), gomock.Any()).Return(nil, nil)
 				m.envDeployer.EXPECT().ForceUpdateOutputID(gomock.Any(), gomock.Any()).Return("", nil)
-				m.envDeployer.EXPECT().UpdateAndRenderEnvironment(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+				m.envDeployer.EXPECT().UpdateAndRenderEnvironment(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			},
 		},
 	}

--- a/internal/pkg/cli/deploy/mocks/mock_env.go
+++ b/internal/pkg/cli/deploy/mocks/mock_env.go
@@ -12,7 +12,6 @@ import (
 	config "github.com/aws/copilot-cli/internal/pkg/config"
 	cloudformation1 "github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation"
 	stack "github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation/stack"
-	progress "github.com/aws/copilot-cli/internal/pkg/term/progress"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -108,9 +107,9 @@ func (mr *MockenvironmentDeployerMockRecorder) ForceUpdateOutputID(app, env inte
 }
 
 // UpdateAndRenderEnvironment mocks base method.
-func (m *MockenvironmentDeployer) UpdateAndRenderEnvironment(out progress.FileWriter, conf cloudformation1.StackConfiguration, bucketARN string, opts ...cloudformation0.StackOption) error {
+func (m *MockenvironmentDeployer) UpdateAndRenderEnvironment(conf cloudformation1.StackConfiguration, bucketARN string, opts ...cloudformation0.StackOption) error {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{out, conf, bucketARN}
+	varargs := []interface{}{conf, bucketARN}
 	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
@@ -120,9 +119,9 @@ func (m *MockenvironmentDeployer) UpdateAndRenderEnvironment(out progress.FileWr
 }
 
 // UpdateAndRenderEnvironment indicates an expected call of UpdateAndRenderEnvironment.
-func (mr *MockenvironmentDeployerMockRecorder) UpdateAndRenderEnvironment(out, conf, bucketARN interface{}, opts ...interface{}) *gomock.Call {
+func (mr *MockenvironmentDeployerMockRecorder) UpdateAndRenderEnvironment(conf, bucketARN interface{}, opts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{out, conf, bucketARN}, opts...)
+	varargs := append([]interface{}{conf, bucketARN}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAndRenderEnvironment", reflect.TypeOf((*MockenvironmentDeployer)(nil).UpdateAndRenderEnvironment), varargs...)
 }
 

--- a/internal/pkg/cli/deploy/mocks/mock_svc.go
+++ b/internal/pkg/cli/deploy/mocks/mock_svc.go
@@ -15,7 +15,6 @@ import (
 	cloudformation0 "github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation"
 	dockerengine "github.com/aws/copilot-cli/internal/pkg/docker/dockerengine"
 	repository "github.com/aws/copilot-cli/internal/pkg/repository"
-	progress "github.com/aws/copilot-cli/internal/pkg/term/progress"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -472,9 +471,9 @@ func (m *MockserviceDeployer) EXPECT() *MockserviceDeployerMockRecorder {
 }
 
 // DeployService mocks base method.
-func (m *MockserviceDeployer) DeployService(out progress.FileWriter, conf cloudformation0.StackConfiguration, bucketName string, opts ...cloudformation.StackOption) error {
+func (m *MockserviceDeployer) DeployService(conf cloudformation0.StackConfiguration, bucketName string, opts ...cloudformation.StackOption) error {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{out, conf, bucketName}
+	varargs := []interface{}{conf, bucketName}
 	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
@@ -484,9 +483,9 @@ func (m *MockserviceDeployer) DeployService(out progress.FileWriter, conf cloudf
 }
 
 // DeployService indicates an expected call of DeployService.
-func (mr *MockserviceDeployerMockRecorder) DeployService(out, conf, bucketName interface{}, opts ...interface{}) *gomock.Call {
+func (mr *MockserviceDeployerMockRecorder) DeployService(conf, bucketName interface{}, opts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{out, conf, bucketName}, opts...)
+	varargs := append([]interface{}{conf, bucketName}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeployService", reflect.TypeOf((*MockserviceDeployer)(nil).DeployService), varargs...)
 }
 

--- a/internal/pkg/cli/deploy/svc_test.go
+++ b/internal/pkg/cli/deploy/svc_test.go
@@ -686,7 +686,7 @@ func TestWorkloadDeployer_DeployWorkload(t *testing.T) {
 			},
 			mock: func(m *deployMocks) {
 				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
-				m.mockServiceDeployer.EXPECT().DeployService(gomock.Any(), gomock.Any(), "mockBucket", gomock.Any()).Return(errors.New("some error"))
+				m.mockServiceDeployer.EXPECT().DeployService(gomock.Any(), "mockBucket", gomock.Any()).Return(errors.New("some error"))
 			},
 			wantErr: fmt.Errorf("deploy service: some error"),
 		},
@@ -700,7 +700,7 @@ func TestWorkloadDeployer_DeployWorkload(t *testing.T) {
 			},
 			mock: func(m *deployMocks) {
 				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
-				m.mockServiceDeployer.EXPECT().DeployService(gomock.Any(), gomock.Any(), "mockBucket", gomock.Any()).Return(cloudformation.NewMockErrChangeSetEmpty())
+				m.mockServiceDeployer.EXPECT().DeployService(gomock.Any(), "mockBucket", gomock.Any()).Return(cloudformation.NewMockErrChangeSetEmpty())
 			},
 			wantErr: fmt.Errorf("deploy service: change set with name mockChangeSet for stack mockStack has no changes"),
 		},
@@ -715,7 +715,7 @@ func TestWorkloadDeployer_DeployWorkload(t *testing.T) {
 			},
 			mock: func(m *deployMocks) {
 				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
-				m.mockServiceDeployer.EXPECT().DeployService(gomock.Any(), gomock.Any(), "mockBucket", gomock.Any()).
+				m.mockServiceDeployer.EXPECT().DeployService(gomock.Any(), "mockBucket", gomock.Any()).
 					Return(nil)
 				m.mockServiceForceUpdater.EXPECT().LastUpdatedAt(mockAppName, mockEnvName, mockName).
 					Return(time.Time{}, mockError)
@@ -733,7 +733,7 @@ func TestWorkloadDeployer_DeployWorkload(t *testing.T) {
 			},
 			mock: func(m *deployMocks) {
 				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
-				m.mockServiceDeployer.EXPECT().DeployService(gomock.Any(), gomock.Any(), "mockBucket", gomock.Any()).
+				m.mockServiceDeployer.EXPECT().DeployService(gomock.Any(), "mockBucket", gomock.Any()).
 					Return(nil)
 				m.mockServiceForceUpdater.EXPECT().LastUpdatedAt(mockAppName, mockEnvName, mockName).
 					Return(mockAfterTime, nil)
@@ -750,7 +750,7 @@ func TestWorkloadDeployer_DeployWorkload(t *testing.T) {
 			},
 			mock: func(m *deployMocks) {
 				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
-				m.mockServiceDeployer.EXPECT().DeployService(gomock.Any(), gomock.Any(), "mockBucket", gomock.Any()).
+				m.mockServiceDeployer.EXPECT().DeployService(gomock.Any(), "mockBucket", gomock.Any()).
 					Return(cloudformation.NewMockErrChangeSetEmpty())
 				m.mockServiceForceUpdater.EXPECT().LastUpdatedAt(mockAppName, mockEnvName, mockName).
 					Return(mockBeforeTime, nil)
@@ -771,7 +771,7 @@ func TestWorkloadDeployer_DeployWorkload(t *testing.T) {
 			},
 			mock: func(m *deployMocks) {
 				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
-				m.mockServiceDeployer.EXPECT().DeployService(gomock.Any(), gomock.Any(), "mockBucket", gomock.Any()).
+				m.mockServiceDeployer.EXPECT().DeployService(gomock.Any(), "mockBucket", gomock.Any()).
 					Return(cloudformation.NewMockErrChangeSetEmpty())
 				m.mockServiceForceUpdater.EXPECT().LastUpdatedAt(mockAppName, mockEnvName, mockName).
 					Return(mockBeforeTime, nil)
@@ -796,7 +796,7 @@ func TestWorkloadDeployer_DeployWorkload(t *testing.T) {
 			},
 			mock: func(m *deployMocks) {
 				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
-				m.mockServiceDeployer.EXPECT().DeployService(gomock.Any(), gomock.Any(), "mockBucket", gomock.Any()).Return(nil)
+				m.mockServiceDeployer.EXPECT().DeployService(gomock.Any(), "mockBucket", gomock.Any()).Return(nil)
 			},
 		},
 		"success": {
@@ -819,7 +819,7 @@ func TestWorkloadDeployer_DeployWorkload(t *testing.T) {
 			mock: func(m *deployMocks) {
 				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
 				m.mockValidator.EXPECT().ValidateCertAliases([]string{"example.com", "foobar.com"}, mockCertARNs).Return(nil)
-				m.mockServiceDeployer.EXPECT().DeployService(gomock.Any(), gomock.Any(), "mockBucket", gomock.Any()).Return(nil)
+				m.mockServiceDeployer.EXPECT().DeployService(gomock.Any(), "mockBucket", gomock.Any()).Return(nil)
 			},
 		},
 		"success with force update": {
@@ -833,7 +833,7 @@ func TestWorkloadDeployer_DeployWorkload(t *testing.T) {
 			},
 			mock: func(m *deployMocks) {
 				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
-				m.mockServiceDeployer.EXPECT().DeployService(gomock.Any(), gomock.Any(), "mockBucket", gomock.Any()).
+				m.mockServiceDeployer.EXPECT().DeployService(gomock.Any(), "mockBucket", gomock.Any()).
 					Return(cloudformation.NewMockErrChangeSetEmpty())
 				m.mockServiceForceUpdater.EXPECT().LastUpdatedAt(mockAppName, mockEnvName, mockName).
 					Return(mockBeforeTime, nil)

--- a/internal/pkg/cli/env_init.go
+++ b/internal/pkg/cli/env_init.go
@@ -204,7 +204,7 @@ func newInitEnvOpts(vars initEnvVars) (*initEnvOpts, error) {
 		initEnvVars:  vars,
 		sessProvider: sessProvider,
 		store:        store,
-		appDeployer:  deploycfn.New(defaultSession),
+		appDeployer:  deploycfn.New(defaultSession, deploycfn.WithProgressTracker(os.Stderr)),
 		identity:     identity.New(defaultSession),
 		prog:         termprogress.NewSpinner(log.DiagnosticWriter),
 		prompt:       prompter,
@@ -214,7 +214,7 @@ func newInitEnvOpts(vars initEnvVars) (*initEnvOpts, error) {
 			Prompt:  prompter,
 		},
 		selApp:         selector.NewAppEnvSelector(prompt.New(), store),
-		appCFN:         deploycfn.New(defaultSession),
+		appCFN:         deploycfn.New(defaultSession, deploycfn.WithProgressTracker(os.Stderr)),
 		manifestWriter: ws,
 
 		wsAppName: tryReadingAppName(),
@@ -334,7 +334,7 @@ func (o *initEnvOpts) initRuntimeClients() {
 		o.envIdentity = identity.New(o.sess)
 	}
 	if o.envDeployer == nil {
-		o.envDeployer = deploycfn.New(o.sess)
+		o.envDeployer = deploycfn.New(o.sess, deploycfn.WithProgressTracker(os.Stderr))
 	}
 	if o.cfn == nil {
 		o.cfn = cloudformation.New(o.sess)
@@ -711,7 +711,7 @@ func (o *initEnvOpts) deployEnv(app *config.Application) error {
 	if err := o.cleanUpDanglingRoles(o.appName, o.name); err != nil {
 		return err
 	}
-	if err := o.envDeployer.CreateAndRenderEnvironment(os.Stderr, deployEnvInput); err != nil {
+	if err := o.envDeployer.CreateAndRenderEnvironment(deployEnvInput); err != nil {
 		var existsErr *cloudformation.ErrStackAlreadyExists
 		if errors.As(err, &existsErr) {
 			// Do nothing if the stack already exists.

--- a/internal/pkg/cli/env_init_test.go
+++ b/internal/pkg/cli/env_init_test.go
@@ -1037,7 +1037,7 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 				)
 				m.cfn.EXPECT().Exists("phonetool-test").Return(false, nil)
 				m.deployer.EXPECT().AddEnvToApp(gomock.Any()).Return(nil)
-				m.deployer.EXPECT().CreateAndRenderEnvironment(gomock.Any(), gomock.Any()).Return(errors.New("some deploy error"))
+				m.deployer.EXPECT().CreateAndRenderEnvironment(gomock.Any()).Return(errors.New("some deploy error"))
 				m.appCFN.EXPECT().GetAppResourcesByRegion(&config.Application{Name: "phonetool"}, "us-west-2").
 					Return(&stack.AppRegionalResources{
 						S3Bucket: "mockBucket",
@@ -1059,7 +1059,7 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 				m.cfn.EXPECT().Exists("phonetool-test").Return(false, nil)
 				m.progress.EXPECT().Start(fmt.Sprintf(fmtAddEnvToAppStart, "1234", "us-west-2", "phonetool"))
 				m.progress.EXPECT().Stop(log.Ssuccessf(fmtAddEnvToAppComplete, "1234", "us-west-2", "phonetool"))
-				m.deployer.EXPECT().CreateAndRenderEnvironment(gomock.Any(), gomock.Any()).Return(nil)
+				m.deployer.EXPECT().CreateAndRenderEnvironment(gomock.Any()).Return(nil)
 				m.deployer.EXPECT().GetEnvironment("phonetool", "test").Return(&config.Environment{
 					App:       "phonetool",
 					Name:      "test",
@@ -1092,7 +1092,7 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 				m.cfn.EXPECT().Exists("phonetool-test").Return(false, nil)
 				m.progress.EXPECT().Start(fmt.Sprintf(fmtAddEnvToAppStart, "1234", "us-west-2", "phonetool"))
 				m.progress.EXPECT().Stop(log.Ssuccessf(fmtAddEnvToAppComplete, "1234", "us-west-2", "phonetool"))
-				m.deployer.EXPECT().CreateAndRenderEnvironment(gomock.Any(), gomock.Any()).Return(nil)
+				m.deployer.EXPECT().CreateAndRenderEnvironment(gomock.Any()).Return(nil)
 				m.deployer.EXPECT().GetEnvironment("phonetool", "test").Return(&config.Environment{
 					AccountID: "1234",
 					Region:    "mars-1",
@@ -1125,7 +1125,7 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 				m.cfn.EXPECT().Exists("phonetool-test").Return(false, nil)
 				m.progress.EXPECT().Start(fmt.Sprintf(fmtAddEnvToAppStart, "1234", "us-west-2", "phonetool"))
 				m.progress.EXPECT().Stop(log.Ssuccessf(fmtAddEnvToAppComplete, "1234", "us-west-2", "phonetool"))
-				m.deployer.EXPECT().CreateAndRenderEnvironment(gomock.Any(), gomock.Any()).Return(nil)
+				m.deployer.EXPECT().CreateAndRenderEnvironment(gomock.Any()).Return(nil)
 				m.deployer.EXPECT().GetEnvironment("phonetool", "test").Return(&config.Environment{
 					AccountID: "1234",
 					Region:    "mars-1",
@@ -1156,7 +1156,7 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 				m.cfn.EXPECT().Exists("phonetool-test").Return(true, nil)
 				m.progress.EXPECT().Start(fmt.Sprintf(fmtAddEnvToAppStart, "1234", "us-west-2", "phonetool"))
 				m.progress.EXPECT().Stop(log.Ssuccessf(fmtAddEnvToAppComplete, "1234", "us-west-2", "phonetool"))
-				m.deployer.EXPECT().CreateAndRenderEnvironment(gomock.Any(), &deploy.CreateEnvironmentInput{
+				m.deployer.EXPECT().CreateAndRenderEnvironment(&deploy.CreateEnvironmentInput{
 					Name: "test",
 					App: deploy.AppInformation{
 						Name:                "phonetool",
@@ -1211,7 +1211,7 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 				m.progress.EXPECT().Start(fmt.Sprintf(fmtAddEnvToAppStart, "4567", "us-west-2", "phonetool"))
 				m.progress.EXPECT().Stop(log.Ssuccessf(fmtAddEnvToAppComplete, "4567", "us-west-2", "phonetool"))
 				m.deployer.EXPECT().DelegateDNSPermissions(gomock.Any(), "4567").Return(nil)
-				m.deployer.EXPECT().CreateAndRenderEnvironment(gomock.Any(), gomock.Any()).Return(nil)
+				m.deployer.EXPECT().CreateAndRenderEnvironment(gomock.Any()).Return(nil)
 				m.deployer.EXPECT().GetEnvironment("phonetool", "test").Return(&config.Environment{
 					AccountID: "4567",
 					Region:    "us-west-2",

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -29,7 +29,6 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/manifest"
 	"github.com/aws/copilot-cli/internal/pkg/repository"
 	"github.com/aws/copilot-cli/internal/pkg/task"
-	termprogress "github.com/aws/copilot-cli/internal/pkg/term/progress"
 	"github.com/aws/copilot-cli/internal/pkg/term/prompt"
 	"github.com/aws/copilot-cli/internal/pkg/term/selector"
 	"github.com/aws/copilot-cli/internal/pkg/workspace"
@@ -332,7 +331,7 @@ type bucketEmptier interface {
 
 // Interfaces for deploying resources through CloudFormation. Facilitates mocking.
 type environmentDeployer interface {
-	CreateAndRenderEnvironment(out termprogress.FileWriter, env *deploy.CreateEnvironmentInput) error
+	CreateAndRenderEnvironment(env *deploy.CreateEnvironmentInput) error
 	DeleteEnvironment(appName, envName, cfnExecRoleARN string) error
 	GetEnvironment(appName, envName string) (*config.Environment, error)
 	EnvironmentTemplate(appName, envName string) (string, error)
@@ -380,7 +379,7 @@ type appResourcesGetter interface {
 }
 
 type taskDeployer interface {
-	DeployTask(out termprogress.FileWriter, input *deploy.CreateTaskResourcesInput, opts ...awscloudformation.StackOption) error
+	DeployTask(input *deploy.CreateTaskResourcesInput, opts ...awscloudformation.StackOption) error
 }
 
 type taskStackManager interface {

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -30,7 +30,6 @@ import (
 	manifest "github.com/aws/copilot-cli/internal/pkg/manifest"
 	repository "github.com/aws/copilot-cli/internal/pkg/repository"
 	task "github.com/aws/copilot-cli/internal/pkg/task"
-	progress "github.com/aws/copilot-cli/internal/pkg/term/progress"
 	prompt "github.com/aws/copilot-cli/internal/pkg/term/prompt"
 	selector "github.com/aws/copilot-cli/internal/pkg/term/selector"
 	workspace "github.com/aws/copilot-cli/internal/pkg/workspace"
@@ -3288,17 +3287,17 @@ func (m *MockenvironmentDeployer) EXPECT() *MockenvironmentDeployerMockRecorder 
 }
 
 // CreateAndRenderEnvironment mocks base method.
-func (m *MockenvironmentDeployer) CreateAndRenderEnvironment(out progress.FileWriter, env *deploy0.CreateEnvironmentInput) error {
+func (m *MockenvironmentDeployer) CreateAndRenderEnvironment(env *deploy0.CreateEnvironmentInput) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateAndRenderEnvironment", out, env)
+	ret := m.ctrl.Call(m, "CreateAndRenderEnvironment", env)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreateAndRenderEnvironment indicates an expected call of CreateAndRenderEnvironment.
-func (mr *MockenvironmentDeployerMockRecorder) CreateAndRenderEnvironment(out, env interface{}) *gomock.Call {
+func (mr *MockenvironmentDeployerMockRecorder) CreateAndRenderEnvironment(env interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAndRenderEnvironment", reflect.TypeOf((*MockenvironmentDeployer)(nil).CreateAndRenderEnvironment), out, env)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAndRenderEnvironment", reflect.TypeOf((*MockenvironmentDeployer)(nil).CreateAndRenderEnvironment), env)
 }
 
 // DeleteEnvironment mocks base method.
@@ -3815,9 +3814,9 @@ func (m *MocktaskDeployer) EXPECT() *MocktaskDeployerMockRecorder {
 }
 
 // DeployTask mocks base method.
-func (m *MocktaskDeployer) DeployTask(out progress.FileWriter, input *deploy0.CreateTaskResourcesInput, opts ...cloudformation.StackOption) error {
+func (m *MocktaskDeployer) DeployTask(input *deploy0.CreateTaskResourcesInput, opts ...cloudformation.StackOption) error {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{out, input}
+	varargs := []interface{}{input}
 	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
@@ -3827,9 +3826,9 @@ func (m *MocktaskDeployer) DeployTask(out progress.FileWriter, input *deploy0.Cr
 }
 
 // DeployTask indicates an expected call of DeployTask.
-func (mr *MocktaskDeployerMockRecorder) DeployTask(out, input interface{}, opts ...interface{}) *gomock.Call {
+func (mr *MocktaskDeployerMockRecorder) DeployTask(input interface{}, opts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{out, input}, opts...)
+	varargs := append([]interface{}{input}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeployTask", reflect.TypeOf((*MocktaskDeployer)(nil).DeployTask), varargs...)
 }
 
@@ -4055,17 +4054,17 @@ func (mr *MockdeployerMockRecorder) AddServiceToApp(app, svcName interface{}) *g
 }
 
 // CreateAndRenderEnvironment mocks base method.
-func (m *Mockdeployer) CreateAndRenderEnvironment(out progress.FileWriter, env *deploy0.CreateEnvironmentInput) error {
+func (m *Mockdeployer) CreateAndRenderEnvironment(env *deploy0.CreateEnvironmentInput) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateAndRenderEnvironment", out, env)
+	ret := m.ctrl.Call(m, "CreateAndRenderEnvironment", env)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreateAndRenderEnvironment indicates an expected call of CreateAndRenderEnvironment.
-func (mr *MockdeployerMockRecorder) CreateAndRenderEnvironment(out, env interface{}) *gomock.Call {
+func (mr *MockdeployerMockRecorder) CreateAndRenderEnvironment(env interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAndRenderEnvironment", reflect.TypeOf((*Mockdeployer)(nil).CreateAndRenderEnvironment), out, env)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAndRenderEnvironment", reflect.TypeOf((*Mockdeployer)(nil).CreateAndRenderEnvironment), env)
 }
 
 // CreatePipeline mocks base method.

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -196,7 +196,7 @@ func newTaskRunOpts(vars runTaskVars) (*runTaskOpts, error) {
 		if err != nil {
 			return fmt.Errorf("configure task runner: %w", err)
 		}
-		opts.deployer = cloudformation.New(opts.sess)
+		opts.deployer = cloudformation.New(opts.sess, cloudformation.WithProgressTracker(os.Stderr))
 		opts.defaultClusterGetter = awsecs.New(opts.sess)
 		opts.publicIPGetter = ec2.New(opts.sess)
 		return nil
@@ -942,7 +942,7 @@ func (o *runTaskOpts) deploy() error {
 		Env:                   o.env,
 		AdditionalTags:        o.resourceTags,
 	}
-	return o.deployer.DeployTask(os.Stderr, input, deployOpts...)
+	return o.deployer.DeployTask(input, deployOpts...)
 }
 
 func (o *runTaskOpts) validateAppName() error {

--- a/internal/pkg/cli/task_run_test.go
+++ b/internal/pkg/cli/task_run_test.go
@@ -764,7 +764,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 				m.provider.EXPECT().Default().Return(&session.Session{}, nil)
 				m.store.EXPECT().GetEnvironment(gomock.Any(), gomock.Any()).AnyTimes()
 				m.defaultClusterGetter.EXPECT().HasDefaultCluster().Return(true, nil)
-				m.deployer.EXPECT().DeployTask(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+				m.deployer.EXPECT().DeployTask(gomock.Any()).Return(nil).AnyTimes()
 				mockRepositoryAnytime(m)
 				m.runner.EXPECT().Run().AnyTimes()
 			},
@@ -779,7 +779,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 						ExecutionRoleARN: "env execution role",
 					}, nil)
 				m.provider.EXPECT().FromRole(gomock.Any(), gomock.Any())
-				m.deployer.EXPECT().DeployTask(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+				m.deployer.EXPECT().DeployTask(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 				mockRepositoryAnytime(m)
 				m.runner.EXPECT().Run().AnyTimes()
 			},
@@ -788,7 +788,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 			setupMocks: func(m runTaskMocks) {
 				m.provider.EXPECT().Default().Return(&session.Session{}, nil)
 				m.store.EXPECT().GetEnvironment(gomock.Any(), gomock.Any()).AnyTimes()
-				m.deployer.EXPECT().DeployTask(gomock.Any(), &deploy.CreateTaskResourcesInput{
+				m.deployer.EXPECT().DeployTask(&deploy.CreateTaskResourcesInput{
 					Name:       inGroupName,
 					Image:      "",
 					Command:    []string{},
@@ -802,7 +802,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 			setupMocks: func(m runTaskMocks) {
 				m.provider.EXPECT().Default().Return(&session.Session{}, nil)
 				m.store.EXPECT().GetEnvironment(gomock.Any(), gomock.Any()).AnyTimes()
-				m.deployer.EXPECT().DeployTask(gomock.Any(), &deploy.CreateTaskResourcesInput{
+				m.deployer.EXPECT().DeployTask(&deploy.CreateTaskResourcesInput{
 					Name:       inGroupName,
 					Image:      "",
 					Command:    []string{},
@@ -818,7 +818,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 			setupMocks: func(m runTaskMocks) {
 				m.provider.EXPECT().Default().Return(&session.Session{}, nil)
 				m.store.EXPECT().GetEnvironment(gomock.Any(), gomock.Any()).AnyTimes()
-				m.deployer.EXPECT().DeployTask(gomock.Any(), &deploy.CreateTaskResourcesInput{
+				m.deployer.EXPECT().DeployTask(&deploy.CreateTaskResourcesInput{
 					Name:       inGroupName,
 					Image:      "",
 					Command:    []string{},
@@ -826,7 +826,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 				}).Return(nil)
 				m.repository.EXPECT().BuildAndPush(gomock.Any(), gomock.Eq(&defaultBuildArguments))
 				m.repository.EXPECT().URI().Return(mockRepoURI, nil)
-				m.deployer.EXPECT().DeployTask(gomock.Any(), &deploy.CreateTaskResourcesInput{
+				m.deployer.EXPECT().DeployTask(&deploy.CreateTaskResourcesInput{
 					Name:       inGroupName,
 					Image:      "uri/repo:latest",
 					Command:    []string{},
@@ -840,7 +840,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 			setupMocks: func(m runTaskMocks) {
 				m.provider.EXPECT().Default().Return(&session.Session{}, nil)
 				m.store.EXPECT().GetEnvironment(gomock.Any(), gomock.Any()).AnyTimes()
-				m.deployer.EXPECT().DeployTask(gomock.Any(), gomock.Any()).Return(nil).Times(2)
+				m.deployer.EXPECT().DeployTask(gomock.Any()).Return(nil).Times(2)
 				mockRepositoryAnytime(m)
 				m.runner.EXPECT().Run().Return(nil, errors.New("error running"))
 				mockHasDefaultCluster(m)
@@ -855,7 +855,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 						ExecutionRoleARN: "env execution role",
 					}, nil)
 				m.provider.EXPECT().FromRole(gomock.Any(), gomock.Any())
-				m.deployer.EXPECT().DeployTask(gomock.Any(), gomock.Any(), gomock.Len(1)).AnyTimes() // NOTE: matching length because gomock is unable to match function arguments.
+				m.deployer.EXPECT().DeployTask(gomock.Any(), gomock.Len(1)).AnyTimes() // NOTE: matching length because gomock is unable to match function arguments.
 				mockRepositoryAnytime(m)
 				m.runner.EXPECT().Run().AnyTimes()
 				m.defaultClusterGetter.EXPECT().HasDefaultCluster().Times(0)
@@ -865,7 +865,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 			setupMocks: func(m runTaskMocks) {
 				m.provider.EXPECT().Default().Return(&session.Session{}, nil)
 				m.store.EXPECT().GetEnvironment(gomock.Any(), gomock.Any()).Times(0)
-				m.deployer.EXPECT().DeployTask(gomock.Any(), gomock.Any(), gomock.Len(0)).AnyTimes() // NOTE: matching length because gomock is unable to match function arguments.
+				m.deployer.EXPECT().DeployTask(gomock.Any(), gomock.Len(0)).AnyTimes() // NOTE: matching length because gomock is unable to match function arguments.
 				mockRepositoryAnytime(m)
 				m.runner.EXPECT().Run().AnyTimes()
 				mockHasDefaultCluster(m)
@@ -876,7 +876,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 			setupMocks: func(m runTaskMocks) {
 				m.provider.EXPECT().Default().Return(&session.Session{}, nil)
 				m.store.EXPECT().GetEnvironment(gomock.Any(), gomock.Any()).AnyTimes()
-				m.deployer.EXPECT().DeployTask(gomock.Any(), gomock.Any()).AnyTimes()
+				m.deployer.EXPECT().DeployTask(gomock.Any()).AnyTimes()
 				m.repository.EXPECT().BuildAndPush(gomock.Any(), gomock.Eq(
 					&dockerengine.BuildArguments{
 						Context: filepath.Dir(defaultDockerfilePath),
@@ -893,7 +893,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 			setupMocks: func(m runTaskMocks) {
 				m.provider.EXPECT().Default().Return(&session.Session{}, nil)
 				m.store.EXPECT().GetEnvironment(gomock.Any(), gomock.Any()).AnyTimes()
-				m.deployer.EXPECT().DeployTask(gomock.Any(), gomock.Any()).AnyTimes()
+				m.deployer.EXPECT().DeployTask(gomock.Any()).AnyTimes()
 				m.repository.EXPECT().BuildAndPush(gomock.Any(), gomock.Eq(
 					&dockerengine.BuildArguments{
 						Context: "../../other",
@@ -911,7 +911,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 			setupMocks: func(m runTaskMocks) {
 				m.provider.EXPECT().Default().Return(&session.Session{}, nil)
 				m.store.EXPECT().GetEnvironment(gomock.Any(), gomock.Any()).AnyTimes()
-				m.deployer.EXPECT().DeployTask(gomock.Any(), &deploy.CreateTaskResourcesInput{
+				m.deployer.EXPECT().DeployTask(&deploy.CreateTaskResourcesInput{
 					Name:       inGroupName,
 					Image:      "",
 					Command:    []string{"/bin/sh", "-c", "curl $ECS_CONTAINER_METADATA_URI_V4"},
@@ -919,7 +919,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 				}).Times(1).Return(nil)
 				m.repository.EXPECT().BuildAndPush(gomock.Any(), gomock.Eq(&defaultBuildArguments))
 				m.repository.EXPECT().URI().Return(mockRepoURI, nil)
-				m.deployer.EXPECT().DeployTask(gomock.Any(), &deploy.CreateTaskResourcesInput{
+				m.deployer.EXPECT().DeployTask(&deploy.CreateTaskResourcesInput{
 					Name:       inGroupName,
 					Image:      "uri/repo:latest",
 					Command:    []string{"/bin/sh", "-c", "curl $ECS_CONTAINER_METADATA_URI_V4"},
@@ -932,7 +932,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 		"fail to get ENI information for some tasks": {
 			setupMocks: func(m runTaskMocks) {
 				m.provider.EXPECT().Default().Return(&session.Session{}, nil)
-				m.deployer.EXPECT().DeployTask(gomock.Any(), gomock.Any()).AnyTimes()
+				m.deployer.EXPECT().DeployTask(gomock.Any()).AnyTimes()
 				m.runner.EXPECT().Run().Return([]*task.Task{
 					{
 						TaskARN: "task-1",
@@ -953,7 +953,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 		"fail to get public ips": {
 			setupMocks: func(m runTaskMocks) {
 				m.provider.EXPECT().Default().Return(&session.Session{}, nil)
-				m.deployer.EXPECT().DeployTask(gomock.Any(), gomock.Any()).AnyTimes()
+				m.deployer.EXPECT().DeployTask(gomock.Any()).AnyTimes()
 				m.runner.EXPECT().Run().Return([]*task.Task{
 					{
 						TaskARN: "task-1",
@@ -971,7 +971,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 			inImage:  "image",
 			setupMocks: func(m runTaskMocks) {
 				m.provider.EXPECT().Default().Return(&session.Session{}, nil)
-				m.deployer.EXPECT().DeployTask(gomock.Any(), gomock.Any()).AnyTimes()
+				m.deployer.EXPECT().DeployTask(gomock.Any()).AnyTimes()
 				m.runner.EXPECT().Run().Return([]*task.Task{
 					{
 						TaskARN: "task-1",

--- a/internal/pkg/deploy/cloudformation/cloudformation_test.go
+++ b/internal/pkg/deploy/cloudformation/cloudformation_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/aws/cloudformation"
 	"github.com/aws/copilot-cli/internal/pkg/aws/ecs"
 	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation/mocks"
-	"github.com/aws/copilot-cli/internal/pkg/term/progress"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 )
@@ -28,24 +27,28 @@ type mockFileWriter struct {
 
 func (m mockFileWriter) Fd() uintptr { return 0 }
 
-func testDeployWorkload_OnPushToS3Failure(t *testing.T, when func(w progress.FileWriter, cf CloudFormation) error) {
+func testDeployWorkload_OnPushToS3Failure(t *testing.T, when func(cf CloudFormation) error) {
 	// GIVEN
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	wantedErr := errors.New("some error")
 	mS3Client := mocks.NewMocks3Client(ctrl)
 	mS3Client.EXPECT().Upload("mockBucket", gomock.Any(), gomock.Any()).Return("", wantedErr)
-	client := CloudFormation{s3Client: mS3Client}
+
 	buf := new(strings.Builder)
+	client := CloudFormation{
+		s3Client: mS3Client,
+		console:  mockFileWriter{Writer: buf},
+	}
 
 	// WHEN
-	err := when(mockFileWriter{Writer: buf}, client)
+	err := when(client)
 
 	// THEN
 	require.True(t, errors.Is(err, wantedErr), `expected returned error to be wrapped with "some error"`)
 }
 
-func testDeployWorkload_OnCreateChangeSetFailure(t *testing.T, when func(w progress.FileWriter, cf CloudFormation) error) {
+func testDeployWorkload_OnCreateChangeSetFailure(t *testing.T, when func(cf CloudFormation) error) {
 	// GIVEN
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -55,17 +58,17 @@ func testDeployWorkload_OnCreateChangeSetFailure(t *testing.T, when func(w progr
 	m := mocks.NewMockcfnClient(ctrl)
 	m.EXPECT().Create(gomock.Any()).Return("", wantedErr)
 	m.EXPECT().ErrorEvents(gomock.Any()).Return(nil, nil)
-	client := CloudFormation{cfnClient: m, s3Client: mS3Client}
 	buf := new(strings.Builder)
+	client := CloudFormation{cfnClient: m, s3Client: mS3Client, console: mockFileWriter{Writer: buf}}
 
 	// WHEN
-	err := when(mockFileWriter{Writer: buf}, client)
+	err := when(client)
 
 	// THEN
 	require.True(t, errors.Is(err, wantedErr), `expected returned error to be wrapped with "some error"`)
 }
 
-func testDeployWorkload_OnUpdateChangeSetFailure(t *testing.T, when func(w progress.FileWriter, cf CloudFormation) error) {
+func testDeployWorkload_OnUpdateChangeSetFailure(t *testing.T, when func(cf CloudFormation) error) {
 	// GIVEN
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -76,17 +79,17 @@ func testDeployWorkload_OnUpdateChangeSetFailure(t *testing.T, when func(w progr
 	m.EXPECT().Create(gomock.Any()).Return("", &cloudformation.ErrStackAlreadyExists{})
 	m.EXPECT().Update(gomock.Any()).Return("", wantedErr)
 	m.EXPECT().ErrorEvents(gomock.Any()).Return(nil, nil)
-	client := CloudFormation{cfnClient: m, s3Client: mS3Client}
 	buf := new(strings.Builder)
+	client := CloudFormation{cfnClient: m, s3Client: mS3Client, console: mockFileWriter{Writer: buf}}
 
 	// WHEN
-	err := when(mockFileWriter{Writer: buf}, client)
+	err := when(client)
 
 	// THEN
 	require.True(t, errors.Is(err, wantedErr), `expected returned error to be wrapped with "some error"`)
 }
 
-func testDeployWorkload_OnDescribeChangeSetFailure(t *testing.T, when func(w progress.FileWriter, cf CloudFormation) error) {
+func testDeployWorkload_OnDescribeChangeSetFailure(t *testing.T, when func(cf CloudFormation) error) {
 	// GIVEN
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -95,17 +98,17 @@ func testDeployWorkload_OnDescribeChangeSetFailure(t *testing.T, when func(w pro
 	m := mocks.NewMockcfnClient(ctrl)
 	m.EXPECT().Create(gomock.Any()).Return("1234", nil)
 	m.EXPECT().DescribeChangeSet(gomock.Any(), gomock.Any()).Return(nil, errors.New("DescribeChangeSet error"))
-	client := CloudFormation{cfnClient: m, s3Client: mS3Client}
 	buf := new(strings.Builder)
+	client := CloudFormation{cfnClient: m, s3Client: mS3Client, console: mockFileWriter{Writer: buf}}
 
 	// WHEN
-	err := when(mockFileWriter{Writer: buf}, client)
+	err := when(client)
 
 	// THEN
 	require.EqualError(t, err, "DescribeChangeSet error")
 }
 
-func testDeployWorkload_OnTemplateBodyFailure(t *testing.T, when func(w progress.FileWriter, cf CloudFormation) error) {
+func testDeployWorkload_OnTemplateBodyFailure(t *testing.T, when func(cf CloudFormation) error) {
 	// GIVEN
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -115,17 +118,17 @@ func testDeployWorkload_OnTemplateBodyFailure(t *testing.T, when func(w progress
 	m.EXPECT().Create(gomock.Any()).Return("1234", nil)
 	m.EXPECT().DescribeChangeSet(gomock.Any(), gomock.Any()).Return(&cloudformation.ChangeSetDescription{}, nil)
 	m.EXPECT().TemplateBodyFromChangeSet(gomock.Any(), gomock.Any()).Return("", errors.New("TemplateBody error"))
-	client := CloudFormation{cfnClient: m, s3Client: mS3Client}
 	buf := new(strings.Builder)
+	client := CloudFormation{cfnClient: m, s3Client: mS3Client, console: mockFileWriter{Writer: buf}}
 
 	// WHEN
-	err := when(mockFileWriter{Writer: buf}, client)
+	err := when(client)
 
 	// THEN
 	require.EqualError(t, err, "TemplateBody error")
 }
 
-func testDeployWorkload_StackStreamerFailureShouldCancelRenderer(t *testing.T, when func(w progress.FileWriter, cf CloudFormation) error) {
+func testDeployWorkload_StackStreamerFailureShouldCancelRenderer(t *testing.T, when func(cf CloudFormation) error) {
 	// GIVEN
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -137,17 +140,17 @@ func testDeployWorkload_StackStreamerFailureShouldCancelRenderer(t *testing.T, w
 	m.EXPECT().DescribeChangeSet(gomock.Any(), gomock.Any()).Return(&cloudformation.ChangeSetDescription{}, nil)
 	m.EXPECT().TemplateBodyFromChangeSet(gomock.Any(), gomock.Any()).Return("", nil)
 	m.EXPECT().DescribeStackEvents(gomock.Any()).Return(nil, wantedErr)
-	client := CloudFormation{cfnClient: m, s3Client: mS3Client}
 	buf := new(strings.Builder)
+	client := CloudFormation{cfnClient: m, s3Client: mS3Client, console: mockFileWriter{Writer: buf}}
 
 	// WHEN
-	err := when(mockFileWriter{Writer: buf}, client)
+	err := when(client)
 
 	// THEN
 	require.True(t, errors.Is(err, wantedErr), "expected streamer error to be wrapped and returned")
 }
 
-func testDeployWorkload_StreamUntilStackCreationFails(t *testing.T, stackName string, when func(w progress.FileWriter, cf CloudFormation) error) {
+func testDeployWorkload_StreamUntilStackCreationFails(t *testing.T, stackName string, when func(cf CloudFormation) error) {
 	// GIVEN
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -171,17 +174,17 @@ func testDeployWorkload_StreamUntilStackCreationFails(t *testing.T, stackName st
 	m.EXPECT().Describe(stackName).Return(&cloudformation.StackDescription{
 		StackStatus: aws.String("CREATE_FAILED"),
 	}, nil)
-	client := CloudFormation{cfnClient: m, s3Client: mS3Client}
 	buf := new(strings.Builder)
+	client := CloudFormation{cfnClient: m, s3Client: mS3Client, console: mockFileWriter{Writer: buf}}
 
 	// WHEN
-	err := when(mockFileWriter{Writer: buf}, client)
+	err := when(client)
 
 	// THEN
 	require.EqualError(t, err, fmt.Sprintf("stack %s did not complete successfully and exited with status CREATE_FAILED", stackName))
 }
 
-func testDeployWorkload_RenderNewlyCreatedStackWithECSService(t *testing.T, stackName string, when func(w progress.FileWriter, cf CloudFormation) error) {
+func testDeployWorkload_RenderNewlyCreatedStackWithECSService(t *testing.T, stackName string, when func(cf CloudFormation) error) {
 	// GIVEN
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -251,11 +254,11 @@ Resources:
 	mockCFN.EXPECT().Describe(stackName).Return(&cloudformation.StackDescription{
 		StackStatus: aws.String("CREATE_COMPLETE"),
 	}, nil)
-	client := CloudFormation{cfnClient: mockCFN, ecsClient: mockECS, s3Client: mS3Client}
 	buf := new(strings.Builder)
+	client := CloudFormation{cfnClient: mockCFN, ecsClient: mockECS, s3Client: mS3Client, console: mockFileWriter{Writer: buf}}
 
 	// WHEN
-	err := when(mockFileWriter{Writer: buf}, client)
+	err := when(client)
 
 	// THEN
 	require.NoError(t, err)
@@ -264,7 +267,7 @@ Resources:
 	require.Contains(t, buf.String(), "[completed]", "Rollout state of service should be rendered")
 }
 
-func testDeployWorkload_WithEnvControllerRenderer_NoStackUpdates(t *testing.T, svcStackName string, when func(w progress.FileWriter, cf CloudFormation) error) {
+func testDeployWorkload_WithEnvControllerRenderer_NoStackUpdates(t *testing.T, svcStackName string, when func(cf CloudFormation) error) {
 	// GIVEN
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -331,18 +334,18 @@ Resources:
 	mockCFN.EXPECT().Describe(svcStackName).Return(&cloudformation.StackDescription{
 		StackStatus: aws.String("CREATE_COMPLETE"),
 	}, nil)
-	client := CloudFormation{cfnClient: mockCFN, s3Client: mS3Client}
 	buf := new(strings.Builder)
+	client := CloudFormation{cfnClient: mockCFN, s3Client: mS3Client, console: mockFileWriter{Writer: buf}}
 
 	// WHEN
-	err := when(mockFileWriter{Writer: buf}, client)
+	err := when(client)
 
 	// THEN
 	require.NoError(t, err)
 	require.Contains(t, buf.String(), "Updating environment", "env stack description is rendered")
 }
 
-func testDeployWorkload_RenderNewlyCreatedStackWithAddons(t *testing.T, stackName string, when func(w progress.FileWriter, cf CloudFormation) error) {
+func testDeployWorkload_RenderNewlyCreatedStackWithAddons(t *testing.T, stackName string, when func(cf CloudFormation) error) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	m := mocks.NewMockcfnClient(ctrl)
@@ -452,11 +455,11 @@ Resources:
 			},
 		},
 	}, nil).AnyTimes()
-	client := CloudFormation{cfnClient: m, s3Client: mS3Client}
 	buf := new(strings.Builder)
+	client := CloudFormation{cfnClient: m, s3Client: mS3Client, console: mockFileWriter{Writer: buf}}
 
 	// WHEN
-	err := when(mockFileWriter{Writer: buf}, client)
+	err := when(client)
 
 	// THEN
 	require.NoError(t, err)
@@ -465,7 +468,7 @@ Resources:
 	require.Contains(t, buf.String(), "A DynamoDB table to store data")
 }
 
-func testDeployTask_OnCreateChangeSetFailure(t *testing.T, when func(w progress.FileWriter, cf CloudFormation) error) {
+func testDeployTask_OnCreateChangeSetFailure(t *testing.T, when func(cf CloudFormation) error) {
 	// GIVEN
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -473,17 +476,17 @@ func testDeployTask_OnCreateChangeSetFailure(t *testing.T, when func(w progress.
 	m := mocks.NewMockcfnClient(ctrl)
 	m.EXPECT().Create(gomock.Any()).Return("", wantedErr)
 	m.EXPECT().ErrorEvents(gomock.Any()).Return(nil, nil)
-	client := CloudFormation{cfnClient: m}
 	buf := new(strings.Builder)
+	client := CloudFormation{cfnClient: m, console: mockFileWriter{Writer: buf}}
 
 	// WHEN
-	err := when(mockFileWriter{Writer: buf}, client)
+	err := when(client)
 
 	// THEN
 	require.True(t, errors.Is(err, wantedErr), `expected returned error to be wrapped with "some error"`)
 }
 
-func testDeployTask_ReturnNilOnEmptyChangeSetWhileUpdatingStack(t *testing.T, when func(w progress.FileWriter, cf CloudFormation) error) {
+func testDeployTask_ReturnNilOnEmptyChangeSetWhileUpdatingStack(t *testing.T, when func(cf CloudFormation) error) {
 	// GIVEN
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -492,17 +495,17 @@ func testDeployTask_ReturnNilOnEmptyChangeSetWhileUpdatingStack(t *testing.T, wh
 	m.EXPECT().Create(gomock.Any()).Return("", &cloudformation.ErrStackAlreadyExists{})
 	m.EXPECT().Update(gomock.Any()).Return("", wantedErr)
 	m.EXPECT().ErrorEvents(gomock.Any()).Return(nil, nil)
-	client := CloudFormation{cfnClient: m}
 	buf := new(strings.Builder)
+	client := CloudFormation{cfnClient: m, console: mockFileWriter{Writer: buf}}
 
 	// WHEN
-	err := when(mockFileWriter{Writer: buf}, client)
+	err := when(client)
 
 	// THEN
 	require.Nil(t, err, "should not fail if the changeset is empty")
 }
 
-func testDeployTask_OnUpdateChangeSetFailure(t *testing.T, when func(w progress.FileWriter, cf CloudFormation) error) {
+func testDeployTask_OnUpdateChangeSetFailure(t *testing.T, when func(cf CloudFormation) error) {
 	// GIVEN
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -511,34 +514,34 @@ func testDeployTask_OnUpdateChangeSetFailure(t *testing.T, when func(w progress.
 	m.EXPECT().Create(gomock.Any()).Return("", &cloudformation.ErrStackAlreadyExists{})
 	m.EXPECT().Update(gomock.Any()).Return("", wantedErr)
 	m.EXPECT().ErrorEvents(gomock.Any()).Return(nil, nil)
-	client := CloudFormation{cfnClient: m}
 	buf := new(strings.Builder)
+	client := CloudFormation{cfnClient: m, console: mockFileWriter{Writer: buf}}
 
 	// WHEN
-	err := when(mockFileWriter{Writer: buf}, client)
+	err := when(client)
 
 	// THEN
 	require.True(t, errors.Is(err, wantedErr), `expected returned error to be wrapped with "some error"`)
 }
 
-func testDeployTask_OnDescribeChangeSetFailure(t *testing.T, when func(w progress.FileWriter, cf CloudFormation) error) {
+func testDeployTask_OnDescribeChangeSetFailure(t *testing.T, when func(cf CloudFormation) error) {
 	// GIVEN
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	m := mocks.NewMockcfnClient(ctrl)
 	m.EXPECT().Create(gomock.Any()).Return("1234", nil)
 	m.EXPECT().DescribeChangeSet(gomock.Any(), gomock.Any()).Return(nil, errors.New("DescribeChangeSet error"))
-	client := CloudFormation{cfnClient: m}
 	buf := new(strings.Builder)
+	client := CloudFormation{cfnClient: m, console: mockFileWriter{Writer: buf}}
 
 	// WHEN
-	err := when(mockFileWriter{Writer: buf}, client)
+	err := when(client)
 
 	// THEN
 	require.EqualError(t, err, "DescribeChangeSet error")
 }
 
-func testDeployTask_OnTemplateBodyFailure(t *testing.T, when func(w progress.FileWriter, cf CloudFormation) error) {
+func testDeployTask_OnTemplateBodyFailure(t *testing.T, when func(cf CloudFormation) error) {
 	// GIVEN
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -546,17 +549,17 @@ func testDeployTask_OnTemplateBodyFailure(t *testing.T, when func(w progress.Fil
 	m.EXPECT().Create(gomock.Any()).Return("1234", nil)
 	m.EXPECT().DescribeChangeSet(gomock.Any(), gomock.Any()).Return(&cloudformation.ChangeSetDescription{}, nil)
 	m.EXPECT().TemplateBodyFromChangeSet(gomock.Any(), gomock.Any()).Return("", errors.New("TemplateBody error"))
-	client := CloudFormation{cfnClient: m}
 	buf := new(strings.Builder)
+	client := CloudFormation{cfnClient: m, console: mockFileWriter{Writer: buf}}
 
 	// WHEN
-	err := when(mockFileWriter{Writer: buf}, client)
+	err := when(client)
 
 	// THEN
 	require.EqualError(t, err, "TemplateBody error")
 }
 
-func testDeployTask_StackStreamerFailureShouldCancelRenderer(t *testing.T, when func(w progress.FileWriter, cf CloudFormation) error) {
+func testDeployTask_StackStreamerFailureShouldCancelRenderer(t *testing.T, when func(cf CloudFormation) error) {
 	// GIVEN
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -566,17 +569,17 @@ func testDeployTask_StackStreamerFailureShouldCancelRenderer(t *testing.T, when 
 	m.EXPECT().DescribeChangeSet(gomock.Any(), gomock.Any()).Return(&cloudformation.ChangeSetDescription{}, nil)
 	m.EXPECT().TemplateBodyFromChangeSet(gomock.Any(), gomock.Any()).Return("", nil)
 	m.EXPECT().DescribeStackEvents(gomock.Any()).Return(nil, wantedErr)
-	client := CloudFormation{cfnClient: m}
 	buf := new(strings.Builder)
+	client := CloudFormation{cfnClient: m, console: mockFileWriter{Writer: buf}}
 
 	// WHEN
-	err := when(mockFileWriter{Writer: buf}, client)
+	err := when(client)
 
 	// THEN
 	require.True(t, errors.Is(err, wantedErr), "expected streamer error to be wrapped and returned")
 }
 
-func testDeployTask_StreamUntilStackCreationFails(t *testing.T, stackName string, when func(w progress.FileWriter, cf CloudFormation) error) {
+func testDeployTask_StreamUntilStackCreationFails(t *testing.T, stackName string, when func(cf CloudFormation) error) {
 	// GIVEN
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -598,17 +601,17 @@ func testDeployTask_StreamUntilStackCreationFails(t *testing.T, stackName string
 	m.EXPECT().Describe(stackName).Return(&cloudformation.StackDescription{
 		StackStatus: aws.String("CREATE_FAILED"),
 	}, nil)
-	client := CloudFormation{cfnClient: m}
 	buf := new(strings.Builder)
+	client := CloudFormation{cfnClient: m, console: mockFileWriter{Writer: buf}}
 
 	// WHEN
-	err := when(mockFileWriter{Writer: buf}, client)
+	err := when(client)
 
 	// THEN
 	require.EqualError(t, err, fmt.Sprintf("stack %s did not complete successfully and exited with status CREATE_FAILED", stackName))
 }
 
-func testDeployTask_RenderNewlyCreatedStackWithAddons(t *testing.T, stackName string, when func(w progress.FileWriter, cf CloudFormation) error) {
+func testDeployTask_RenderNewlyCreatedStackWithAddons(t *testing.T, stackName string, when func(cf CloudFormation) error) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	m := mocks.NewMockcfnClient(ctrl)
@@ -716,11 +719,11 @@ Resources:
 			},
 		},
 	}, nil).AnyTimes()
-	client := CloudFormation{cfnClient: m}
 	buf := new(strings.Builder)
+	client := CloudFormation{cfnClient: m, console: mockFileWriter{Writer: buf}}
 
 	// WHEN
-	err := when(mockFileWriter{Writer: buf}, client)
+	err := when(client)
 
 	// THEN
 	require.NoError(t, err)

--- a/internal/pkg/deploy/cloudformation/task.go
+++ b/internal/pkg/deploy/cloudformation/task.go
@@ -10,8 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/copilot-cli/internal/pkg/aws/cloudformation"
 	"github.com/aws/copilot-cli/internal/pkg/deploy"
-	"github.com/aws/copilot-cli/internal/pkg/term/progress"
-
 	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation/stack"
 )
 
@@ -19,7 +17,7 @@ import (
 // If the task stack doesn't exist, then it creates the stack.
 // If the task stack already exists, it updates the stack.
 // If the task stack doesn't have any changes, it returns nil
-func (cf CloudFormation) DeployTask(out progress.FileWriter, input *deploy.CreateTaskResourcesInput, opts ...cloudformation.StackOption) error {
+func (cf CloudFormation) DeployTask(input *deploy.CreateTaskResourcesInput, opts ...cloudformation.StackOption) error {
 	conf := stack.NewTaskStackConfig(input)
 	stack, err := toStack(conf)
 	if err != nil {
@@ -29,7 +27,7 @@ func (cf CloudFormation) DeployTask(out progress.FileWriter, input *deploy.Creat
 		opt(stack)
 	}
 
-	if err := cf.renderStackChanges(cf.newRenderWorkloadInput(out, stack)); err != nil {
+	if err := cf.renderStackChanges(cf.newRenderWorkloadInput(cf.console, stack)); err != nil {
 		var errChangeSetEmpty *cloudformation.ErrChangeSetEmpty
 		if !errors.As(err, &errChangeSetEmpty) {
 			return err

--- a/internal/pkg/deploy/cloudformation/task_test.go
+++ b/internal/pkg/deploy/cloudformation/task_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	awscfn "github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/copilot-cli/internal/pkg/deploy"
-	"github.com/aws/copilot-cli/internal/pkg/term/progress"
 
 	"github.com/aws/copilot-cli/internal/pkg/aws/cloudformation"
 	"github.com/stretchr/testify/require"
@@ -23,8 +22,8 @@ func TestCloudFormation_DeployTask(t *testing.T) {
 	mockTask := &deploy.CreateTaskResourcesInput{
 		Name: "hello",
 	}
-	when := func(w progress.FileWriter, cf CloudFormation) error {
-		return cf.DeployTask(w, mockTask)
+	when := func(cf CloudFormation) error {
+		return cf.DeployTask(mockTask)
 	}
 
 	t.Run("returns a wrapped error if creating a change set fails", func(t *testing.T) {

--- a/internal/pkg/deploy/cloudformation/workload.go
+++ b/internal/pkg/deploy/cloudformation/workload.go
@@ -10,13 +10,12 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/aws/cloudformation"
 	"github.com/aws/copilot-cli/internal/pkg/deploy"
 	"github.com/aws/copilot-cli/internal/pkg/template/artifactpath"
-	"github.com/aws/copilot-cli/internal/pkg/term/progress"
 )
 
 // DeployService deploys a service stack and renders progress updates to out until the deployment is done.
 // If the service stack doesn't exist, then it creates the stack.
 // If the service stack already exists, it updates the stack.
-func (cf CloudFormation) DeployService(out progress.FileWriter, conf StackConfiguration, bucketName string, opts ...cloudformation.StackOption) error {
+func (cf CloudFormation) DeployService(conf StackConfiguration, bucketName string, opts ...cloudformation.StackOption) error {
 	templateURL, err := cf.uploadStackTemplateToS3(bucketName, conf)
 	if err != nil {
 		return err
@@ -28,7 +27,7 @@ func (cf CloudFormation) DeployService(out progress.FileWriter, conf StackConfig
 	for _, opt := range opts {
 		opt(stack)
 	}
-	return cf.renderStackChanges(cf.newRenderWorkloadInput(out, stack))
+	return cf.renderStackChanges(cf.newRenderWorkloadInput(cf.console, stack))
 }
 
 type uploadableStack interface {

--- a/internal/pkg/deploy/cloudformation/workload_test.go
+++ b/internal/pkg/deploy/cloudformation/workload_test.go
@@ -10,7 +10,6 @@ import (
 	sdkcloudformation "github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/copilot-cli/internal/pkg/deploy"
 	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation/mocks"
-	"github.com/aws/copilot-cli/internal/pkg/term/progress"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 )
@@ -67,8 +66,8 @@ func TestCloudFormation_DeployService(t *testing.T) {
 			"app": "myapp",
 		},
 	}
-	when := func(w progress.FileWriter, cf CloudFormation) error {
-		return cf.DeployService(w, serviceConfig, "mockBucket")
+	when := func(cf CloudFormation) error {
+		return cf.DeployService(serviceConfig, "mockBucket")
 	}
 
 	t.Run("returns a wrapped error if pushing to s3 bucket fails", func(t *testing.T) {


### PR DESCRIPTION
Previously, each method in the `deploy/cloudformation` pkg took `os.Stderr` as a parameter to render events. 

This refactor moves the parameter to a struct field instead, and makes the progress tracker optional by defaulting to a `discardFile` as the target file for progress events.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
