### PR TITLE
chore(stackset): split functions to return the opID for streaming

### DIFF
--- a/internal/pkg/aws/cloudformation/stackset/errors.go
+++ b/internal/pkg/aws/cloudformation/stackset/errors.go
@@ -4,7 +4,6 @@
 package stackset
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -32,7 +31,8 @@ func (e *ErrStackSetNotFound) Error() string {
 	return fmt.Sprintf("stack set %q not found", e.name)
 }
 
-func (e *ErrStackSetNotFound) isEmpty() bool {
+// IsEmpty reports whether this error is occurs on an empty cloudformation resource.
+func (e *ErrStackSetNotFound) IsEmpty() bool {
 	return true
 }
 
@@ -46,18 +46,9 @@ func (e *ErrStackSetInstancesNotFound) Error() string {
 	return fmt.Sprintf("stack set %q has no instances", e.name)
 }
 
-func (e *ErrStackSetInstancesNotFound) isEmpty() bool {
+// IsEmpty reports whether this error is occurs on an empty cloudformation resource.
+func (e *ErrStackSetInstancesNotFound) IsEmpty() bool {
 	return true
-}
-
-// IsEmptyStackSetErr returns true if the error occurred because the stack set does not exist or does not contain any instances.
-func IsEmptyStackSetErr(err error) bool {
-	type isEmpty interface {
-		isEmpty() bool
-	}
-
-	var emptyErr isEmpty
-	return errors.As(err, &emptyErr)
 }
 
 // isAlreadyExistingStackSet returns true if the underlying error is a stack already exists error.

--- a/internal/pkg/aws/cloudformation/stackset/errors_test.go
+++ b/internal/pkg/aws/cloudformation/stackset/errors_test.go
@@ -1,0 +1,61 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package stackset
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestErrStackSetOutOfDate_Error(t *testing.T) {
+	err := &ErrStackSetOutOfDate{
+		name:      "demo-infrastructure",
+		parentErr: errors.New("some error"),
+	}
+
+	require.EqualError(t, err, `stack set "demo-infrastructure" update was out of date (feel free to try again): some error`)
+}
+
+func TestErrStackSetNotFound_Error(t *testing.T) {
+	err := &ErrStackSetNotFound{
+		name: "demo-infrastructure",
+	}
+
+	require.EqualError(t, err, `stack set "demo-infrastructure" not found`)
+}
+
+func TestErrStackSetInstancesNotFound_Error(t *testing.T) {
+	err := &ErrStackSetInstancesNotFound{
+		name: "demo-infrastructure",
+	}
+
+	require.EqualError(t, err, `stack set "demo-infrastructure" has no instances`)
+}
+
+func TestIsEmptyStackSetErr(t *testing.T) {
+	testCases := map[string]struct {
+		err    error
+		wanted bool
+	}{
+		"should return true when the error is an ErrStackSetNotFound": {
+			err:    &ErrStackSetNotFound{},
+			wanted: true,
+		},
+		"should return true when the error is an ErrStackSetInstancesNotFound": {
+			err:    &ErrStackSetInstancesNotFound{},
+			wanted: true,
+		},
+		"should return false on any other error": {
+			err: errors.New("some error"),
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.wanted, IsEmptyStackSetErr(tc.err))
+		})
+	}
+}

--- a/internal/pkg/aws/cloudformation/stackset/errors_test.go
+++ b/internal/pkg/aws/cloudformation/stackset/errors_test.go
@@ -34,28 +34,3 @@ func TestErrStackSetInstancesNotFound_Error(t *testing.T) {
 
 	require.EqualError(t, err, `stack set "demo-infrastructure" has no instances`)
 }
-
-func TestIsEmptyStackSetErr(t *testing.T) {
-	testCases := map[string]struct {
-		err    error
-		wanted bool
-	}{
-		"should return true when the error is an ErrStackSetNotFound": {
-			err:    &ErrStackSetNotFound{},
-			wanted: true,
-		},
-		"should return true when the error is an ErrStackSetInstancesNotFound": {
-			err:    &ErrStackSetInstancesNotFound{},
-			wanted: true,
-		},
-		"should return false on any other error": {
-			err: errors.New("some error"),
-		},
-	}
-
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			require.Equal(t, tc.wanted, IsEmptyStackSetErr(tc.err))
-		})
-	}
-}

