### PR TITLE
feat: enable IAM permissions boundaries

### DIFF
--- a/internal/pkg/cli/app_init.go
+++ b/internal/pkg/cli/app_init.go
@@ -34,9 +34,10 @@ const (
 )
 
 type initAppVars struct {
-	name         string
-	domainName   string
-	resourceTags map[string]string
+	name                string
+	permissionsBoundary string
+	domainName          string
+	resourceTags        map[string]string
 }
 
 type initAppOpts struct {
@@ -192,6 +193,7 @@ func (o *initAppOpts) Execute() error {
 		AccountID:          caller.Account,
 		DomainName:         o.domainName,
 		DomainHostedZoneID: hostedZoneID,
+		PermissionBoundary: o.permissionsBoundary,
 		AdditionalTags:     o.resourceTags,
 		Version:            deploy.LatestAppTemplateVersion,
 	})

--- a/internal/pkg/deploy/app.go
+++ b/internal/pkg/deploy/app.go
@@ -20,6 +20,7 @@ type CreateAppInput struct {
 	DNSDelegationAccounts []string          // Accounts to grant DNS access to for this application.
 	DomainName            string            // DNS Name used for this application.
 	DomainHostedZoneID    string            // Hosted Zone ID for the domain.
+	PermissionBoundary    string            // Name of the permission boundary for IAM roles.
 	AdditionalTags        map[string]string // AdditionalTags are labels applied to resources under the application.
 	Version               string            // The version of the application template to create the stack/stackset. If empty, creates the legacy stack/stackset.
 }

--- a/internal/pkg/deploy/cloudformation/stack/app.go
+++ b/internal/pkg/deploy/cloudformation/stack/app.go
@@ -87,18 +87,20 @@ func NewAppStackConfig(in *deploy.CreateAppInput) *AppStackConfig {
 	}
 }
 
-// Template returns the environment CloudFormation template.
+// Template returns the application CloudFormation template.
 func (c *AppStackConfig) Template() (string, error) {
 	content, err := c.parser.Parse(appTemplatePath, struct {
 		TemplateVersion         string
 		AppDNSDelegatedAccounts []string
 		Domain                  string
 		Name                    string
+		PermissionsBoundary     string
 	}{
 		c.Version,
 		c.dnsDelegationAccounts(),
 		c.DomainName,
 		c.Name,
+		c.PermissionBoundary,
 	}, template.WithFuncs(map[string]any{
 		"join": strings.Join,
 	}))

--- a/internal/pkg/deploy/cloudformation/stack/app_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/app_test.go
@@ -48,11 +48,13 @@ func TestAppTemplate(t *testing.T) {
 					AppDNSDelegatedAccounts []string
 					Domain                  string
 					Name                    string
+					PermissionsBoundary     string
 				}{
 					"v1.0.0",
 					[]string{"123456"},
 					"",
 					"demo",
+					"",
 				}, gomock.Any()).Return(&template.Content{
 					Buffer: bytes.NewBufferString("template"),
 				}, nil)
@@ -74,6 +76,7 @@ func TestAppTemplate(t *testing.T) {
 					AccountID:  "123456",
 					Name:       "demo",
 					DomainName: "",
+					PermissionBoundary: "",
 				},
 			}
 			tc.mockDependencies(ctrl, appStack)

--- a/internal/pkg/template/templates/app/app.yml
+++ b/internal/pkg/template/templates/app/app.yml
@@ -42,6 +42,9 @@ Resources:
               Service: cloudformation.amazonaws.com
             Action:
               - sts:AssumeRole
+{{- if .PermissionsBoundary }}
+      PermissionsBoundary: !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/{{.PermissionsBoundary}}'
+{{- end }} 
       Path: /
       Policies:
         - PolicyName: AssumeRole-AWSCloudFormationStackSetExecutionRole
@@ -67,6 +70,9 @@ Resources:
               AWS: !GetAtt AdministrationRole.Arn
             Action:
               - sts:AssumeRole
+{{- if .PermissionsBoundary }}
+      PermissionsBoundary: !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/{{.PermissionsBoundary}}'
+{{- end }}
       Path: /
       Policies:
       - PolicyName: ExecutionRolePolicy
@@ -130,6 +136,9 @@ Resources:
 {{- end}}
             Action:
               - sts:AssumeRole
+{{- if .PermissionsBoundary }}
+      PermissionsBoundary: !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/{{.PermissionsBoundary}}'
+{{- end }}
       Path: /
       Policies:
       - PolicyName: DNSDelegationPolicy

--- a/internal/pkg/template/templates/app/app.yml
+++ b/internal/pkg/template/templates/app/app.yml
@@ -3,7 +3,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: Configure the AWSCloudFormationStackSetAdministrationRole to enable use of AWS CloudFormation StackSets.
 Metadata:
-  TemplateVersion: 'v1.0.2'
+  TemplateVersion: 'v1.0.3'
 Parameters:
   AdminRoleName:
     Type: String


### PR DESCRIPTION
Related: #2986.

This is the first PR in the IAM permissions boundary feature.

Some companies leverage AWS Organizations's [Service Control Policies](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scps.html) (SCP) feature, which can be used together with [IAM Permissions Boundaries](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html) (see diagram below) to [limit](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scps.html#scp-effects-on-permissions) the actions devs may perform and the resources they may affect. 
![image](https://user-images.githubusercontent.com/60631893/187802170-9f505add-1157-4324-86e6-15b1cfd8ebd6.png)

By allowing users to indicate their existing permissions boundary policies when running `app init`, Copilot can add them to IAM Roles when creating them. This PR conditionally adds a boundary policy to the IAM roles created at the app level. More IAM Role modifications to come.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
