### PR TITLE
test(integration): retrieve latest tag from a shallow-cloned repo

### DIFF
--- a/.release/buildspec_regression.yml
+++ b/.release/buildspec_regression.yml
@@ -34,10 +34,7 @@ phases:
       - make build-regression
       - |
         if [ -z "$FROM_VERSION" ]; then
-            version_tag=$(git describe --always --tag) # Example: v1.20.0-54-g67546c3b
-            version="${version_tag%%-*}" # Example: v1.20.0
-            minor="${version%.*}" # Remove ".0" from "v1.20.0". The result is "v1.20".
-            FROM_VERSION=$(git tag --list | grep ${minor} | sort -n | tail -1)  # Get the latest patch of "v1.20". Example: "v1.20.2".
+            FROM_VERSION=$(git describe --tags $(git rev-list --tags --max-count=1)) # Latest tag. Example: "v1.20.0".
         fi
       - wget -q https://ecs-cli-v2-release.s3.amazonaws.com/copilot-linux-${FROM_VERSION}
       - chmod +x ./copilot-linux-${FROM_VERSION}


### PR DESCRIPTION
The original way of retrieving the latest tag does not work for a repo that is shallowly-copied (i.e. not full copy). This PR updates the buildspec so that it uses a more robust and cleaner way to do it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
