### PR TITLE
chore: Docker Compose import experiment - work around automatic handling of env files in compose-go

### DIFF
--- a/internal/pkg/docker/dockercompose/decompose.go
+++ b/internal/pkg/docker/dockercompose/decompose.go
@@ -145,13 +145,13 @@ func isolateEnvFiles(service map[string]interface{}) ([]string, error) {
 		return []string{envFileStr.EnvFile}, nil
 	}
 
-	envFileOnly := struct {
+	envFileList := struct {
 		EnvFile []string `mapstructure:"env_file"`
 	}{}
-	err = mapstructure.Decode(service, &envFileOnly)
+	err = mapstructure.Decode(service, &envFileList)
 
 	if err == nil {
-		return envFileOnly.EnvFile, nil
+		return envFileList.EnvFile, nil
 	}
 
 	return nil, err

--- a/internal/pkg/docker/dockercompose/decompose.go
+++ b/internal/pkg/docker/dockercompose/decompose.go
@@ -37,6 +37,7 @@ func DecomposeService(content []byte, svcName string, workingDir string) (*Conve
 
 	// workaround for compose-go automatically loading env files from disk and merging their
 	// content into the "environment" field (the equivalent of the Copilot variables key)
+	// this separates them from the YAML before compose-go has a chance to parse the YAML.
 	// TODO (rclinard-amzn): make a PR to compose-go instead of using this workaround
 	envFiles, err := isolateEnvFiles(service)
 	if err != nil {

--- a/internal/pkg/docker/dockercompose/decompose_test.go
+++ b/internal/pkg/docker/dockercompose/decompose_test.go
@@ -143,6 +143,12 @@ func TestDecomposeService(t *testing.T) {
 				},
 			},
 		},
+		"multiple env files": {
+			filename: "single-service.yml",
+			svcName:  "multiple-env-files",
+
+			wantError: errors.New("convert Compose service to Copilot manifest: at most one env file is supported, but 3 env files were attached to this service"),
+		},
 		"single-service complete": {
 			filename: "single-service.yml",
 			svcName:  "complete",
@@ -193,6 +199,7 @@ func TestDecomposeService(t *testing.T) {
 					Platform: manifest.PlatformArgsOrString{
 						PlatformString: (*manifest.PlatformString)(aws.String("linux/arm64")),
 					},
+					EnvFile: aws.String("/file-that-does-not-exist.env"),
 					Variables: map[string]string{
 						"HOST_PATH":    "/home/nginx",
 						"ENABLE_HTTPS": "true",

--- a/internal/pkg/docker/dockercompose/testdata/single-service.yml
+++ b/internal/pkg/docker/dockercompose/testdata/single-service.yml
@@ -1,4 +1,10 @@
 services:
+  multiple-env-files:
+    image: "wordpress"
+    env_file:
+      - "file1.env"
+      - "file2.env"
+      - "file3.env"
   complete:
     runtime: "ignored"
     userns_mode: "ignored"
@@ -6,6 +12,7 @@ services:
 
     command: ["CMD-SHELL", "/bin/nginx"]
     entrypoint: ["CMD", "/bin/sh"]
+    env_file: "/file-that-does-not-exist.env"
     environment:
       HOST_PATH: "/home/nginx"
       ENABLE_HTTPS: "true"


### PR DESCRIPTION
<!-- Provide summary of changes -->

The `compose-go` library will automatically load any `env_file`s and merge their content into the `environment` keys, which is equivalent to our `variables` section in Copilot manifests. What this means is that we can no longer differentiate environment variables passed individually as overrides from environment variables sourced from env files. This feature is useful to simplify a Compose implementation that just deploys the application straight away, but this breaks our importing use case.

While ideally this can be addressed in a PR to the compose-go library perhaps to add an option to disable this behavior, for now this works and allows us to keep on iterating on this experiment.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
