### PR TITLE
docs: updated quick start instructions

### DIFF
--- a/site/content/docs/getting-started/first-app-tutorial.en.md
+++ b/site/content/docs/getting-started/first-app-tutorial.en.md
@@ -4,7 +4,7 @@ Sound fun? Let’s do it!
 
 ## Step 1: Download & Configure AWS Copilot
 
-You’ll need a few things to use AWS Copilot - the AWS Copilot binary, AWS CLI, Docker Desktop and AWS credentials.
+You’ll need a few things to use AWS Copilot - the AWS Copilot binary, AWS CLI, Docker Desktop (needs to be running) and AWS credentials.
 
 Follow our instructions here on how to set up and configure all these tools.
 


### PR DESCRIPTION
Added instructions to have Docker running.

Context: https://gitter.im/aws/copilot-cli?at=633c6176133b6458ca0faeff

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
