### PR TITLE
test(regression): disable Ginkgo color output for regression test in CICD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ node_modules/
 site/node_modules/
 site/themes/docsy
 internal/pkg/template/templates/custom-resources/
+regression/*/copilot/
+e2e/*/copilot/

--- a/.release/buildspec_regression.yml
+++ b/.release/buildspec_regression.yml
@@ -43,4 +43,4 @@ phases:
       - chmod +x ./copilot-linux-${FROM_VERSION}
       - export REGRESSION_TEST_FROM_PATH=../../copilot-linux-${FROM_VERSION}
       - export REGRESSION_TEST_TO_PATH=../../bin/local/copilot-linux-amd64
-      - cd regression/${TEST_SUITE} && ginkgo -v -r
+      - cd regression/${TEST_SUITE} && ginkgo -v -r -noColor


### PR DESCRIPTION


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
