### PR TITLE
docs: update server side swift guide link

### DIFF
--- a/site/content/community/guides.en.md
+++ b/site/content/community/guides.en.md
@@ -45,7 +45,7 @@ Share your applications, videos, and blog posts with fellow Copilots!
 
 | Repository      | Description                          | Key features |
 | ----------- | ------------------------------------ | ------------ |
-[**Server Side Swift Guides**](https://github.com/swift-server/guides/blob/main/docs/aws-copilot-fargate-vapor-mongo.md) | Server Side Swift on AWS with Fargate, Vapor, and MongoDB Atlas deployed with Copilot | Fargate, Vapor, MongoDB, API Gateway
+[**Server Side Swift Guides**](https://www.swift.org/server/guides/deploying/aws-copilot-fargate-vapor-mongo.html) | Server Side Swift on AWS with Fargate, Vapor, and MongoDB Atlas deployed with Copilot | Fargate, Vapor, MongoDB, API Gateway
 [**github.com/kcearns/fargate-node-example**](https://github.com/kcearns/fargate-node-example) | A sample Node application that includes a pipeline. | Node, pipeline
 [**github.com/efekarakus/day2-with-copilot**](https://github.com/efekarakus/day2-with-copilot) | A REST API coffeeshop application that goes beyond the basics, demoed in the ["Container Day" video](./guides.en.md#videos), above. | `alias`, secrets, DynamoDB, Redis |
 [**github.com/bvtujo/copilot-wordpress**](https://github.com/bvtujo/copilot-wordpress) | A WordPress installation launched by AWS Copilot with step-by-step instructions and options for customization. | [EFS](../docs/developing/storage.en.md#managed-efs), MySQL RDS cluster, autoscaling |

--- a/site/content/community/guides.en.md
+++ b/site/content/community/guides.en.md
@@ -45,6 +45,7 @@ Share your applications, videos, and blog posts with fellow Copilots!
 
 | Repository      | Description                          | Key features |
 | ----------- | ------------------------------------ | ------------ |
+[**Server Side Swift Guides**](https://github.com/swift-server/guides/blob/main/docs/aws-copilot-fargate-vapor-mongo.md) | Server Side Swift on AWS with Fargate, Vapor, and MongoDB Atlas deployed with Copilot | Fargate, Vapor, MongoDB, API Gateway
 [**github.com/kcearns/fargate-node-example**](https://github.com/kcearns/fargate-node-example) | A sample Node application that includes a pipeline. | Node, pipeline
 [**github.com/efekarakus/day2-with-copilot**](https://github.com/efekarakus/day2-with-copilot) | A REST API coffeeshop application that goes beyond the basics, demoed in the ["Container Day" video](./guides.en.md#videos), above. | `alias`, secrets, DynamoDB, Redis |
 [**github.com/bvtujo/copilot-wordpress**](https://github.com/bvtujo/copilot-wordpress) | A WordPress installation launched by AWS Copilot with step-by-step instructions and options for customization. | [EFS](../docs/developing/storage.en.md#managed-efs), MySQL RDS cluster, autoscaling |

--- a/site/content/community/guides.ja.md
+++ b/site/content/community/guides.ja.md
@@ -43,6 +43,7 @@ Copilot な仲間たちとアプリケーションや動画、ブログポスト
 
 | リポジトリ     | 詳細                         | 特徴 |
 | ----------- | ------------------------------------ | ------------ |
+[**Server Side Swift Guides**](https://www.swift.org/server/guides/deploying/aws-copilot-fargate-vapor-mongo.html) | Server Side Swift on AWS with Fargate, Vapor, and MongoDB Atlas deployed with Copilot | Fargate, Vapor, MongoDB, API Gateway
 [**github.com/kcearns/fargate-node-example**](https://github.com/kcearns/fargate-node-example) | A sample Node application that includes a pipeline. | Node, pipeline
 [**github.com/efekarakus/day2-with-copilot**](https://github.com/efekarakus/day2-with-copilot) | A REST API coffeeshop application that goes beyond the basics, demoed in the ["Container Day" video](./guides.en.md#videos), above. | `alias`, secrets, DynamoDB, Redis |
 [**github.com/bvtujo/copilot-wordpress**](https://github.com/bvtujo/copilot-wordpress) | A WordPress installation launched by AWS Copilot with step-by-step instructions and options for customization. | [EFS](../docs/developing/storage.en.md#managed-efs), MySQL RDS cluster, autoscaling |


### PR DESCRIPTION
The link to Server Side Swift guides has changed. I have updated the link in the EN code samples page. I also noticed the JP version of the page was missing the link, so I added it there as well.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
