### PR TITLE
docs: add command page for `env deploy`

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,24 +69,24 @@ nav:
         - app upgrade: docs/commands/app-upgrade.en.md
         - app delete: docs/commands/app-delete.en.md
         - env init: docs/commands/env-init.en.md
-        - env deploy: docs/commands/env-deploy.en.md
         - env package: docs/commands/env-package.en.md
         - env delete: docs/commands/env-delete.en.md
         - job init: docs/commands/job-init.en.md
         - job package: docs/commands/job-package.en.md
-        - job deploy: docs/commands/job-deploy.en.md
         - job delete: docs/commands/job-delete.en.md
         - svc init: docs/commands/svc-init.en.md
         - svc package: docs/commands/svc-package.en.md
-        - svc deploy: docs/commands/svc-deploy.en.md
         - svc delete: docs/commands/svc-delete.en.md
       - Release:
+        - env deploy: docs/commands/env-deploy.en.md
+        - job deploy: docs/commands/job-deploy.en.md
         - pipeline init: docs/commands/pipeline-init.en.md
         - pipeline deploy: docs/commands/pipeline-deploy.en.md
         - pipeline ls: docs/commands/pipeline-ls.en.md
         - pipeline show: docs/commands/pipeline-show.en.md
         - pipeline status: docs/commands/pipeline-status.en.md
         - pipeline delete: docs/commands/pipeline-delete.en.md
+        - svc deploy: docs/commands/svc-deploy.en.md
         - deploy: docs/commands/deploy.en.md
       - Operate:
         - app ls: docs/commands/app-ls.en.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,6 +69,7 @@ nav:
         - app upgrade: docs/commands/app-upgrade.en.md
         - app delete: docs/commands/app-delete.en.md
         - env init: docs/commands/env-init.en.md
+        - env deploy: docs/commands/env-deploy.en.md
         - env package: docs/commands/env-package.en.md
         - env delete: docs/commands/env-delete.en.md
         - job init: docs/commands/job-init.en.md
@@ -117,6 +118,7 @@ nav:
         - completion: docs/commands/completion.en.md
         - docs: docs/commands/docs.en.md
         - env delete: docs/commands/env-delete.en.md
+        - env deploy: docs/commands/env-deploy.en.md
         - env init: docs/commands/env-init.en.md
         - env ls: docs/commands/env-ls.en.md
         - env package: docs/commands/env-package.en.md

--- a/site/content/docs/commands/env-deploy.en.md
+++ b/site/content/docs/commands/env-deploy.en.md
@@ -1,4 +1,4 @@
-# env deploy
+# env deploy <span class="version" > added in [v1.20.0](../../blogs/release-v120.en.md) </span>
 ```console
 $ copilot env deploy
 ```

--- a/site/content/docs/commands/env-deploy.en.md
+++ b/site/content/docs/commands/env-deploy.en.md
@@ -1,0 +1,17 @@
+# env deploy
+```console
+$ copilot env deploy
+```
+
+## What does it do?
+
+`copilot env deploy` takes the configurations in your [environment manifest](../manifest/environment.en.md) and deploys your environment infrastructure.
+
+## What are the flags?
+
+```
+  -a, --app string    Name of the application.
+      --force         Optional. Force update the environment stack template.
+  -h, --help          help for deploy
+  -n, --name string   Name of the environment.
+```

--- a/site/content/stylesheets/extra.css
+++ b/site/content/stylesheets/extra.css
@@ -27,3 +27,9 @@ span.type {
   font-size: .7rem;
   margin-right: 4px;
 }
+
+span.version {
+  color: #8792a2;
+  font-size: .7rem;
+  float: right;
+}


### PR DESCRIPTION
As well as adding a version number beside the title.

<img width="791" alt="Screen Shot 2022-08-10 at 4 54 00 PM" src="https://user-images.githubusercontent.com/79273084/184042555-e228c47c-29bf-4361-aabd-5a90972d6398.png">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.


