### PR TITLE
chore: package addons `Fn::Transform`

### DIFF
--- a/internal/pkg/addon/package.go
+++ b/internal/pkg/addon/package.go
@@ -241,7 +241,7 @@ func (a *Addons) packageTransforms(nodes ...yaml.Node) error {
 
 				obj, err := a.uploadAddonAsset(loc.Value, false)
 				if err != nil {
-					return fmt.Errorf("upload asset %q: %w", loc.Value, err)
+					return fmt.Errorf("upload asset: %w", err)
 				}
 
 				loc.Value = s3.Location(obj.Bucket, obj.Key)

--- a/internal/pkg/addon/package_test.go
+++ b/internal/pkg/addon/package_test.go
@@ -215,7 +215,7 @@ Resources:
     Properties:
       Fn::Transform:
         # test comment uno
-        Name: AWS::Include
+        Name: "AWS::Include"
         Parameters:
           # test comment dos
           Location: ./lambda/index.js
@@ -235,7 +235,7 @@ Resources:
     Properties:
       Fn::Transform:
         # test comment uno
-        Name: AWS::Include
+        Name: "AWS::Include"
         Parameters:
           # test comment dos
           Location: s3://mockBucket/asdf

--- a/internal/pkg/addon/package_test.go
+++ b/internal/pkg/addon/package_test.go
@@ -214,8 +214,10 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Fn::Transform:
-        Name: "AWS::Include"
+        # test comment uno
+        Name: AWS::Include
         Parameters:
+          # test comment dos
           Location: ./lambda/index.js
       Code: lambda
       Handler: "index.handler"
@@ -232,8 +234,10 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Fn::Transform:
-        Name: "AWS::Include"
+        # test comment uno
+        Name: AWS::Include
         Parameters:
+          # test comment dos
           Location: s3://mockBucket/asdf
       Code:
         S3Bucket: mockBucket

--- a/internal/pkg/addon/package_test.go
+++ b/internal/pkg/addon/package_test.go
@@ -292,9 +292,9 @@ Resources:
             Location: s3://mockBucket/asdf
 `,
 		},
-		"Fn::Transform example from https://medium.com/swlh/using-the-cloudformation-aws-include-macro-9e3056cf75b0": {
+		"Fn::Transform ignores top level Transform": {
+			// example from https://medium.com/swlh/using-the-cloudformation-aws-include-macro-9e3056cf75b0
 			setupMocks: func(m addonMocks) {
-				// m.uploader.EXPECT().Upload(bucket, lambdaZipS3Path, gomock.Any()).Return(s3.URL("us-west-2", "chris.hare", "alb-cw-mapping.yaml"), nil)
 				m.uploader.EXPECT().Upload(bucket, indexFileS3Path, gomock.Any()).Return(s3.URL("us-west-2", "chris.hare", "common-tags.yaml"), nil)
 			},
 			inTemplate: `

--- a/internal/pkg/aws/s3/s3.go
+++ b/internal/pkg/aws/s3/s3.go
@@ -160,7 +160,7 @@ func ParseURL(url string) (bucket string, key string, err error) {
 	// <bucket>.s3-<region>.amazonaws.com and <bucket>.s3.<region>.amazonaws.com
 	split := strings.Split(parsedURL[0], ".")
 	bucketEndIdx := len(split) - 1
-	for ; bucketEndIdx >= 0; bucketEndIdx-- {
+	for ; bucketEndIdx > 0; bucketEndIdx-- {
 		if strings.HasPrefix(split[bucketEndIdx], "s3") {
 			break
 		}

--- a/internal/pkg/aws/s3/s3.go
+++ b/internal/pkg/aws/s3/s3.go
@@ -153,8 +153,20 @@ func ParseURL(url string) (bucket string, key string, err error) {
 	if len(parsedURL) != 2 {
 		return "", "", fmt.Errorf("cannot parse S3 URL %s into bucket name and key", url)
 	}
-	bucket, key = strings.Split(parsedURL[0], ".")[0], parsedURL[1]
-	return
+
+	// go through the host backwards and find the first piece that
+	// starts with 's3' - the rest of the host (to the left of 's3')
+	// is the bucket name. this is to support both URL host formats:
+	// <bucket>.s3-<region>.amazonaws.com and <bucket>.s3.<region>.amazonaws.com
+	split := strings.Split(parsedURL[0], ".")
+	bucketEndIdx := len(split) - 1
+	for ; bucketEndIdx >= 0; bucketEndIdx-- {
+		if strings.HasPrefix(split[bucketEndIdx], "s3") {
+			break
+		}
+	}
+
+	return strings.Join(split[:bucketEndIdx], "."), parsedURL[1], nil
 }
 
 // URL returns a virtual-hosted–style S3 url for the object stored at key in a bucket created in the specified region.

--- a/internal/pkg/aws/s3/s3_test.go
+++ b/internal/pkg/aws/s3/s3_test.go
@@ -392,6 +392,11 @@ func TestS3_ParseURL(t *testing.T) {
 			wantedBucketName: "stackset-myapp-infrastru-pipelinebuiltartifactbuc-1nk5t9zkymh8r",
 			wantedKey:        "scripts/dns-cert-validator/dd2278811c3",
 		},
+		"success with dots": {
+			inURL:            "https://bucket.with.dots.in.name.s3-us-west-2.amazonaws.com/scripts/dns-cert-validator/dd2278811c3",
+			wantedBucketName: "bucket.with.dots.in.name",
+			wantedKey:        "scripts/dns-cert-validator/dd2278811c3",
+		},
 	}
 
 	for name, tc := range testCases {
@@ -402,8 +407,8 @@ func TestS3_ParseURL(t *testing.T) {
 				require.EqualError(t, gotErr, tc.wantError.Error())
 			} else {
 				require.Equal(t, gotErr, nil)
-				require.Equal(t, gotBucketName, tc.wantedBucketName)
-				require.Equal(t, gotKey, tc.wantedKey)
+				require.Equal(t, tc.wantedBucketName, gotBucketName)
+				require.Equal(t, tc.wantedKey, gotKey)
 			}
 		})
 	}

--- a/internal/pkg/aws/s3/s3_test.go
+++ b/internal/pkg/aws/s3/s3_test.go
@@ -393,6 +393,11 @@ func TestS3_ParseURL(t *testing.T) {
 			wantedKey:        "scripts/dns-cert-validator/dd2278811c3",
 		},
 		"success with dots": {
+			inURL:            "https://bucket.with.dots.in.name.s3.us-west-2.amazonaws.com/scripts/dns-cert-validator/dd2278811c3",
+			wantedBucketName: "bucket.with.dots.in.name",
+			wantedKey:        "scripts/dns-cert-validator/dd2278811c3",
+		},
+		"success with dots legacy URL": {
 			inURL:            "https://bucket.with.dots.in.name.s3-us-west-2.amazonaws.com/scripts/dns-cert-validator/dd2278811c3",
 			wantedBucketName: "bucket.with.dots.in.name",
 			wantedKey:        "scripts/dns-cert-validator/dd2278811c3",


### PR DESCRIPTION
This adds support for packaging the `Location` parameter on a [`Fn::Transform`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-transform.html) that uses the [`AWS::Include`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/create-reusable-transform-function-snippets-and-add-to-your-template-with-aws-include-transform.html) macro.

This also fixes a small bug in `s3.ParseURL()` where we don't correctly parse bucket names with `.`'s in it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