--- a/internal/pkg/aws/cloudformation/stackset/opstatus.go
+++ b/internal/pkg/aws/cloudformation/stackset/opstatus.go
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package stackset
+
+// OpStatus represents a stack set operation status.
+type OpStatus string
+
+// IsCompleted returns true if the operation is in a final state.
+func (s OpStatus) IsCompleted() bool {
+	return s.IsSuccessful() || s.IsFailure()
+}
+
+// IsSuccessful returns true if the operation is completed successfully.
+func (s OpStatus) IsSuccessful() bool {
+	return s == opStatusSucceeded
+}
+
+// IsFailure returns true if the operation terminated in failure.
+func (s OpStatus) IsFailure() bool {
+	return s == opStatusStopped || s == opStatusFailed
+}

--- a/internal/pkg/aws/cloudformation/stackset/opstatus.go
+++ b/internal/pkg/aws/cloudformation/stackset/opstatus.go
@@ -3,6 +3,14 @@
 
 package stackset
 
+import "github.com/aws/aws-sdk-go/service/cloudformation"
+
+const (
+	opStatusSucceeded = cloudformation.StackSetOperationStatusSucceeded
+	opStatusStopped   = cloudformation.StackSetOperationStatusStopped
+	opStatusFailed    = cloudformation.StackSetOperationStatusFailed
+)
+
 // OpStatus represents a stack set operation status.
 type OpStatus string
 

--- a/internal/pkg/aws/cloudformation/stackset/opstatus_test.go
+++ b/internal/pkg/aws/cloudformation/stackset/opstatus_test.go
@@ -1,0 +1,113 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package stackset
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpStatus_IsCompleted(t *testing.T) {
+	testCases := map[string]struct {
+		status string
+		wanted bool
+	}{
+		"false when queued": {
+			status: cloudformation.StackSetOperationStatusQueued,
+		},
+		"false when running": {
+			status: cloudformation.StackSetOperationStatusRunning,
+		},
+		"false when stopping": {
+			status: cloudformation.StackSetOperationStatusStopping,
+		},
+		"true when succeeded": {
+			status: cloudformation.StackSetOperationStatusSucceeded,
+			wanted: true,
+		},
+		"true when stopped": {
+			status: cloudformation.StackSetOperationStatusStopped,
+			wanted: true,
+		},
+		"true when failed": {
+			status: cloudformation.StackSetOperationStatusFailed,
+			wanted: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.wanted, OpStatus(tc.status).IsCompleted())
+		})
+	}
+}
+
+func TestOpStatus_IsSuccessful(t *testing.T) {
+	testCases := map[string]struct {
+		status string
+		wanted bool
+	}{
+		"false when queued": {
+			status: cloudformation.StackSetOperationStatusQueued,
+		},
+		"false when running": {
+			status: cloudformation.StackSetOperationStatusRunning,
+		},
+		"false when stopping": {
+			status: cloudformation.StackSetOperationStatusStopping,
+		},
+		"true when succeeded": {
+			status: cloudformation.StackSetOperationStatusSucceeded,
+			wanted: true,
+		},
+		"false when stopped": {
+			status: cloudformation.StackSetOperationStatusStopped,
+		},
+		"false when failed": {
+			status: cloudformation.StackSetOperationStatusFailed,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.wanted, OpStatus(tc.status).IsSuccessful())
+		})
+	}
+}
+
+func TestOpStatus_IsFailure(t *testing.T) {
+	testCases := map[string]struct {
+		status string
+		wanted bool
+	}{
+		"false when queued": {
+			status: cloudformation.StackSetOperationStatusQueued,
+		},
+		"false when running": {
+			status: cloudformation.StackSetOperationStatusRunning,
+		},
+		"false when stopping": {
+			status: cloudformation.StackSetOperationStatusStopping,
+		},
+		"true when succeeded": {
+			status: cloudformation.StackSetOperationStatusSucceeded,
+		},
+		"false when stopped": {
+			status: cloudformation.StackSetOperationStatusStopped,
+			wanted: true,
+		},
+		"false when failed": {
+			status: cloudformation.StackSetOperationStatusFailed,
+			wanted: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.wanted, OpStatus(tc.status).IsFailure())
+		})
+	}
+}

