### PR TITLE
test: add integ test for permissions boundary

### DIFF
--- a/internal/pkg/template/permissions_boundary_integration_test.go
+++ b/internal/pkg/template/permissions_boundary_integration_test.go
@@ -7,6 +7,7 @@ package template
 
 import (
 	"bytes"
+	"fmt"
 	"github.com/stretchr/testify/require"
 	"os"
 	"os/exec"
@@ -21,17 +22,15 @@ func TestPermissions_Boundary(t *testing.T) {
 		require.NoError(t, err, "should return output of 'find' command")
 		
 		files := strings.Fields(string(output))
-		var totalIAMRoles int
-		var totalPermissionsBoundaryFields int
 		for _, file := range files {
 			contents, err := os.ReadFile(file)
 			require.NoError(t, err, "should read file")
 			IAMRoles := bytes.Count(contents, []byte("AWS::IAM::Role"))
 			permissionsBoundaryFields := bytes.Count(contents, []byte("PermissionsBoundary:"))
-				
-			totalIAMRoles += IAMRoles
-			totalPermissionsBoundaryFields += permissionsBoundaryFields
+			
+			msg := fmt.Sprintf("number of IAM roles (%d) does not equal number of permissions boundary fields (%d) in file '%s'", IAMRoles, permissionsBoundaryFields, file)
+			require.True(t, IAMRoles == permissionsBoundaryFields, msg)
+
 		}
-		require.True(t, totalIAMRoles == totalPermissionsBoundaryFields, "number of IAM roles does not equal number of permissions boundary fields")
 	})
 }

