### PR TITLE
fix: route 53 hosted zone resource should use ref

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-basic-manifest.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-basic-manifest.yml
@@ -1070,7 +1070,7 @@ Outputs:
       Name: !Sub ${AWS::StackName}-InternalLoadBalancerCanonicalHostedZoneID
   InternalWorkloadsHostedZone:
     Condition: CreateInternalALB
-    Value: !GetAtt InternalWorkloadsHostedZone.Id
+    Value: !Ref InternalWorkloadsHostedZone
     Export:
       Name: !Sub ${AWS::StackName}-InternalWorkloadsHostedZoneID
   InternalWorkloadsHostedZoneName:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-custom-empty-security-group.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-custom-empty-security-group.yml
@@ -958,7 +958,7 @@ Outputs:
       Name: !Sub ${AWS::StackName}-InternalLoadBalancerCanonicalHostedZoneID
   InternalWorkloadsHostedZone:
     Condition: CreateInternalALB
-    Value: !GetAtt InternalWorkloadsHostedZone.Id
+    Value: !Ref InternalWorkloadsHostedZone
     Export:
       Name: !Sub ${AWS::StackName}-InternalWorkloadsHostedZoneID
   InternalWorkloadsHostedZoneName:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-custom-security-group.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-custom-security-group.yml
@@ -983,7 +983,7 @@ Outputs:
       Name: !Sub ${AWS::StackName}-InternalLoadBalancerCanonicalHostedZoneID
   InternalWorkloadsHostedZone:
     Condition: CreateInternalALB
-    Value: !GetAtt InternalWorkloadsHostedZone.Id
+    Value: !Ref InternalWorkloadsHostedZone
     Export:
       Name: !Sub ${AWS::StackName}-InternalWorkloadsHostedZoneID
   InternalWorkloadsHostedZoneName:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-default-access-log-config.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-default-access-log-config.yml
@@ -1166,7 +1166,7 @@ Outputs:
       Name: !Sub ${AWS::StackName}-InternalLoadBalancerCanonicalHostedZoneID
   InternalWorkloadsHostedZone:
     Condition: CreateInternalALB
-    Value: !GetAtt InternalWorkloadsHostedZone.Id
+    Value: !Ref InternalWorkloadsHostedZone
     Export:
       Name: !Sub ${AWS::StackName}-InternalWorkloadsHostedZoneID
   InternalWorkloadsHostedZoneName:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-imported-certs-observability.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-imported-certs-observability.yml
@@ -1064,7 +1064,7 @@ Outputs:
       Name: !Sub ${AWS::StackName}-InternalLoadBalancerCanonicalHostedZoneID
   InternalWorkloadsHostedZone:
     Condition: CreateInternalALB
-    Value: !GetAtt InternalWorkloadsHostedZone.Id
+    Value: !Ref InternalWorkloadsHostedZone
     Export:
       Name: !Sub ${AWS::StackName}-InternalWorkloadsHostedZoneID
   InternalWorkloadsHostedZoneName:

--- a/internal/pkg/template/templates/environment/cf.yml
+++ b/internal/pkg/template/templates/environment/cf.yml
@@ -663,7 +663,7 @@ Outputs:
   {{- if not .PrivateHTTPConfig.ImportedCertARNs}}
   InternalWorkloadsHostedZone:
     Condition: CreateInternalALB
-    Value: !GetAtt InternalWorkloadsHostedZone.Id
+    Value: !Ref InternalWorkloadsHostedZone
     Export:
       Name: !Sub ${AWS::StackName}-InternalWorkloadsHostedZoneID
   InternalWorkloadsHostedZoneName:


### PR DESCRIPTION
<!-- Provide summary of changes -->
fixes #3977. `InternalWorkloadsHostedZone` does not support `Fn::GetAtt` in Gov cloud and China partition as a `AWS::Route53::HostedZone` resource. We'll use `Fn::Ref` instead.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
