### PR TITLE
test(regression): maintain count of 1 for frontend service

### DIFF
--- a/regression/multi-svc-app/copilot/front-end/manifest.yml
+++ b/regression/multi-svc-app/copilot/front-end/manifest.yml
@@ -27,10 +27,7 @@ cpu: 256
 # Amount of memory in MiB used by the task.
 memory: 512
 # Number of tasks that should be running in your service.
-count:
-  range: 2-5
-  cpu_percentage: 70
-  memory_percentage: 80
+count: 1
 
 storage:
   ephemeral: 30


### PR DESCRIPTION
Due to the architecture of the application, setting the task count to > 1 introduces flakiness into the regression test. The job `query` hits the front-end endpoint `/job-setter` that sets an environment variable, and that environment variable is later used to validate that the job `query` indeed has hit the endpoint by checking the response from `/job-checker`. Having count=1 ensures that traffic to both endpoint is routed to the same task.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
