### PR TITLE
chore: Docker Compose Import milestone 3 - port detection

### DIFF
--- a/internal/pkg/docker/dockercompose/decompose.go
+++ b/internal/pkg/docker/dockercompose/decompose.go
@@ -8,6 +8,7 @@ import (
 	"github.com/compose-spec/compose-go/loader"
 	compose "github.com/compose-spec/compose-go/types"
 	"sort"
+	"strings"
 )
 
 type composeServices map[string]map[string]any
@@ -98,8 +99,11 @@ func serviceConfig(services composeServices, svcName string) (map[string]any, er
 	for svc := range services {
 		validNames = append(validNames, svc)
 	}
+	if len(validNames) == 0 {
+		return nil, fmt.Errorf("compose file has no services")
+	}
 	sort.Strings(validNames)
-	return nil, fmt.Errorf("no service named \"%s\" in this Compose file, valid services are: %v", svcName, validNames)
+	return nil, fmt.Errorf("no service named \"%s\" in this Compose file, valid services are: %s", svcName, strings.Join(validNames, ", "))
 }
 
 // unsupportedServiceKeys scans over fields in the parsed yaml to find unsupported keys.
@@ -117,7 +121,7 @@ func unsupportedServiceKeys(service map[string]any, svcName string) (IgnoredKeys
 	if len(fatal) != 0 {
 		// sort so we have consistent (testable) error messages
 		sort.Strings(fatal)
-		return nil, fmt.Errorf("\"services.%s\" relies on fatally-unsupported Compose keys: %v", svcName, fatal)
+		return nil, fmt.Errorf("\"services.%s\" relies on fatally-unsupported Compose keys: %s", svcName, strings.Join(fatal, ", "))
 	}
 
 	return ignored, nil

--- a/internal/pkg/docker/dockercompose/decompose.go
+++ b/internal/pkg/docker/dockercompose/decompose.go
@@ -52,7 +52,7 @@ func DecomposeService(content []byte, svcName string, workingDir string) (*Conve
 			"service is valid and exists")
 	}
 
-	svc, svcIgnored, err := convertService(&svcConfig)
+	svc, svcIgnored, err := convertService(&svcConfig, workingDir)
 	if err != nil {
 		return nil, nil, fmt.Errorf("convert Compose service to Copilot manifest: %w", err)
 	}