--- a/internal/pkg/aws/cloudformation/stackset/opstatus_test.go
+++ b/internal/pkg/aws/cloudformation/stackset/opstatus_test.go
@@ -92,14 +92,14 @@ func TestOpStatus_IsFailure(t *testing.T) {
 		"false when stopping": {
 			status: cloudformation.StackSetOperationStatusStopping,
 		},
-		"true when succeeded": {
+		"false when succeeded": {
 			status: cloudformation.StackSetOperationStatusSucceeded,
 		},
-		"false when stopped": {
+		"true when stopped": {
 			status: cloudformation.StackSetOperationStatusStopped,
 			wanted: true,
 		},
-		"false when failed": {
+		"true when failed": {
 			status: cloudformation.StackSetOperationStatusFailed,
 			wanted: true,
 		},

--- a/internal/pkg/aws/cloudformation/stackset/stackset.go
+++ b/internal/pkg/aws/cloudformation/stackset/stackset.go
@@ -27,12 +27,6 @@ type api interface {
 	ListStackInstances(*cloudformation.ListStackInstancesInput) (*cloudformation.ListStackInstancesOutput, error)
 }
 
-const (
-	opStatusSucceeded = cloudformation.StackSetOperationStatusSucceeded
-	opStatusStopped   = cloudformation.StackSetOperationStatusStopped
-	opStatusFailed    = cloudformation.StackSetOperationStatusFailed
-)
-
 // StackSet represents an AWS CloudFormation client to interact with stack sets.
 type StackSet struct {
 	client api

--- a/internal/pkg/aws/cloudformation/stackset/stackset.go
+++ b/internal/pkg/aws/cloudformation/stackset/stackset.go
@@ -134,7 +134,7 @@ func (ss *StackSet) DeleteAllInstances(name string) (string, error) {
 		}
 	}
 
-	// We want to delete all the stack instances, so we create a set of account ids and regions.
+	// We want to delete all the stack instances, so we create a set of account IDs and regions.
 	uniqueAccounts := make(map[string]bool)
 	uniqueRegions := make(map[string]bool)
 	for _, summary := range summaries {

--- a/internal/pkg/aws/cloudformation/stackset/stackset_test.go
+++ b/internal/pkg/aws/cloudformation/stackset/stackset_test.go
@@ -146,6 +146,67 @@ func TestStackSet_Describe(t *testing.T) {
 	}
 }
 
+func TestStackSet_DescribeOperation(t *testing.T) {
+	const testOpID = "1"
+	testCases := map[string]struct {
+		mockClient func(ctrl *gomock.Controller) api
+
+		wantedOp    Operation
+		wantedError error
+	}{
+		"returns the operation description on successful call": {
+			mockClient: func(ctrl *gomock.Controller) api {
+				m := mocks.NewMockapi(ctrl)
+				m.EXPECT().DescribeStackSetOperation(&cloudformation.DescribeStackSetOperationInput{
+					StackSetName: aws.String(testName),
+					OperationId:  aws.String(testOpID),
+				}).Return(&cloudformation.DescribeStackSetOperationOutput{
+					StackSetOperation: &cloudformation.StackSetOperation{
+						Status:       aws.String(cloudformation.StackSetOperationStatusStopped),
+						StatusReason: aws.String("manually stopped"),
+					},
+				}, nil)
+				return m
+			},
+			wantedOp: Operation{
+				ID:     testOpID,
+				Status: OpStatus(cloudformation.StackSetOperationStatusStopped),
+				Reason: "manually stopped",
+			},
+		},
+		"wraps error on unexpected failure": {
+			mockClient: func(ctrl *gomock.Controller) api {
+				m := mocks.NewMockapi(ctrl)
+				m.EXPECT().DescribeStackSetOperation(gomock.Any()).Return(nil, testError)
+				return m
+			},
+			wantedError: errors.New("describe operation 1 for stack set stackset: some error"),
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// GIVEN
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			client := StackSet{
+				client: tc.mockClient(ctrl),
+			}
+
+			// WHEN
+			op, err := client.DescribeOperation(testName, testOpID)
+
+			// THEN
+			if tc.wantedError != nil {
+				require.EqualError(t, err, tc.wantedError.Error())
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.wantedOp, op)
+			}
+		})
+	}
+}
+
 func TestStackSet_Update(t *testing.T) {
 	const (
 		testTemplate           = "body"
@@ -164,7 +225,9 @@ func TestStackSet_Update(t *testing.T) {
 	)
 
 	testCases := map[string]struct {
-		mockClient  func(ctrl *gomock.Controller) api
+		mockClient func(ctrl *gomock.Controller) api
+
+		wantedOpID  string
 		wantedError error
 	}{
 		"updates stack with operation is valid": {
@@ -191,6 +254,7 @@ func TestStackSet_Update(t *testing.T) {
 				}, nil)
 				return m
 			},
+			wantedOpID: testOperationID,
 		},
 		"returns ErrStackSetOutOfDate if operation exists already": {
 			mockClient: func(ctrl *gomock.Controller) api {
@@ -199,8 +263,8 @@ func TestStackSet_Update(t *testing.T) {
 				return m
 			},
 			wantedError: &ErrStackSetOutOfDate{
-				stackSetName: testName,
-				parentErr:    errOpExists,
+				name:      testName,
+				parentErr: errOpExists,
 			},
 		},
 		"returns ErrStackSetOutOfDate if operation in progress": {
@@ -210,8 +274,8 @@ func TestStackSet_Update(t *testing.T) {
 				return m
 			},
 			wantedError: &ErrStackSetOutOfDate{
-				stackSetName: testName,
-				parentErr:    errOpInProg,
+				name:      testName,
+				parentErr: errOpInProg,
 			},
 		},
 		"returns ErrStackSetOutOfDate if operation is stale": {
@@ -221,8 +285,8 @@ func TestStackSet_Update(t *testing.T) {
 				return m
 			},
 			wantedError: &ErrStackSetOutOfDate{
-				stackSetName: testName,
-				parentErr:    errOpStale,
+				name:      testName,
+				parentErr: errOpStale,
 			},
 		},
 		"wrap error on unexpected failure": {
@@ -245,7 +309,7 @@ func TestStackSet_Update(t *testing.T) {
 			}
 
 			// WHEN
-			err := client.Update(testName, testTemplate,
+			opID, err := client.Update(testName, testTemplate,
 				WithOperationID(testOperationID),
 				WithDescription(testDescription),
 				WithAdministrationRoleARN(testAdministrationRole),
@@ -253,7 +317,12 @@ func TestStackSet_Update(t *testing.T) {
 				WithTags(testTags))
 
 			// THEN
-			require.Equal(t, tc.wantedError, err)
+			if tc.wantedError != nil {
+				require.EqualError(t, err, tc.wantedError.Error())
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.wantedOpID, opID)
+			}
 		})
 	}
 }
@@ -405,74 +474,104 @@ func TestStackSet_WaitForStackSetLastOperationComplete(t *testing.T) {
 	}
 }
 
+func TestStackSet_DeleteAllInstances(t *testing.T) {
+	testCases := map[string]struct {
+		mockClient func(t *testing.T, ctrl *gomock.Controller) api
+
+		wantedOpID  string
+		wantedError error
+	}{
+		"return ErrStackSetNotFound if the stack set does not exist": {
+			mockClient: func(t *testing.T, ctrl *gomock.Controller) api {
+				m := mocks.NewMockapi(ctrl)
+				m.EXPECT().ListStackInstances(gomock.Any()).Return(nil, awserr.New(cloudformation.ErrCodeStackSetNotFoundException, "", nil))
+				return m
+			},
+			wantedError: &ErrStackSetNotFound{name: testName},
+		},
+		"returns ErrStackSetInstancesNotFound if there are no stack set instances": {
+			mockClient: func(t *testing.T, ctrl *gomock.Controller) api {
+				m := mocks.NewMockapi(ctrl)
+				m.EXPECT().ListStackInstances(gomock.Any()).Return(&cloudformation.ListStackInstancesOutput{
+					Summaries: []*cloudformation.StackInstanceSummary{},
+				}, nil)
+				return m
+			},
+			wantedError: &ErrStackSetInstancesNotFound{name: testName},
+		},
+		"successfully deletes stack instances and returns the operation ID": {
+			mockClient: func(t *testing.T, ctrl *gomock.Controller) api {
+				m := mocks.NewMockapi(ctrl)
+				m.EXPECT().ListStackInstances(gomock.Any()).Return(&cloudformation.ListStackInstancesOutput{
+					Summaries: []*cloudformation.StackInstanceSummary{
+						{
+							Account: aws.String("1111"),
+							Region:  aws.String("us-east-1"),
+						},
+						{
+							Account: aws.String("2222"),
+							Region:  aws.String("us-east-1"),
+						},
+						{
+							Account: aws.String("1111"),
+							Region:  aws.String("us-west-2"),
+						},
+					},
+				}, nil)
+				m.EXPECT().DeleteStackInstances(gomock.Any()).
+					DoAndReturn(func(in *cloudformation.DeleteStackInstancesInput) (*cloudformation.DeleteStackInstancesOutput, error) {
+						require.Equal(t, testName, aws.StringValue(in.StackSetName))
+						require.ElementsMatch(t, []string{"1111", "2222"}, aws.StringValueSlice(in.Accounts))
+						require.ElementsMatch(t, []string{"us-east-1", "us-west-2"}, aws.StringValueSlice(in.Regions))
+						require.False(t, aws.BoolValue(in.RetainStacks))
+						return &cloudformation.DeleteStackInstancesOutput{
+							OperationId: aws.String("1"),
+						}, nil
+					})
+				return m
+			},
+			wantedOpID: "1",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// GIVEN
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			client := StackSet{
+				client: tc.mockClient(t, ctrl),
+			}
+
+			// WHEN
+			opID, err := client.DeleteAllInstances(testName)
+
+			// THEN
+			if tc.wantedError != nil {
+				require.EqualError(t, err, tc.wantedError.Error())
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.wantedOpID, opID)
+			}
+		})
+	}
+}
+
 func TestStackSet_Delete(t *testing.T) {
 	testCases := map[string]struct {
 		mockClient  func(ctrl *gomock.Controller) api
 		wantedError error
 	}{
-		"do nothing if stack set does not exist": {
-			mockClient: func(ctrl *gomock.Controller) api {
-				m := mocks.NewMockapi(ctrl)
-				m.EXPECT().ListStackInstances(gomock.Any()).Return(nil, awserr.New(cloudformation.ErrCodeStackSetNotFoundException, "", nil))
-				return m
-			},
-		},
-		"successfully deletes stack instances then stack set": {
-			mockClient: func(ctrl *gomock.Controller) api {
-				m := mocks.NewMockapi(ctrl)
-				m.EXPECT().ListStackInstances(gomock.Any()).Return(&cloudformation.ListStackInstancesOutput{
-					Summaries: []*cloudformation.StackInstanceSummary{
-						{
-							Account: aws.String("1234"),
-							Region:  aws.String("us-east-1"),
-						},
-					},
-				}, nil)
-				m.EXPECT().DeleteStackInstances(&cloudformation.DeleteStackInstancesInput{
-					StackSetName: aws.String(testName),
-					Accounts:     aws.StringSlice([]string{"1234"}),
-					Regions:      aws.StringSlice([]string{"us-east-1"}),
-					RetainStacks: aws.Bool(false),
-				}).Return(&cloudformation.DeleteStackInstancesOutput{
-					OperationId: aws.String("1"),
-				}, nil)
-				m.EXPECT().DescribeStackSetOperation(gomock.Any()).Return(&cloudformation.DescribeStackSetOperationOutput{
-					StackSetOperation: &cloudformation.StackSetOperation{
-						Status: aws.String(opStatusSucceeded),
-					},
-				}, nil)
-				m.EXPECT().DeleteStackSet(&cloudformation.DeleteStackSetInput{
-					StackSetName: aws.String(testName),
-				}).Return(nil, nil)
-				return m
-			},
-		},
 		"successfully exits if stack set does not exist": {
 			mockClient: func(ctrl *gomock.Controller) api {
 				m := mocks.NewMockapi(ctrl)
-				m.EXPECT().ListStackInstances(gomock.Any()).Return(&cloudformation.ListStackInstancesOutput{
-					Summaries: []*cloudformation.StackInstanceSummary{},
-				}, nil)
 				m.EXPECT().DeleteStackSet(gomock.Any()).Return(nil, awserr.New(cloudformation.ErrCodeStackSetNotFoundException, "", nil))
-				return m
-			},
-		},
-		"successfully exits if deletes stack set": {
-			mockClient: func(ctrl *gomock.Controller) api {
-				m := mocks.NewMockapi(ctrl)
-				m.EXPECT().ListStackInstances(gomock.Any()).Return(&cloudformation.ListStackInstancesOutput{
-					Summaries: []*cloudformation.StackInstanceSummary{},
-				}, nil)
-				m.EXPECT().DeleteStackSet(gomock.Any()).Return(nil, nil)
 				return m
 			},
 		},
 		"wraps error on unexpected failure": {
 			mockClient: func(ctrl *gomock.Controller) api {
 				m := mocks.NewMockapi(ctrl)
-				m.EXPECT().ListStackInstances(gomock.Any()).Return(&cloudformation.ListStackInstancesOutput{
-					Summaries: []*cloudformation.StackInstanceSummary{},
-				}, nil)
 				m.EXPECT().DeleteStackSet(gomock.Any()).Return(nil, testError)
 				return m
 			},
@@ -504,7 +603,9 @@ func TestStackSet_CreateInstances(t *testing.T) {
 		testRegions  = []string{"us-west-1"}
 	)
 	testCases := map[string]struct {
-		mockClient  func(ctrl *gomock.Controller) api
+		mockClient func(ctrl *gomock.Controller) api
+
+		wantedOpID  string
 		wantedError error
 	}{
 		"successfully creates stack instances": {
@@ -519,6 +620,7 @@ func TestStackSet_CreateInstances(t *testing.T) {
 				}, nil)
 				return m
 			},
+			wantedOpID: "1",
 		},
 		"wraps error on unexpected failure": {
 			mockClient: func(ctrl *gomock.Controller) api {
@@ -544,10 +646,15 @@ func TestStackSet_CreateInstances(t *testing.T) {
 			}
 
 			// WHEN
-			err := client.CreateInstances(testName, testAccounts, testRegions)
+			opID, err := client.CreateInstances(testName, testAccounts, testRegions)
 
 			// THEN
-			require.Equal(t, tc.wantedError, err)
+			if tc.wantedError != nil {
+				require.EqualError(t, err, tc.wantedError.Error())
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.wantedOpID, opID)
+			}
 		})
 	}
 }
