### PR TITLE
docs: fix typos in concepts/application doc

### DIFF
--- a/site/content/docs/concepts/applications.en.md
+++ b/site/content/docs/concepts/applications.en.md
@@ -1,4 +1,4 @@
-An application is a group of related services, environments, and pipelines. Whether you have one service that does everything or a constellation of micro-services, Copilot organizes them and the environments they're deployed into an "application".
+An application is a group of related services, environments, and pipelines. Whether you have one service that does everything or a constellation of micro-services, Copilot organizes the service(s), and the environments into which they can be deployed, into an "application."
 
 Let's walk through an example. We want to build a voting app which needs to collect votes and aggregate the results.
 

--- a/site/content/docs/concepts/applications.en.md
+++ b/site/content/docs/concepts/applications.en.md
@@ -1,4 +1,4 @@
-An application is a group of related services, environments, and pipelines. Whether you have one service that does everything or a constellation of micro-services, Copilot organizes them and the environments they're deployed to into an "application".
+An application is a group of related services, environments, and pipelines. Whether you have one service that does everything or a constellation of micro-services, Copilot organizes them and the environments they're deployed into an "application".
 
 Let's walk through an example. We want to build a voting app which needs to collect votes and aggregate the results.
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
This is just a typo fixing. 

Before: (...) the environments they're deployed **to into** an "application".
After: (...) the environments they're deployed **into** an "application".

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->
No issue available.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