--- a/internal/pkg/docker/dockercompose/decompose_test.go
+++ b/internal/pkg/docker/dockercompose/decompose_test.go
@@ -88,31 +88,31 @@ func TestDecomposeService(t *testing.T) {
 			filename: "nginx-golang-postgres.yml",
 			svcName:  "db",
 
-			wantError: errors.New("\"services.db\" relies on fatally-unsupported Compose keys: [expose secrets volumes]"),
+			wantError: errors.New("\"services.db\" relies on fatally-unsupported Compose keys: [secrets volumes]"),
 		},
 		"nginx-golang-postgres proxy": {
 			filename: "nginx-golang-postgres.yml",
 			svcName:  "proxy",
 
-			wantError: errors.New("\"services.proxy\" relies on fatally-unsupported Compose keys: [ports volumes]"),
+			wantError: errors.New("\"services.proxy\" relies on fatally-unsupported Compose keys: [volumes]"),
 		},
 		"react-express-mongo frontend": {
 			filename: "react-express-mongo.yml",
 			svcName:  "frontend",
 
-			wantError: errors.New("\"services.frontend\" relies on fatally-unsupported Compose keys: [networks ports volumes]"),
+			wantError: errors.New("\"services.frontend\" relies on fatally-unsupported Compose keys: [networks volumes]"),
 		},
 		"react-express-mongo backend": {
 			filename: "react-express-mongo.yml",
 			svcName:  "backend",
 
-			wantError: errors.New("\"services.backend\" relies on fatally-unsupported Compose keys: [expose networks volumes]"),
+			wantError: errors.New("\"services.backend\" relies on fatally-unsupported Compose keys: [networks volumes]"),
 		},
 		"react-express-mongo mongo": {
 			filename: "react-express-mongo.yml",
 			svcName:  "mongo",
 
-			wantError: errors.New("\"services.mongo\" relies on fatally-unsupported Compose keys: [expose networks volumes]"),
+			wantError: errors.New("\"services.mongo\" relies on fatally-unsupported Compose keys: [networks volumes]"),
 		},
 		"unrecognized-field-name": {
 			filename: "unrecognized-field-name.yml",
@@ -131,7 +131,7 @@ func TestDecomposeService(t *testing.T) {
 						Image: manifest.Image{
 							Location: aws.String("nginx"),
 						},
-						Port: aws.Uint16(80),
+						Port: aws.Uint16(8096),
 					},
 				},
 				TaskConfig: manifest.TaskConfig{
@@ -152,9 +152,9 @@ func TestDecomposeService(t *testing.T) {
 				"runtime",
 				"userns_mode",
 			},
-			wantBs: &manifest.BackendServiceConfig{
-				ImageConfig: manifest.ImageWithHealthcheckAndOptionalPort{
-					ImageWithOptionalPort: manifest.ImageWithOptionalPort{
+			wantLbws: &manifest.LoadBalancedWebServiceConfig{
+				ImageConfig: manifest.ImageWithPortAndHealthcheck{
+					ImageWithPort: manifest.ImageWithPort{
 						Image: manifest.Image{
 							Location: aws.String("nginx"),
 							DockerLabels: map[string]string{
@@ -162,7 +162,7 @@ func TestDecomposeService(t *testing.T) {
 								"docker.test2": "val2",
 							},
 						},
-						Port: aws.Uint16(80),
+						Port: aws.Uint16(443),
 					},
 					HealthCheck: manifest.ContainerHealthCheck{
 						Command: []string{

--- a/internal/pkg/docker/dockercompose/decompose_test.go
+++ b/internal/pkg/docker/dockercompose/decompose_test.go
@@ -80,7 +80,7 @@ func TestDecomposeService_General(t *testing.T) {
 			filename: "unsupported-keys.yml",
 			svcName:  "test",
 
-			wantError: errors.New("no service named \"test\" in this Compose file, valid services are: [fatal1 fatal2 fatal3]"),
+			wantError: errors.New("no service named \"test\" in this Compose file, valid services are: fatal1, fatal2, fatal3"),
 		},
 		"invalid service not a map": {
 			filename: "bad-service-compose.yml",
@@ -92,7 +92,7 @@ func TestDecomposeService_General(t *testing.T) {
 			filename: "unsupported-keys.yml",
 			svcName:  "fatal1",
 
-			wantError: errors.New("\"services.fatal1\" relies on fatally-unsupported Compose keys: [external_links privileged]"),
+			wantError: errors.New("\"services.fatal1\" relies on fatally-unsupported Compose keys: external_links, privileged"),
 		},
 		"unsupported keys fatal2": {
 			filename: "unsupported-keys.yml",
@@ -104,7 +104,7 @@ func TestDecomposeService_General(t *testing.T) {
 			filename: "unsupported-keys.yml",
 			svcName:  "fatal3",
 
-			wantError: errors.New("\"services.fatal3\" relies on fatally-unsupported Compose keys: [domainname init networks]"),
+			wantError: errors.New("\"services.fatal3\" relies on fatally-unsupported Compose keys: domainname, init, networks"),
 		},
 		"invalid compose": {
 			filename: "invalid-compose.yml",
@@ -116,37 +116,37 @@ func TestDecomposeService_General(t *testing.T) {
 			filename: "nginx-golang-postgres.yml",
 			svcName:  "backend",
 
-			wantError: errors.New("\"services.backend\" relies on fatally-unsupported Compose keys: [secrets]"),
+			wantError: errors.New("\"services.backend\" relies on fatally-unsupported Compose keys: secrets"),
 		},
 		"nginx-golang-postgres db": {
 			filename: "nginx-golang-postgres.yml",
 			svcName:  "db",
 
-			wantError: errors.New("\"services.db\" relies on fatally-unsupported Compose keys: [secrets volumes]"),
+			wantError: errors.New("\"services.db\" relies on fatally-unsupported Compose keys: secrets, volumes"),
 		},
 		"nginx-golang-postgres proxy": {
 			filename: "nginx-golang-postgres.yml",
 			svcName:  "proxy",
 
-			wantError: errors.New("\"services.proxy\" relies on fatally-unsupported Compose keys: [volumes]"),
+			wantError: errors.New("\"services.proxy\" relies on fatally-unsupported Compose keys: volumes"),
 		},
 		"react-express-mongo frontend": {
 			filename: "react-express-mongo.yml",
 			svcName:  "frontend",
 
-			wantError: errors.New("\"services.frontend\" relies on fatally-unsupported Compose keys: [networks volumes]"),
+			wantError: errors.New("\"services.frontend\" relies on fatally-unsupported Compose keys: networks, volumes"),
 		},
 		"react-express-mongo backend": {
 			filename: "react-express-mongo.yml",
 			svcName:  "backend",
 
-			wantError: errors.New("\"services.backend\" relies on fatally-unsupported Compose keys: [networks volumes]"),
+			wantError: errors.New("\"services.backend\" relies on fatally-unsupported Compose keys: networks, volumes"),
 		},
 		"react-express-mongo mongo": {
 			filename: "react-express-mongo.yml",
 			svcName:  "mongo",
 
-			wantError: errors.New("\"services.mongo\" relies on fatally-unsupported Compose keys: [networks volumes]"),
+			wantError: errors.New("\"services.mongo\" relies on fatally-unsupported Compose keys: networks, volumes"),
 		},
 		"unrecognized-field-name": {
 			filename: "unrecognized-field-name.yml",
@@ -270,7 +270,7 @@ func TestDecomposeService_ExposedPorts(t *testing.T) {
 		},
 		{
 			svcName:   "two-exposed-ports",
-			wantError: errors.New("convert Compose service to Copilot manifest: cannot expose more than one port in Copilot, but 2 ports are exposed: [80 443]"),
+			wantError: errors.New("convert Compose service to Copilot manifest: cannot expose more than one port in Copilot, but 2 ports are exposed: 80, 443"),
 		},
 		{
 			svcName: "no-exposed-ports",

--- a/internal/pkg/docker/dockercompose/svc.go
+++ b/internal/pkg/docker/dockercompose/svc.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/afero"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -115,7 +116,8 @@ func findExposedPort(service *compose.ServiceConfig, workingDir string) (*expose
 			public: true,
 		}, nil
 	} else if len(service.Ports) > 1 {
-		return nil, fmt.Errorf("cannot expose more than one public port in Copilot, but %v ports are exposed publicly: %v", len(service.Ports), service.Ports)
+		return nil, fmt.Errorf("cannot expose more than one public port in Copilot, but %v ports are exposed publicly: %v",
+			len(service.Ports), service.Ports)
 	}
 
 	if len(service.Expose) == 1 {
@@ -129,7 +131,8 @@ func findExposedPort(service *compose.ServiceConfig, workingDir string) (*expose
 			public: false,
 		}, nil
 	} else if len(service.Expose) > 1 {
-		return nil, fmt.Errorf("cannot expose more than one port in Copilot, but %v ports are exposed: %v", len(service.Expose), service.Expose)
+		return nil, fmt.Errorf("cannot expose more than one port in Copilot, but %v ports are exposed: %s",
+			len(service.Expose), strings.Join(service.Expose, ", "))
 	}
 
 	if service.Image != "" || service.Build == nil {

--- a/internal/pkg/docker/dockercompose/svc.go
+++ b/internal/pkg/docker/dockercompose/svc.go
@@ -47,10 +47,11 @@ func convertService(service *compose.ServiceConfig, workingDir string) (*Convert
 		hc = convertHealthCheckConfig(service.HealthCheck)
 	}
 
-	exposed, err := findExposedPort(service, workingDir)
+	exposed, portIgnored, err := findExposedPort(service, workingDir)
 	if err != nil {
 		return nil, nil, err
 	}
+	ignored = append(ignored, portIgnored...)
 
 	if exposed != nil && exposed.public {
 		lbws := manifest.LoadBalancedWebService{}
@@ -102,45 +103,35 @@ type exposedPort struct {
 }
 
 // findExposedPort attempts to detect a singular exposed port in the given service and determines if it is publicly exposed.
-func findExposedPort(service *compose.ServiceConfig, workingDir string) (*exposedPort, error) {
+func findExposedPort(service *compose.ServiceConfig, workingDir string) (*exposedPort, IgnoredKeys, error) {
 	switch {
 	case len(service.Ports) > 1:
-		return nil, fmt.Errorf("cannot expose more than one public port in Copilot, but %v ports are exposed publicly: %v",
+		return nil, nil, fmt.Errorf("cannot expose more than one public port in Copilot, but %v ports are exposed publicly: %v",
 			len(service.Ports), service.Ports)
 	case len(service.Ports) == 1:
-		binding := service.Ports[0]
-		port := uint16(binding.Target)
-
-		if binding.Published != "" && strconv.Itoa(int(port)) != binding.Published {
-			return nil, fmt.Errorf("cannot publish the container port %v under a different public port %v in Copilot", port, binding.Published)
-		}
-
-		return &exposedPort{
-			port:   port,
-			public: true,
-		}, nil
+		return toExposedPort(service.Ports[0])
 	case len(service.Expose) > 1:
-		return nil, fmt.Errorf("cannot expose more than one port in Copilot, but %v ports are exposed: %s",
+		return nil, nil, fmt.Errorf("cannot expose more than one port in Copilot, but %v ports are exposed: %s",
 			len(service.Expose), strings.Join(service.Expose, ", "))
 	case len(service.Expose) == 1:
 		port, err := strconv.Atoi(service.Expose[0])
 		if err != nil {
-			return nil, fmt.Errorf("could not parse exposed port: %w", err)
+			return nil, nil, fmt.Errorf("could not parse exposed port: %w", err)
 		}
 
 		return &exposedPort{
 			port:   uint16(port),
 			public: false,
-		}, nil
+		}, nil, nil
 	}
 
 	if service.Image != "" || service.Build == nil {
 		// No dockerfile to parse, don't infer any ports.
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	if service.Build.Context == "" {
-		return nil, errors.New("service is missing an image location or Dockerfile path")
+		return nil, nil, errors.New("service is missing an image location or Dockerfile path")
 	}
 
 	dockerfilePath := service.Build.Dockerfile
@@ -154,19 +145,51 @@ func findExposedPort(service *compose.ServiceConfig, workingDir string) (*expose
 	ports, err := df.GetExposedPorts()
 	var exposeErr dockerfile.ErrNoExpose
 	if err != nil && !errors.As(err, &exposeErr) {
-		return nil, fmt.Errorf("parse dockerfile for exposed ports: %w", err)
+		return nil, nil, fmt.Errorf("parse dockerfile for exposed ports: %w", err)
 	}
 
 	if len(ports) == 0 {
 		// No exposed ports
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	return &exposedPort{
 		// matches "svc init" behavior
 		port:   ports[0].Port,
 		public: false,
-	}, nil
+	}, nil, nil
+}
+
+// toExposedPort converts a single published Compose port to a simplified Copilot exposed port.
+func toExposedPort(binding compose.ServicePortConfig) (*exposedPort, IgnoredKeys, error) {
+	port := uint16(binding.Target)
+	var ignored IgnoredKeys
+
+	if binding.HostIP != "" {
+		ignored = append(ignored, "ports.<port>.host_ip")
+	}
+
+	if binding.Protocol != "" && binding.Protocol != "tcp" {
+		ignored = append(ignored, "ports.<port>.protocol")
+	}
+
+	if binding.Mode != "" && binding.Mode != "ingress" {
+		ignored = append(ignored, "ports.<port>.mode")
+	}
+
+	if strings.Contains(binding.Published, "-") {
+		return nil, nil, fmt.Errorf("cannot map a published port range (%s) to a single container port (%v) yet", binding.Published, binding.Target)
+	}
+
+	// if binding.Published is empty, we can choose any port on the host, so we'll just choose the container port.
+	if binding.Published != "" && strconv.Itoa(int(port)) != binding.Published {
+		return nil, nil, fmt.Errorf("cannot publish the container port %v under a different public port %v in Copilot", port, binding.Published)
+	}
+
+	return &exposedPort{
+		port:   port,
+		public: true,
+	}, ignored, nil
 }
 
 // convertTaskConfig converts environment variables, env files, and platform strings.

--- a/internal/pkg/docker/dockercompose/svc_test.go
+++ b/internal/pkg/docker/dockercompose/svc_test.go
@@ -28,8 +28,9 @@ func TestConvertBackendService(t *testing.T) {
 	}{
 		"happy path trivial image": {
 			inSvc: compose.ServiceConfig{
-				Name:  "web",
-				Image: "nginx",
+				Name:   "internalweb",
+				Image:  "nginx",
+				Expose: []string{"8080"},
 			},
 
 			wantBackendSvc: &manifest.BackendServiceConfig{
@@ -38,7 +39,7 @@ func TestConvertBackendService(t *testing.T) {
 						Image: manifest.Image{
 							Location: aws.String("nginx"),
 						},
-						Port: aws.Uint16(80),
+						Port: aws.Uint16(8080),
 					},
 				},
 				TaskConfig: manifest.TaskConfig{
@@ -54,6 +55,12 @@ func TestConvertBackendService(t *testing.T) {
 			inSvc: compose.ServiceConfig{
 				Name: "web",
 
+				Ports: []compose.ServicePortConfig{
+					{
+						Target:    443,
+						Published: "443",
+					},
+				},
 				Command: compose.ShellCommand{
 					"CMD-SHELL",
 					"/bin/nginx",
@@ -95,8 +102,8 @@ func TestConvertBackendService(t *testing.T) {
 				},
 			},
 
-			wantBackendSvc: &manifest.BackendServiceConfig{ImageConfig: manifest.ImageWithHealthcheckAndOptionalPort{
-				ImageWithOptionalPort: manifest.ImageWithOptionalPort{
+			wantLbws: &manifest.LoadBalancedWebServiceConfig{ImageConfig: manifest.ImageWithPortAndHealthcheck{
+				ImageWithPort: manifest.ImageWithPort{
 					Image: manifest.Image{
 						Location: aws.String("nginx"),
 						DockerLabels: map[string]string{
@@ -104,7 +111,7 @@ func TestConvertBackendService(t *testing.T) {
 							"docker.test2": "val2",
 						},
 					},
-					Port: aws.Uint16(80),
+					Port: aws.Uint16(443),
 				},
 				HealthCheck: manifest.ContainerHealthCheck{
 					Command: []string{
@@ -178,6 +185,7 @@ func TestConvertBackendService(t *testing.T) {
 				Name:     "web",
 				Image:    "nginx",
 				Platform: "windows",
+				Expose:   []string{"80"},
 			},
 
 			wantBackendSvc: &manifest.BackendServiceConfig{
@@ -208,12 +216,19 @@ func TestConvertBackendService(t *testing.T) {
 					Timeout:     &fiveSeconds,
 					StartPeriod: &threeSeconds,
 				},
-				Image: "nginx",
+				Image:  "nginx",
+				Expose: []string{"80"},
+				Ports: []compose.ServicePortConfig{
+					{
+						Target:    80,
+						Published: "80",
+					},
+				},
 			},
 
-			wantBackendSvc: &manifest.BackendServiceConfig{
-				ImageConfig: manifest.ImageWithHealthcheckAndOptionalPort{
-					ImageWithOptionalPort: manifest.ImageWithOptionalPort{
+			wantLbws: &manifest.LoadBalancedWebServiceConfig{
+				ImageConfig: manifest.ImageWithPortAndHealthcheck{
+					ImageWithPort: manifest.ImageWithPort{
 						Image: manifest.Image{
 							Location: aws.String("nginx"),
 						},
@@ -251,7 +266,6 @@ func TestConvertBackendService(t *testing.T) {
 						Image: manifest.Image{
 							Location: aws.String("nginx"),
 						},
-						Port: aws.Uint16(80),
 					},
 					HealthCheck: manifest.ContainerHealthCheck{
 						Command:     []string{"NONE"},
@@ -290,7 +304,6 @@ func TestConvertBackendService(t *testing.T) {
 						Image: manifest.Image{
 							Location: aws.String("nginx"),
 						},
-						Port: aws.Uint16(80),
 					},
 					HealthCheck: manifest.ContainerHealthCheck{
 						Command:     []string{"NONE"},

--- a/internal/pkg/docker/dockercompose/svc_test.go
+++ b/internal/pkg/docker/dockercompose/svc_test.go
@@ -325,7 +325,7 @@ func TestConvertBackendService(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			svc, ignored, err := convertService(&tc.inSvc)
+			svc, ignored, err := convertService(&tc.inSvc, "")
 
 			if tc.wantError != nil {
 				require.EqualError(t, err, tc.wantError.Error())

--- a/internal/pkg/docker/dockercompose/testdata/buildtest/Dockerfile-expose
+++ b/internal/pkg/docker/dockercompose/testdata/buildtest/Dockerfile-expose
@@ -1,0 +1,2 @@
+FROM nginx
+EXPOSE 8096

--- a/internal/pkg/docker/dockercompose/testdata/buildtest/Dockerfile-no-expose
+++ b/internal/pkg/docker/dockercompose/testdata/buildtest/Dockerfile-no-expose
@@ -1,0 +1,1 @@
+FROM nginx

--- a/internal/pkg/docker/dockercompose/testdata/buildtest/Dockerfile-unparseable
+++ b/internal/pkg/docker/dockercompose/testdata/buildtest/Dockerfile-unparseable
@@ -1,0 +1,1 @@
+EXPOSE "FACT: According to all known laws of aviation, there is no way that a bee should be able to fly."

--- a/internal/pkg/docker/dockercompose/testdata/exposed-port-tests.yml
+++ b/internal/pkg/docker/dockercompose/testdata/exposed-port-tests.yml
@@ -1,0 +1,66 @@
+services:
+  two-public-ports:
+    image: nginx
+    ports:
+      - "80:80"
+      - "443:443"
+  two-exposed-ports:
+    image: nginx
+    expose:
+      - 80
+      - 443
+  no-exposed-ports:
+    image: nginx
+  expose-only:
+    image: nginx
+    expose:
+      - 80
+  different-public-and-exposed:
+    image: nginx
+    ports:
+      - "432:432"
+    expose:
+      - 80
+  expose-and-ports:
+    image: nginx
+    ports:
+      - "8096:8096"
+    expose:
+      - 8096
+  remap-ports:
+    image: nginx
+    ports:
+      - "8080:80"
+  remap-ports-long-form:
+    image: nginx
+    ports:
+      - published: 8080
+        target: 80
+        protocol: tcp
+  normal-ports-long-form:
+    image: nginx
+    ports:
+      - published: 80
+        target: 80
+  invalid-expose:
+    image: nginx
+    expose:
+      - "pony"
+  no-ports:
+    image: nginx
+  parsed-from-dockerfile:
+    build:
+      context: buildtest
+      dockerfile: Dockerfile-expose
+  dockerfile-no-expose:
+    build:
+      context: buildtest
+      dockerfile: Dockerfile-no-expose
+  dockerfile-cant-parse:
+    build:
+      context: buildtest
+      dockerfile: Dockerfile-unparseable
+  dockerfile-doesnt-exist:
+    build:
+      context: buildtest
+      dockerfile: Dockerfile-dsoajdosajoidsao

--- a/internal/pkg/docker/dockercompose/testdata/exposed-port-tests.yml
+++ b/internal/pkg/docker/dockercompose/testdata/exposed-port-tests.yml
@@ -64,3 +64,26 @@ services:
     build:
       context: buildtest
       dockerfile: Dockerfile-dsoajdosajoidsao
+  public-port-container-only:
+    image: nginx
+    ports:
+      - target: 8096
+  public-host-ip:
+    image: nginx
+    ports:
+      - "192.168.1.1:8096:8096"
+  public-port-range-to-one:
+    image: nginx
+    ports:
+      - "8000-9000:80"
+  public-port-range-to-range:
+    image: nginx
+    ports:
+      - "8000-9000:8001-9001"
+  public-port-complete:
+    image: nginx
+    ports:
+      - target: 8096
+        published: 8096
+        protocol: tcp
+        mode: host

--- a/internal/pkg/docker/dockercompose/testdata/extends/extending.yml
+++ b/internal/pkg/docker/dockercompose/testdata/extends/extending.yml
@@ -1,5 +1,7 @@
 services:
   web:
+    expose:
+      - 8096
     extends:
       file: extended.yml
       service: webapp

--- a/internal/pkg/docker/dockercompose/testdata/invalid-ports.yml
+++ b/internal/pkg/docker/dockercompose/testdata/invalid-ports.yml
@@ -1,0 +1,5 @@
+services:
+  invalid-ports:
+    image: nginx
+    ports:
+      - "pony"

--- a/internal/pkg/docker/dockercompose/testdata/single-service.yml
+++ b/internal/pkg/docker/dockercompose/testdata/single-service.yml
@@ -4,6 +4,8 @@ services:
     userns_mode: "ignored"
     oom_score_adj: 999
 
+    ports:
+      - "443:443"
     command: ["CMD-SHELL", "/bin/nginx"]
     entrypoint: ["CMD", "/bin/sh"]
     environment:

--- a/internal/pkg/docker/dockercompose/unsupported.go
+++ b/internal/pkg/docker/dockercompose/unsupported.go
@@ -87,9 +87,6 @@ var fatalServiceKeys = map[string]string{
 	"stop_signal":       "unsupported in Copilot manifests",
 	"volumes_from":      "sharing volumes is not yet supported",
 	"volume_driver":     "Set the `driver` property on a volume instead",
-	// Lifted in Milestone 3
-	"expose": "implemented in milestone 3",
-	"ports":  "implemented in milestone 3",
 	// Lifted in Milestone 4
 	"volumes": "implemented in milestone 4",
 	// Lifted in Milestone 5


### PR DESCRIPTION
<!-- Provide summary of changes -->

This implements the third milestone of the Docker Compose import experiment, adding support for parsing the `expose` and `ports` keys from Compose files as well as reusing our `EXPOSE` detection from any provided `Dockerfile`s. This is the first revision of the code that is actually useful at all for converting Compose services to Copilot!

Relates to https://github.com/aws/copilot-cli/issues/1612

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