@@ -616,6 +723,83 @@ func TestStackSet_InstanceSummaries(t *testing.T) {
 			// THEN
 			require.ElementsMatch(t, tc.wantedSummaries, summaries)
 			require.Equal(t, tc.wantedError, err)
+		})
+	}
+}
+
+func TestStackSet_WaitForOperation(t *testing.T) {
+	const (
+		testName = "demo-infrastructure"
+		testOpID = "1"
+	)
+	testCases := map[string]struct {
+		mockClient func(ctrl *gomock.Controller) api
+		wantedErr  error
+	}{
+		"returns nil if the operation status is successful": {
+			mockClient: func(ctrl *gomock.Controller) api {
+				m := mocks.NewMockapi(ctrl)
+				m.EXPECT().DescribeStackSetOperation(&cloudformation.DescribeStackSetOperationInput{
+					StackSetName: aws.String(testName),
+					OperationId:  aws.String(testOpID),
+				}).Return(&cloudformation.DescribeStackSetOperationOutput{
+					StackSetOperation: &cloudformation.StackSetOperation{
+						Status: aws.String(cloudformation.StackSetOperationStatusSucceeded),
+					},
+				}, nil)
+				return m
+			},
+		},
+		"returns an error if the operation stopped": {
+			mockClient: func(ctrl *gomock.Controller) api {
+				m := mocks.NewMockapi(ctrl)
+				m.EXPECT().DescribeStackSetOperation(&cloudformation.DescribeStackSetOperationInput{
+					StackSetName: aws.String(testName),
+					OperationId:  aws.String(testOpID),
+				}).Return(&cloudformation.DescribeStackSetOperationOutput{
+					StackSetOperation: &cloudformation.StackSetOperation{
+						Status: aws.String(cloudformation.StackSetOperationStatusStopped),
+					},
+				}, nil)
+				return m
+			},
+			wantedErr: errors.New("operation 1 for stack set demo-infrastructure was manually stopped"),
+		},
+		"returns an error if the operation failed": {
+			mockClient: func(ctrl *gomock.Controller) api {
+				m := mocks.NewMockapi(ctrl)
+				m.EXPECT().DescribeStackSetOperation(&cloudformation.DescribeStackSetOperationInput{
+					StackSetName: aws.String(testName),
+					OperationId:  aws.String(testOpID),
+				}).Return(&cloudformation.DescribeStackSetOperationOutput{
+					StackSetOperation: &cloudformation.StackSetOperation{
+						Status: aws.String(cloudformation.StackSetOperationStatusFailed),
+					},
+				}, nil)
+				return m
+			},
+			wantedErr: errors.New("operation 1 for stack set demo-infrastructure failed"),
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// GIVEN
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			client := StackSet{
+				client: tc.mockClient(ctrl),
+			}
+
+			// WHEN
+			err := client.WaitForOperation(testName, testOpID)
+
+			// THEN
+			if tc.wantedErr != nil {
+				require.EqualError(t, err, tc.wantedErr.Error())
+			} else {
+				require.NoError(t, err)
+			}
 		})
 	}
 }

