### PR TITLE
chore(render): collapse resource updates on successful deletion

### DIFF
--- a/internal/pkg/deploy/cloudformation/app.go
+++ b/internal/pkg/deploy/cloudformation/app.go
@@ -507,7 +507,7 @@ func (cf CloudFormation) DeleteApp(appName string) error {
 	}
 	spinner.Stop(log.Ssuccessf("Deleted regional resources for application %q\n", appName))
 	stackName := fmt.Sprintf("%s-infrastructure-roles", appName)
-	description := fmt.Sprintf("Deleting application roles stack %s", stackName)
+	description := fmt.Sprintf("Delete application roles stack %s", stackName)
 	return cf.deleteAndRenderStack(stackName, description, func() error {
 		return cf.cfnClient.DeleteAndWait(stackName)
 	})

--- a/internal/pkg/deploy/cloudformation/env.go
+++ b/internal/pkg/deploy/cloudformation/env.go
@@ -75,7 +75,7 @@ func newRenderEnvironmentInput(cfnStack *cloudformation.Stack) *executeAndRender
 // DeleteEnvironment deletes the CloudFormation stack of an environment.
 func (cf CloudFormation) DeleteEnvironment(appName, envName, cfnExecRoleARN string) error {
 	stackName := stack.NameForEnv(appName, envName)
-	description := fmt.Sprintf("Deleting environment stack %s", stackName)
+	description := fmt.Sprintf("Delete environment stack %s", stackName)
 	return cf.deleteAndRenderStack(stackName, description, func() error {
 		return cf.cfnClient.DeleteAndWaitWithRoleARN(stackName, cfnExecRoleARN)
 	})

--- a/internal/pkg/deploy/cloudformation/workload.go
+++ b/internal/pkg/deploy/cloudformation/workload.go
@@ -64,7 +64,7 @@ func (cf CloudFormation) handleStackError(stackName string, err error) error {
 // DeleteWorkload removes the CloudFormation stack of a deployed workload.
 func (cf CloudFormation) DeleteWorkload(in deploy.DeleteWorkloadInput) error {
 	stackName := fmt.Sprintf("%s-%s-%s", in.AppName, in.EnvName, in.Name)
-	description := fmt.Sprintf("Deleting stack %s", stackName)
+	description := fmt.Sprintf("Delete stack %s", stackName)
 	return cf.deleteAndRenderStack(stackName, description, func() error {
 		return cf.cfnClient.DeleteAndWait(stackName)
 	})

--- a/internal/pkg/term/progress/component.go
+++ b/internal/pkg/term/progress/component.go
@@ -24,6 +24,14 @@ func (c *noopComponent) Render(out io.Writer) (numLines int, err error) {
 	return 0, nil
 }
 
+// LineRenderer returns a Renderer that can display a single line of text.
+func LineRenderer(text string, padding int) Renderer {
+	return &singleLineComponent{
+		Text:    text,
+		Padding: padding,
+	}
+}
+
 // singleLineComponent can display a single line of text.
 type singleLineComponent struct {
 	Text    string // Line of text to print.

--- a/internal/pkg/term/progress/render.go
+++ b/internal/pkg/term/progress/render.go
@@ -52,12 +52,12 @@ func Render(ctx context.Context, out FileWriteFlusher, r DynamicRenderer) error 
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-r.Done():
-			if _, err := eraseAndRender(out, r, writtenLines); err != nil {
+			if _, err := EraseAndRender(out, r, writtenLines); err != nil {
 				return err
 			}
 			return nil
 		case <-time.After(renderInterval):
-			nl, err := eraseAndRender(out, r, writtenLines)
+			nl, err := EraseAndRender(out, r, writtenLines)
 			if err != nil {
 				return err
 			}
@@ -66,8 +66,8 @@ func Render(ctx context.Context, out FileWriteFlusher, r DynamicRenderer) error 
 	}
 }
 
-// eraseAndRender erases prevNumLines from out and then renders r.
-func eraseAndRender(out FileWriteFlusher, r Renderer, prevNumLines int) (int, error) {
+// EraseAndRender erases prevNumLines from out and then renders r.
+func EraseAndRender(out FileWriteFlusher, r Renderer, prevNumLines int) (int, error) {
 	cursor.EraseLinesAbove(out, prevNumLines)
 	if err := out.Flush(); err != nil {
 		return 0, err

--- a/internal/pkg/term/progress/render_test.go
+++ b/internal/pkg/term/progress/render_test.go
@@ -87,7 +87,7 @@ func TestRender(t *testing.T) {
 		}
 
 		// WHEN
-		err := Render(ctx, out, r)
+		_, err := Render(ctx, out, r)
 
 		// THEN
 		require.EqualError(t, err, ctx.Err().Error(), "expected the context to be canceled")
@@ -111,10 +111,11 @@ func TestRender(t *testing.T) {
 		}()
 
 		// WHEN
-		err := Render(context.Background(), out, r)
+		nl, err := Render(context.Background(), out, r)
 
 		// THEN
 		require.NoError(t, err)
+		require.Equal(t, 1, nl)
 
 		// We should be doing the following operations in order:
 		// 1. Hide the cursor.

--- a/internal/pkg/term/progress/render_test.go
+++ b/internal/pkg/term/progress/render_test.go
@@ -159,3 +159,29 @@ func TestNestedRenderOptions(t *testing.T) {
 		Padding: 2,
 	}, actual)
 }
+
+func TestEraseAndRender(t *testing.T) {
+	// GIVEN
+	wanted := new(strings.Builder)
+	file := &mockFileWriter{
+		Writer: wanted,
+	}
+	cur := cursor.NewWithWriter(file)
+	for i := 0; i < 10; i++ {
+		cursor.EraseLine(file)
+		cur.Up(1)
+	}
+	cursor.EraseLine(file)
+	wanted.WriteString("hello\n")
+
+	// WHEN
+	actual := new(strings.Builder)
+	nl, err := EraseAndRender(&mockFileWriteFlusher{
+		wrapper: actual,
+	}, &singleLineComponent{Text: "hello"}, 10) // Erase 10 lines, and then write "hello\n"
+
+	// THEN
+	require.NoError(t, err)
+	require.Equal(t, 1, nl, `only hello\n should have been written`)
+	require.Equal(t, wanted.String(), actual.String())
+}


### PR DESCRIPTION
Only display individual progress tracker updates while the stack is being deleted. 
If it's successfully deleted, then collapse all the progress tracker updates into a single line.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
