### PR TITLE
chore: Docker Compose import milestone 1 - library setup and basic service conversion

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.2
 	github.com/aws/aws-sdk-go v1.44.66
 	github.com/briandowns/spinner v1.19.0
+	github.com/compose-spec/compose-go v1.4.0
 	github.com/dustin/go-humanize v1.0.0
 	github.com/fatih/color v1.13.0
 	github.com/fatih/structs v1.1.0
@@ -24,7 +25,7 @@ require (
 	github.com/stretchr/testify v1.8.0
 	github.com/xlab/treeprint v1.1.0
 	golang.org/x/mod v0.6.0-dev.0.20211013180041-c96bc1413d57
-	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
+	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4
 	golang.org/x/text v0.3.7
 	gopkg.in/ini.v1 v1.67.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -35,6 +36,7 @@ require (
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/containerd/typeurl v1.0.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/distribution/distribution/v3 v3.0.0-20220725133111-4bf3547399eb // indirect
 	github.com/docker/docker v20.10.7+incompatible // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.4.0 // indirect
@@ -48,13 +50,21 @@ require (
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/mattn/go-shellwords v1.0.12 // indirect
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
+	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
+	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/sirupsen/logrus v1.9.0 // indirect
+	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
+	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
+	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4 // indirect
-	golang.org/x/sys v0.0.0-20220422013727-9388b58f7150 // indirect
+	golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -232,6 +232,8 @@ github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnht
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20160425231609-f8ad88b59a58/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
+github.com/compose-spec/compose-go v1.4.0 h1:zaYVAZ6lIByr7Jffi20AabfeUwcTrdXfH3X1R5HEm+g=
+github.com/compose-spec/compose-go v1.4.0/go.mod h1:l7RUULbFFLzlQHuxtJr7SVLyWdqEpbJEGTWCgcu6Eqw=
 github.com/containerd/aufs v0.0.0-20200908144142-dab0cbea06f4/go.mod h1:nukgQABAEopAHvB6j7cnP5zJ+/3aVcE7hCYqvIwAHyE=
 github.com/containerd/aufs v0.0.0-20201003224125-76a6863f2989/go.mod h1:AkGGQs9NM2vtYHaUen+NljV0/baGCAPELGm2q9ZXpWU=
 github.com/containerd/aufs v0.0.0-20210316121734-20793ff83c97/go.mod h1:kL5kd6KM5TzQjR79jljyi4olc1Vrx6XBlcyj3gNv2PU=
@@ -367,6 +369,8 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dimchansky/utfbom v1.1.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=
 github.com/dimchansky/utfbom v1.1.1/go.mod h1:SxdoEBH5qIqFocHMyGOXVAybYJdr71b1Q/j0mACtrfE=
+github.com/distribution/distribution/v3 v3.0.0-20220725133111-4bf3547399eb h1:oCCuuU3kMO3sjZH/p7LamvQNW9SWoT4yQuMGcdSxGAE=
+github.com/distribution/distribution/v3 v3.0.0-20220725133111-4bf3547399eb/go.mod h1:28YO/VJk9/64+sTGNuYaBjWxrXTPrj0C0XmgTIOjxX4=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/docker/cli v0.0.0-20190925022749-754388324470/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/cli v0.0.0-20191017083524-a8ff7f821017/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
@@ -804,6 +808,8 @@ github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27k
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-shellwords v1.0.3/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
 github.com/mattn/go-shellwords v1.0.10/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
+github.com/mattn/go-shellwords v1.0.12 h1:M2zGm7EW6UQJvDeQxo4T51eKPurbeFbe8WtebGE2xrk=
+github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/mattn/go-sqlite3 v1.9.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-zglob v0.0.1/go.mod h1:9fxibJccNxU2cnpIKLRRFA7zX7qhkJIQWBb449FYHOo=
 github.com/mattn/goveralls v0.0.2/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpevwGNQEw=
@@ -826,6 +832,8 @@ github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0Qu
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.3.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
+github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f/go.mod h1:OkQIRizQZAeMln+1tSwduZz7+Af5oFlKirV/MSYes2A=
 github.com/moby/buildkit v0.8.1/go.mod h1:/kyU1hKy/aYCuP39GZA9MaKioovHku57N6cqlKZIaiQ=
 github.com/moby/buildkit v0.9.3 h1:0JmMLY45KIKFogJXv4LyWo+KmIMuvhit5TDrwBlxDp0=
@@ -896,6 +904,7 @@ github.com/opencontainers/go-digest v0.0.0-20170106003457-a6d0ee40d420/go.mod h1
 github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v1.0.0-rc1.0.20180430190053-c9281466c8b2/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
+github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.0/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
@@ -1024,6 +1033,8 @@ github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6Mwd
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
+github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/assertions v1.0.0/go.mod h1:kHHU4qYBaI3q23Pp3VPrmWhuIUrLW/7eUrw0BU5VaoM=
 github.com/smartystreets/go-aws-auth v0.0.0-20180515143844-0c1422d1fdb9/go.mod h1:SnhjPscd9TpLiy1LpzGSKh3bXCfxxXuqd9xmQJy3slM=
@@ -1130,9 +1141,13 @@ github.com/willf/bitset v1.1.11-0.20200630133818-d5bec3311243/go.mod h1:RjeCKbqT
 github.com/willf/bitset v1.1.11/go.mod h1:83CECat5yLh5zVOf4P1ErAgKA5UDvKtgyUABdr3+MjI=
 github.com/xanzy/go-gitlab v0.31.0/go.mod h1:sPLojNBn68fMUWSxIJtdVVIP8uSBYqesTfDUseX11Ug=
 github.com/xanzy/go-gitlab v0.32.0/go.mod h1:sPLojNBn68fMUWSxIJtdVVIP8uSBYqesTfDUseX11Ug=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v0.0.0-20180618132009-1d523034197f/go.mod h1:5yf86TLmAcydyeJq5YvxkGPE2fm/u4myDekKRoLuqhs=
+github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
+github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v1.1.0 h1:G/1DjNkPpfZCFt9CSh6b5/nY4VimlbHF3Rh4obvtzDk=
@@ -1333,8 +1348,9 @@ golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 h1:uVc8UZUe6tr40fFVnUP5Oj+veunVezqYl9z7DYw9xzw=
+golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -1431,8 +1447,8 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220422013727-9388b58f7150 h1:xHms4gcpe1YE7A3yIllJXP16CMAGuqwO2lX1mTyyRRc=
-golang.org/x/sys v0.0.0-20220422013727-9388b58f7150/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210503060354-a79de5458b56/go.mod h1:tfny5GFUkzUvx4ps4ajbZsCe5lw1metzhBm9T3x7oIY=
@@ -1711,9 +1727,11 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
 gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=
+gotest.tools/v3 v3.3.0 h1:MfDY1b1/0xN1CyMlQDac0ziEy9zJQd9CXBRRDHw2jJo=
 grpc.go4.org v0.0.0-20170609214715-11d0a25b4919/go.mod h1:77eQGdRu53HpSqPFJFmuJdjuHRquDANNeA4x7B8WQ9o=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20180920025451-e3ad64cb4ed3/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/internal/pkg/docker/dockercompose/svc.go
+++ b/internal/pkg/docker/dockercompose/svc.go
@@ -66,18 +66,23 @@ func convertTaskConfig(service *types.ServiceConfig) (manifest.TaskConfig, error
 		}
 	}
 
+	taskCfg := manifest.TaskConfig{
+		Platform: manifest.PlatformArgsOrString{
+			PlatformString: (*manifest.PlatformString)(nilIfEmpty(service.Platform)),
+		},
+		EnvFile: envFile,
+	}
+
 	envVars, err := convertMappingWithEquals(service.Environment)
 	if err != nil {
 		return manifest.TaskConfig{}, fmt.Errorf("convert environment variables: %w", err)
 	}
 
-	return manifest.TaskConfig{
-		Platform: manifest.PlatformArgsOrString{
-			PlatformString: (*manifest.PlatformString)(nilIfEmpty(service.Platform)),
-		},
-		Variables: envVars,
-		EnvFile:   envFile,
-	}, nil
+	if len(envVars) != 0 {
+		taskCfg.Variables = envVars
+	}
+
+	return taskCfg, nil
 }
 
 // convertHealthCheckConfig trivially converts a Compose container health check into its Copilot variant.

--- a/internal/pkg/docker/dockercompose/svc.go
+++ b/internal/pkg/docker/dockercompose/svc.go
@@ -41,13 +41,6 @@ func convertBackendService(service *compose.ServiceConfig, port uint16) (*manife
 
 	if service.HealthCheck != nil {
 		svcCfg.ImageConfig.HealthCheck = convertHealthCheckConfig(service.HealthCheck)
-		for ext := range service.HealthCheck.Extensions {
-			ignored = append(ignored, "healthcheck."+ext)
-		}
-	}
-
-	for ext := range service.Extensions {
-		ignored = append(ignored, ext)
 	}
 
 	return svcCfg, ignored, nil

--- a/internal/pkg/docker/dockercompose/svc.go
+++ b/internal/pkg/docker/dockercompose/svc.go
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package dockercompose
 
 import (

--- a/internal/pkg/docker/dockercompose/svc.go
+++ b/internal/pkg/docker/dockercompose/svc.go
@@ -51,49 +51,6 @@ func convertBackendService(service *types.ServiceConfig, port uint16) (*manifest
 	return svcCfg, ignored, nil
 }
 
-func convertLBWS(service *types.ServiceConfig, port uint16) (*manifest.LoadBalancedWebServiceConfig, IgnoredKeys, error) {
-	image, ignored, err := convertImageConfig(service.Build, service.Labels, service.Image)
-	if err != nil {
-		return nil, ignored, fmt.Errorf("convert image config: %w", err)
-	}
-
-	taskCfg, err := convertTaskConfig(service)
-	if err != nil {
-		return nil, ignored, fmt.Errorf("convert task config: %w", err)
-	}
-
-	svcCfg := &manifest.LoadBalancedWebServiceConfig{
-		ImageConfig: manifest.ImageWithPortAndHealthcheck{
-			ImageWithPort: manifest.ImageWithPort{
-				Image: image,
-				Port:  &port,
-			},
-		},
-		ImageOverride: manifest.ImageOverride{
-			Command: manifest.CommandOverride{
-				StringSlice: service.Command,
-			},
-			EntryPoint: manifest.EntryPointOverride{
-				StringSlice: service.Entrypoint,
-			},
-		},
-		TaskConfig: taskCfg,
-	}
-
-	if service.HealthCheck != nil {
-		svcCfg.ImageConfig.HealthCheck = convertHealthCheckConfig(service.HealthCheck)
-		for ext := range service.HealthCheck.Extensions {
-			ignored = append(ignored, "healthcheck"+ext)
-		}
-	}
-
-	for ext := range service.Extensions {
-		ignored = append(ignored, ext)
-	}
-
-	return svcCfg, ignored, nil
-}
-
 // convertTaskConfig converts environment variables, env files, and platform strings.
 func convertTaskConfig(service *types.ServiceConfig) (manifest.TaskConfig, error) {
 	var envFile *string

--- a/internal/pkg/docker/dockercompose/svc.go
+++ b/internal/pkg/docker/dockercompose/svc.go
@@ -39,6 +39,13 @@ func convertBackendService(service *types.ServiceConfig, port uint16) (*manifest
 
 	if service.HealthCheck != nil {
 		svcCfg.ImageConfig.HealthCheck = convertHealthCheckConfig(service.HealthCheck)
+		for ext := range service.HealthCheck.Extensions {
+			ignored = append(ignored, "healthcheck."+ext)
+		}
+	}
+
+	for ext := range service.Extensions {
+		ignored = append(ignored, ext)
 	}
 
 	return svcCfg, ignored, nil
@@ -75,6 +82,13 @@ func convertLBWS(service *types.ServiceConfig, port uint16) (*manifest.LoadBalan
 
 	if service.HealthCheck != nil {
 		svcCfg.ImageConfig.HealthCheck = convertHealthCheckConfig(service.HealthCheck)
+		for ext := range service.HealthCheck.Extensions {
+			ignored = append(ignored, "healthcheck"+ext)
+		}
+	}
+
+	for ext := range service.Extensions {
+		ignored = append(ignored, ext)
 	}
 
 	return svcCfg, ignored, nil

--- a/internal/pkg/docker/dockercompose/svc.go
+++ b/internal/pkg/docker/dockercompose/svc.go
@@ -79,13 +79,11 @@ func convertTaskConfig(service *compose.ServiceConfig) (manifest.TaskConfig, err
 // convertHealthCheckConfig trivially converts a Compose container health check into its Copilot variant.
 func convertHealthCheckConfig(healthcheck *compose.HealthCheckConfig) manifest.ContainerHealthCheck {
 	retries := 3
-
 	if healthcheck.Retries != nil {
 		retries = int(*healthcheck.Retries)
 	}
 
 	cmd := healthcheck.Test
-
 	if healthcheck.Disable {
 		cmd = []string{"NONE"}
 	}

--- a/internal/pkg/docker/dockercompose/svc.go
+++ b/internal/pkg/docker/dockercompose/svc.go
@@ -1,0 +1,119 @@
+package dockercompose
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/copilot-cli/internal/pkg/manifest"
+	"github.com/compose-spec/compose-go/types"
+	"time"
+)
+
+func convertBackendService(service *types.ServiceConfig, port uint16) (*manifest.BackendServiceConfig, IgnoredKeys, error) {
+	image, ignored, err := convertImageConfig(service.Build, service.Labels, service.Image)
+	if err != nil {
+		return nil, ignored, fmt.Errorf("convert image config: %w", err)
+	}
+
+	taskCfg, err := convertTaskConfig(service)
+	if err != nil {
+		return nil, ignored, fmt.Errorf("convert task config: %w", err)
+	}
+
+	svcCfg := &manifest.BackendServiceConfig{
+		ImageConfig: manifest.ImageWithHealthcheckAndOptionalPort{
+			ImageWithOptionalPort: manifest.ImageWithOptionalPort{
+				Image: image,
+				Port:  &port,
+			},
+		},
+		ImageOverride: manifest.ImageOverride{
+			Command: manifest.CommandOverride{
+				StringSlice: service.Command,
+			},
+			EntryPoint: manifest.EntryPointOverride{
+				StringSlice: service.Entrypoint,
+			},
+		},
+		TaskConfig: taskCfg,
+	}
+
+	if service.HealthCheck != nil {
+		svcCfg.ImageConfig.HealthCheck = convertHealthCheckConfig(service.HealthCheck)
+	}
+
+	return svcCfg, ignored, nil
+}
+
+func convertLBWS(service *types.ServiceConfig, port uint16) (*manifest.LoadBalancedWebServiceConfig, IgnoredKeys, error) {
+	image, ignored, err := convertImageConfig(service.Build, service.Labels, service.Image)
+	if err != nil {
+		return nil, ignored, fmt.Errorf("convert image config: %w", err)
+	}
+
+	taskCfg, err := convertTaskConfig(service)
+	if err != nil {
+		return nil, ignored, fmt.Errorf("convert task config: %w", err)
+	}
+
+	svcCfg := &manifest.LoadBalancedWebServiceConfig{
+		ImageConfig: manifest.ImageWithPortAndHealthcheck{
+			ImageWithPort: manifest.ImageWithPort{
+				Image: image,
+				Port:  &port,
+			},
+		},
+		ImageOverride: manifest.ImageOverride{
+			Command: manifest.CommandOverride{
+				StringSlice: service.Command,
+			},
+			EntryPoint: manifest.EntryPointOverride{
+				StringSlice: service.Entrypoint,
+			},
+		},
+		TaskConfig: taskCfg,
+	}
+
+	if service.HealthCheck != nil {
+		svcCfg.ImageConfig.HealthCheck = convertHealthCheckConfig(service.HealthCheck)
+	}
+
+	return svcCfg, ignored, nil
+}
+
+// convertTaskConfig converts environment variables, env files, and platform strings.
+func convertTaskConfig(service *types.ServiceConfig) (manifest.TaskConfig, error) {
+	var envFile *string
+
+	if service.EnvFile != nil {
+		if len(service.EnvFile) == 1 {
+			envFile = &service.EnvFile[0]
+		} else if len(service.EnvFile) > 1 {
+			return manifest.TaskConfig{}, fmt.Errorf("at most one env file is supported, but %d env files "+
+				"were attached to this service", len(service.EnvFile))
+		}
+	}
+
+	envVars, err := convertMappingWithEquals(service.Environment)
+	if err != nil {
+		return manifest.TaskConfig{}, fmt.Errorf("convert environment variables: %w", err)
+	}
+
+	return manifest.TaskConfig{
+		Platform: manifest.PlatformArgsOrString{
+			PlatformString: (*manifest.PlatformString)(nilIfEmpty(service.Platform)),
+		},
+		Variables: envVars,
+		EnvFile:   envFile,
+	}, nil
+}
+
+// convertHealthCheckConfig trivially converts a Compose container health check into its Copilot variant.
+func convertHealthCheckConfig(healthcheck *types.HealthCheckConfig) manifest.ContainerHealthCheck {
+	return manifest.ContainerHealthCheck{
+		Command:     healthcheck.Test,
+		Interval:    (*time.Duration)(healthcheck.Interval),
+		Retries:     aws.Int(int(*healthcheck.Retries)),
+		Timeout:     (*time.Duration)(healthcheck.Timeout),
+		StartPeriod: (*time.Duration)(healthcheck.StartPeriod),
+	}
+}

--- a/internal/pkg/docker/dockercompose/svc.go
+++ b/internal/pkg/docker/dockercompose/svc.go
@@ -57,13 +57,11 @@ func convertBackendService(service *compose.ServiceConfig, port uint16) (*manife
 func convertTaskConfig(service *compose.ServiceConfig) (manifest.TaskConfig, error) {
 	var envFile *string
 
-	if service.EnvFile != nil {
-		if len(service.EnvFile) == 1 {
-			envFile = &service.EnvFile[0]
-		} else if len(service.EnvFile) > 1 {
-			return manifest.TaskConfig{}, fmt.Errorf("at most one env file is supported, but %d env files "+
-				"were attached to this service", len(service.EnvFile))
-		}
+	if len(service.EnvFile) == 1 {
+		envFile = &service.EnvFile[0]
+	} else if len(service.EnvFile) > 1 {
+		return manifest.TaskConfig{}, fmt.Errorf("at most one env file is supported, but %d env files "+
+			"were attached to this service", len(service.EnvFile))
 	}
 
 	taskCfg := manifest.TaskConfig{

--- a/internal/pkg/docker/dockercompose/svc.go
+++ b/internal/pkg/docker/dockercompose/svc.go
@@ -2,7 +2,6 @@ package dockercompose
 
 import (
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/copilot-cli/internal/pkg/manifest"
 	"github.com/compose-spec/compose-go/types"
 	"time"
@@ -80,10 +79,22 @@ func convertTaskConfig(service *types.ServiceConfig) (manifest.TaskConfig, error
 
 // convertHealthCheckConfig trivially converts a Compose container health check into its Copilot variant.
 func convertHealthCheckConfig(healthcheck *types.HealthCheckConfig) manifest.ContainerHealthCheck {
+	retries := 3
+
+	if healthcheck.Retries != nil {
+		retries = int(*healthcheck.Retries)
+	}
+
+	cmd := healthcheck.Test
+
+	if healthcheck.Disable {
+		cmd = []string{"NONE"}
+	}
+
 	return manifest.ContainerHealthCheck{
-		Command:     healthcheck.Test,
+		Command:     cmd,
 		Interval:    (*time.Duration)(healthcheck.Interval),
-		Retries:     aws.Int(int(*healthcheck.Retries)),
+		Retries:     &retries,
 		Timeout:     (*time.Duration)(healthcheck.Timeout),
 		StartPeriod: (*time.Duration)(healthcheck.StartPeriod),
 	}

--- a/internal/pkg/docker/dockercompose/svc.go
+++ b/internal/pkg/docker/dockercompose/svc.go
@@ -13,12 +13,12 @@ import (
 func convertBackendService(service *types.ServiceConfig, port uint16) (*manifest.BackendServiceConfig, IgnoredKeys, error) {
 	image, ignored, err := convertImageConfig(service.Build, service.Labels, service.Image)
 	if err != nil {
-		return nil, ignored, fmt.Errorf("convert image config: %w", err)
+		return nil, nil, fmt.Errorf("convert image config: %w", err)
 	}
 
 	taskCfg, err := convertTaskConfig(service)
 	if err != nil {
-		return nil, ignored, fmt.Errorf("convert task config: %w", err)
+		return nil, nil, fmt.Errorf("convert task config: %w", err)
 	}
 
 	svcCfg := &manifest.BackendServiceConfig{

--- a/internal/pkg/docker/dockercompose/svc.go
+++ b/internal/pkg/docker/dockercompose/svc.go
@@ -6,11 +6,11 @@ package dockercompose
 import (
 	"fmt"
 	"github.com/aws/copilot-cli/internal/pkg/manifest"
-	"github.com/compose-spec/compose-go/types"
+	compose "github.com/compose-spec/compose-go/types"
 	"time"
 )
 
-func convertBackendService(service *types.ServiceConfig, port uint16) (*manifest.BackendServiceConfig, IgnoredKeys, error) {
+func convertBackendService(service *compose.ServiceConfig, port uint16) (*manifest.BackendServiceConfig, IgnoredKeys, error) {
 	image, ignored, err := convertImageConfig(service.Build, service.Labels, service.Image)
 	if err != nil {
 		return nil, nil, fmt.Errorf("convert image config: %w", err)
@@ -54,7 +54,7 @@ func convertBackendService(service *types.ServiceConfig, port uint16) (*manifest
 }
 
 // convertTaskConfig converts environment variables, env files, and platform strings.
-func convertTaskConfig(service *types.ServiceConfig) (manifest.TaskConfig, error) {
+func convertTaskConfig(service *compose.ServiceConfig) (manifest.TaskConfig, error) {
 	var envFile *string
 
 	if service.EnvFile != nil {
@@ -86,7 +86,7 @@ func convertTaskConfig(service *types.ServiceConfig) (manifest.TaskConfig, error
 }
 
 // convertHealthCheckConfig trivially converts a Compose container health check into its Copilot variant.
-func convertHealthCheckConfig(healthcheck *types.HealthCheckConfig) manifest.ContainerHealthCheck {
+func convertHealthCheckConfig(healthcheck *compose.HealthCheckConfig) manifest.ContainerHealthCheck {
 	retries := 3
 
 	if healthcheck.Retries != nil {

--- a/internal/pkg/docker/dockercompose/svc_image.go
+++ b/internal/pkg/docker/dockercompose/svc_image.go
@@ -18,7 +18,7 @@ func convertImageConfig(build *types.BuildConfig, labels map[string]string, imag
 	}
 
 	// note: Compose allows both build & image to be specified, but image takes precedence.
-	//       in Copilot, however, build & image are mutually exclusive.
+	// In Copilot, however, build and image are mutually exclusive.
 	if imageLoc != "" {
 		image.Location = aws.String(imageLoc)
 		return image, nil, nil

--- a/internal/pkg/docker/dockercompose/svc_image.go
+++ b/internal/pkg/docker/dockercompose/svc_image.go
@@ -18,7 +18,7 @@ func convertImageConfig(build *types.BuildConfig, labels map[string]string, imag
 		DockerLabels: labels,
 	}
 
-	// note: Compose allows both build & image to be specified, but image takes precedence.
+	// Compose allows both build & image to be specified, but image takes precedence.
 	// In Copilot, however, build and image are mutually exclusive.
 	if imageLoc != "" {
 		image.Location = aws.String(imageLoc)

--- a/internal/pkg/docker/dockercompose/svc_image.go
+++ b/internal/pkg/docker/dockercompose/svc_image.go
@@ -76,9 +76,8 @@ func convertMappingWithEquals(inArgs compose.MappingWithEquals) (map[string]stri
 	}
 
 	if len(badArgs) != 0 {
-		return nil, fmt.Errorf("%s '%v' %s missing %s and %s user input, this is unsupported in Copilot",
+		return nil, fmt.Errorf("%s '%v' %s missing %s; this is unsupported in Copilot",
 			english.PluralWord(len(badArgs), "entry", "entries"), badArgs,
-			english.PluralWord(len(badArgs), "is", "are"),
 			english.PluralWord(len(badArgs), "a value", "values"),
 			english.PluralWord(len(badArgs), "requires", "require"))
 	}

--- a/internal/pkg/docker/dockercompose/svc_image.go
+++ b/internal/pkg/docker/dockercompose/svc_image.go
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package dockercompose
 
 import (

--- a/internal/pkg/docker/dockercompose/svc_image.go
+++ b/internal/pkg/docker/dockercompose/svc_image.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/copilot-cli/internal/pkg/manifest"
 	"github.com/compose-spec/compose-go/types"
+	"github.com/dustin/go-humanize/english"
 )
 
 // convertImageConfig takes in a Compose build config & image field and returns a Copilot image manifest.
@@ -73,7 +74,11 @@ func convertMappingWithEquals(inArgs types.MappingWithEquals) (map[string]string
 	}
 
 	if badArgs != nil {
-		return nil, fmt.Errorf("%s '%v' %s missing %s and %s user input", english.PluralWord(badArgs, "entry", "entries"), badArgs, english.PluralWord(badArgs, "is", "are"), english.PluralWord(badArgs, "a value", "values"), english.PluralWord(badArgs, "requires", "require"))
+		return nil, fmt.Errorf("%s '%v' %s missing %s and %s user input, this is unsupported in Copilot",
+			english.PluralWord(len(badArgs), "entry", "entries"), badArgs,
+			english.PluralWord(len(badArgs), "is", "are"),
+			english.PluralWord(len(badArgs), "a value", "values"),
+			english.PluralWord(len(badArgs), "requires", "require"))
 	}
 
 	if len(args) == 0 {

--- a/internal/pkg/docker/dockercompose/svc_image.go
+++ b/internal/pkg/docker/dockercompose/svc_image.go
@@ -78,8 +78,8 @@ func convertMappingWithEquals(inArgs compose.MappingWithEquals) (map[string]stri
 	if len(badArgs) != 0 {
 		return nil, fmt.Errorf("%s '%v' %s missing %s; this is unsupported in Copilot",
 			english.PluralWord(len(badArgs), "entry", "entries"), badArgs,
-			english.PluralWord(len(badArgs), "a value", "values"),
-			english.PluralWord(len(badArgs), "requires", "require"))
+			english.PluralWord(len(badArgs), "is", "are"),
+			english.PluralWord(len(badArgs), "a value", "values"))
 	}
 
 	return args, nil

--- a/internal/pkg/docker/dockercompose/svc_image.go
+++ b/internal/pkg/docker/dockercompose/svc_image.go
@@ -119,7 +119,10 @@ func unsupportedBuildKeys(build *types.BuildConfig) (IgnoredKeys, error) {
 	}
 
 	if build.Extensions != nil {
-		ignoredKeys = append(ignoredKeys, "build.extensions")
+		// catchall for any unrecognized key
+		for ext := range build.Extensions {
+			ignoredKeys = append(ignoredKeys, ext)
+		}
 	}
 
 	if build.Labels != nil {

--- a/internal/pkg/docker/dockercompose/svc_image.go
+++ b/internal/pkg/docker/dockercompose/svc_image.go
@@ -121,7 +121,7 @@ func unsupportedBuildKeys(build *types.BuildConfig) (IgnoredKeys, error) {
 	if build.Extensions != nil {
 		// catchall for any unrecognized key
 		for ext := range build.Extensions {
-			ignoredKeys = append(ignoredKeys, ext)
+			ignoredKeys = append(ignoredKeys, "build."+ext)
 		}
 	}
 

--- a/internal/pkg/docker/dockercompose/svc_image.go
+++ b/internal/pkg/docker/dockercompose/svc_image.go
@@ -73,7 +73,7 @@ func convertMappingWithEquals(inArgs types.MappingWithEquals) (map[string]string
 		}
 	}
 
-	if badArgs != nil {
+	if len(badArgs) != 0 {
 		return nil, fmt.Errorf("%s '%v' %s missing %s and %s user input, this is unsupported in Copilot",
 			english.PluralWord(len(badArgs), "entry", "entries"), badArgs,
 			english.PluralWord(len(badArgs), "is", "are"),

--- a/internal/pkg/docker/dockercompose/svc_image.go
+++ b/internal/pkg/docker/dockercompose/svc_image.go
@@ -73,8 +73,7 @@ func convertMappingWithEquals(inArgs types.MappingWithEquals) (map[string]string
 	}
 
 	if badArgs != nil {
-		return nil, fmt.Errorf("some entries are missing values and require user input, "+
-			"this is not supported in Copilot: %v", badArgs)
+		return nil, fmt.Errorf("%s '%v' %s missing %s and %s user input", english.PluralWord(badArgs, "entry", "entries"), badArgs, english.PluralWord(badArgs, "is", "are"), english.PluralWord(badArgs, "a value", "values"), english.PluralWord(badArgs, "requires", "require"))
 	}
 
 	if len(args) == 0 {

--- a/internal/pkg/docker/dockercompose/svc_image.go
+++ b/internal/pkg/docker/dockercompose/svc_image.go
@@ -135,9 +135,5 @@ func unsupportedBuildKeys(build *compose.BuildConfig) (IgnoredKeys, error) {
 		ignoredKeys = append(ignoredKeys, "build.labels")
 	}
 
-	if len(ignoredKeys) == 0 {
-		return nil, nil
-	}
-
 	return ignoredKeys, nil
 }

--- a/internal/pkg/docker/dockercompose/svc_image.go
+++ b/internal/pkg/docker/dockercompose/svc_image.go
@@ -122,13 +122,6 @@ func unsupportedBuildKeys(build *compose.BuildConfig) (IgnoredKeys, error) {
 		ignoredKeys = append(ignoredKeys, "build.tags")
 	}
 
-	if build.Extensions != nil {
-		// catchall for any unrecognized key
-		for ext := range build.Extensions {
-			ignoredKeys = append(ignoredKeys, "build."+ext)
-		}
-	}
-
 	if build.Labels != nil {
 		ignoredKeys = append(ignoredKeys, "build.labels")
 	}

--- a/internal/pkg/docker/dockercompose/svc_image.go
+++ b/internal/pkg/docker/dockercompose/svc_image.go
@@ -58,9 +58,8 @@ func convertImageConfig(build *compose.BuildConfig, labels map[string]string, im
 func nilIfEmpty(s string) *string {
 	if s == "" {
 		return nil
-	} else {
-		return &s
 	}
+	return &s
 }
 
 // convertMappingWithEquals checks for entries with missing values and generates an error if any are found.

--- a/internal/pkg/docker/dockercompose/svc_image.go
+++ b/internal/pkg/docker/dockercompose/svc_image.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/copilot-cli/internal/pkg/manifest"
-	"github.com/compose-spec/compose-go/types"
+	compose "github.com/compose-spec/compose-go/types"
 	"github.com/dustin/go-humanize/english"
 )
 
 // convertImageConfig takes in a Compose build config & image field and returns a Copilot image manifest.
-func convertImageConfig(build *types.BuildConfig, labels map[string]string, imageLoc string) (manifest.Image, IgnoredKeys, error) {
+func convertImageConfig(build *compose.BuildConfig, labels map[string]string, imageLoc string) (manifest.Image, IgnoredKeys, error) {
 	image := manifest.Image{
 		DockerLabels: labels,
 	}
@@ -64,7 +64,7 @@ func nilIfEmpty(s string) *string {
 }
 
 // convertMappingWithEquals checks for entries with missing values and generates an error if any are found.
-func convertMappingWithEquals(inArgs types.MappingWithEquals) (map[string]string, error) {
+func convertMappingWithEquals(inArgs compose.MappingWithEquals) (map[string]string, error) {
 	args := map[string]string{}
 	var badArgs []string
 
@@ -88,7 +88,7 @@ func convertMappingWithEquals(inArgs types.MappingWithEquals) (map[string]string
 }
 
 // unsupportedBuildKeys checks for unsupported keys in the given Compose build config.
-func unsupportedBuildKeys(build *types.BuildConfig) (IgnoredKeys, error) {
+func unsupportedBuildKeys(build *compose.BuildConfig) (IgnoredKeys, error) {
 	if build.SSH != nil || build.Secrets != nil {
 		return nil, errors.New("`build.ssh` and `build.secrets` are not supported yet, see " +
 			"https://github.com/aws/copilot-cli/issues/2090 for details")

--- a/internal/pkg/docker/dockercompose/svc_image.go
+++ b/internal/pkg/docker/dockercompose/svc_image.go
@@ -1,0 +1,108 @@
+package dockercompose
+
+import (
+	"errors"
+	"fmt"
+	"github.com/aws/copilot-cli/internal/pkg/manifest"
+	"github.com/compose-spec/compose-go/types"
+)
+
+// convertImageConfig takes in a Compose build config & image field and returns a Copilot image manifest.
+func convertImageConfig(build *types.BuildConfig, imageLoc string) (manifest.Image, IgnoredKeys, error) {
+	ignored, err := unsupportedBuildKeys(build)
+	if err != nil {
+		return manifest.Image{}, ignored, err
+	}
+
+	image := manifest.Image{
+		DockerLabels: build.Labels,
+	}
+
+	// note: Compose allows both build & image to be specified, but image takes precedence.
+	//       in Copilot, however, build & image are mutually exclusive.
+	if imageLoc != "" {
+		image.Location = &imageLoc
+	} else {
+		args, err := convertMappingWithEquals(build.Args)
+		if err != nil {
+			return manifest.Image{}, nil, fmt.Errorf("convert build args: %w", err)
+		}
+
+		image.Build = manifest.BuildArgsOrString{
+			BuildArgs: manifest.DockerBuildArgs{
+				Context:    &build.Context,
+				Dockerfile: &build.Dockerfile,
+				Args:       args,
+				Target:     &build.Target,
+				CacheFrom:  build.CacheFrom,
+			},
+		}
+	}
+
+	return image, ignored, nil
+}
+
+// convertMappingWithEquals checks for entries with missing values and generates an error if any are found.
+func convertMappingWithEquals(inArgs types.MappingWithEquals) (map[string]string, error) {
+	args := map[string]string{}
+	var badArgs []string
+
+	for k, v := range inArgs {
+		if v == nil {
+			badArgs = append(badArgs, k)
+		} else {
+			args[k] = *v
+		}
+	}
+
+	if badArgs != nil {
+		return nil, fmt.Errorf("some entries are missing values and require user input, "+
+			"this is not supported in Copilot: %v", badArgs)
+	}
+
+	return args, nil
+}
+
+// unsupportedBuildKeys checks for unsupported keys in the given Compose build config.
+func unsupportedBuildKeys(build *types.BuildConfig) (IgnoredKeys, error) {
+	if build.SSH != nil || build.Secrets != nil {
+		return nil, errors.New("`build.ssh` and `build.secrets` are not supported yet, see " +
+			"https://github.com/aws/copilot-cli/issues/2090 for details")
+	}
+
+	if build.ExtraHosts != nil {
+		return nil, errors.New("key `build.extra_hosts` is not supported yet, this might break your app")
+	}
+
+	if build.Network != "" {
+		return nil, errors.New("key `build.network` is not supported yet, this might break your app")
+	}
+
+	var ignoredKeys []string
+
+	if build.CacheTo != nil {
+		ignoredKeys = append(ignoredKeys, "build.cache_to")
+	}
+
+	if build.NoCache {
+		ignoredKeys = append(ignoredKeys, "build.no_cache")
+	}
+
+	if build.Pull {
+		ignoredKeys = append(ignoredKeys, "build.pull")
+	}
+
+	if build.Isolation != "" {
+		ignoredKeys = append(ignoredKeys, "build.isolation")
+	}
+
+	if build.Tags != nil {
+		ignoredKeys = append(ignoredKeys, "build.tags")
+	}
+
+	if build.Extensions != nil {
+		ignoredKeys = append(ignoredKeys, "build.extensions")
+	}
+
+	return ignoredKeys, nil
+}

--- a/internal/pkg/docker/dockercompose/svc_image.go
+++ b/internal/pkg/docker/dockercompose/svc_image.go
@@ -122,6 +122,10 @@ func unsupportedBuildKeys(build *types.BuildConfig) (IgnoredKeys, error) {
 		ignoredKeys = append(ignoredKeys, "build.extensions")
 	}
 
+	if build.Labels != nil {
+		ignoredKeys = append(ignoredKeys, "build.labels")
+	}
+
 	if len(ignoredKeys) == 0 {
 		return nil, nil
 	}

--- a/internal/pkg/docker/dockercompose/svc_image.go
+++ b/internal/pkg/docker/dockercompose/svc_image.go
@@ -28,18 +28,28 @@ func convertImageConfig(build *types.BuildConfig, imageLoc string) (manifest.Ima
 			return manifest.Image{}, nil, fmt.Errorf("convert build args: %w", err)
 		}
 
+		buildArgs := manifest.DockerBuildArgs{
+			Context:    nilIfEmpty(build.Context),
+			Dockerfile: nilIfEmpty(build.Dockerfile),
+			Args:       args,
+			Target:     nilIfEmpty(build.Target),
+			CacheFrom:  build.CacheFrom,
+		}
+
 		image.Build = manifest.BuildArgsOrString{
-			BuildArgs: manifest.DockerBuildArgs{
-				Context:    &build.Context,
-				Dockerfile: &build.Dockerfile,
-				Args:       args,
-				Target:     &build.Target,
-				CacheFrom:  build.CacheFrom,
-			},
+			BuildArgs: buildArgs,
 		}
 	}
 
 	return image, ignored, nil
+}
+
+func nilIfEmpty(s string) *string {
+	if s == "" {
+		return nil
+	} else {
+		return &s
+	}
 }
 
 // convertMappingWithEquals checks for entries with missing values and generates an error if any are found.
@@ -58,6 +68,10 @@ func convertMappingWithEquals(inArgs types.MappingWithEquals) (map[string]string
 	if badArgs != nil {
 		return nil, fmt.Errorf("some entries are missing values and require user input, "+
 			"this is not supported in Copilot: %v", badArgs)
+	}
+
+	if len(args) == 0 {
+		return nil, nil
 	}
 
 	return args, nil

--- a/internal/pkg/docker/dockercompose/svc_image.go
+++ b/internal/pkg/docker/dockercompose/svc_image.go
@@ -32,17 +32,20 @@ func convertImageConfig(build *types.BuildConfig, labels map[string]string, imag
 		return manifest.Image{}, ignored, err
 	}
 
+	buildArgs := manifest.DockerBuildArgs{
+		Context:    nilIfEmpty(build.Context),
+		Dockerfile: nilIfEmpty(build.Dockerfile),
+		Target:     nilIfEmpty(build.Target),
+		CacheFrom:  build.CacheFrom,
+	}
+
 	args, err := convertMappingWithEquals(build.Args)
 	if err != nil {
 		return manifest.Image{}, nil, fmt.Errorf("convert build args: %w", err)
 	}
 
-	buildArgs := manifest.DockerBuildArgs{
-		Context:    nilIfEmpty(build.Context),
-		Dockerfile: nilIfEmpty(build.Dockerfile),
-		Args:       args,
-		Target:     nilIfEmpty(build.Target),
-		CacheFrom:  build.CacheFrom,
+	if len(args) != 0 {
+		buildArgs.Args = args
 	}
 
 	image.Build = manifest.BuildArgsOrString{
@@ -79,10 +82,6 @@ func convertMappingWithEquals(inArgs types.MappingWithEquals) (map[string]string
 			english.PluralWord(len(badArgs), "is", "are"),
 			english.PluralWord(len(badArgs), "a value", "values"),
 			english.PluralWord(len(badArgs), "requires", "require"))
-	}
-
-	if len(args) == 0 {
-		return nil, nil
 	}
 
 	return args, nil

--- a/internal/pkg/docker/dockercompose/svc_image.go
+++ b/internal/pkg/docker/dockercompose/svc_image.go
@@ -71,9 +71,9 @@ func convertMappingWithEquals(inArgs types.MappingWithEquals) (map[string]string
 	for k, v := range inArgs {
 		if v == nil {
 			badArgs = append(badArgs, k)
-		} else {
-			args[k] = *v
+			continue
 		}
+		args[k] = *v
 	}
 
 	if len(badArgs) != 0 {

--- a/internal/pkg/docker/dockercompose/svc_image_test.go
+++ b/internal/pkg/docker/dockercompose/svc_image_test.go
@@ -20,7 +20,7 @@ func TestConvertImageConfigNil(t *testing.T) {
 		Location: aws.String("test"),
 	}, img)
 
-	img, ignored, err = convertImageConfig(nil, nil, "")
+	_, _, err = convertImageConfig(nil, nil, "")
 	require.EqualError(t, err, "missing one of `build` or `image`")
 }
 

--- a/internal/pkg/docker/dockercompose/svc_image_test.go
+++ b/internal/pkg/docker/dockercompose/svc_image_test.go
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package dockercompose
 
 import (

--- a/internal/pkg/docker/dockercompose/svc_image_test.go
+++ b/internal/pkg/docker/dockercompose/svc_image_test.go
@@ -1,0 +1,162 @@
+package dockercompose
+
+import (
+	"errors"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/copilot-cli/internal/pkg/manifest"
+	"github.com/compose-spec/compose-go/types"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestConvertImageConfig(t *testing.T) {
+	testCases := map[string]struct {
+		inBuild  types.BuildConfig
+		inImgLoc string
+
+		wantImage       manifest.Image
+		wantIgnoredKeys IgnoredKeys
+		wantErr         error
+	}{
+		"happy path image only": {
+			inImgLoc: "nginx",
+			wantImage: manifest.Image{
+				Location: aws.String("nginx"),
+			},
+		},
+		"happy path image and build": {
+			inImgLoc: "nginx",
+			inBuild: types.BuildConfig{
+				Context:    "test",
+				Dockerfile: "Dockerfile.test",
+			},
+			wantImage: manifest.Image{
+				Location: aws.String("nginx"),
+			},
+		},
+		"happy path build only": {
+			inBuild: types.BuildConfig{
+				Context:    "test",
+				Dockerfile: "Dockerfile.test",
+			},
+			wantImage: manifest.Image{
+				Build: manifest.BuildArgsOrString{BuildArgs: manifest.DockerBuildArgs{
+					Context:    aws.String("test"),
+					Dockerfile: aws.String("Dockerfile.test"),
+				}},
+			},
+		},
+		"build with all non-fatal properties": {
+			inBuild: types.BuildConfig{
+				Context:    "test",
+				Dockerfile: "Dockerfile.test",
+				Args: map[string]*string{
+					"GIT_COMMIT": aws.String("323189ab"),
+					"ARG2":       aws.String("VAL"),
+				},
+				Labels: map[string]string{
+					"docker.test": "val",
+				},
+				CacheFrom: []string{
+					"example.com",
+				},
+				CacheTo: []string{
+					"example2.com",
+				},
+				NoCache:   true,
+				Pull:      true,
+				Isolation: "none",
+				Target:    "myapp",
+				Tags: []string{
+					"tag",
+				},
+				Extensions: map[string]interface{}{
+					"test": "ext",
+				},
+			},
+			wantIgnoredKeys: []string{
+				"build.cache_to",
+				"build.no_cache",
+				"build.pull",
+				"build.isolation",
+				"build.tags",
+				"build.extensions",
+			},
+			wantImage: manifest.Image{
+				DockerLabels: map[string]string{
+					"docker.test": "val",
+				},
+				Build: manifest.BuildArgsOrString{BuildArgs: manifest.DockerBuildArgs{
+					Context:    aws.String("test"),
+					Dockerfile: aws.String("Dockerfile.test"),
+					Args: map[string]string{
+						"GIT_COMMIT": "323189ab",
+						"ARG2":       "VAL",
+					},
+					CacheFrom: []string{"example.com"},
+					Target:    aws.String("myapp"),
+				}},
+			},
+		},
+		"fatal build.ssh": {
+			inBuild: types.BuildConfig{
+				SSH: []types.SSHKey{
+					{
+						ID:   "ssh",
+						Path: "/test",
+					},
+				},
+			},
+			wantErr: errors.New("`build.ssh` and `build.secrets` are not supported yet, see https://github.com/aws/copilot-cli/issues/2090 for details"),
+		},
+		"fatal build.secrets": {
+			inBuild: types.BuildConfig{
+				Secrets: []types.ServiceSecretConfig{
+					{
+						Source: "/root",
+					},
+				},
+			},
+			wantErr: errors.New("`build.ssh` and `build.secrets` are not supported yet, see https://github.com/aws/copilot-cli/issues/2090 for details"),
+		},
+		"fatal build.extra_hosts": {
+			inBuild: types.BuildConfig{
+				ExtraHosts: map[string]string{
+					"host1": "192.168.1.1",
+				},
+			},
+			wantErr: errors.New("key `build.extra_hosts` is not supported yet, this might break your app"),
+		},
+		"fatal build.network": {
+			inBuild: types.BuildConfig{
+				Network: "none",
+			},
+			wantErr: errors.New("key `build.network` is not supported yet, this might break your app"),
+		},
+		"fatal missing arg values": {
+			inBuild: types.BuildConfig{
+				Args: map[string]*string{
+					"GIT_COMMIT": nil,
+					"ARG2":       aws.String("VAL"),
+				},
+			},
+			wantErr: errors.New("convert build args: some entries are missing values and require user input, this is not supported in Copilot: [GIT_COMMIT]"),
+		},
+		// TODO
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			img, ignored, err := convertImageConfig(&tc.inBuild, tc.inImgLoc)
+
+			if tc.wantErr != nil {
+				require.Error(t, err)
+				require.EqualError(t, err, tc.wantErr.Error())
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.wantIgnoredKeys, ignored)
+				require.Equal(t, tc.wantImage, img)
+			}
+		})
+	}
+}

--- a/internal/pkg/docker/dockercompose/svc_image_test.go
+++ b/internal/pkg/docker/dockercompose/svc_image_test.go
@@ -160,8 +160,8 @@ func TestConvertImageConfig(t *testing.T) {
 					"ARG2":       aws.String("VAL"),
 				},
 			},
-			wantErr: errors.New("convert build args: entry '[GIT_COMMIT]' is missing a value and requires user " +
-				"input, this is unsupported in Copilot"),
+			wantErr: errors.New("convert build args: entry '[GIT_COMMIT]' is missing a value; " +
+				"this is unsupported in Copilot"),
 		},
 	}
 

--- a/internal/pkg/docker/dockercompose/svc_image_test.go
+++ b/internal/pkg/docker/dockercompose/svc_image_test.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/copilot-cli/internal/pkg/manifest"
-	"github.com/compose-spec/compose-go/types"
+	compose "github.com/compose-spec/compose-go/types"
 	"github.com/stretchr/testify/require"
 	"testing"
 )
@@ -26,7 +26,7 @@ func TestConvertImageConfigNil(t *testing.T) {
 
 func TestConvertImageConfig(t *testing.T) {
 	testCases := map[string]struct {
-		inBuild  types.BuildConfig
+		inBuild  compose.BuildConfig
 		inLabels map[string]string
 		inImgLoc string
 
@@ -42,7 +42,7 @@ func TestConvertImageConfig(t *testing.T) {
 		},
 		"happy path image and build": {
 			inImgLoc: "nginx",
-			inBuild: types.BuildConfig{
+			inBuild: compose.BuildConfig{
 				Context:    "test",
 				Dockerfile: "Dockerfile.test",
 			},
@@ -51,7 +51,7 @@ func TestConvertImageConfig(t *testing.T) {
 			},
 		},
 		"happy path build only": {
-			inBuild: types.BuildConfig{
+			inBuild: compose.BuildConfig{
 				Context:    "test",
 				Dockerfile: "Dockerfile.test",
 			},
@@ -63,7 +63,7 @@ func TestConvertImageConfig(t *testing.T) {
 			},
 		},
 		"build with all non-fatal properties": {
-			inBuild: types.BuildConfig{
+			inBuild: compose.BuildConfig{
 				Context:    "test",
 				Dockerfile: "Dockerfile.test",
 				Args: map[string]*string{
@@ -119,8 +119,8 @@ func TestConvertImageConfig(t *testing.T) {
 			},
 		},
 		"fatal build.ssh": {
-			inBuild: types.BuildConfig{
-				SSH: []types.SSHKey{
+			inBuild: compose.BuildConfig{
+				SSH: []compose.SSHKey{
 					{
 						ID:   "ssh",
 						Path: "/test",
@@ -130,8 +130,8 @@ func TestConvertImageConfig(t *testing.T) {
 			wantErr: errors.New("`build.ssh` and `build.secrets` are not supported yet, see https://github.com/aws/copilot-cli/issues/2090 for details"),
 		},
 		"fatal build.secrets": {
-			inBuild: types.BuildConfig{
-				Secrets: []types.ServiceSecretConfig{
+			inBuild: compose.BuildConfig{
+				Secrets: []compose.ServiceSecretConfig{
 					{
 						Source: "/root",
 					},
@@ -140,7 +140,7 @@ func TestConvertImageConfig(t *testing.T) {
 			wantErr: errors.New("`build.ssh` and `build.secrets` are not supported yet, see https://github.com/aws/copilot-cli/issues/2090 for details"),
 		},
 		"fatal build.extra_hosts": {
-			inBuild: types.BuildConfig{
+			inBuild: compose.BuildConfig{
 				ExtraHosts: map[string]string{
 					"host1": "192.168.1.1",
 				},
@@ -148,13 +148,13 @@ func TestConvertImageConfig(t *testing.T) {
 			wantErr: errors.New("key `build.extra_hosts` is not supported yet, this might break your app"),
 		},
 		"fatal build.network": {
-			inBuild: types.BuildConfig{
+			inBuild: compose.BuildConfig{
 				Network: "none",
 			},
 			wantErr: errors.New("key `build.network` is not supported yet, this might break your app"),
 		},
 		"fatal missing arg values": {
-			inBuild: types.BuildConfig{
+			inBuild: compose.BuildConfig{
 				Args: map[string]*string{
 					"GIT_COMMIT": nil,
 					"ARG2":       aws.String("VAL"),

--- a/internal/pkg/docker/dockercompose/svc_image_test.go
+++ b/internal/pkg/docker/dockercompose/svc_image_test.go
@@ -160,7 +160,8 @@ func TestConvertImageConfig(t *testing.T) {
 					"ARG2":       aws.String("VAL"),
 				},
 			},
-			wantErr: errors.New("convert build args: some entries are missing values and require user input, this is not supported in Copilot: [GIT_COMMIT]"),
+			wantErr: errors.New("convert build args: entry '[GIT_COMMIT]' is missing a value and requires user " +
+				"input, this is unsupported in Copilot"),
 		},
 	}
 

--- a/internal/pkg/docker/dockercompose/svc_image_test.go
+++ b/internal/pkg/docker/dockercompose/svc_image_test.go
@@ -97,6 +97,7 @@ func TestConvertImageConfig(t *testing.T) {
 				"build.isolation",
 				"build.tags",
 				"build.extensions",
+				"build.labels",
 			},
 			wantImage: manifest.Image{
 				DockerLabels: map[string]string{

--- a/internal/pkg/docker/dockercompose/svc_image_test.go
+++ b/internal/pkg/docker/dockercompose/svc_image_test.go
@@ -84,7 +84,7 @@ func TestConvertImageConfig(t *testing.T) {
 					"tag",
 				},
 				Extensions: map[string]interface{}{
-					"test": "ext",
+					"extfield": "ext",
 				},
 			},
 			inLabels: map[string]string{
@@ -96,7 +96,7 @@ func TestConvertImageConfig(t *testing.T) {
 				"build.pull",
 				"build.isolation",
 				"build.tags",
-				"build.extensions",
+				"build.extfield",
 				"build.labels",
 			},
 			wantImage: manifest.Image{

--- a/internal/pkg/docker/dockercompose/svc_image_test.go
+++ b/internal/pkg/docker/dockercompose/svc_image_test.go
@@ -86,9 +86,6 @@ func TestConvertImageConfig(t *testing.T) {
 				Tags: []string{
 					"tag",
 				},
-				Extensions: map[string]interface{}{
-					"extfield": "ext",
-				},
 			},
 			inLabels: map[string]string{
 				"docker.test": "val",
@@ -99,7 +96,6 @@ func TestConvertImageConfig(t *testing.T) {
 				"build.pull",
 				"build.isolation",
 				"build.tags",
-				"build.extfield",
 				"build.labels",
 			},
 			wantImage: manifest.Image{

--- a/internal/pkg/docker/dockercompose/svc_test.go
+++ b/internal/pkg/docker/dockercompose/svc_test.go
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package dockercompose
 
 import (

--- a/internal/pkg/docker/dockercompose/svc_test.go
+++ b/internal/pkg/docker/dockercompose/svc_test.go
@@ -7,19 +7,19 @@ import (
 	"errors"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/copilot-cli/internal/pkg/manifest"
-	"github.com/compose-spec/compose-go/types"
+	compose "github.com/compose-spec/compose-go/types"
 	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
 )
 
 func TestConvertBackendService(t *testing.T) {
-	fiveSeconds := types.Duration(5 * time.Second)
-	threeSeconds := types.Duration(3 * time.Second)
-	oneSecond := types.Duration(time.Second)
+	fiveSeconds := compose.Duration(5 * time.Second)
+	threeSeconds := compose.Duration(3 * time.Second)
+	oneSecond := compose.Duration(time.Second)
 
 	testCases := map[string]struct {
-		inSvc  types.ServiceConfig
+		inSvc  compose.ServiceConfig
 		inPort uint16
 
 		wantBackendSvc manifest.BackendServiceConfig
@@ -27,7 +27,7 @@ func TestConvertBackendService(t *testing.T) {
 		wantError      error
 	}{
 		"happy path trivial image": {
-			inSvc: types.ServiceConfig{
+			inSvc: compose.ServiceConfig{
 				Name:  "web",
 				Image: "nginx",
 			},
@@ -43,14 +43,14 @@ func TestConvertBackendService(t *testing.T) {
 			}},
 		},
 		"happy path complete": {
-			inSvc: types.ServiceConfig{
+			inSvc: compose.ServiceConfig{
 				Name: "web",
 
-				Command: types.ShellCommand{
+				Command: compose.ShellCommand{
 					"CMD-SHELL",
 					"/bin/nginx",
 				},
-				Entrypoint: types.ShellCommand{
+				Entrypoint: compose.ShellCommand{
 					"CMD",
 					"/bin/sh",
 				},
@@ -60,7 +60,7 @@ func TestConvertBackendService(t *testing.T) {
 					"ENABLE_HTTPS": aws.String("true"),
 				},
 				Platform: "linux/arm64",
-				HealthCheck: &types.HealthCheckConfig{
+				HealthCheck: &compose.HealthCheckConfig{
 					Test: []string{
 						"CMD",
 						"/bin/echo",
@@ -75,7 +75,7 @@ func TestConvertBackendService(t *testing.T) {
 					"docker.test2": "val2",
 				},
 				Image: "nginx",
-				Build: &types.BuildConfig{
+				Build: &compose.BuildConfig{
 					Context:    "dir",
 					Dockerfile: "dir/Dockerfile",
 					Args: map[string]*string{
@@ -136,7 +136,7 @@ func TestConvertBackendService(t *testing.T) {
 				}},
 		},
 		"multiple env files": {
-			inSvc: types.ServiceConfig{
+			inSvc: compose.ServiceConfig{
 				Name:  "web",
 				Image: "nginx",
 				EnvFile: []string{
@@ -149,7 +149,7 @@ func TestConvertBackendService(t *testing.T) {
 			wantError: errors.New("convert task config: at most one env file is supported, but 2 env files were attached to this service"),
 		},
 		"env variables with missing values": {
-			inSvc: types.ServiceConfig{
+			inSvc: compose.ServiceConfig{
 				Name:  "web",
 				Image: "nginx",
 				Environment: map[string]*string{
@@ -163,7 +163,7 @@ func TestConvertBackendService(t *testing.T) {
 				"a value and requires user input, this is unsupported in Copilot"),
 		},
 		"platform windows": {
-			inSvc: types.ServiceConfig{
+			inSvc: compose.ServiceConfig{
 				Name:     "web",
 				Image:    "nginx",
 				Platform: "windows",
@@ -187,9 +187,9 @@ func TestConvertBackendService(t *testing.T) {
 			},
 		},
 		"partial healthcheck": {
-			inSvc: types.ServiceConfig{
+			inSvc: compose.ServiceConfig{
 				Name: "web",
-				HealthCheck: &types.HealthCheckConfig{
+				HealthCheck: &compose.HealthCheckConfig{
 					Timeout:     &fiveSeconds,
 					StartPeriod: &threeSeconds,
 				},
@@ -214,9 +214,9 @@ func TestConvertBackendService(t *testing.T) {
 			},
 		},
 		"disabled healthcheck": {
-			inSvc: types.ServiceConfig{
+			inSvc: compose.ServiceConfig{
 				Name: "web",
-				HealthCheck: &types.HealthCheckConfig{
+				HealthCheck: &compose.HealthCheckConfig{
 					Timeout:     &fiveSeconds,
 					StartPeriod: &threeSeconds,
 					Disable:     true,
@@ -243,9 +243,9 @@ func TestConvertBackendService(t *testing.T) {
 			},
 		},
 		"disabled healthcheck with cmd": {
-			inSvc: types.ServiceConfig{
+			inSvc: compose.ServiceConfig{
 				Name: "web",
-				HealthCheck: &types.HealthCheckConfig{
+				HealthCheck: &compose.HealthCheckConfig{
 					Test: []string{
 						"CMD",
 						"/bin/echo",
@@ -282,14 +282,14 @@ func TestConvertBackendService(t *testing.T) {
 				"unrecognized",
 			},
 
-			inSvc: types.ServiceConfig{
+			inSvc: compose.ServiceConfig{
 				Name: "web",
-				HealthCheck: &types.HealthCheckConfig{
+				HealthCheck: &compose.HealthCheckConfig{
 					Extensions: map[string]interface{}{
 						"extfield": 1,
 					},
 				},
-				Build: &types.BuildConfig{
+				Build: &compose.BuildConfig{
 					Context: "here/",
 					Extensions: map[string]interface{}{
 						"ext": "field",

--- a/internal/pkg/docker/dockercompose/svc_test.go
+++ b/internal/pkg/docker/dockercompose/svc_test.go
@@ -275,46 +275,6 @@ func TestConvertBackendService(t *testing.T) {
 				},
 			},
 		},
-		"extension fields": {
-			wantIgnored: []string{
-				"build.ext",
-				"healthcheck.extfield",
-				"unrecognized",
-			},
-
-			inSvc: compose.ServiceConfig{
-				Name: "web",
-				HealthCheck: &compose.HealthCheckConfig{
-					Extensions: map[string]interface{}{
-						"extfield": 1,
-					},
-				},
-				Build: &compose.BuildConfig{
-					Context: "here/",
-					Extensions: map[string]interface{}{
-						"ext": "field",
-					},
-				},
-				Extensions: map[string]interface{}{
-					"unrecognized": "ignored",
-				},
-			},
-			inPort: 443,
-
-			wantBackendSvc: manifest.BackendServiceConfig{ImageConfig: manifest.ImageWithHealthcheckAndOptionalPort{
-				ImageWithOptionalPort: manifest.ImageWithOptionalPort{
-					Image: manifest.Image{
-						Build: manifest.BuildArgsOrString{BuildArgs: manifest.DockerBuildArgs{
-							Context: aws.String("here/"),
-						}},
-					},
-					Port: aws.Uint16(443),
-				},
-				HealthCheck: manifest.ContainerHealthCheck{
-					Retries: aws.Int(3),
-				},
-			}},
-		},
 	}
 
 	for name, tc := range testCases {

--- a/internal/pkg/docker/dockercompose/svc_test.go
+++ b/internal/pkg/docker/dockercompose/svc_test.go
@@ -6,9 +6,14 @@ import (
 	"github.com/compose-spec/compose-go/types"
 	"github.com/stretchr/testify/require"
 	"testing"
+	"time"
 )
 
 func TestConvertBackendService(t *testing.T) {
+	fiveSeconds := types.Duration(5 * time.Second)
+	threeSeconds := types.Duration(3 * time.Second)
+	oneSecond := types.Duration(time.Second)
+
 	testCases := map[string]struct {
 		inSvc  types.ServiceConfig
 		inPort uint16
@@ -33,6 +38,105 @@ func TestConvertBackendService(t *testing.T) {
 				},
 			}},
 		},
+		"happy path complete": {
+			inSvc: types.ServiceConfig{
+				Name: "web",
+
+				Command: types.ShellCommand{
+					"CMD-SHELL",
+					"/bin/nginx",
+				},
+				Entrypoint: types.ShellCommand{
+					"CMD",
+					"/bin/sh",
+				},
+				EnvFile: []string{"/test.env"},
+				Environment: map[string]*string{
+					"HOST_PATH":    aws.String("/home/nginx"),
+					"ENABLE_HTTPS": aws.String("true"),
+				},
+				Platform: "linux/arm64",
+				HealthCheck: &types.HealthCheckConfig{
+					Test: []string{
+						"CMD",
+						"/bin/echo",
+					},
+					Timeout:     &fiveSeconds,
+					Interval:    &oneSecond,
+					Retries:     aws.Uint64(100),
+					StartPeriod: &threeSeconds,
+				},
+				Labels: map[string]string{
+					"docker.test":  "val",
+					"docker.test2": "val2",
+				},
+				Image: "nginx",
+				Build: &types.BuildConfig{
+					Context:    "dir",
+					Dockerfile: "dir/Dockerfile",
+					Args: map[string]*string{
+						"GIT_COMMIT": aws.String("323189ab"),
+						"ARG2":       aws.String("VAL"),
+					},
+					CacheFrom: []string{"example.com"},
+					Target:    "myapp",
+				},
+			},
+			inPort: 443,
+
+			wantBackendSvc: manifest.BackendServiceConfig{ImageConfig: manifest.ImageWithHealthcheckAndOptionalPort{
+				ImageWithOptionalPort: manifest.ImageWithOptionalPort{
+					Image: manifest.Image{
+						Location: aws.String("nginx"),
+						DockerLabels: map[string]string{
+							"docker.test":  "val",
+							"docker.test2": "val2",
+						},
+					},
+					Port: aws.Uint16(443),
+				},
+				HealthCheck: manifest.ContainerHealthCheck{
+					Command: []string{
+						"CMD",
+						"/bin/echo",
+					},
+					Timeout:     (*time.Duration)(&fiveSeconds),
+					Interval:    (*time.Duration)(&oneSecond),
+					Retries:     aws.Int(100),
+					StartPeriod: (*time.Duration)(&threeSeconds),
+				},
+			},
+				ImageOverride: manifest.ImageOverride{
+					Command: manifest.CommandOverride{
+						StringSlice: []string{
+							"CMD-SHELL",
+							"/bin/nginx",
+						},
+					},
+					EntryPoint: manifest.EntryPointOverride{
+						StringSlice: []string{
+							"CMD",
+							"/bin/sh",
+						},
+					},
+				},
+				TaskConfig: manifest.TaskConfig{
+					Platform: manifest.PlatformArgsOrString{
+						PlatformString: (*manifest.PlatformString)(aws.String("linux/arm64")),
+					},
+					Variables: map[string]string{
+						"HOST_PATH":    "/home/nginx",
+						"ENABLE_HTTPS": "true",
+					},
+					EnvFile: aws.String("/test.env"),
+				}},
+		},
+		// TODO: Multiple env files
+		// TODO: Env variable with missing values
+		// TODO: Platform values
+		// TODO: Healthcheck some values nil
+		// TODO: Healthcheck disable
+		// TODO: Extensions fields on healthcheck, build, service
 	}
 
 	for name, tc := range testCases {

--- a/internal/pkg/docker/dockercompose/svc_test.go
+++ b/internal/pkg/docker/dockercompose/svc_test.go
@@ -160,7 +160,7 @@ func TestConvertBackendService(t *testing.T) {
 			inPort: 8080,
 
 			wantError: errors.New("convert task config: convert environment variables: entry '[test]' is missing " +
-				"a value and requires user input, this is unsupported in Copilot"),
+				"a value; this is unsupported in Copilot"),
 		},
 		"platform windows": {
 			inSvc: compose.ServiceConfig{

--- a/internal/pkg/docker/dockercompose/svc_test.go
+++ b/internal/pkg/docker/dockercompose/svc_test.go
@@ -1,0 +1,51 @@
+package dockercompose
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/copilot-cli/internal/pkg/manifest"
+	"github.com/compose-spec/compose-go/types"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestConvertBackendService(t *testing.T) {
+	testCases := map[string]struct {
+		inSvc  types.ServiceConfig
+		inPort uint16
+
+		wantBackendSvc manifest.BackendServiceConfig
+		wantIgnored    IgnoredKeys
+		wantError      error
+	}{
+		"happy path trivial image": {
+			inSvc: types.ServiceConfig{
+				Name:  "web",
+				Image: "nginx",
+			},
+			inPort: 8080,
+
+			wantBackendSvc: manifest.BackendServiceConfig{ImageConfig: manifest.ImageWithHealthcheckAndOptionalPort{
+				ImageWithOptionalPort: manifest.ImageWithOptionalPort{
+					Image: manifest.Image{
+						Location: aws.String("nginx"),
+					},
+					Port: aws.Uint16(8080),
+				},
+			}},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			svc, ignored, err := convertBackendService(&tc.inSvc, tc.inPort)
+
+			if tc.wantError != nil {
+				require.EqualError(t, err, tc.wantError.Error())
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.wantIgnored, ignored)
+				require.Equal(t, tc.wantBackendSvc, *svc)
+			}
+		})
+	}
+}

--- a/internal/pkg/docker/dockercompose/svc_test.go
+++ b/internal/pkg/docker/dockercompose/svc_test.go
@@ -159,8 +159,8 @@ func TestConvertBackendService(t *testing.T) {
 			},
 			inPort: 8080,
 
-			wantError: errors.New("convert task config: convert environment variables: some entries are missing " +
-				"values and require user input, this is not supported in Copilot: [test]"),
+			wantError: errors.New("convert task config: convert environment variables: entry '[test]' is missing " +
+				"a value and requires user input, this is unsupported in Copilot"),
 		},
 		"platform windows": {
 			inSvc: types.ServiceConfig{

--- a/internal/pkg/docker/dockercompose/unsupported.go
+++ b/internal/pkg/docker/dockercompose/unsupported.go
@@ -3,10 +3,11 @@
 
 package dockercompose
 
-// NOTE: This file is currently unused, it will be used in the next PR.
+// NOTE: This file is currently unused, it will be used in the next PR. Don't mind the comments for now!
 
 type IgnoredKeys []string
 
+/*
 // ignoredServiceKeys lists out the keys on Compose services that are ignored in conversion.
 //
 // note: build keys are handled separately in convertBuildConfig
@@ -75,3 +76,4 @@ var fatalServiceKeys = map[string]string{
 	"stop_signal":       "unsupported in Copilot manifests",
 	"volumes_from":      "sharing volumes is not yet supported",
 }
+*/

--- a/internal/pkg/docker/dockercompose/unsupported.go
+++ b/internal/pkg/docker/dockercompose/unsupported.go
@@ -1,0 +1,72 @@
+package dockercompose
+
+type IgnoredKeys []string
+
+// IgnoredServiceKeys lists out the keys on Compose services that are ignored in conversion.
+//
+// note: build keys are handled separately in convertBuildConfig
+var IgnoredServiceKeys = map[string]struct{}{
+	"blkio_config":        {},
+	"cpu_count":           {},
+	"cpu_percent":         {},
+	"cpu_shares":          {},
+	"cpu_period":          {},
+	"cpu_quota":           {},
+	"cpu_rt_runtime":      {},
+	"cpu_rt_period":       {},
+	"cpus":                {},
+	"cpuset":              {},
+	"cap_add":             {},
+	"cap_drop":            {},
+	"cgroup_parent":       {},
+	"device_cgroup_rules": {},
+	"logging":             {},
+	"mac_address":         {},
+	"mem_limit":           {},
+	"mem_reservation":     {},
+	"mem_swappiness":      {},
+	"memswap_limit":       {},
+	"oom_kill_disable":    {},
+	"oom_score_adj":       {},
+	"pid":                 {},
+	"pids_limit":          {},
+	"profiles":            {},
+	"pull_policy":         {},
+	"runtime":             {},
+	"security_opt":        {},
+	"shm_size":            {},
+	"stdin_open":          {},
+	"storage_opt":         {},
+	"sysctls":             {},
+	"tmpfs":               {},
+	"user":                {},
+	"userns_mode":         {},
+	"hostname":            {},
+	"depends_on":          {},
+	"restart":             {},
+}
+
+// FatalServiceKeys lists out the service keys that are unsupported and whose absence will
+// break applications.
+//
+// note: build keys are handled separately in convertBuildConfig
+// TODO(rclinard-amzn): Handle unsupported network keys when network conversion is implemented
+var FatalServiceKeys = map[string]string{
+	"credential_spec":   "",
+	"devices":           "",
+	"domainname":        "",
+	"group_add":         "",
+	"init":              "",
+	"ipc":               "",
+	"isolation":         "",
+	"privileged":        "unsupported in Fargate",
+	"external_links":    "",
+	"working_dir":       "unsupported in Copilot manifests",
+	"configs":           "unsupported, use secrets for similar functionality",
+	"dns":               "unsupported in Copilot manifests",
+	"dns_opt":           "unsupported in Copilot manifests",
+	"dns_search":        "unsupported in Copilot manifests",
+	"stop_grace_period": "unsupported in Copilot manifests",
+	"stop_signal":       "unsupported in Copilot manifests",
+	"volumes_from":      "sharing volumes is not yet supported",
+}

--- a/internal/pkg/docker/dockercompose/unsupported.go
+++ b/internal/pkg/docker/dockercompose/unsupported.go
@@ -1,11 +1,13 @@
 package dockercompose
 
+// NOTE: This file is currently unused, it will be used in the next PR.
+
 type IgnoredKeys []string
 
-// IgnoredServiceKeys lists out the keys on Compose services that are ignored in conversion.
+// ignoredServiceKeys lists out the keys on Compose services that are ignored in conversion.
 //
 // note: build keys are handled separately in convertBuildConfig
-var IgnoredServiceKeys = map[string]struct{}{
+var ignoredServiceKeys = map[string]struct{}{
 	"blkio_config":        {},
 	"cpu_count":           {},
 	"cpu_percent":         {},
@@ -46,12 +48,12 @@ var IgnoredServiceKeys = map[string]struct{}{
 	"restart":             {},
 }
 
-// FatalServiceKeys lists out the service keys that are unsupported and whose absence will
+// fatalServiceKeys lists out the service keys that are unsupported and whose absence will
 // break applications.
 //
 // note: build keys are handled separately in convertBuildConfig
 // TODO(rclinard-amzn): Handle unsupported network keys when network conversion is implemented
-var FatalServiceKeys = map[string]string{
+var fatalServiceKeys = map[string]string{
 	"credential_spec":   "",
 	"devices":           "",
 	"domainname":        "",

--- a/internal/pkg/docker/dockercompose/unsupported.go
+++ b/internal/pkg/docker/dockercompose/unsupported.go
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package dockercompose
 
 // NOTE: This file is currently unused, it will be used in the next PR.

--- a/internal/pkg/docker/dockercompose/unsupported.go
+++ b/internal/pkg/docker/dockercompose/unsupported.go
@@ -5,6 +5,9 @@ package dockercompose
 
 // NOTE: This file is currently unused, it will be used in the next PR. Don't mind the comments for now!
 
+// IgnoredKeys stores a list of keys in the Compose YAML that couldn't be processed,
+// but are likely to not be significant enough to cause the converted application to
+// fail. It's expected that this will eventually be displayed to the user.
 type IgnoredKeys []string
 
 /*


### PR DESCRIPTION
<!-- Provide summary of changes -->

Note: This is targeting the `experiment/docker-compose-import` branch. It is not targeting the mainline release branch. 
Also note that most of the added code is unit tests - there's <250 lines of actual functional code.

This PR implements the first milestone of the Docker Compose import experiment. We set up the library and handle the Compose concepts that mostly mirror 1:1 with Copilot fields.

In the next PR, I will add detection for unsupported Compose fields that this experiment won't support.

Relates to https://github.com/aws/copilot-cli/issues/1612

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
