### PR TITLE
test: fix regression test job failure

### DIFF
--- a/.release/buildspec_e2e.yml
+++ b/.release/buildspec_e2e.yml
@@ -99,7 +99,7 @@ batch:
         image: aws/codebuild/standard:5.0
         variables:
           TEST_SUITE: import-certs
-           APP_REGION: us-west-2
+          APP_REGION: us-west-2
     - identifier: exec
       env:
         privileged-mode: true
@@ -155,36 +155,36 @@ phases:
     runtime-versions:
       nodejs: 12
     commands:
-      - 'cd $HOME/.goenv && git pull --ff-only && cd -'
-      - 'goenv install 1.18.4'
-      - 'goenv global 1.18.4'
+      - "cd $HOME/.goenv && git pull --ff-only && cd -"
+      - "goenv install 1.18.4"
+      - "goenv global 1.18.4"
   pre_build:
     commands:
-       - printenv DOCKERHUB_TOKEN | docker login --username ${DOCKERHUB_USERNAME} --password-stdin
+      - printenv DOCKERHUB_TOKEN | docker login --username ${DOCKERHUB_USERNAME} --password-stdin
   build:
     commands:
-       - cd $CODEBUILD_SRC_DIR
-       - export GOPATH=/go
-       - rm -rf cf-custom-resources/node_modules
-       - mkdir -p /tmp/.aws
-       - TEST_RGN=$TESTENV_REGION
-       - |
-         if [ -z "$TEST_RGN" ]; then
-            TEST_RGN=us-west-1
-         fi
-       - PROD_RGN=$PRODENV_REGION
-       - |
-         if [ -z "$PROD_RGN" ]; then
-            PROD_RGN=us-east-1
-         fi
-       - printf "[default]\nregion = $APP_REGION\n[profile e2etestenv]\nregion=$TEST_RGN\n[profile e2eprodenv]\nregion=$PROD_RGN\n" > /tmp/.aws/config
-       - printf "[default]\naws_access_key_id=$E2E_USER_1_ACCESS_KEY\naws_secret_access_key=$E2E_USER_1_SECRET_KEY\n\n[e2etestenv]\naws_access_key_id=$E2E_USER_2_ACCESS_KEY\naws_secret_access_key=$E2E_USER_2_SECRET_KEY\n\n[e2eprodenv]\naws_access_key_id=$E2E_USER_3_ACCESS_KEY\naws_secret_access_key=$E2E_USER_3_SECRET_KEY\n" > /tmp/.aws/credentials
-       - sed -i -e '$s/$/ --noColor/' e2e/e2e.sh
-       - make build-e2e
-       - docker build -t copilot-cli/e2e . -f e2e/Dockerfile
-       - >
-         docker run --privileged -v /tmp/.aws:/home/.aws -e "HOME=/home"
-         -e "TEST_SUITE=$TEST_SUITE"
-         -e "DOCKERHUB_USERNAME=$DOCKERHUB_USERNAME"
-         -e "DOCKERHUB_TOKEN=$DOCKERHUB_TOKEN"
-         copilot-cli/e2e:latest
+      - cd $CODEBUILD_SRC_DIR
+      - export GOPATH=/go
+      - rm -rf cf-custom-resources/node_modules
+      - mkdir -p /tmp/.aws
+      - TEST_RGN=$TESTENV_REGION
+      - |
+        if [ -z "$TEST_RGN" ]; then
+           TEST_RGN=us-west-1
+        fi
+      - PROD_RGN=$PRODENV_REGION
+      - |
+        if [ -z "$PROD_RGN" ]; then
+           PROD_RGN=us-east-1
+        fi
+      - printf "[default]\nregion = $APP_REGION\n[profile e2etestenv]\nregion=$TEST_RGN\n[profile e2eprodenv]\nregion=$PROD_RGN\n" > /tmp/.aws/config
+      - printf "[default]\naws_access_key_id=$E2E_USER_1_ACCESS_KEY\naws_secret_access_key=$E2E_USER_1_SECRET_KEY\n\n[e2etestenv]\naws_access_key_id=$E2E_USER_2_ACCESS_KEY\naws_secret_access_key=$E2E_USER_2_SECRET_KEY\n\n[e2eprodenv]\naws_access_key_id=$E2E_USER_3_ACCESS_KEY\naws_secret_access_key=$E2E_USER_3_SECRET_KEY\n" > /tmp/.aws/credentials
+      - sed -i -e '$s/$/ --noColor/' e2e/e2e.sh
+      - make build-e2e
+      - docker build -t copilot-cli/e2e . -f e2e/Dockerfile
+      - >
+        docker run --privileged -v /tmp/.aws:/home/.aws -e "HOME=/home"
+        -e "TEST_SUITE=$TEST_SUITE"
+        -e "DOCKERHUB_USERNAME=$DOCKERHUB_USERNAME"
+        -e "DOCKERHUB_TOKEN=$DOCKERHUB_TOKEN"
+        copilot-cli/e2e:latest

--- a/e2e/multi-svc-app/multi_svc_app_test.go
+++ b/e2e/multi-svc-app/multi_svc_app_test.go
@@ -109,7 +109,7 @@ var _ = Describe("Multiple Service App", func() {
 			_, jobInitErr = cli.JobInit(&client.JobInitInput{
 				Name:       "query",
 				Dockerfile: "./query/Dockerfile",
-				Schedule:   "@every 4m", // This should run once, immediately after creation, then every 4m thereafter.
+				Schedule:   "@every 4m",
 			})
 		})
 

--- a/regression/multi-svc-app/multi_svc_app_test.go
+++ b/regression/multi-svc-app/multi_svc_app_test.go
@@ -183,7 +183,7 @@ var _ = Describe("regression", func() {
 				Expect(err).NotTo(HaveOccurred())
 				_, err = cli.Run("job", "init",
 					"--name", "query",
-					"--schedule", "@every 4m",
+					"--schedule", "@every 1m",
 					"--dockerfile", fmt.Sprintf("./%s/Dockerfile", "query"))
 				Expect(err).NotTo(HaveOccurred())
 			})


### PR DESCRIPTION
The `query` job doesn't run ~50% of the time in the regression test suite. This is because we are creating the job with the schedule of `@every 4m`, with the assumption that it will run once on start, and every 4 minutes thereafter. However, after testing, this is not the case - it waits 4 minutes to run the first time.

In the regression test suite, the `query` job is the last one we deploy. Then, we wait a max of 4 minutes to see if the job has run. Since it waits 4 minutes to run after being deployed, it often doesn't get run before we decide it failed. 

This doesn't occur in the e2e test suite because the job is the _second_ (of 4) workloads we deploy. The deployments of the other two services after the job take long enough that the job always has time to execute.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
