### PR TITLE
chore: fix small issues with cloudfront

### DIFF
--- a/internal/pkg/aws/cloudfront/cloudfront.go
+++ b/internal/pkg/aws/cloudfront/cloudfront.go
@@ -1,0 +1,8 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package cloudfront
+
+const (
+	// CertRegion is the only AWS region accepted by CloudFront while attaching certificates to a distribution.
+	CertRegion = "us-east-1"
+)

--- a/internal/pkg/cli/deploy/env.go
+++ b/internal/pkg/cli/deploy/env.go
@@ -23,10 +23,6 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/template"
 )
 
-const (
-	envCloudFrontCertRegion = "us-east-1"
-)
-
 type appResourcesGetter interface {
 	GetAppResourcesByRegion(app *config.Application, region string) (*stack.AppRegionalResources, error)
 }

--- a/internal/pkg/cli/deploy/svc.go
+++ b/internal/pkg/cli/deploy/svc.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ssm"
 
 	"github.com/aws/copilot-cli/internal/pkg/aws/acm"
+	"github.com/aws/copilot-cli/internal/pkg/aws/cloudfront"
 	"github.com/aws/copilot-cli/internal/pkg/aws/identity"
 	"github.com/aws/copilot-cli/internal/pkg/template/artifactpath"
 
