### PR TITLE
build: upgrade lambda runtime from nodejs12.x to nodejs16.x

### DIFF
--- a/internal/pkg/addon/package_test.go
+++ b/internal/pkg/addon/package_test.go
@@ -80,7 +80,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt "TestRole.Arn"
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
 `,
 			outTemplate: `
 Resources:
@@ -96,7 +96,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt "TestRole.Arn"
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
 `,
 		},
 		"AWS::Glue::Job, non-zipped file": {
@@ -225,7 +225,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt "TestRole.Arn"
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
 `,
 			outTemplate: `
 Resources:
@@ -247,7 +247,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt "TestRole.Arn"
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
 `,
 		},
 		"Fn::Transform nested in a yaml mapping and sequence node": {

--- a/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-basic-manifest.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-basic-manifest.yml
@@ -913,7 +913,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'CustomResourceRole.Arn'
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
   
   CustomDomainFunction:
     Condition: ManagedAliases
@@ -926,7 +926,7 @@ Resources:
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt 'CustomResourceRole.Arn'
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
   
   DNSDelegationFunction:
     Type: AWS::Lambda::Function
@@ -939,7 +939,7 @@ Resources:
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt 'CustomResourceRole.Arn'
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
   DelegateDNSAction:
     Metadata:
       'aws:copilot:description': 'Delegate DNS for environment subdomain'

--- a/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-default-access-log-config.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-default-access-log-config.yml
@@ -1009,7 +1009,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'CustomResourceRole.Arn'
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
   
   CustomDomainFunction:
     Condition: ManagedAliases
@@ -1022,7 +1022,7 @@ Resources:
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt 'CustomResourceRole.Arn'
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
   
   DNSDelegationFunction:
     Type: AWS::Lambda::Function
@@ -1035,7 +1035,7 @@ Resources:
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt 'CustomResourceRole.Arn'
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
   DelegateDNSAction:
     Metadata:
       'aws:copilot:description': 'Delegate DNS for environment subdomain'

--- a/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-imported-certs-observability.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-imported-certs-observability.yml
@@ -301,7 +301,7 @@ Resources:
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt "UniqueJSONValuesFunctionRole.Arn"
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
   UniqueAliasesAction:
     Metadata:
       "aws:copilot:description": "An action to get unique custom aliases for services in your environment"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/http-autoscaling-template.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/http-autoscaling-template.yml
@@ -291,7 +291,7 @@ Resources:
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt "DynamicDesiredCountFunctionRole.Arn"
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
   DynamicDesiredCountFunctionRole:
     Metadata:
       "aws:copilot:description": "An IAM Role for describing number of running tasks in your ECS service"
@@ -462,7 +462,7 @@ Resources:
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt "RulePriorityFunctionRole.Arn"
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
   RulePriorityFunctionRole:
     Metadata:
       "aws:copilot:description": "An IAM Role to describe load balancer rules for assigning a priority"
@@ -570,7 +570,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt "EnvControllerRole.Arn"
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
   EnvControllerRole:
     Metadata:
       "aws:copilot:description": "An IAM role to update your environment stack"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/http-full-config-template.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/http-full-config-template.yml
@@ -347,7 +347,7 @@ Resources:
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt "RulePriorityFunctionRole.Arn"
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
   RulePriorityFunctionRole:
     Metadata:
       "aws:copilot:description": "An IAM Role to describe load balancer rules for assigning a priority"
@@ -459,7 +459,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt "EnvControllerRole.Arn"
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
   EnvControllerRole:
     Metadata:
       "aws:copilot:description": "An IAM role to update your environment stack"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/http-only-path-template.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/http-only-path-template.yml
@@ -340,7 +340,7 @@ Resources:
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt "RulePriorityFunctionRole.Arn"
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
   RulePriorityFunctionRole:
     Metadata:
       "aws:copilot:description": "An IAM Role to describe load balancer rules for assigning a priority"
@@ -448,7 +448,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt "EnvControllerRole.Arn"
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
   EnvControllerRole:
     Metadata:
       "aws:copilot:description": "An IAM role to update your environment stack"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/https-path-alias-template.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/https-path-alias-template.yml
@@ -243,7 +243,7 @@ Resources:
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt "RulePriorityFunctionRole.Arn"
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
   RulePriorityFunctionRole:
     Metadata:
       'aws:copilot:description': "An IAM Role to describe load balancer rules for assigning a priority"
@@ -437,7 +437,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'EnvControllerRole.Arn'
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
   EnvControllerRole:
     Metadata:
       'aws:copilot:description': "An IAM role to update your environment stack"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/simple-template.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/simple-template.yml
@@ -325,7 +325,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt "EnvControllerRole.Arn"
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
   EnvControllerRole:
     Metadata:
       "aws:copilot:description": "An IAM role to update your environment stack"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/job-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/job-test.stack.yml
@@ -64,7 +64,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'EnvControllerRole.Arn'
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
 
   EnvControllerRole:
     Metadata:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/rdws-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/rdws-test.stack.yml
@@ -220,7 +220,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'EnvControllerRole.Arn'
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
   
   EnvControllerRole:
     Metadata:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-grpc-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-grpc-test.stack.yml
@@ -256,7 +256,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt 'DynamicDesiredCountFunctionRole.Arn'
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
   DynamicDesiredCountFunctionRole:
     Metadata:
       'aws:copilot:description': "An IAM Role for describing number of running tasks in your ECS service"
@@ -363,7 +363,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'EnvControllerRole.Arn'
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
   EnvControllerRole:
     Metadata:
       'aws:copilot:description': "An IAM role to update your environment stack"
@@ -473,7 +473,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt 'RulePriorityFunctionRole.Arn'
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
   RulePriorityFunctionRole:
     Metadata:
       'aws:copilot:description': "An IAM Role to describe load balancer rules for assigning a priority"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-dev.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-dev.stack.yml
@@ -240,7 +240,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'EnvControllerRole.Arn'
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
   EnvControllerRole:
     Metadata:
       'aws:copilot:description': "An IAM role to update your environment stack"
@@ -356,7 +356,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt 'RulePriorityFunctionRole.Arn'
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
   RulePriorityFunctionRole:
     Metadata:
       'aws:copilot:description': "An IAM Role to describe load balancer rules for assigning a priority"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-prod.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-prod.stack.yml
@@ -246,7 +246,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'EnvControllerRole.Arn'
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
   EnvControllerRole:
     Metadata:
       'aws:copilot:description': "An IAM role to update your environment stack"
@@ -415,7 +415,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'NLBCustomDomainRole.Arn'
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
   NLBCustomDomainRole:
     Metadata:
       'aws:copilot:description': "An IAM role to update the environment Route 53 hosted zone"
@@ -482,7 +482,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'NLBCertValidatorRole.Arn'
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
   NLBCertValidatorRole:
     Metadata:
       'aws:copilot:description': "An IAM role to request and validate a certificate for your service"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-test.stack.yml
@@ -229,7 +229,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'EnvControllerRole.Arn'
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
   EnvControllerRole:
     Metadata:
       'aws:copilot:description': "An IAM role to update your environment stack"
@@ -427,7 +427,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'NLBCertValidatorRole.Arn'
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
   NLBCertValidatorRole:
     Metadata:
       'aws:copilot:description': "An IAM role to request and validate a certificate for your service"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-prod.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-prod.stack.yml
@@ -339,7 +339,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt 'DynamicDesiredCountFunctionRole.Arn'
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
   DynamicDesiredCountFunctionRole:
     Metadata:
       'aws:copilot:description': "An IAM Role for describing number of running tasks in your ECS service"
@@ -446,7 +446,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'EnvControllerRole.Arn'
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
   EnvControllerRole:
     Metadata:
       'aws:copilot:description': "An IAM role to update your environment stack"
@@ -560,7 +560,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt 'RulePriorityFunctionRole.Arn'
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
   RulePriorityFunctionRole:
     Type: AWS::IAM::Role
     Metadata:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-staging.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-staging.stack.yml
@@ -252,7 +252,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'EnvControllerRole.Arn'
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
   EnvControllerRole:
     Metadata:
       'aws:copilot:description': "An IAM role to update your environment stack"
@@ -363,7 +363,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt 'RulePriorityFunctionRole.Arn'
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
   RulePriorityFunctionRole:
     Metadata:
       'aws:copilot:description': "An IAM Role to describe load balancer rules for assigning a priority"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-test.stack.yml
@@ -256,7 +256,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt 'DynamicDesiredCountFunctionRole.Arn'
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
   DynamicDesiredCountFunctionRole:
     Metadata:
       'aws:copilot:description': "An IAM Role for describing number of running tasks in your ECS service"
@@ -363,7 +363,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'EnvControllerRole.Arn'
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
   EnvControllerRole:
     Metadata:
       'aws:copilot:description': "An IAM role to update your environment stack"
@@ -472,7 +472,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt 'RulePriorityFunctionRole.Arn'
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
   RulePriorityFunctionRole:
     Metadata:
       'aws:copilot:description': "An IAM Role to describe load balancer rules for assigning a priority"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/windows-svc-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/windows-svc-test.stack.yml
@@ -234,7 +234,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'EnvControllerRole.Arn'
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
   EnvControllerRole:
     Metadata:
       'aws:copilot:description': "An IAM role to update your environment stack"
@@ -342,7 +342,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt 'RulePriorityFunctionRole.Arn'
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
   RulePriorityFunctionRole:
     Metadata:
       'aws:copilot:description': "An IAM Role to describe load balancer rules for assigning a priority"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/worker-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/worker-test.stack.yml
@@ -290,7 +290,7 @@ Resources:
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt 'DynamicDesiredCountFunctionRole.Arn'
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
   DynamicDesiredCountFunctionRole:
     Metadata:
       'aws:copilot:description': "An IAM Role for describing number of running tasks in your ECS service"
@@ -387,7 +387,7 @@ Resources:
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt BacklogPerTaskCalculatorRole.Arn
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Environment:
         Variables:
           CLUSTER_NAME:
@@ -754,7 +754,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'EnvControllerRole.Arn'
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
   EnvControllerRole:
     Metadata:
       'aws:copilot:description': "An IAM role to update your environment stack"

--- a/internal/pkg/template/templates/environment/partials/cdn-resources.yml
+++ b/internal/pkg/template/templates/environment/partials/cdn-resources.yml
@@ -31,7 +31,7 @@ UniqueJSONValuesFunction:
     Timeout: 600
     MemorySize: 512
     Role: !GetAtt 'UniqueJSONValuesFunctionRole.Arn'
-    Runtime: nodejs12.x
+    Runtime: nodejs16.x
 
 UniqueAliasesAction:
   Metadata:
@@ -94,7 +94,7 @@ CertificateReplicatorFunction:
     Timeout: 900
     MemorySize: 512
     Role: !GetAtt 'CustomResourceRole.Arn'
-    Runtime: nodejs12.x
+    Runtime: nodejs16.x
     
 CertificateReplicator:
   Metadata:

--- a/internal/pkg/template/templates/environment/partials/lambdas.yml
+++ b/internal/pkg/template/templates/environment/partials/lambdas.yml
@@ -11,7 +11,7 @@ CertificateValidationFunction:
     Timeout: 900
     MemorySize: 512
     Role: !GetAtt 'CustomResourceRole.Arn'
-    Runtime: nodejs12.x
+    Runtime: nodejs16.x
 
 CustomDomainFunction:
   Condition: ManagedAliases
@@ -26,7 +26,7 @@ CustomDomainFunction:
     Timeout: 600
     MemorySize: 512
     Role: !GetAtt 'CustomResourceRole.Arn'
-    Runtime: nodejs12.x 
+    Runtime: nodejs16.x 
 
 DNSDelegationFunction:
   Type: AWS::Lambda::Function
@@ -41,4 +41,4 @@ DNSDelegationFunction:
     Timeout: 600
     MemorySize: 512
     Role: !GetAtt 'CustomResourceRole.Arn'
-    Runtime: nodejs12.x
+    Runtime: nodejs16.x

--- a/internal/pkg/template/templates/workloads/partials/cf/alb.yml
+++ b/internal/pkg/template/templates/workloads/partials/cf/alb.yml
@@ -50,7 +50,7 @@ RulePriorityFunction:
     Timeout: 600
     MemorySize: 512
     Role: !GetAtt "RulePriorityFunctionRole.Arn"
-    Runtime: nodejs12.x
+    Runtime: nodejs16.x
 
 RulePriorityFunctionRole:
   Metadata:

--- a/internal/pkg/template/templates/workloads/partials/cf/autoscaling.yml
+++ b/internal/pkg/template/templates/workloads/partials/cf/autoscaling.yml
@@ -26,7 +26,7 @@ DynamicDesiredCountFunction:
     Timeout: 600
     MemorySize: 512
     Role: !GetAtt 'DynamicDesiredCountFunctionRole.Arn'
-    Runtime: nodejs12.x
+    Runtime: nodejs16.x
 
 DynamicDesiredCountFunctionRole:
   Metadata:
@@ -176,7 +176,7 @@ BacklogPerTaskCalculatorFunction:
     Timeout: 600
     MemorySize: 512
     Role: !GetAtt BacklogPerTaskCalculatorRole.Arn
-    Runtime: nodejs12.x
+    Runtime: nodejs16.x
     Environment:
       Variables:
         CLUSTER_NAME:

--- a/internal/pkg/template/templates/workloads/partials/cf/env-controller.yml
+++ b/internal/pkg/template/templates/workloads/partials/cf/env-controller.yml
@@ -23,7 +23,7 @@ EnvControllerFunction:
     Timeout: 900
     MemorySize: 512
     Role: !GetAtt 'EnvControllerRole.Arn'
-    Runtime: nodejs12.x
+    Runtime: nodejs16.x
 
 EnvControllerRole:
   Metadata:

--- a/internal/pkg/template/templates/workloads/partials/cf/nlb.yml
+++ b/internal/pkg/template/templates/workloads/partials/cf/nlb.yml
@@ -145,7 +145,7 @@ NLBCustomDomainFunction:
     Timeout: 900
     MemorySize: 512
     Role: !GetAtt 'NLBCustomDomainRole.Arn'
-    Runtime: nodejs12.x
+    Runtime: nodejs16.x
 
 NLBCustomDomainRole:
   Metadata:
@@ -222,7 +222,7 @@ NLBCertValidatorFunction:
     Timeout: 900
     MemorySize: 512
     Role: !GetAtt 'NLBCertValidatorRole.Arn'
-    Runtime: nodejs12.x
+    Runtime: nodejs16.x
 
 NLBCertValidatorRole:
   Metadata:


### PR DESCRIPTION
Fixes #3896 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
