### PR TITLE
chore: Docker Compose import experiment milestone 4 - Named Volume Import

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/aws/aws-sdk-go v1.44.70
 	github.com/briandowns/spinner v1.19.0
 	github.com/compose-spec/compose-go v1.4.0
+	github.com/docker/go-units v0.4.0
 	github.com/dustin/go-humanize v1.0.0
 	github.com/fatih/color v1.13.0
 	github.com/fatih/structs v1.1.0
@@ -39,7 +40,6 @@ require (
 	github.com/distribution/distribution/v3 v3.0.0-20220725133111-4bf3547399eb // indirect
 	github.com/docker/docker v20.10.7+incompatible // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
-	github.com/docker/go-units v0.4.0 // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect

--- a/internal/pkg/docker/dockercompose/decompose.go
+++ b/internal/pkg/docker/dockercompose/decompose.go
@@ -90,7 +90,7 @@ func getServices(config map[string]any) (composeServices, error) {
 
 	services, ok := svcs.(map[string]any)
 	if !ok {
-		return nil, fmt.Errorf("\"services\" top-level element was not a map, was: %v", svcs)
+		return nil, fmt.Errorf(`"services" top-level element was not a map, was: %v`, svcs)
 	}
 
 	typedServices := make(composeServices)
@@ -98,7 +98,7 @@ func getServices(config map[string]any) (composeServices, error) {
 	for name, svc := range services {
 		service, ok := svc.(map[string]any)
 		if !ok {
-			return nil, fmt.Errorf("\"services.%s\" element was not a map", name)
+			return nil, fmt.Errorf(`"services.%s" element was not a map`, name)
 		}
 		typedServices[name] = service
 	}
@@ -121,7 +121,7 @@ func serviceConfig(services composeServices, svcName string) (map[string]any, er
 		return nil, fmt.Errorf("compose file has no services")
 	}
 	sort.Strings(validNames)
-	return nil, fmt.Errorf("no service named \"%s\" in this Compose file, valid services are: %s", svcName, strings.Join(validNames, ", "))
+	return nil, fmt.Errorf(`no service named "%s" in this Compose file, valid services are: %s`, svcName, strings.Join(validNames, ", "))
 }
 
 // unsupportedServiceKeys scans over fields in the parsed yaml to find unsupported keys.
@@ -139,7 +139,7 @@ func unsupportedServiceKeys(service map[string]any, svcName string) (IgnoredKeys
 	if len(fatal) != 0 {
 		// sort so we have consistent (testable) error messages
 		sort.Strings(fatal)
-		return nil, fmt.Errorf("\"services.%s\" relies on fatally-unsupported Compose keys: %s", svcName, strings.Join(fatal, ", "))
+		return nil, fmt.Errorf(`"services.%s" relies on fatally-unsupported Compose keys: %s`, svcName, strings.Join(fatal, ", "))
 	}
 
 	return ignored, nil

--- a/internal/pkg/docker/dockercompose/decompose.go
+++ b/internal/pkg/docker/dockercompose/decompose.go
@@ -71,7 +71,7 @@ func DecomposeService(content []byte, svcName string, workingDir string) (*Conve
 	}
 
 	svcConfig.EnvFile = envFiles
-	svc, svcIgnored, err := convertService(&svcConfig, otherSvcs, project.Volumes)
+	svc, svcIgnored, err := convertService(&svcConfig, workingDir, otherSvcs, project.Volumes)
 	if err != nil {
 		return nil, nil, fmt.Errorf("convert Compose service to Copilot manifest: %w", err)
 	}

--- a/internal/pkg/docker/dockercompose/decompose.go
+++ b/internal/pkg/docker/dockercompose/decompose.go
@@ -63,8 +63,15 @@ func DecomposeService(content []byte, svcName string, workingDir string) (*Conve
 			"service is valid and exists")
 	}
 
+	var otherSvcs []compose.ServiceConfig
+	for _, otherSvc := range project.Services {
+		if otherSvc.Name != svcConfig.Name {
+			otherSvcs = append(otherSvcs, otherSvc)
+		}
+	}
+
 	svcConfig.EnvFile = envFiles
-	svc, svcIgnored, err := convertService(&svcConfig, workingDir)
+	svc, svcIgnored, err := convertService(&svcConfig, otherSvcs, project.Volumes)
 	if err != nil {
 		return nil, nil, fmt.Errorf("convert Compose service to Copilot manifest: %w", err)
 	}

--- a/internal/pkg/docker/dockercompose/decompose_test.go
+++ b/internal/pkg/docker/dockercompose/decompose_test.go
@@ -128,7 +128,7 @@ func TestDecomposeService_General(t *testing.T) {
 			filename: "nginx-golang-postgres.yml",
 			svcName:  "proxy",
 
-			wantError: errors.New("\"services.proxy\" relies on fatally-unsupported Compose keys: volumes"),
+			wantError: errors.New("convert Compose service to Copilot manifest: volume type bind is not supported yet"),
 		},
 		"react-express-mongo frontend": {
 			filename: "react-express-mongo.yml",

--- a/internal/pkg/docker/dockercompose/decompose_test.go
+++ b/internal/pkg/docker/dockercompose/decompose_test.go
@@ -128,7 +128,7 @@ func TestDecomposeService_General(t *testing.T) {
 			filename: "nginx-golang-postgres.yml",
 			svcName:  "proxy",
 
-			wantError: errors.New("convert Compose service to Copilot manifest: volume type \"bind\" is not supported yet"),
+			wantError: errors.New(`convert Compose service to Copilot manifest: volume type "bind" is not supported yet`),
 		},
 		"react-express-mongo frontend": {
 			filename: "react-express-mongo.yml",

--- a/internal/pkg/docker/dockercompose/decompose_test.go
+++ b/internal/pkg/docker/dockercompose/decompose_test.go
@@ -74,25 +74,25 @@ func TestDecomposeService_General(t *testing.T) {
 			filename: "bad-services-compose.yml",
 			svcName:  "test",
 
-			wantError: errors.New("\"services\" top-level element was not a map, was: invalid"),
+			wantError: errors.New(`"services" top-level element was not a map, was: invalid`),
 		},
 		"wrong name": {
 			filename: "unsupported-keys.yml",
 			svcName:  "test",
 
-			wantError: errors.New("no service named \"test\" in this Compose file, valid services are: fatal1, fatal2, fatal3"),
+			wantError: errors.New(`no service named "test" in this Compose file, valid services are: fatal1, fatal2, fatal3`),
 		},
 		"invalid service not a map": {
 			filename: "bad-service-compose.yml",
 			svcName:  "bad",
 
-			wantError: errors.New("\"services.bad\" element was not a map"),
+			wantError: errors.New(`"services.bad" element was not a map`),
 		},
 		"unsupported keys fatal1": {
 			filename: "unsupported-keys.yml",
 			svcName:  "fatal1",
 
-			wantError: errors.New("\"services.fatal1\" relies on fatally-unsupported Compose keys: external_links, privileged"),
+			wantError: errors.New(`"services.fatal1" relies on fatally-unsupported Compose keys: external_links, privileged`),
 		},
 		"unsupported keys fatal2": {
 			filename: "unsupported-keys.yml",
@@ -104,7 +104,7 @@ func TestDecomposeService_General(t *testing.T) {
 			filename: "unsupported-keys.yml",
 			svcName:  "fatal3",
 
-			wantError: errors.New("\"services.fatal3\" relies on fatally-unsupported Compose keys: domainname, init, networks"),
+			wantError: errors.New(`"services.fatal3" relies on fatally-unsupported Compose keys: domainname, init, networks`),
 		},
 		"invalid compose": {
 			filename: "invalid-compose.yml",
@@ -116,13 +116,13 @@ func TestDecomposeService_General(t *testing.T) {
 			filename: "nginx-golang-postgres.yml",
 			svcName:  "backend",
 
-			wantError: errors.New("\"services.backend\" relies on fatally-unsupported Compose keys: secrets"),
+			wantError: errors.New(`"services.backend" relies on fatally-unsupported Compose keys: secrets`),
 		},
 		"nginx-golang-postgres db": {
 			filename: "nginx-golang-postgres.yml",
 			svcName:  "db",
 
-			wantError: errors.New("\"services.db\" relies on fatally-unsupported Compose keys: secrets"),
+			wantError: errors.New(`"services.db" relies on fatally-unsupported Compose keys: secrets`),
 		},
 		"nginx-golang-postgres proxy": {
 			filename: "nginx-golang-postgres.yml",
@@ -134,19 +134,19 @@ func TestDecomposeService_General(t *testing.T) {
 			filename: "react-express-mongo.yml",
 			svcName:  "frontend",
 
-			wantError: errors.New("\"services.frontend\" relies on fatally-unsupported Compose keys: networks"),
+			wantError: errors.New(`"services.frontend" relies on fatally-unsupported Compose keys: networks`),
 		},
 		"react-express-mongo backend": {
 			filename: "react-express-mongo.yml",
 			svcName:  "backend",
 
-			wantError: errors.New("\"services.backend\" relies on fatally-unsupported Compose keys: networks"),
+			wantError: errors.New(`"services.backend" relies on fatally-unsupported Compose keys: networks`),
 		},
 		"react-express-mongo mongo": {
 			filename: "react-express-mongo.yml",
 			svcName:  "mongo",
 
-			wantError: errors.New("\"services.mongo\" relies on fatally-unsupported Compose keys: networks"),
+			wantError: errors.New(`"services.mongo" relies on fatally-unsupported Compose keys: networks`),
 		},
 		"unrecognized-field-name": {
 			filename: "unrecognized-field-name.yml",
@@ -322,7 +322,7 @@ func TestDecomposeService_ExposedPorts(t *testing.T) {
 		},
 		{
 			svcName:   "invalid-expose",
-			wantError: errors.New("convert Compose service to Copilot manifest: could not parse exposed port: strconv.Atoi: parsing \"pony\": invalid syntax"),
+			wantError: errors.New(`convert Compose service to Copilot manifest: could not parse exposed port: strconv.Atoi: parsing "pony": invalid syntax`),
 		},
 		{
 			filename:          "invalid-ports.yml",
@@ -453,10 +453,10 @@ func TestDecomposeService_Volumes(t *testing.T) {
 			},
 		},
 		"bind-file": {
-			wantError: errors.New("convert Compose service to Copilot manifest: volume type \"bind\" is not supported yet"),
+			wantError: errors.New(`convert Compose service to Copilot manifest: volume type "bind" is not supported yet`),
 		},
 		"bind-directory": {
-			wantError: errors.New("convert Compose service to Copilot manifest: volume type \"bind\" is not supported yet"),
+			wantError: errors.New(`convert Compose service to Copilot manifest: volume type "bind" is not supported yet`),
 		},
 		"sharing1": {
 			wantError: errors.New("convert Compose service to Copilot manifest: named volume nvol-shared-1 is shared with service [sharing2], this is not supported in Copilot"),
@@ -516,7 +516,7 @@ func TestDecomposeService_Volumes(t *testing.T) {
 			},
 		},
 		"tmpfs-missing-target": {
-			wantError: errors.New("convert Compose service to Copilot manifest: volume mounted from \"\" (type \"tmpfs\") is missing a target mount point"),
+			wantError: errors.New(`convert Compose service to Copilot manifest: volume mounted from "" (type "tmpfs") is missing a target mount point`),
 		},
 		"tmpfs-name-collision-1": {
 			wantError: errors.New("convert Compose service to Copilot manifest: named volume tmpfs-0 collides with the generated name of a tmpfs mount"),
@@ -525,7 +525,7 @@ func TestDecomposeService_Volumes(t *testing.T) {
 			wantError: errors.New("convert Compose service to Copilot manifest: generated tmpfs volume name tmpfs-1 collides with an existing volume name"),
 		},
 		"unsupported-volume-type": {
-			wantError: errors.New("convert Compose service to Copilot manifest: volume type \"npipe\" is not supported yet"),
+			wantError: errors.New(`convert Compose service to Copilot manifest: volume type "npipe" is not supported yet`),
 		},
 		"unsupported-driver": {
 			wantError: errors.New("convert Compose service to Copilot manifest: only the default driver is supported, but the volume uses-driver tries to use a different driver"),

--- a/internal/pkg/docker/dockercompose/decompose_test.go
+++ b/internal/pkg/docker/dockercompose/decompose_test.go
@@ -128,7 +128,7 @@ func TestDecomposeService_General(t *testing.T) {
 			filename: "nginx-golang-postgres.yml",
 			svcName:  "proxy",
 
-			wantError: errors.New("convert Compose service to Copilot manifest: volume type bind is not supported yet"),
+			wantError: errors.New("convert Compose service to Copilot manifest: volume type \"bind\" is not supported yet"),
 		},
 		"react-express-mongo frontend": {
 			filename: "react-express-mongo.yml",

--- a/internal/pkg/docker/dockercompose/decompose_test.go
+++ b/internal/pkg/docker/dockercompose/decompose_test.go
@@ -122,7 +122,7 @@ func TestDecomposeService_General(t *testing.T) {
 			filename: "nginx-golang-postgres.yml",
 			svcName:  "db",
 
-			wantError: errors.New("\"services.db\" relies on fatally-unsupported Compose keys: secrets, volumes"),
+			wantError: errors.New("\"services.db\" relies on fatally-unsupported Compose keys: secrets"),
 		},
 		"nginx-golang-postgres proxy": {
 			filename: "nginx-golang-postgres.yml",
@@ -134,19 +134,19 @@ func TestDecomposeService_General(t *testing.T) {
 			filename: "react-express-mongo.yml",
 			svcName:  "frontend",
 
-			wantError: errors.New("\"services.frontend\" relies on fatally-unsupported Compose keys: networks, volumes"),
+			wantError: errors.New("\"services.frontend\" relies on fatally-unsupported Compose keys: networks"),
 		},
 		"react-express-mongo backend": {
 			filename: "react-express-mongo.yml",
 			svcName:  "backend",
 
-			wantError: errors.New("\"services.backend\" relies on fatally-unsupported Compose keys: networks, volumes"),
+			wantError: errors.New("\"services.backend\" relies on fatally-unsupported Compose keys: networks"),
 		},
 		"react-express-mongo mongo": {
 			filename: "react-express-mongo.yml",
 			svcName:  "mongo",
 
-			wantError: errors.New("\"services.mongo\" relies on fatally-unsupported Compose keys: networks, volumes"),
+			wantError: errors.New("\"services.mongo\" relies on fatally-unsupported Compose keys: networks"),
 		},
 		"unrecognized-field-name": {
 			filename: "unrecognized-field-name.yml",

--- a/internal/pkg/docker/dockercompose/svc.go
+++ b/internal/pkg/docker/dockercompose/svc.go
@@ -32,6 +32,7 @@ func convertService(service *compose.ServiceConfig, workingDir string, otherSvcs
 	if err != nil {
 		return nil, nil, err
 	}
+	ignored = append(ignored, tcIgn...)
 
 	imgOverride := manifest.ImageOverride{
 		Command: manifest.CommandOverride{
@@ -52,7 +53,6 @@ func convertService(service *compose.ServiceConfig, workingDir string, otherSvcs
 		return nil, nil, err
 	}
 	ignored = append(ignored, portIgnored...)
-	ignored = append(ignored, tcIgn...)
 
 	if exposed != nil && exposed.public {
 		lbws := manifest.LoadBalancedWebService{}

--- a/internal/pkg/docker/dockercompose/svc.go
+++ b/internal/pkg/docker/dockercompose/svc.go
@@ -276,15 +276,15 @@ func convertVolumes(volumes []compose.ServiceVolumeConfig, otherSvcs compose.Ser
 			return nil, fmt.Errorf("volume type %v is not supported yet", vol.Type)
 		}
 
-		if shared := otherSvcVols[vol.Source]; shared != nil {
+		name := vol.Source
+		if shared := otherSvcVols[name]; shared != nil {
 			return nil, fmt.Errorf("named volume %s is shared with %s [%s], this is not supported in Copilot",
-				vol.Source, english.PluralWord(len(shared), "service", "services"), strings.Join(shared, ", "))
+				name, english.PluralWord(len(shared), "service", "services"), strings.Join(shared, ", "))
 		}
 
-		name := vol.Source
 		if copilotVols[name] != nil {
-			// avoid name collision
-			name = fmt.Sprintf("%s-%v", name, idx)
+			return nil, fmt.Errorf("cannot mount named volume %s a second time at %s, it is already mounted at %s",
+				name, vol.Target, *copilotVols[name].ContainerPath)
 		}
 
 		copilotVols[name] = &manifest.Volume{

--- a/internal/pkg/docker/dockercompose/svc.go
+++ b/internal/pkg/docker/dockercompose/svc.go
@@ -193,7 +193,9 @@ func toExposedPort(binding compose.ServicePortConfig) (*exposedPort, IgnoredKeys
 	}, ignored, nil
 }
 
-// convertTaskConfig converts environment variables, env files, and platform strings.
+// convertTaskConfig converts environment variables, env files, volumes, and platform strings.
+// topLevelVols is the top-level volume list in the Compose file shared between services, as opposed to the volumes
+// key of the service config which describes bind mounts and mounts of top-level named volumes.
 func convertTaskConfig(service *compose.ServiceConfig, otherSvcs compose.Services, topLevelVols compose.Volumes) (manifest.TaskConfig, IgnoredKeys, error) {
 	var envFile *string
 

--- a/internal/pkg/docker/dockercompose/svc_test.go
+++ b/internal/pkg/docker/dockercompose/svc_test.go
@@ -325,7 +325,7 @@ func TestConvertBackendService(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			svc, ignored, err := convertService(&tc.inSvc, "")
+			svc, ignored, err := convertService(&tc.inSvc, "", nil, nil)
 
 			if tc.wantError != nil {
 				require.EqualError(t, err, tc.wantError.Error())

--- a/internal/pkg/docker/dockercompose/testdata/volume-tests.yml
+++ b/internal/pkg/docker/dockercompose/testdata/volume-tests.yml
@@ -36,6 +36,52 @@ services:
     image: nginx
     volumes:
       - "nvol-external:/"
+  tmpfs-simple:
+    image: nginx
+    volumes:
+      - type: tmpfs
+        target: "/tmp2"
+        tmpfs:
+          size: "32GiB"
+      - type: tmpfs
+        target: "/tmp3"
+        tmpfs:
+          size: "1MiB"
+  tmpfs-missing-target:
+    image: nginx
+    volumes:
+      - type: tmpfs
+        tmpfs:
+          size: "2GiB"
+  tmpfs-name-collision-1:
+    image: nginx
+    volumes:
+      - type: tmpfs
+        target: "/boom2"
+        tmpfs:
+          size: "1GiB"
+      - "tmpfs-0:/boom"
+  tmpfs-name-collision-2:
+    image: nginx
+    volumes:
+      - "tmpfs-1:/boom"
+      - type: tmpfs
+        target: "/boom2"
+        tmpfs:
+          size: "1GiB"
+  unsupported-volume-type:
+    image: nginx
+    volumes:
+      - type: npipe
+        target: "/pipe"
+  unsupported-driver:
+    image: nginx
+    volumes:
+      - "uses-driver:/drivervol"
+  ignored-top-level-keys:
+    image: nginx
+    volumes:
+      - "ignored-top-level:/ignored"
 volumes:
   nvol-1:
   nvol-shared-1:
@@ -44,3 +90,12 @@ volumes:
   nvol-3:
   nvol-external:
     external: true
+  tmpfs-0:
+  tmpfs-1:
+  uses-driver:
+    driver: "notsupporteddriver"
+  ignored-top-level:
+    labels:
+      "com.example.fail": "fail"
+    driver_opts:
+      floppy_disk_count: 23120012

--- a/internal/pkg/docker/dockercompose/testdata/volume-tests.yml
+++ b/internal/pkg/docker/dockercompose/testdata/volume-tests.yml
@@ -1,0 +1,46 @@
+services:
+  simple-named:
+    image: nginx
+    volumes:
+      - "nvol-1:/test/path/please/ignore"
+  bind-file:
+    image: nginx
+    volumes:
+      - "./testfile.txt:/cont/testfile.txt"
+  bind-directory:
+    image: nginx
+    volumes:
+      - "./testdir:/cont/testdir"
+  sharing1:
+    image: nginx
+    volumes:
+      - "nvol-shared-1:/test"
+  sharing2:
+    image: nginx
+    volumes:
+      - "nvol-shared-1:/test"
+  sharing-within:
+    image: nginx
+    volumes:
+      - "nvol-shared-2:/test"
+      - "nvol-shared-2:/test2"
+  mount-ro-simple:
+    image: nginx
+    volumes:
+      - "nvol-2:/testdir:ro"
+  mount-ro-selinux-simple:
+    image: nginx
+    volumes:
+      - "nvol-3:/testdir:ro,Z"
+  uses-external-volume:
+    image: nginx
+    volumes:
+      - "nvol-external:/"
+volumes:
+  nvol-1:
+  nvol-shared-1:
+  nvol-shared-2:
+  nvol-2:
+  nvol-3:
+  nvol-external:
+    external: true

--- a/internal/pkg/docker/dockercompose/unsupported.go
+++ b/internal/pkg/docker/dockercompose/unsupported.go
@@ -87,8 +87,6 @@ var fatalServiceKeys = map[string]string{
 	"stop_signal":       "unsupported in Copilot manifests",
 	"volumes_from":      "sharing volumes is not yet supported",
 	"volume_driver":     "Set the `driver` property on a volume instead",
-	// Lifted in Milestone 4
-	"volumes": "implemented in milestone 4",
 	// Lifted in Milestone 5
 	"secrets": "implemented in milestone 5",
 	// Lifted in Milestone 6

--- a/internal/pkg/docker/dockercompose/volume.go
+++ b/internal/pkg/docker/dockercompose/volume.go
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package dockercompose
 
 import (

--- a/internal/pkg/docker/dockercompose/volume.go
+++ b/internal/pkg/docker/dockercompose/volume.go
@@ -33,7 +33,8 @@ func newVolumeConverter(topLevelVols compose.Volumes) volumeConverter {
 	}
 }
 
-// convertVolumes converts a list of Compose volumes into the Copilot storage equivalent.
+// convertVolumes converts a list of Compose volumes into the Copilot storage equivalent. Currently, only tmpfs mounts
+// and mounts of named volumes that are not shared between services are supported. Notably, bind mounts are unsupported.
 func (vc *volumeConverter) convertVolumes(volumes []compose.ServiceVolumeConfig, otherSvcs compose.Services) (*manifest.Storage, IgnoredKeys, error) {
 	for _, otherSvc := range otherSvcs {
 		for _, vol := range otherSvc.Volumes {

--- a/internal/pkg/docker/dockercompose/volume.go
+++ b/internal/pkg/docker/dockercompose/volume.go
@@ -126,21 +126,16 @@ func (vc *volumeConverter) checkNamedVolume(vol compose.ServiceVolumeConfig) (*s
 	var ignored IgnoredKeys
 
 	if topLevel, ok := vc.topLevelVols[name]; ok {
-		var err error
-
 		switch {
 		case topLevel.External.External:
-			err = fmt.Errorf("named volume %s is marked as external, this is unsupported", name)
+			return nil, nil, fmt.Errorf("named volume %s is marked as external, this is unsupported", name)
 		case topLevel.Driver != "":
-			err = fmt.Errorf("only the default driver is supported, but the volume %s tries to use a different driver", name)
+			return nil, nil, fmt.Errorf("only the default driver is supported, but the volume %s tries to use a different driver", name)
 		case len(topLevel.DriverOpts) != 0:
 			ignored = append(ignored, fmt.Sprintf("volumes.%s.driver_opts", name))
 			fallthrough
 		case len(topLevel.Labels) != 0:
 			ignored = append(ignored, fmt.Sprintf("volumes.%s.labels", name))
-		}
-		if err != nil {
-			return nil, nil, err
 		}
 	}
 

--- a/internal/pkg/docker/dockercompose/volume.go
+++ b/internal/pkg/docker/dockercompose/volume.go
@@ -1,0 +1,124 @@
+package dockercompose
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/copilot-cli/internal/pkg/manifest"
+	compose "github.com/compose-spec/compose-go/types"
+	"github.com/docker/go-units"
+	"github.com/dustin/go-humanize/english"
+	"strings"
+)
+
+type volumeConverter struct {
+	otherSvcVols  map[string][]string
+	copilotVols   map[string]*manifest.Volume
+	topLevelVols  compose.Volumes
+	tmpfsVolNames map[string]bool
+}
+
+func newVolumeConverter(topLevelVols compose.Volumes) volumeConverter {
+	return volumeConverter{topLevelVols: topLevelVols}
+}
+
+// convertVolumes converts a list of Compose volumes into the Copilot storage equivalent.
+func (vc *volumeConverter) convertVolumes(volumes []compose.ServiceVolumeConfig, otherSvcs compose.Services) (*manifest.Storage, error) {
+	for _, otherSvc := range otherSvcs {
+		for _, vol := range otherSvc.Volumes {
+			if vol.Type == "volume" {
+				vc.otherSvcVols[vol.Source] = append(vc.otherSvcVols[vol.Source], otherSvc.Name)
+			}
+		}
+	}
+
+	var ephemeralBytes uint64 = 20 * units.GiB
+
+	for idx, vol := range volumes {
+		mountOpts := manifest.MountPointOpts{
+			ContainerPath: aws.String(vol.Target),
+			ReadOnly:      aws.Bool(vol.ReadOnly),
+		}
+
+		if vol.Type == "tmpfs" {
+			ephemeralBytes += uint64(vol.Tmpfs.Size)
+
+			name := fmt.Sprintf("tmpfs-%v", idx)
+
+			if vc.copilotVols[name] != nil {
+				return nil, fmt.Errorf("generated tmpfs volume name %s collides with an existing volume name", name)
+			}
+
+			vc.tmpfsVolNames[name] = true
+			vc.copilotVols[name] = &manifest.Volume{
+				EFS: manifest.EFSConfigOrBool{
+					Enabled: aws.Bool(false),
+				},
+				MountPointOpts: mountOpts,
+			}
+			continue
+		}
+
+		if vol.Type != "volume" {
+			// TODO (rclinard-amzn): Relax the "bind" restriction in Milestone 6
+			return nil, fmt.Errorf("volume type %v is not supported yet", vol.Type)
+		}
+
+		name, err := vc.checkNamedVolume(vol)
+		if err != nil {
+			return nil, err
+		}
+
+		vc.copilotVols[*name] = &manifest.Volume{
+			EFS: manifest.EFSConfigOrBool{
+				Enabled: aws.Bool(true),
+			},
+			MountPointOpts: mountOpts,
+		}
+	}
+
+	// math trick to round up to the next highest GiB if it's not an even size in GiB
+	ephemeralGiB := (ephemeralBytes + units.GiB - 1) / units.GiB
+
+	return &manifest.Storage{
+		Ephemeral: aws.Int(int(ephemeralGiB)),
+		Volumes:   vc.copilotVols,
+	}, nil
+}
+
+func (vc *volumeConverter) checkNamedVolume(vol compose.ServiceVolumeConfig) (*string, error) {
+	name := vol.Source
+	if shared := vc.otherSvcVols[name]; shared != nil {
+		return nil, fmt.Errorf("named volume %s is shared with %s [%s], this is not supported in Copilot",
+			name, english.PluralWord(len(shared), "service", "services"), strings.Join(shared, ", "))
+	}
+
+	if vc.tmpfsVolNames[name] {
+		return nil, fmt.Errorf("named volume %s collides with the generated name of a tmpfs mount", name)
+	}
+
+	if vc.copilotVols[name] != nil {
+		return nil, fmt.Errorf("cannot mount named volume %s a second time at %s, it is already mounted at %s",
+			name, vol.Target, *vc.copilotVols[name].ContainerPath)
+	}
+
+	if topLevel, ok := vc.topLevelVols[name]; ok {
+		var err error
+		var ignored IgnoredKeys
+
+		switch {
+		case topLevel.External.External:
+			err = fmt.Errorf("named volume %s is marked as external, this is unsupported", name)
+		case topLevel.Driver != "":
+			err = fmt.Errorf("only the default driver is supported, but %s tries to use a different driver", name)
+		case len(topLevel.Labels) != 0:
+			ignored = append(ignored, fmt.Sprintf("volumes.%s.labels", name))
+		case len(topLevel.DriverOpts) != 0:
+			ignored = append(ignored, fmt.Sprintf("volumes.%s.driver_opts", name))
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &name, nil
+}

--- a/internal/pkg/docker/dockercompose/volume.go
+++ b/internal/pkg/docker/dockercompose/volume.go
@@ -27,7 +27,7 @@ func newVolumeConverter(topLevelVols compose.Volumes) volumeConverter {
 }
 
 // convertVolumes converts a list of Compose volumes into the Copilot storage equivalent.
-func (vc *volumeConverter) convertVolumes(volumes []compose.ServiceVolumeConfig, otherSvcs compose.Services) (*manifest.Storage, error) {
+func (vc *volumeConverter) convertVolumes(volumes []compose.ServiceVolumeConfig, otherSvcs compose.Services) (*manifest.Storage, IgnoredKeys, error) {
 	for _, otherSvc := range otherSvcs {
 		for _, vol := range otherSvc.Volumes {
 			if vol.Type == "volume" {
@@ -37,8 +37,13 @@ func (vc *volumeConverter) convertVolumes(volumes []compose.ServiceVolumeConfig,
 	}
 
 	var ephemeralBytes uint64 = 20 * units.GiB
+	var ignored IgnoredKeys
 
 	for idx, vol := range volumes {
+		if vol.Target == "" {
+			return nil, nil, fmt.Errorf("volume mounted from \"%v\" (type \"%v\") is missing a target mount point", vol.Source, vol.Type)
+		}
+
 		mountOpts := manifest.MountPointOpts{
 			ContainerPath: aws.String(vol.Target),
 			ReadOnly:      aws.Bool(vol.ReadOnly),
@@ -50,14 +55,12 @@ func (vc *volumeConverter) convertVolumes(volumes []compose.ServiceVolumeConfig,
 			name := fmt.Sprintf("tmpfs-%v", idx)
 
 			if vc.copilotVols[name] != nil {
-				return nil, fmt.Errorf("generated tmpfs volume name %s collides with an existing volume name", name)
+				return nil, nil, fmt.Errorf("generated tmpfs volume name %s collides with an existing volume name", name)
 			}
 
 			vc.tmpfsVolNames[name] = true
 			vc.copilotVols[name] = &manifest.Volume{
-				EFS: manifest.EFSConfigOrBool{
-					Enabled: aws.Bool(false),
-				},
+				// efs is off by default
 				MountPointOpts: mountOpts,
 			}
 			continue
@@ -65,13 +68,14 @@ func (vc *volumeConverter) convertVolumes(volumes []compose.ServiceVolumeConfig,
 
 		if vol.Type != "volume" {
 			// TODO (rclinard-amzn): Relax the "bind" restriction in Milestone 6
-			return nil, fmt.Errorf("volume type \"%v\" is not supported yet", vol.Type)
+			return nil, nil, fmt.Errorf("volume type \"%v\" is not supported yet", vol.Type)
 		}
 
-		name, err := vc.checkNamedVolume(vol)
+		name, ign, err := vc.checkNamedVolume(vol)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
+		ignored = append(ignored, ign...)
 
 		vc.copilotVols[*name] = &manifest.Volume{
 			EFS: manifest.EFSConfigOrBool{
@@ -94,43 +98,45 @@ func (vc *volumeConverter) convertVolumes(volumes []compose.ServiceVolumeConfig,
 		storage.Volumes = vc.copilotVols
 	}
 
-	return &storage, nil
+	return &storage, ignored, nil
 }
 
-func (vc *volumeConverter) checkNamedVolume(vol compose.ServiceVolumeConfig) (*string, error) {
+func (vc *volumeConverter) checkNamedVolume(vol compose.ServiceVolumeConfig) (*string, IgnoredKeys, error) {
 	name := vol.Source
 	if shared := vc.otherSvcVols[name]; shared != nil {
-		return nil, fmt.Errorf("named volume %s is shared with %s [%s], this is not supported in Copilot",
+		return nil, nil, fmt.Errorf("named volume %s is shared with %s [%s], this is not supported in Copilot",
 			name, english.PluralWord(len(shared), "service", "services"), strings.Join(shared, ", "))
 	}
 
 	if vc.tmpfsVolNames[name] {
-		return nil, fmt.Errorf("named volume %s collides with the generated name of a tmpfs mount", name)
+		return nil, nil, fmt.Errorf("named volume %s collides with the generated name of a tmpfs mount", name)
 	}
 
 	if vc.copilotVols[name] != nil {
-		return nil, fmt.Errorf("cannot mount named volume %s a second time at %s, it is already mounted at %s",
+		return nil, nil, fmt.Errorf("cannot mount named volume %s a second time at %s, it is already mounted at %s",
 			name, vol.Target, *vc.copilotVols[name].ContainerPath)
 	}
 
+	var ignored IgnoredKeys
+
 	if topLevel, ok := vc.topLevelVols[name]; ok {
 		var err error
-		var ignored IgnoredKeys
 
 		switch {
 		case topLevel.External.External:
 			err = fmt.Errorf("named volume %s is marked as external, this is unsupported", name)
 		case topLevel.Driver != "":
-			err = fmt.Errorf("only the default driver is supported, but %s tries to use a different driver", name)
-		case len(topLevel.Labels) != 0:
-			ignored = append(ignored, fmt.Sprintf("volumes.%s.labels", name))
+			err = fmt.Errorf("only the default driver is supported, but the volume %s tries to use a different driver", name)
 		case len(topLevel.DriverOpts) != 0:
 			ignored = append(ignored, fmt.Sprintf("volumes.%s.driver_opts", name))
+			fallthrough
+		case len(topLevel.Labels) != 0:
+			ignored = append(ignored, fmt.Sprintf("volumes.%s.labels", name))
 		}
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
-	return &name, nil
+	return &name, ignored, nil
 }

--- a/internal/pkg/docker/dockercompose/volume.go
+++ b/internal/pkg/docker/dockercompose/volume.go
@@ -20,7 +20,7 @@ type volumeConverter struct {
 func newVolumeConverter(topLevelVols compose.Volumes) volumeConverter {
 	return volumeConverter{
 		otherSvcVols:  map[string][]string{},
-		copilotVols:   nil,
+		copilotVols:   map[string]*manifest.Volume{},
 		topLevelVols:  topLevelVols,
 		tmpfsVolNames: map[string]bool{},
 	}

--- a/internal/pkg/docker/dockercompose/volume.go
+++ b/internal/pkg/docker/dockercompose/volume.go
@@ -48,7 +48,7 @@ func (vc *volumeConverter) convertVolumes(volumes []compose.ServiceVolumeConfig,
 
 	for idx, vol := range volumes {
 		if vol.Target == "" {
-			return nil, nil, fmt.Errorf("volume mounted from \"%v\" (type \"%v\") is missing a target mount point", vol.Source, vol.Type)
+			return nil, nil, fmt.Errorf("volume mounted from %q (type %q) is missing a target mount point", vol.Source, vol.Type)
 		}
 
 		mountOpts := manifest.MountPointOpts{
@@ -75,7 +75,7 @@ func (vc *volumeConverter) convertVolumes(volumes []compose.ServiceVolumeConfig,
 
 		if vol.Type != "volume" {
 			// TODO (rclinard-amzn): Relax the "bind" restriction in Milestone 6
-			return nil, nil, fmt.Errorf("volume type \"%v\" is not supported yet", vol.Type)
+			return nil, nil, fmt.Errorf("volume type %q is not supported yet", vol.Type)
 		}
 
 		name, ign, err := vc.checkNamedVolume(vol)

--- a/internal/pkg/docker/dockercompose/volume.go
+++ b/internal/pkg/docker/dockercompose/volume.go
@@ -65,7 +65,7 @@ func (vc *volumeConverter) convertVolumes(volumes []compose.ServiceVolumeConfig,
 
 		if vol.Type != "volume" {
 			// TODO (rclinard-amzn): Relax the "bind" restriction in Milestone 6
-			return nil, fmt.Errorf("volume type %v is not supported yet", vol.Type)
+			return nil, fmt.Errorf("volume type \"%v\" is not supported yet", vol.Type)
 		}
 
 		name, err := vc.checkNamedVolume(vol)

--- a/internal/pkg/docker/dockercompose/volume.go
+++ b/internal/pkg/docker/dockercompose/volume.go
@@ -13,6 +13,10 @@ import (
 	"strings"
 )
 
+// The default size that Copilot reserves for a service's ephemeral on-disk storage.
+const defaultEphemeralGiB = 20
+const defaultEphemeralBytes uint64 = defaultEphemeralGiB * units.GiB
+
 type volumeConverter struct {
 	otherSvcVols  map[string][]string
 	copilotVols   map[string]*manifest.Volume
@@ -39,7 +43,7 @@ func (vc *volumeConverter) convertVolumes(volumes []compose.ServiceVolumeConfig,
 		}
 	}
 
-	var ephemeralBytes uint64 = 20 * units.GiB
+	var ephemeralBytes = defaultEphemeralBytes
 	var ignored IgnoredKeys
 
 	for idx, vol := range volumes {
@@ -92,8 +96,7 @@ func (vc *volumeConverter) convertVolumes(volumes []compose.ServiceVolumeConfig,
 	ephemeralGiB := (ephemeralBytes + units.GiB - 1) / units.GiB
 	var storage manifest.Storage
 
-	// default: 20 GiB
-	if ephemeralGiB != 20 {
+	if ephemeralGiB != defaultEphemeralGiB {
 		storage.Ephemeral = aws.Int(int(ephemeralGiB))
 	}
 


### PR DESCRIPTION
<!-- Provide summary of changes -->

This PR implements Milestone 4 of the Docker Compose import experiment, adding partial support for the `volumes` key on services. This gets us extremely close to successfully importing one of our Compose file examples and this is the last of the really important but also straightforward feature milestones - everything from here on out is smaller things that need extra effort to support in Copilot but are also somewhat commonly used.

There are a lot of checks to make sure that volumes aren't being used to share data between services since this isn't something that Copilot currently accommodates with EFS. Additionally, bind mounts are currently completely unsupported.

Finally, some light support has been added for the mechanics of `tmpfs` volumes in Compose.

Relates to https://github.com/aws/copilot-cli/issues/1612

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