@@ -1401,7 +1402,7 @@ func (d *lbWebSvcDeployer) validateALBRuntime() error {
 
 		cdnCert := d.environmentConfig.CDNConfig.Config.Certificate
 		albCertValidator := d.newAliasCertValidator(nil)
-		cfCertValidator := d.newAliasCertValidator(aws.String(manifest.EnvCloudFrontCertRegion))
+		cfCertValidator := d.newAliasCertValidator(aws.String(cloudfront.CertRegion))
 		if err := albCertValidator.ValidateCertAliases(aliases, d.environmentConfig.HTTPConfig.Public.Certificates); err != nil {
 			return fmt.Errorf("validate aliases against the imported public ALB certificate for env %s: %w", d.env.Name, err)
 		}

--- a/internal/pkg/cli/deploy/svc.go
+++ b/internal/pkg/cli/deploy/svc.go
@@ -1401,7 +1401,7 @@ func (d *lbWebSvcDeployer) validateALBRuntime() error {
 
 		cdnCert := d.environmentConfig.CDNConfig.Config.Certificate
 		albCertValidator := d.newAliasCertValidator(nil)
-		cfCertValidator := d.newAliasCertValidator(aws.String(envCloudFrontCertRegion))
+		cfCertValidator := d.newAliasCertValidator(aws.String(manifest.EnvCloudFrontCertRegion))
 		if err := albCertValidator.ValidateCertAliases(aliases, d.environmentConfig.HTTPConfig.Public.Certificates); err != nil {
 			return fmt.Errorf("validate aliases against the imported public ALB certificate for env %s: %w", d.env.Name, err)
 		}

--- a/internal/pkg/cli/env_deploy.go
+++ b/internal/pkg/cli/env_deploy.go
@@ -143,7 +143,7 @@ func (o *deployEnvOpts) Execute() error {
 	if o.isManagedCDNEnabled(mft) {
 		describer, err := o.newEnvDescriber()
 		if err != nil {
-			return fmt.Errorf("new env describer: %w", err)
+			return err
 		}
 		// With managed domain, if the customer isn't using `alias` the A-records are inserted in the service stack as each service domain is unique.
 		// However, when clients enable CloudFront, they would need to update all their existing records to now point to the distribution.

--- a/internal/pkg/cli/env_deploy.go
+++ b/internal/pkg/cli/env_deploy.go
@@ -127,7 +127,7 @@ func (o *deployEnvOpts) Ask() error {
 }
 
 func (o *deployEnvOpts) isManagedCDNEnabled(mft *manifest.Environment) bool {
-	return mft.CDNConfig.CDNEnabled() && mft.HTTPConfig.Public.Certificates == nil && o.targetApp.Domain != ""
+	return mft.CDNEnabled() && mft.HTTPConfig.Public.Certificates == nil && o.targetApp.Domain != ""
 }
 
 // Execute deploys an environment given a manifest.

--- a/internal/pkg/cli/env_deploy.go
+++ b/internal/pkg/cli/env_deploy.go
@@ -126,6 +126,10 @@ func (o *deployEnvOpts) Ask() error {
 	return o.validateOrAskEnvName()
 }
 
+func (o *deployEnvOpts) isManagedCDNEnabled(mft *manifest.Environment) bool {
+	return mft.CDNConfig.CDNEnabled() && mft.HTTPConfig.Public.Certificates == nil && o.targetApp.Domain != ""
+}
+
 // Execute deploys an environment given a manifest.
 func (o *deployEnvOpts) Execute() error {
 	rawMft, err := o.ws.ReadEnvironmentManifest(o.name)
@@ -136,11 +140,14 @@ func (o *deployEnvOpts) Execute() error {
 	if err != nil {
 		return err
 	}
-	if mft.CDNConfig.CDNEnabled() && mft.HTTPConfig.Public.Certificates == nil && o.targetApp.Domain != "" {
+	if o.isManagedCDNEnabled(mft) {
 		describer, err := o.newEnvDescriber()
 		if err != nil {
-			return fmt.Errorf("describe env: %w", err)
+			return fmt.Errorf("new env describer: %w", err)
 		}
+		// With managed domain, if the customer isn't using `alias` the A-records are inserted in the service stack as each service domain is unique.
+		// However, when clients enable CloudFront, they would need to update all their existing records to now point to the distribution.
+		// Hence, we force users to use `alias` and let the records be written in the environment stack instead.
 		if err := describer.ValidateCFServiceDomainAliases(); err != nil {
 			return err
 		}

--- a/internal/pkg/deploy/cloudformation/stack/env.go
+++ b/internal/pkg/deploy/cloudformation/stack/env.go
@@ -357,7 +357,7 @@ func (e *EnvStackConfig) cdnConfig() *template.CDNConfig {
 	if e.in.Mft == nil {
 		return nil
 	}
-	if !e.in.Mft.CDNConfig.CDNEnabled() {
+	if !e.in.Mft.CDNEnabled() {
 		return nil
 	}
 	return &template.CDNConfig{

--- a/internal/pkg/describe/env.go
+++ b/internal/pkg/describe/env.go
@@ -336,7 +336,9 @@ func (d *EnvDescriber) ValidateCFServiceDomainAliases() error {
 	}
 
 	var aliases map[string][]string
-	err = json.Unmarshal([]byte(jsonOutput), &aliases)
+	if jsonOutput != "" {
+		err = json.Unmarshal([]byte(jsonOutput), &aliases)
+	}
 	if err != nil {
 		return fmt.Errorf("unmarshal %q: %w", jsonOutput, err)
 	}

--- a/internal/pkg/describe/env.go
+++ b/internal/pkg/describe/env.go
@@ -338,10 +338,11 @@ func (d *EnvDescriber) ValidateCFServiceDomainAliases() error {
 	var aliases map[string][]string
 	if jsonOutput != "" {
 		err = json.Unmarshal([]byte(jsonOutput), &aliases)
+		if err != nil {
+			return fmt.Errorf("unmarshal %q: %w", jsonOutput, err)
+		}
 	}
-	if err != nil {
-		return fmt.Errorf("unmarshal %q: %w", jsonOutput, err)
-	}
+
 	var lbSvcsWithoutAlias []string
 	for _, service := range services {
 		if _, ok := aliases[service]; !ok {

--- a/internal/pkg/describe/env_test.go
+++ b/internal/pkg/describe/env_test.go
@@ -700,6 +700,20 @@ func TestEnvDescriber_ValidateCFServiceDomainAliases(t *testing.T) {
 			},
 			wantedErr: fmt.Errorf("unmarshal \"mock-invalid-aliases\": invalid character 'm' looking for beginning of value"),
 		},
+		"no alb workloads have aliases parameter": {
+			setupMock: func(m *envDescriberMocks) {
+				mockParams := map[string]string{
+					"AppName":         mockAppName,
+					"EnvironmentName": mockEnvName,
+					"ALBWorkloads":    mockALBWorkloads,
+					"Aliases":         "",
+				}
+				m.stackDescriber.EXPECT().Describe().Return(stack.StackDescription{
+					Parameters: mockParams,
+				}, nil)
+			},
+			wantedErr: fmt.Errorf("services \"svc-1\" and \"svc-2\" must have \"http.alias\" specified when CloudFront is enabled"),
+		},
 		"not all valid services have an alias": {
 			setupMock: func(m *envDescriberMocks) {
 				mockParams := map[string]string{

--- a/internal/pkg/describe/errors.go
+++ b/internal/pkg/describe/errors.go
@@ -28,6 +28,6 @@ type errLBWebSvcsOnCFWithoutAlias struct {
 
 // Error implements the error interface.
 func (err *errLBWebSvcsOnCFWithoutAlias) Error() string {
-	return fmt.Sprintf("%v %v must have %q specified when CloudFront is enabled", english.PluralWord(len(err.services), "service", "services"),
+	return fmt.Sprintf("%s %s must have %q specified when CloudFront is enabled", english.PluralWord(len(err.services), "service", "services"),
 		english.WordSeries(template.QuoteSliceFunc(err.services), "and"), err.aliasField)
 }

--- a/internal/pkg/manifest/env.go
+++ b/internal/pkg/manifest/env.go
@@ -17,9 +17,6 @@ import (
 // EnvironmentManifestType identifies that the type of manifest is environment manifest.
 const EnvironmentManifestType = "Environment"
 
-// EnvCloudFrontCertRegion identifies the region that CloudFront accepts imported certificates.
-const EnvCloudFrontCertRegion = "us-east-1"
-
 var environmentManifestPath = "environment/manifest.yml"
 
 // Error definitions.
@@ -207,11 +204,11 @@ func (cfg *advancedCDNConfig) isEmpty() bool {
 }
 
 // CDNEnabled returns whether a CDN configuration has been enabled in the environment manifest.
-func (cfg *environmentCDNConfig) CDNEnabled() bool {
-	if !cfg.Config.isEmpty() {
+func (cfg *EnvironmentConfig) CDNEnabled() bool {
+	if !cfg.CDNConfig.Config.isEmpty() {
 		return true
 	}
-	return aws.BoolValue(cfg.Enabled)
+	return aws.BoolValue(cfg.CDNConfig.Enabled)
 }
 
 // UnmarshalYAML overrides the default YAML unmarshaling logic for the environmentCDNConfig

--- a/internal/pkg/manifest/env.go
+++ b/internal/pkg/manifest/env.go
@@ -17,6 +17,10 @@ import (
 // EnvironmentManifestType identifies that the type of manifest is environment manifest.
 const EnvironmentManifestType = "Environment"
 
+const (
+	EnvCloudFrontCertRegion = "us-east-1"
+)
+
 var environmentManifestPath = "environment/manifest.yml"
 
 // Error definitions.

--- a/internal/pkg/manifest/env.go
+++ b/internal/pkg/manifest/env.go
@@ -17,9 +17,8 @@ import (
 // EnvironmentManifestType identifies that the type of manifest is environment manifest.
 const EnvironmentManifestType = "Environment"
 
-const (
-	EnvCloudFrontCertRegion = "us-east-1"
-)
+// EnvCloudFrontCertRegion identifies the region that CloudFront accepts imported certificates.
+const EnvCloudFrontCertRegion = "us-east-1"
 
 var environmentManifestPath = "environment/manifest.yml"
 

--- a/internal/pkg/manifest/env_test.go
+++ b/internal/pkg/manifest/env_test.go
@@ -835,32 +835,38 @@ func TestEnvironmentCDNConfig_IsEmpty(t *testing.T) {
 	}
 }
 
-func TestEnvironmentCDNConfig_CDNEnabled(t *testing.T) {
+func TestEnvironmentConfig_CDNEnabled(t *testing.T) {
 	testCases := map[string]struct {
-		in     environmentCDNConfig
+		in     EnvironmentConfig
 		wanted bool
 	}{
 		"enabled via bool": {
-			in: environmentCDNConfig{
-				Enabled: aws.Bool(true),
+			in: EnvironmentConfig{
+				CDNConfig: environmentCDNConfig{
+					Enabled: aws.Bool(true),
+				},
 			},
 			wanted: true,
 		},
 		"enabled via config": {
-			in: environmentCDNConfig{
-				Config: advancedCDNConfig{
-					Certificate: aws.String("arn:aws:acm:us-east-1:1111111:certificate/look-like-a-good-arn"),
+			in: EnvironmentConfig{
+				CDNConfig: environmentCDNConfig{
+					Config: advancedCDNConfig{
+						Certificate: aws.String("arn:aws:acm:us-east-1:1111111:certificate/look-like-a-good-arn"),
+					},
 				},
 			},
 			wanted: true,
 		},
 		"not enabled because empty": {
-			in:     environmentCDNConfig{},
+			in:     EnvironmentConfig{},
 			wanted: false,
 		},
 		"not enabled via bool": {
-			in: environmentCDNConfig{
-				Enabled: aws.Bool(false),
+			in: EnvironmentConfig{
+				CDNConfig: environmentCDNConfig{
+					Enabled: aws.Bool(false),
+				},
 			},
 			wanted: false,
 		},

--- a/internal/pkg/manifest/errors.go
+++ b/internal/pkg/manifest/errors.go
@@ -122,7 +122,7 @@ func (e *errAtLeastOneFieldMustBeSpecified) Error() string {
 type errInvalidCloudFrontRegion struct{}
 
 func (e *errInvalidCloudFrontRegion) Error() string {
-	return fmt.Sprintf(`cdn certificate must belong to region %s`, EnvCloudFrontCertRegion)
+	return fmt.Sprintf(`cdn certificate must be in region %s`, EnvCloudFrontCertRegion)
 }
 
 // RecommendActions returns recommended actions to be taken after the error.

--- a/internal/pkg/manifest/errors.go
+++ b/internal/pkg/manifest/errors.go
@@ -119,6 +119,19 @@ func (e *errAtLeastOneFieldMustBeSpecified) Error() string {
 	return errMsg
 }
 
+type errInvalidCloudFrontRegion struct{}
+
+func (e *errInvalidCloudFrontRegion) Error() string {
+	return fmt.Sprintf(`cdn certificate must belong to region %s`, EnvCloudFrontCertRegion)
+}
+
+// RecommendActions returns recommended actions to be taken after the error.
+func (e *errInvalidCloudFrontRegion) RecommendActions() string {
+	return fmt.Sprintf(`It looks like your CloudFront certificate is in the wrong region. CloudFront only supports certificates in %s.
+We recommend creating a duplicate certificate in the %s region through AWS Certificate Manager.
+More information: https://go.aws/3BMxY4J`, EnvCloudFrontCertRegion, EnvCloudFrontCertRegion)
+}
+
 func quoteStringSlice(in []string) []string {
 	quoted := make([]string, len(in))
 	for idx, str := range in {

--- a/internal/pkg/manifest/errors.go
+++ b/internal/pkg/manifest/errors.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/aws/copilot-cli/internal/pkg/aws/cloudfront"
 	"github.com/aws/copilot-cli/internal/pkg/template"
 	"github.com/dustin/go-humanize/english"
 )
@@ -122,14 +123,14 @@ func (e *errAtLeastOneFieldMustBeSpecified) Error() string {
 type errInvalidCloudFrontRegion struct{}
 
 func (e *errInvalidCloudFrontRegion) Error() string {
-	return fmt.Sprintf(`cdn certificate must be in region %s`, EnvCloudFrontCertRegion)
+	return fmt.Sprintf(`cdn certificate must be in region %s`, cloudfront.CertRegion)
 }
 
 // RecommendActions returns recommended actions to be taken after the error.
 func (e *errInvalidCloudFrontRegion) RecommendActions() string {
 	return fmt.Sprintf(`It looks like your CloudFront certificate is in the wrong region. CloudFront only supports certificates in %s.
 We recommend creating a duplicate certificate in the %s region through AWS Certificate Manager.
-More information: https://go.aws/3BMxY4J`, EnvCloudFrontCertRegion, EnvCloudFrontCertRegion)
+More information: https://go.aws/3BMxY4J`, cloudfront.CertRegion, cloudfront.CertRegion)
 }
 
 func quoteStringSlice(in []string) []string {

--- a/internal/pkg/manifest/validate_env.go
+++ b/internal/pkg/manifest/validate_env.go
@@ -40,7 +40,7 @@ func (e EnvironmentConfig) validate() error {
 		return fmt.Errorf(`validate "security_group": %w`, err)
 	}
 	if err := e.CDNConfig.validate(); err != nil {
-		return fmt.Errorf(`validate "cdn config": %w`, err)
+		return fmt.Errorf(`validate "cdn": %w`, err)
 	}
 	if e.IsIngressRestrictedToCDN() && !e.CDNConfig.CDNEnabled() {
 		return errors.New("CDN must be enabled to limit security group ingress to CloudFront")

--- a/internal/pkg/manifest/validate_env.go
+++ b/internal/pkg/manifest/validate_env.go
@@ -355,7 +355,7 @@ func (cfg advancedCDNConfig) validate() error {
 			return fmt.Errorf(`parse cdn certificate: %w`, err)
 		}
 		if certARN.Region != EnvCloudFrontCertRegion {
-			return fmt.Errorf(`cdn certificate must belong to region %s`, EnvCloudFrontCertRegion)
+			return &errInvalidCloudFrontRegion{}
 		}
 	}
 	return nil

--- a/internal/pkg/manifest/validate_env_test.go
+++ b/internal/pkg/manifest/validate_env_test.go
@@ -738,7 +738,7 @@ func TestCDNConfiguration_validate(t *testing.T) {
 					Certificate: aws.String("arn:aws:acm:us-west-2:1111111:certificate/look-like-a-good-arn"),
 				},
 			},
-			wantedError: errors.New("cdn certificate must belong to region us-east-1"),
+			wantedError: errors.New("cdn certificate must be in region us-east-1"),
 		},
 	}
 	for name, tc := range testCases {


### PR DESCRIPTION
<!-- Provide summary of changes -->
Summary of changes:
- Addresses feedback from @efekarakus on PR #3842 
- Fixes issue where wrong error was given when no aliases are specified when importing certs with cloudfront
- Adds manifest validation for users trying to use a certificate for cloudfront in the wrong region

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