--- a/internal/pkg/deploy/cloudformation/app.go
+++ b/internal/pkg/deploy/cloudformation/app.go
@@ -522,7 +522,7 @@ func (cf CloudFormation) DeleteApp(appName string) error {
 func (cf CloudFormation) deleteStackSetInstances(name string) error {
 	opID, err := cf.appStackSet.DeleteAllInstances(name)
 	if err != nil {
-		if stackset.IsEmptyStackSetErr(err) {
+		if IsEmptyErr(err) {
 			return nil
 		}
 		return err

--- a/internal/pkg/deploy/cloudformation/app.go
+++ b/internal/pkg/deploy/cloudformation/app.go
@@ -501,7 +501,13 @@ func (cf CloudFormation) getLastDeployedAppConfig(appConfig *stack.AppStackConfi
 func (cf CloudFormation) DeleteApp(appName string) error {
 	spinner := progress.NewSpinner(cf.console)
 	spinner.Start(fmt.Sprintf("Delete regional resources for application %q", appName))
-	if err := cf.appStackSet.Delete(fmt.Sprintf("%s-infrastructure", appName)); err != nil {
+
+	stackSetName := fmt.Sprintf("%s-infrastructure", appName)
+	if err := cf.deleteStackSetInstances(stackSetName); err != nil {
+		spinner.Stop(log.Serrorf("Error deleting regional resources for application %q\n", appName))
+		return err
+	}
+	if err := cf.appStackSet.Delete(stackSetName); err != nil {
 		spinner.Stop(log.Serrorf("Error deleting regional resources for application %q\n", appName))
 		return err
 	}
@@ -511,4 +517,15 @@ func (cf CloudFormation) DeleteApp(appName string) error {
 	return cf.deleteAndRenderStack(stackName, description, func() error {
 		return cf.cfnClient.DeleteAndWait(stackName)
 	})
+}
+
+func (cf CloudFormation) deleteStackSetInstances(name string) error {
+	opID, err := cf.appStackSet.DeleteAllInstances(name)
+	if err != nil {
+		if stackset.IsEmptyStackSetErr(err) {
+			return nil
+		}
+		return err
+	}
+	return cf.appStackSet.WaitForOperation(name, opID)
 }

--- a/internal/pkg/deploy/cloudformation/app_test.go
+++ b/internal/pkg/deploy/cloudformation/app_test.go
@@ -913,6 +913,27 @@ func TestCloudFormation_DeleteApp(t *testing.T) {
 			},
 			mockStackSet: func(ctrl *gomock.Controller) stackSetClient {
 				m := mocks.NewMockstackSetClient(ctrl)
+				m.EXPECT().DeleteAllInstances("testApp-infrastructure").Return("1", nil)
+				m.EXPECT().WaitForOperation("testApp-infrastructure", "1").Return(nil)
+				m.EXPECT().Delete("testApp-infrastructure").Return(nil)
+				return m
+			},
+		},
+		"should skip waiting for delete instance operation if the stack set is already deleted": {
+			appName: "testApp",
+			createMock: func(ctrl *gomock.Controller) cfnClient {
+				m := mocks.NewMockcfnClient(ctrl)
+				m.EXPECT().TemplateBody(gomock.Any()).Return("", nil)
+				m.EXPECT().Describe(gomock.Any()).Return(&cloudformation.StackDescription{
+					StackId: aws.String("some stack"),
+				}, nil)
+				m.EXPECT().DeleteAndWait(gomock.Any()).Return(&cloudformation.ErrStackNotFound{})
+				m.EXPECT().DescribeStackEvents(gomock.Any()).Return(&awscfn.DescribeStackEventsOutput{}, nil).AnyTimes()
+				return m
+			},
+			mockStackSet: func(ctrl *gomock.Controller) stackSetClient {
+				m := mocks.NewMockstackSetClient(ctrl)
+				m.EXPECT().DeleteAllInstances(gomock.Any()).Return("", &stackset.ErrStackSetNotFound{})
 				m.EXPECT().Delete(gomock.Any()).Return(nil)
 				return m
 			},

--- a/internal/pkg/deploy/cloudformation/cloudformation.go
+++ b/internal/pkg/deploy/cloudformation/cloudformation.go
@@ -102,8 +102,10 @@ type stackSetClient interface {
 	UpdateAndWait(name, template string, opts ...stackset.CreateOrUpdateOption) error
 	Describe(name string) (stackset.Description, error)
 	InstanceSummaries(name string, opts ...stackset.InstanceSummariesOption) ([]stackset.InstanceSummary, error)
+	DeleteAllInstances(name string) (string, error)
 	Delete(name string) error
 	WaitForStackSetLastOperationComplete(name string) error
+	WaitForOperation(name, opID string) error
 }
 
 // OptFn represents an optional configuration function for the CloudFormation client.

--- a/internal/pkg/deploy/cloudformation/cloudformation.go
+++ b/internal/pkg/deploy/cloudformation/cloudformation.go
@@ -169,6 +169,16 @@ func New(sess *session.Session, opts ...OptFn) CloudFormation {
 	return client
 }
 
+// IsEmptyErr returns true if the error occurred because the cloudformation resource does not exist or does not contain any sub-resources.
+func IsEmptyErr(err error) bool {
+	type isEmpty interface {
+		IsEmpty() bool
+	}
+
+	var emptyErr isEmpty
+	return errors.As(err, &emptyErr)
+}
+
 // errorEvents returns the list of status reasons of failed resource events
 func (cf CloudFormation) errorEvents(stackName string) ([]string, error) {
 	events, err := cf.cfnClient.ErrorEvents(stackName)

--- a/internal/pkg/deploy/cloudformation/cloudformation_test.go
+++ b/internal/pkg/deploy/cloudformation/cloudformation_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/copilot-cli/internal/pkg/aws/cloudformation/stackset"
+
 	"github.com/aws/aws-sdk-go/aws"
 	sdkcloudformation "github.com/aws/aws-sdk-go/service/cloudformation"
 	awsecs "github.com/aws/aws-sdk-go/service/ecs"
@@ -20,6 +22,31 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 )
+
+func TestIsEmptyErr(t *testing.T) {
+	testCases := map[string]struct {
+		err    error
+		wanted bool
+	}{
+		"should return true when the error is an ErrStackSetNotFound": {
+			err:    &stackset.ErrStackSetNotFound{},
+			wanted: true,
+		},
+		"should return true when the error is an ErrStackSetInstancesNotFound": {
+			err:    &stackset.ErrStackSetInstancesNotFound{},
+			wanted: true,
+		},
+		"should return false on any other error": {
+			err: errors.New("some error"),
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.wanted, IsEmptyErr(tc.err))
+		})
+	}
+}
 
 type mockFileWriter struct {
 	io.Writer

--- a/internal/pkg/deploy/cloudformation/mocks/mock_cloudformation.go
+++ b/internal/pkg/deploy/cloudformation/mocks/mock_cloudformation.go
@@ -633,6 +633,21 @@ func (mr *MockstackSetClientMockRecorder) Delete(name interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockstackSetClient)(nil).Delete), name)
 }
 
+// DeleteAllInstances mocks base method.
+func (m *MockstackSetClient) DeleteAllInstances(name string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteAllInstances", name)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteAllInstances indicates an expected call of DeleteAllInstances.
+func (mr *MockstackSetClientMockRecorder) DeleteAllInstances(name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAllInstances", reflect.TypeOf((*MockstackSetClient)(nil).DeleteAllInstances), name)
+}
+
 // Describe mocks base method.
 func (m *MockstackSetClient) Describe(name string) (stackset.Description, error) {
 	m.ctrl.T.Helper()
@@ -685,6 +700,20 @@ func (mr *MockstackSetClientMockRecorder) UpdateAndWait(name, template interface
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{name, template}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAndWait", reflect.TypeOf((*MockstackSetClient)(nil).UpdateAndWait), varargs...)
+}
+
+// WaitForOperation mocks base method.
+func (m *MockstackSetClient) WaitForOperation(name, opID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitForOperation", name, opID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WaitForOperation indicates an expected call of WaitForOperation.
+func (mr *MockstackSetClientMockRecorder) WaitForOperation(name, opID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForOperation", reflect.TypeOf((*MockstackSetClient)(nil).WaitForOperation), name, opID)
 }
 
 // WaitForStackSetLastOperationComplete mocks base method.


### PR DESCRIPTION
We need to split the `stackset` methods to no longer create operation + wait operation to complete. This will allow us to start the progress tracker once an operation starts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
