### PR TITLE
chore: update gitignore to match custom resource location after template refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ node_modules/
 .DS_Store
 site/node_modules/
 site/themes/docsy
-templates/custom-resources/
+internal/pkg/template/templates/custom-resources/


### PR DESCRIPTION
<!-- Provide summary of changes -->
This PR sets the gitignore folder correctly. We refactored template about a year ago but never updated the main 
.gitignore file, I think? Anyway this stops git from trying to add the minified js to the repo after a build.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
