### PR TITLE
chore: show URI after workload deploy and fix backward compatibility

### DIFF
--- a/internal/pkg/cli/job_deploy.go
+++ b/internal/pkg/cli/job_deploy.go
@@ -43,11 +43,11 @@ type deployJobOpts struct {
 	sel                  wsSelector
 
 	// cached variables
-	targetApp       *config.Application
-	targetEnv       *config.Environment
-	envSess         *session.Session
-	appliedManifest manifest.DynamicWorkload
-	rootUserARN     string
+	targetApp         *config.Application
+	targetEnv         *config.Environment
+	envSess           *session.Session
+	appliedDynamicMft manifest.DynamicWorkload
+	rootUserARN       string
 }
 
 func newJobDeployOpts(vars deployWkldVars) (*deployJobOpts, error) {
@@ -86,7 +86,7 @@ func newJobDeployer(o *deployJobOpts) (workloadDeployer, error) {
 	if err != nil {
 		return nil, fmt.Errorf("read manifest file for %s: %w", o.name, err)
 	}
-	content := o.appliedManifest.Manifest()
+	content := o.appliedDynamicMft.Manifest()
 	in := deploy.WorkloadDeployerInput{
 		SessionProvider: o.sessProvider,
 		Name:            o.name,
@@ -157,7 +157,7 @@ func (o *deployJobOpts) Execute() error {
 	if err != nil {
 		return err
 	}
-	o.appliedManifest = mft
+	o.appliedDynamicMft = mft
 	if err := validateWorkloadManifestCompatibilityWithEnv(o.ws, o.envFeaturesDescriber, mft, o.envName); err != nil {
 		return err
 	}

--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -62,13 +62,13 @@ type deploySvcOpts struct {
 	prompt  prompter
 
 	// cached variables
-	targetApp       *config.Application
-	targetEnv       *config.Environment
-	envSess         *session.Session
-	svcType         string
-	appliedManifest manifest.DynamicWorkload
-	rootUserARN     string
-	deployRecs      clideploy.ActionRecommender
+	targetApp         *config.Application
+	targetEnv         *config.Environment
+	envSess           *session.Session
+	svcType           string
+	appliedDynamicMft manifest.DynamicWorkload
+	rootUserARN       string
+	deployRecs        clideploy.ActionRecommender
 }
 
 func newSvcDeployOpts(vars deployWkldVars) (*deploySvcOpts, error) {
@@ -115,7 +115,7 @@ func newSvcDeployer(o *deploySvcOpts) (workloadDeployer, error) {
 	if err != nil {
 		return nil, fmt.Errorf("read manifest file for %s: %w", o.name, err)
 	}
-	content := o.appliedManifest.Manifest()
+	content := o.appliedDynamicMft.Manifest()
 	var deployer workloadDeployer
 	in := clideploy.WorkloadDeployerInput{
 		SessionProvider:   o.sessProvider,
@@ -194,7 +194,7 @@ func (o *deploySvcOpts) Execute() error {
 	if err != nil {
 		return err
 	}
-	o.appliedManifest = mft
+	o.appliedDynamicMft = mft
 	if err := validateWorkloadManifestCompatibilityWithEnv(o.ws, o.envFeaturesDescriber, mft, o.envName); err != nil {
 		return err
 	}
@@ -431,7 +431,7 @@ func (o *deploySvcOpts) uriRecommendedActions() ([]string, error) {
 	type reachable interface {
 		Port() (uint16, bool)
 	}
-	mft, ok := o.appliedManifest.(reachable)
+	mft, ok := o.appliedDynamicMft.Manifest().(reachable)
 	if !ok {
 		return nil, nil
 	}
@@ -465,7 +465,7 @@ func (o *deploySvcOpts) publishRecommendedActions() []string {
 	type publisher interface {
 		Publish() []manifest.Topic
 	}
-	mft, ok := o.appliedManifest.(publisher)
+	mft, ok := o.appliedDynamicMft.Manifest().(publisher)
 	if !ok {
 		return nil
 	}

--- a/internal/pkg/cli/svc_package.go
+++ b/internal/pkg/cli/svc_package.go
@@ -66,11 +66,11 @@ type packageSvcOpts struct {
 	envFeaturesDescriber versionCompatibilityChecker
 
 	// cached variables
-	targetApp       *config.Application
-	targetEnv       *config.Environment
-	envSess         *session.Session
-	appliedManifest manifest.DynamicWorkload
-	rootUserARN     string
+	targetApp         *config.Application
+	targetEnv         *config.Environment
+	envSess           *session.Session
+	appliedDynamicMft manifest.DynamicWorkload
+	rootUserARN       string
 }
 
 func newPackageSvcOpts(vars packageSvcVars) (*packageSvcOpts, error) {
@@ -119,7 +119,7 @@ func newWorkloadStackGenerator(o *packageSvcOpts) (workloadStackGenerator, error
 		return nil, fmt.Errorf("read manifest file for %s: %w", o.name, err)
 	}
 
-	content := o.appliedManifest.Manifest()
+	content := o.appliedDynamicMft.Manifest()
 	var deployer workloadStackGenerator
 	in := clideploy.WorkloadDeployerInput{
 		SessionProvider:   o.sessProvider,
@@ -311,7 +311,7 @@ func (o *packageSvcOpts) getStackGenerator(env *config.Environment) (workloadSta
 	if err != nil {
 		return nil, err
 	}
-	o.appliedManifest = mft
+	o.appliedDynamicMft = mft
 	return o.newStackGenerator(o)
 }
 
@@ -419,7 +419,7 @@ func (o *packageSvcOpts) writeAndClose(wc io.WriteCloser, dat string) error {
 
 // RecommendActions suggests recommended actions before the packaged template is used for deployment.
 func (o *packageSvcOpts) RecommendActions() error {
-	return validateWorkloadManifestCompatibilityWithEnv(o.ws, o.envFeaturesDescriber, o.appliedManifest, o.envName)
+	return validateWorkloadManifestCompatibilityWithEnv(o.ws, o.envFeaturesDescriber, o.appliedDynamicMft, o.envName)
 }
 
 func contains(s string, items []string) bool {

--- a/internal/pkg/cli/svc_package_test.go
+++ b/internal/pkg/cli/svc_package_test.go
@@ -342,7 +342,7 @@ func TestPackageSvcOpts_RecommendedActions(t *testing.T) {
 					envName: "mockEnv",
 				},
 				envFeaturesDescriber: m.envFeaturesDescriber,
-				appliedManifest:      m.mft,
+				appliedDynamicMft:    m.mft,
 			}
 			got := opts.RecommendActions()
 			if tc.wantedError != nil {

--- a/internal/pkg/describe/uri.go
+++ b/internal/pkg/describe/uri.go
@@ -230,7 +230,8 @@ func (d *uriDescriber) envDNSName(path string) (accessURI, error) {
 	if err != nil {
 		return accessURI{}, fmt.Errorf("get stack outputs for environment %s: %w", d.env, err)
 	}
-	// Backward compatibility concern since envOutputPublicALBAccessible didn't exist before.
+	// Backward compatibility concern since envOutputPublicALBAccessible didn't exist before,
+	// and public ALB DNS name previously was always accessible until the introduction of envOutputPublicALBAccessible.
 	if accessible, ok := envOutputs[envOutputPublicALBAccessible]; !ok || accessible == "true" {
 		dnsNames = append(dnsNames, envOutputs[d.albCFNOutputName])
 	}

--- a/internal/pkg/describe/uri.go
+++ b/internal/pkg/describe/uri.go
@@ -230,7 +230,8 @@ func (d *uriDescriber) envDNSName(path string) (accessURI, error) {
 	if err != nil {
 		return accessURI{}, fmt.Errorf("get stack outputs for environment %s: %w", d.env, err)
 	}
-	if accessible, ok := envOutputs[envOutputPublicALBAccessible]; ok && accessible == "true" {
+	// Backward compatibility concern since envOutputPublicALBAccessible didn't exist before.
+	if accessible, ok := envOutputs[envOutputPublicALBAccessible]; !ok || accessible == "true" {
 		dnsNames = append(dnsNames, envOutputs[d.albCFNOutputName])
 	}
 	if cfDNS, ok := envOutputs[envOutputCloudFrontDomainName]; ok {

--- a/internal/pkg/describe/uri_test.go
+++ b/internal/pkg/describe/uri_test.go
@@ -138,7 +138,6 @@ func TestLBWebServiceDescriber_URI(t *testing.T) {
 					}, nil),
 					m.envDescriber.EXPECT().Outputs().Return(map[string]string{
 						envOutputPublicLoadBalancerDNSName: testEnvLBDNSName,
-						envOutputPublicALBAccessible:       testALBAccessible,
 					}, nil),
 				)
 			},


### PR DESCRIPTION
<!-- Provide summary of changes -->
Due to the dynamicworkload type, workload deploy temporarily can't show any URL after deployment. Also currently svc show won't show http URL correctly for env lastly deployed by v1.20 customers.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
