### PR TITLE
docs: remove duplicated word in job-deploy.en.md

### DIFF
--- a/site/content/docs/commands/job-deploy.en.md
+++ b/site/content/docs/commands/job-deploy.en.md
@@ -33,8 +33,7 @@ The steps involved in `job deploy` are:
 
 !!!info
 The `--no-rollback` flag is **not** recommended while deploying to a production environment as it may introduce service downtime.
-If the deployment fails when automatic stack rollback is disabled, you may be required to manually start the stack
-rollback of the stack via the AWS console or AWS CLI before the next deployment.
+If the deployment fails when automatic stack rollback is disabled, you may be required to manually start the rollback of the stack via the AWS console or AWS CLI before the next deployment.
 
 ## Examples
 


### PR DESCRIPTION
The word `stack` seems redundant, although you may prefer to keep the `stack rollback` wording. Please close this PR if the change is not desired.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
