### PR TITLE
fix(cli): use `image.location` value instead of digest on `svc package`

### DIFF
--- a/internal/pkg/cli/deploy/svc.go
+++ b/internal/pkg/cli/deploy/svc.go
@@ -994,7 +994,7 @@ func (d *workloadDeployer) runtimeConfig(in *StackRuntimeConfiguration) (*stack.
 	if err != nil {
 		return nil, fmt.Errorf("get version of environment %q: %w", d.env.Name, err)
 	}
-	if in.ImageDigest == nil {
+	if len(aws.StringValue(in.ImageDigest)) == 0 {
 		return &stack.RuntimeConfig{
 			AddonsTemplateURL:        in.AddonsURL,
 			EnvFileARN:               in.EnvFileARN,

--- a/internal/pkg/cli/svc_package.go
+++ b/internal/pkg/cli/svc_package.go
@@ -316,9 +316,7 @@ func (o *packageSvcOpts) getWorkloadStack(generator workloadStackGenerator) (*cf
 	if err != nil {
 		return nil, err
 	}
-	uploadOut := clideploy.UploadArtifactsOutput{
-		ImageDigest: aws.String(""),
-	}
+	var uploadOut clideploy.UploadArtifactsOutput
 	if o.uploadAssets {
 		out, err := generator.UploadArtifacts()
 		if err != nil {
@@ -334,7 +332,7 @@ func (o *packageSvcOpts) getWorkloadStack(generator workloadStackGenerator) (*cf
 			EnvFileARN:         uploadOut.EnvFileARN,
 			AddonsURL:          uploadOut.AddonsURL,
 			CustomResourceURLs: uploadOut.CustomResourceURLs,
- 		},
+		},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("generate workload %s template against environment %s: %w", o.name, o.envName, err)

--- a/internal/pkg/cli/svc_package_test.go
+++ b/internal/pkg/cli/svc_package_test.go
@@ -232,7 +232,6 @@ count: 1`
 				m.generator.EXPECT().AddonsTemplate().Return("", nil)
 				m.generator.EXPECT().GenerateCloudFormationTemplate(&deploy.GenerateCloudFormationTemplateInput{
 					StackRuntimeConfiguration: deploy.StackRuntimeConfiguration{
-						ImageDigest: aws.String(""),
 						RootUserARN: mockARN,
 					},
 				}).Return(&deploy.GenerateCloudFormationTemplateOutput{


### PR DESCRIPTION
Fixes #2912#issuecomment-1265324677

In `svc package`, we previously set a default value of `*string("")` for the `ImageDigest` which caused us to incorrectly think there is a digest available (because we were checking if `digest != nil`).

Fixes by setting the default value of `ImageDigest` to just nil.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