--- a/internal/pkg/template/permissions_boundary_integration_test.go
+++ b/internal/pkg/template/permissions_boundary_integration_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestPermissions_Boundary(t *testing.T) {
-	t.Run("CloudFormation template must contain conditional permissions boundary field for all IAM roles", func(t *testing.T) {
+	t.Run("every CloudFormation template must contain conditional permissions boundary field for all IAM roles", func(t *testing.T) {
 		cmd := exec.Command("find", "templates", "-name", "*yml")
 		output, err := cmd.Output()
 		require.NoError(t, err, "should return output of 'find' command")
@@ -20,13 +20,13 @@ func TestPermissions_Boundary(t *testing.T) {
 		var totalPermissionsBoundaryFields int
 		for _, file := range files {
 			contents, err := os.ReadFile(file)
-			require.NoError(t, err, "should read file %s", file)
+			require.NoError(t, err, "should read file")
 			IAMRoles := bytes.Count(contents, []byte("AWS::IAM::Role"))
 			permissionsBoundaryFields := bytes.Count(contents, []byte("PermissionsBoundary:"))
 				
 			totalIAMRoles = totalIAMRoles + IAMRoles
 			totalPermissionsBoundaryFields = totalPermissionsBoundaryFields + permissionsBoundaryFields
 		}
-		require.True(t, totalIAMRoles == totalPermissionsBoundaryFields, "every IAM role in templates should have a conditional permissions boundary field")
+		require.True(t, totalIAMRoles == totalPermissionsBoundaryFields, "number of IAM roles does not equal number of permissions boundary fields")
 	})
 }

--- a/internal/pkg/template/permissions_boundary_integration_test.go
+++ b/internal/pkg/template/permissions_boundary_integration_test.go
@@ -24,8 +24,8 @@ func TestPermissions_Boundary(t *testing.T) {
 			IAMRoles := bytes.Count(contents, []byte("AWS::IAM::Role"))
 			permissionsBoundaryFields := bytes.Count(contents, []byte("PermissionsBoundary:"))
 				
-			totalIAMRoles = totalIAMRoles + IAMRoles
-			totalPermissionsBoundaryFields = totalPermissionsBoundaryFields + permissionsBoundaryFields
+			totalIAMRoles += IAMRoles
+			totalPermissionsBoundaryFields += permissionsBoundaryFields
 		}
 		require.True(t, totalIAMRoles == totalPermissionsBoundaryFields, "number of IAM roles does not equal number of permissions boundary fields")
 	})

--- a/internal/pkg/template/permissions_boundary_integration_test.go
+++ b/internal/pkg/template/permissions_boundary_integration_test.go
@@ -17,11 +17,14 @@ import (
 func TestPermissions_Boundary(t *testing.T) {
 	t.Run("every CloudFormation template must contain conditional permissions boundary field for all IAM roles", func(t *testing.T) {
 		err := filepath.WalkDir("templates", func(path string, di fs.DirEntry, err error) error {
-			contents, _ := os.ReadFile(path)
-			roleCount := bytes.Count(contents, []byte("AWS::IAM::Role"))
-			pbFieldCount := bytes.Count(contents, []byte("PermissionsBoundary:"))
+			if !di.IsDir() {
+				contents, err := os.ReadFile(path)
+				require.NoError(t, err, "read file at %s", path)
+				roleCount := bytes.Count(contents, []byte("AWS::IAM::Role"))
+				pbFieldCount := bytes.Count(contents, []byte("PermissionsBoundary:"))
 
-			require.Equal(t, roleCount, pbFieldCount, "number of IAM roles does not equal number of permissions boundary fields in file '%s'", path)
+				require.Equal(t, roleCount, pbFieldCount, "number of IAM roles does not equal number of permissions boundary fields in file '%s'", path)
+			}
 			return nil
 		})
 		require.NoError(t, err, "should walk templates dir for template files")

--- a/internal/pkg/template/permissions_boundary_integration_test.go
+++ b/internal/pkg/template/permissions_boundary_integration_test.go
@@ -7,7 +7,6 @@ package template
 
 import (
 	"bytes"
-	"fmt"
 	"github.com/stretchr/testify/require"
 	"io/fs"
 	"os"
@@ -19,11 +18,10 @@ func TestPermissions_Boundary(t *testing.T) {
 	t.Run("every CloudFormation template must contain conditional permissions boundary field for all IAM roles", func(t *testing.T) {
 		err := filepath.WalkDir("templates", func(path string, di fs.DirEntry, err error) error {
 			contents, _ := os.ReadFile(path)
-			IAMRoles := bytes.Count(contents, []byte("AWS::IAM::Role"))
-			permissionsBoundaryFields := bytes.Count(contents, []byte("PermissionsBoundary:"))
+			roleCount := bytes.Count(contents, []byte("AWS::IAM::Role"))
+			pbFieldCount := bytes.Count(contents, []byte("PermissionsBoundary:"))
 
-			msg := fmt.Sprintf("number of IAM roles (%d) does not equal number of permissions boundary fields (%d) in file '%s'", IAMRoles, permissionsBoundaryFields, path)
-			require.True(t, IAMRoles == permissionsBoundaryFields, msg)
+			require.Equal(t, roleCount, pbFieldCount, "number of IAM roles does not equal number of permissions boundary fields in file '%s'", path)
 			return nil
 		})
 		require.NoError(t, err, "should walk templates dir for template files")

--- a/internal/pkg/template/permissions_boundary_integration_test.go
+++ b/internal/pkg/template/permissions_boundary_integration_test.go
@@ -1,0 +1,32 @@
+package template
+
+import (
+	"bytes"
+	"github.com/stretchr/testify/require"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestPermissions_Boundary(t *testing.T) {
+	t.Run("CloudFormation template must contain conditional permissions boundary field for all IAM roles", func(t *testing.T) {
+		cmd := exec.Command("find", "templates", "-name", "*yml")
+		output, err := cmd.Output()
+		require.NoError(t, err, "should return output of 'find' command")
+		
+		files := strings.Fields(string(output))
+		var totalIAMRoles int
+		var totalPermissionsBoundaryFields int
+		for _, file := range files {
+			contents, err := os.ReadFile(file)
+			require.NoError(t, err, "should read file %s", file)
+			IAMRoles := bytes.Count(contents, []byte("AWS::IAM::Role"))
+			permissionsBoundaryFields := bytes.Count(contents, []byte("PermissionsBoundary:"))
+				
+			totalIAMRoles = totalIAMRoles + IAMRoles
+			totalPermissionsBoundaryFields = totalPermissionsBoundaryFields + permissionsBoundaryFields
+		}
+		require.True(t, totalIAMRoles == totalPermissionsBoundaryFields, "every IAM role in templates should have a conditional permissions boundary field")
+	})
+}

--- a/internal/pkg/template/permissions_boundary_integration_test.go
+++ b/internal/pkg/template/permissions_boundary_integration_test.go
@@ -1,3 +1,8 @@
+//go:build integration || localintegration
+
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package template
 
 import (

--- a/site/content/blogs/release-v122.en.md
+++ b/site/content/blogs/release-v122.en.md
@@ -1,5 +1,5 @@
 ---
-title: 'AWS Copilot v1.22: Try out IAM Permission Boundaries and more!'
+title: 'AWS Copilot v1.22: Try out IAM Permissions Boundaries and more!'
 twitter_title: 'AWS Copilot v1.22'
 image: ''
 image_alt: ''
@@ -7,7 +7,7 @@ image_width: '1051'
 image_height: '747'
 ---
 
-# AWS Copilot v1.22: Try out IAM Permission Boundaries and more!
+# AWS Copilot v1.22: Try out IAM Permissions Boundaries and more!
 
 Posted On: Sep 27, 2022
 
@@ -33,6 +33,19 @@ Copilot v1.22 brings several new features and improvements:
     See the section [Overview](../docs/concepts/overview.en.md) for a more detailed introduction to AWS Copilot.
 
 ## IAM Role Permissions Boundary
+Whether you have an AWS Organizations Service Control Policy that requires an attached permissions boundary for IAM role creation, or simply want to want to add some guardrails to your application, Copilot can help. By using the `--permissions-boundary` flag with the `copilot app init` command, you can specify your existing IAM policy. That policy will get attached to any and all IAM roles that Copilot creates (within that application) as a permissions boundary. 
+  
+If you init your application like this:
+```console
+copilot app init --permissions-boundary examplePermissionsBoundaryPolicy
+```
+Copilot will attach the permissions boundary to every IAM role created in the app like this:
+```yaml
+ExampleIAMRole
+  Type: AWS::IAM::Role
+  Properties:
+    PermissionsBoundary: 'arn:aws:iam::123456789012:policy/examplePermissionsBoundaryPolicy'
+```
 
 ## FIFO SNS/SQS
 


### PR DESCRIPTION
This integ test ensures that as we add CFN templates and/or IAM roles to CFN templates, we also conditionally attach a permission boundary if present in the app.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
