### PR TITLE
chore: remove unused config for s3 upload

### DIFF
--- a/internal/pkg/aws/s3/s3.go
+++ b/internal/pkg/aws/s3/s3.go
@@ -190,7 +190,6 @@ func (s *S3) upload(bucket, key string, buf io.Reader) (string, error) {
 		Body:   buf,
 		Bucket: aws.String(bucket),
 		Key:    aws.String(key),
-		ACL:    aws.String(s3.ObjectCannedACLBucketOwnerFullControl),
 	}
 	resp, err := s.s3Manager.Upload(in)
 	if err != nil {

--- a/internal/pkg/aws/s3/s3_test.go
+++ b/internal/pkg/aws/s3/s3_test.go
@@ -44,7 +44,6 @@ func TestS3_Upload(t *testing.T) {
 					require.Equal(t, "bar", string(b))
 					require.Equal(t, "mockBucket", aws.StringValue(in.Bucket))
 					require.Equal(t, "mockFileName", aws.StringValue(in.Key))
-					require.Equal(t, s3.ObjectCannedACLBucketOwnerFullControl, aws.StringValue(in.ACL))
 				}).Return(&s3manager.UploadOutput{
 					Location: "mockURL",
 				}, nil)


### PR DESCRIPTION
<!-- Provide summary of changes -->
`ObjectCannedACLBucketOwnerFullControl` is useless because ACL has already been disabled by https://github.com/aws/copilot-cli/blob/mainline/internal/pkg/template/templates/app/cf.yml#L94
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
