### PR TITLE
fix: allow cdn certificate import without http cert import

### DIFF
--- a/cf-custom-resources/test/unique-json-values-test.js
+++ b/cf-custom-resources/test/unique-json-values-test.js
@@ -75,8 +75,8 @@ describe("Unique Aliases", () => {
       });
   });
 
-  const aliasTest = (name, input, expectedOutput) => {
-    const tt = (name, reqType, input, expectedOutput) => {
+  const aliasTest = (name, props, expectedOutput) => {
+    const tt = (name, reqType, props, expectedOutput) => {
       test(name, () => {
         const request = nock(responseURL)
           .put("/", (body) => {
@@ -95,9 +95,7 @@ describe("Unique Aliases", () => {
             ResponseURL: responseURL,
             RequestType: reqType,
             RequestId: testRequestId,
-            ResourceProperties: {
-              Aliases: JSON.stringify(input), // aliases get passed as a string
-            },
+            ResourceProperties: props,
             LogicalResourceId: "mockID",
           })
           .expectResolve(() => {
@@ -106,28 +104,80 @@ describe("Unique Aliases", () => {
       });
     };
 
-    tt(`Create/${name}`, "Create", input, expectedOutput);
-    tt(`Update/${name}`, "Update", input, expectedOutput);
+    tt(`Create/${name}`, "Create", props, expectedOutput);
+    tt(`Update/${name}`, "Update", props, expectedOutput);
   };
 
-  aliasTest("no aliases", {}, []);
+  aliasTest("no aliases", {
+    Aliases: "",
+    FilterFor: ""
+  }, []);
 
   aliasTest("one service", {
-    "svc1": ["svc1.com", "example.com"],
+    Aliases: JSON.stringify({
+      "svc1": ["svc1.com", "example.com"]
+    }),
+    FilterFor: "svc1",
   }, ["example.com", "svc1.com"]);
 
+  aliasTest("one service excluded", {
+    Aliases: JSON.stringify({
+      "svc1": ["svc1.com", "example.com"]
+    }),
+    FilterFor: "svc2",
+  }, []);
+
+  aliasTest("one service empty filter for", {
+    Aliases: JSON.stringify({
+      "svc1": ["svc1.com", "example.com"]
+    }),
+    FilterFor: "",
+  }, []);
+
   aliasTest("two services no common aliases", {
-    "svc1": ["svc1.com"],
-    "svc2": ["svc2.com"]
+    Aliases: JSON.stringify({
+      "svc1": ["svc1.com"],
+      "svc2": ["svc2.com"]
+    }),
+    FilterFor: "svc1,svc2",
   }, ["svc1.com", "svc2.com"]);
 
   aliasTest("two services, one with multiple common aliases", {
-    "svc1": ["svc1.com"],
-    "svc2": ["svc2.com", "example.com"]
+    Aliases: JSON.stringify({
+      "svc1": ["svc1.com"],
+      "svc2": ["svc2.com", "example.com"]
+    }),
+    FilterFor: "svc1,svc2",
   }, ["example.com", "svc1.com", "svc2.com"]);
 
   aliasTest("two services with a common alias", {
-    "svc1": ["svc1.com", "example.com"],
-    "svc2": ["svc2.com", "example.com"]
+    Aliases: JSON.stringify({
+      "svc1": ["svc1.com", "example.com"],
+      "svc2": ["svc2.com", "example.com"]
+    }),
+    FilterFor: "svc1,svc2",
   }, ["example.com", "svc1.com", "svc2.com"]);
+
+  aliasTest("three services with a common alias one service filtered out", {
+    Aliases: JSON.stringify({
+      "svc1": ["svc1.com", "example.com"],
+      "svc2": ["svc2.com", "example.com", "example2.com"],
+      "svc3": ["svc3.com", "example.com", "example2.com"]
+    }),
+    FilterFor: "svc2,svc1",
+  }, ["example.com", "example2.com", "svc1.com", "svc2.com"]);
+
+  aliasTest("bunch of services with single alias, some filtered out, out of order", {
+    Aliases: JSON.stringify({
+      "lbws3": ["three.lbws.com"],
+      "backend1": ["one.backend.internal"],
+      "lbws1": ["one.lbws.com"],
+      "lbws4": ["four.lbws.com"],
+      "backend2": ["two.backend.internal"],
+      "lbws2": ["two.lbws.com"],
+      "lbws6": ["lbws.com"],
+      "lbws5": ["lbws.com"],
+    }),
+    FilterFor: "lbws2,lbws3,lbws4,lbws1,lbws5,lbws6",
+  }, ["four.lbws.com", "lbws.com", "one.lbws.com", "three.lbws.com", "two.lbws.com"]);
 });

--- a/cf-custom-resources/test/unique-json-values-test.js
+++ b/cf-custom-resources/test/unique-json-values-test.js
@@ -180,4 +180,14 @@ describe("Unique Aliases", () => {
     }),
     FilterFor: "lbws2,lbws3,lbws4,lbws1,lbws5,lbws6",
   }, ["four.lbws.com", "lbws.com", "one.lbws.com", "three.lbws.com", "two.lbws.com"]);
+
+  aliasTest("bunch of services with single alias, some FilterFor services don't exist", {
+    Aliases: JSON.stringify({
+      "lbws1": ["lbws1.com"],
+      "lbws2": ["lbws2.com"],
+      "lbws3": ["lbws3.com"],
+      "lbws4": ["lbws4.com"],
+    }),
+    FilterFor: "lbws1,lbws5,lbws6,lbws3",
+  }, ["lbws1.com", "lbws3.com"]);
 });

--- a/internal/pkg/cli/deploy/env.go
+++ b/internal/pkg/cli/deploy/env.go
@@ -160,7 +160,7 @@ func (d *envDeployer) validateCDN(mft *manifest.Environment) error {
 		}
 	}
 
-	if mft.CDNEnabled() && mft.CDNDoesTLSTermination() && (mft.HasImportedPublicALBCerts() || d.app.Domain != "") {
+	if mft.CDNEnabled() && mft.CDNDoesTLSTermination() {
 		err := d.validateALBWorkloadsDontRedirect()
 		var redirErr *errEnvHasPublicServicesWithRedirect
 		switch {
@@ -240,7 +240,8 @@ func (d *envDeployer) lbServiceRedirects(ctx context.Context, svc string) (bool,
 		}
 	}
 	if ruleARN == "" {
-		return false, fmt.Errorf("http listener not found on service %q", svc)
+		// this will happen if the service doesn't support https.
+		return false, nil
 	}
 
 	rule, err := d.lbDescriber.DescribeRule(ctx, ruleARN)

--- a/internal/pkg/cli/deploy/env.go
+++ b/internal/pkg/cli/deploy/env.go
@@ -222,9 +222,7 @@ func (d *envDeployer) validateALBWorkloadsDontRedirect() error {
 }
 
 // lbServiceRedirects returns true if svc's HTTP listener rule redirects. We only check
-// HTTPListenerRuleWithDomain because HTTPListenerRule:
-// a) doesn't ever redirect
-// b) won't work with cloudfront anyways (can't point ALB default DNS to CF)
+// HTTPListenerRuleWithDomain because HTTPListenerRule doesn't ever redirect.
 func (d *envDeployer) lbServiceRedirects(ctx context.Context, svc string) (bool, error) {
 	stackDescriber := d.newServiceStackDescriber(svc)
 	resources, err := stackDescriber.Resources()

--- a/internal/pkg/cli/deploy/env_test.go
+++ b/internal/pkg/cli/deploy/env_test.go
@@ -561,7 +561,7 @@ These services will not be reachable through the CDN.
 To fix this, set the following field in each manifest:
 %s
 http:
-  redirect_to_https: true
+  redirect_to_https: false
 %s
 and run %scopilot svc deploy%s.
 If you'd like to use these services without a CDN, ensure each service's A record is pointed to the ALB.

--- a/internal/pkg/cli/deploy/env_test.go
+++ b/internal/pkg/cli/deploy/env_test.go
@@ -415,7 +415,7 @@ func TestEnvDeployer_Validate(t *testing.T) {
 			},
 		},
 	}
-	mftCDNTerminateTLS := &manifest.Environment{
+	mftCDNTerminateTLSAndHTTPCert := &manifest.Environment{
 		EnvironmentConfig: manifest.EnvironmentConfig{
 			HTTPConfig: manifest.EnvironmentHTTPConfig{
 				Public: manifest.PublicHTTPConfig{
@@ -429,6 +429,16 @@ func TestEnvDeployer_Validate(t *testing.T) {
 			},
 		},
 	}
+	mftCDNTerminateTLS := &manifest.Environment{
+		EnvironmentConfig: manifest.EnvironmentConfig{
+			CDNConfig: manifest.EnvironmentCDNConfig{
+				Config: manifest.AdvancedCDNConfig{
+					Certificate:  aws.String("mockCDNCertARN"),
+					TerminateTLS: aws.Bool(true),
+				},
+			},
+		},
+	}
 	tests := map[string]struct {
 		app            *config.Application
 		mft            *manifest.Environment
@@ -436,7 +446,7 @@ func TestEnvDeployer_Validate(t *testing.T) {
 		expected       string
 		expectedStdErr string
 	}{
-		"cdn enabled, domain imported, no public http certs and validate aliases fails": {
+		"cdn enabled, domain imported, no public http certs, and validate aliases fails": {
 			app: &config.Application{
 				Domain: "example.com",
 			},
@@ -452,7 +462,7 @@ func TestEnvDeployer_Validate(t *testing.T) {
 			},
 			expected: "some error",
 		},
-		"cdn enabled, domain imported, no public http certs and validate aliases succeeds": {
+		"cdn enabled, domain imported, no public http certs, and validate aliases succeeds": {
 			app: &config.Application{
 				Domain: "example.com",
 			},
@@ -469,7 +479,7 @@ func TestEnvDeployer_Validate(t *testing.T) {
 		},
 		"cdn tls termination enabled, fail to get env stack params": {
 			app: &config.Application{},
-			mft: mftCDNTerminateTLS,
+			mft: mftCDNTerminateTLSAndHTTPCert,
 			setUpMocks: func(m *envDeployerMocks, ctrl *gomock.Controller) {
 				m.envDescriber.EXPECT().Params().Return(nil, errors.New("some error"))
 			},
@@ -477,7 +487,7 @@ func TestEnvDeployer_Validate(t *testing.T) {
 		},
 		"cdn tls termination enabled, fail to get service resources": {
 			app: &config.Application{},
-			mft: mftCDNTerminateTLS,
+			mft: mftCDNTerminateTLSAndHTTPCert,
 			setUpMocks: func(m *envDeployerMocks, ctrl *gomock.Controller) {
 				m.stackDescribers = map[string]*mocks.MockstackDescriber{
 					"svc1": mocks.NewMockstackDescriber(ctrl),
@@ -492,7 +502,7 @@ func TestEnvDeployer_Validate(t *testing.T) {
 		},
 		"cdn tls termination enabled, fail to check listener rule": {
 			app: &config.Application{},
-			mft: mftCDNTerminateTLS,
+			mft: mftCDNTerminateTLSAndHTTPCert,
 			setUpMocks: func(m *envDeployerMocks, ctrl *gomock.Controller) {
 				m.stackDescribers = map[string]*mocks.MockstackDescriber{
 					"svc1": mocks.NewMockstackDescriber(ctrl),
@@ -513,7 +523,7 @@ func TestEnvDeployer_Validate(t *testing.T) {
 		},
 		"cdn tls termination enabled, warn with one service that doesn't redirect, two that do redirect": {
 			app: &config.Application{},
-			mft: mftCDNTerminateTLS,
+			mft: mftCDNTerminateTLSAndHTTPCert,
 			setUpMocks: func(m *envDeployerMocks, ctrl *gomock.Controller) {
 				m.stackDescribers = map[string]*mocks.MockstackDescriber{
 					"svc1": mocks.NewMockstackDescriber(ctrl),
@@ -617,7 +627,7 @@ If you'd like to use these services without a CDN, ensure each service's A recor
 		},
 		"cdn tls termination enabled, success with three services that don't redirect": {
 			app: &config.Application{},
-			mft: mftCDNTerminateTLS,
+			mft: mftCDNTerminateTLSAndHTTPCert,
 			setUpMocks: func(m *envDeployerMocks, ctrl *gomock.Controller) {
 				m.stackDescribers = map[string]*mocks.MockstackDescriber{
 					"svc1": mocks.NewMockstackDescriber(ctrl),
@@ -649,6 +659,25 @@ If you'd like to use these services without a CDN, ensure each service's A recor
 				m.lbDescriber.EXPECT().DescribeRule(gomock.Any(), "svc1RuleARN").Return(listenerRuleNoRedirect, nil)
 				m.lbDescriber.EXPECT().DescribeRule(gomock.Any(), "svc2RuleARN").Return(listenerRuleNoRedirect, nil)
 				m.lbDescriber.EXPECT().DescribeRule(gomock.Any(), "svc3RuleARN").Return(listenerRuleNoRedirect, nil)
+			},
+		},
+		"cdn tls termination enabled, one http only service deployed": {
+			app: &config.Application{},
+			mft: mftCDNTerminateTLS,
+			setUpMocks: func(m *envDeployerMocks, ctrl *gomock.Controller) {
+				m.stackDescribers = map[string]*mocks.MockstackDescriber{
+					"svc1": mocks.NewMockstackDescriber(ctrl),
+				}
+				m.envDescriber.EXPECT().Params().Return(map[string]string{
+					"ALBWorkloads": "svc1",
+				}, nil)
+				m.stackDescribers["svc1"].EXPECT().Resources().Return([]*stack.Resource{
+					{
+						LogicalID:  "HTTPListenerRuleWithDomain",
+						PhysicalID: "svc1RuleARN",
+					},
+				}, nil)
+				m.lbDescriber.EXPECT().DescribeRule(gomock.Any(), "svc1RuleARN").Return(listenerRuleNoRedirect, nil)
 			},
 		},
 	}

--- a/internal/pkg/cli/deploy/errors.go
+++ b/internal/pkg/cli/deploy/errors.go
@@ -46,7 +46,10 @@ type errEnvHasPublicServicesWithRedirect struct {
 }
 
 func (e *errEnvHasPublicServicesWithRedirect) Error() string {
-	return fmt.Sprintf("%v services redirect HTTP to HTTPS", len(e.services))
+	return fmt.Sprintf("%v %s HTTP to HTTPS",
+		len(e.services),
+		english.PluralWord(len(e.services), "service redirects", "services redirect"),
+	)
 }
 
 // RecommendActions returns recommended actions to be taken after the error.

--- a/internal/pkg/cli/deploy/errors.go
+++ b/internal/pkg/cli/deploy/errors.go
@@ -71,7 +71,7 @@ and run %s.`,
 		english.PluralWord(n, "redirects", "redirect"),
 		color.Emphasize(english.PluralWord(n, "This service", "These services")+" will not be reachable through the CDN."),
 		english.PluralWord(n, "its", "each"),
-		color.HighlightCodeBlock("http:\n  redirect_to_https: true"),
+		color.HighlightCodeBlock("http:\n  redirect_to_https: false"),
 		color.HighlightCode("copilot svc deploy"),
 	)
 }

--- a/internal/pkg/cli/deploy/svc.go
+++ b/internal/pkg/cli/deploy/svc.go
@@ -1391,15 +1391,14 @@ func (d *lbWebSvcDeployer) validateALBRuntime() error {
 			return fmt.Errorf("convert aliases to string slice: %w", err)
 		}
 
-		albCertValidator := d.newAliasCertValidator(nil)
-		cfCertValidator := d.newAliasCertValidator(aws.String(cloudfront.CertRegion))
-
 		if hasALBCerts {
+			albCertValidator := d.newAliasCertValidator(nil)
 			if err := albCertValidator.ValidateCertAliases(aliases, d.envConfig.HTTPConfig.Public.Certificates); err != nil {
 				return fmt.Errorf("validate aliases against the imported public ALB certificate for env %s: %w", d.env.Name, err)
 			}
 		}
 		if hasCDNCerts {
+			cfCertValidator := d.newAliasCertValidator(aws.String(cloudfront.CertRegion))
 			if err := cfCertValidator.ValidateCertAliases(aliases, []string{*d.envConfig.CDNConfig.Config.Certificate}); err != nil {
 				return fmt.Errorf("validate aliases against the imported CDN certificate for env %s: %w", d.env.Name, err)
 			}

--- a/internal/pkg/cli/deploy/svc_test.go
+++ b/internal/pkg/cli/deploy/svc_test.go
@@ -993,7 +993,7 @@ func TestWorkloadDeployer_DeployWorkload(t *testing.T) {
 				m.mockServiceDeployer.EXPECT().DeployService(gomock.Any(), "mockBucket", gomock.Any()).Return(nil)
 			},
 		},
-		"success with http redirect disabled and certs imported": {
+		"success with http redirect disabled and alb certs imported": {
 			inRedirectToHTTPS: aws.Bool(false),
 			inAliases: manifest.Alias{
 				AdvancedAliases: mockMultiAliases,
@@ -1014,6 +1014,29 @@ func TestWorkloadDeployer_DeployWorkload(t *testing.T) {
 				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
 				m.mockEnvVersionGetter.EXPECT().Version().Return("v1.42.0", nil)
 				m.mockValidator.EXPECT().ValidateCertAliases([]string{"example.com", "foobar.com"}, mockCertARNs).Return(nil)
+				m.mockServiceDeployer.EXPECT().DeployService(gomock.Any(), "mockBucket", gomock.Any()).Return(nil)
+			},
+		},
+		"success with only cdn certs imported": {
+			inAliases: manifest.Alias{
+				AdvancedAliases: mockMultiAliases,
+			},
+			inEnvironment: &config.Environment{
+				Name:   mockEnvName,
+				Region: "us-west-2",
+			},
+			inEnvironmentConfig: func() *manifest.Environment {
+				envConfig := &manifest.Environment{}
+				envConfig.CDNConfig.Config.Certificate = aws.String(mockCDNCertARN)
+				return envConfig
+			},
+			inApp: &config.Application{
+				Name: mockAppName,
+			},
+			mock: func(m *deployMocks) {
+				m.mockEndpointGetter.EXPECT().ServiceDiscoveryEndpoint().Return("mockApp.local", nil)
+				m.mockEnvVersionGetter.EXPECT().Version().Return("v1.42.0", nil)
+				m.mockValidator.EXPECT().ValidateCertAliases([]string{"example.com", "foobar.com"}, []string{mockCDNCertARN}).Return(nil)
 				m.mockServiceDeployer.EXPECT().DeployService(gomock.Any(), "mockBucket", gomock.Any()).Return(nil)
 			},
 		},

--- a/internal/pkg/cli/env_package.go
+++ b/internal/pkg/cli/env_package.go
@@ -113,6 +113,7 @@ func newPackageEnvOpts(vars packageEnvVars) (*packageEnvOpts, error) {
 			App:             appCfg,
 			Env:             envCfg,
 			SessionProvider: sessProvider,
+			ConfigStore:     opts.cfgStore,
 		})
 	}
 	return opts, nil

--- a/internal/pkg/deploy/cloudformation/stack/lb_web_svc_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/lb_web_svc_test.go
@@ -905,7 +905,7 @@ func TestLoadBalancedWebService_Parameters(t *testing.T) {
 }
 
 func TestLoadBalancedWebService_SerializedParameters(t *testing.T) {
-	var testLBWebServiceManifest = manifest.NewLoadBalancedWebService(&manifest.LoadBalancedWebServiceProps{
+	testLBWebServiceManifest := manifest.NewLoadBalancedWebService(&manifest.LoadBalancedWebServiceProps{
 		WorkloadProps: &manifest.WorkloadProps{
 			Name:       "frontend",
 			Dockerfile: "frontend/Dockerfile",
@@ -913,66 +913,57 @@ func TestLoadBalancedWebService_SerializedParameters(t *testing.T) {
 		Path: "frontend",
 		Port: 80,
 	})
-	testCases := map[string]struct {
-		mockDependencies func(ctrl *gomock.Controller, c *LoadBalancedWebService)
 
-		wantedParams string
-		wantedError  error
-	}{
-		"unavailable template": {
-			mockDependencies: func(ctrl *gomock.Controller, c *LoadBalancedWebService) {
-				m := mocks.NewMockloadBalancedWebSvcReadParser(ctrl)
-				m.EXPECT().Parse(wkldParamsTemplatePath, gomock.Any(), gomock.Any()).Return(nil, errors.New("some error"))
-				c.wkld.parser = m
-			},
-			wantedParams: "",
-			wantedError:  errors.New("some error"),
-		},
-		"render params template": {
-			mockDependencies: func(ctrl *gomock.Controller, c *LoadBalancedWebService) {
-				m := mocks.NewMockloadBalancedWebSvcReadParser(ctrl)
-				m.EXPECT().Parse(wkldParamsTemplatePath, gomock.Any(), gomock.Any()).Return(&template.Content{Buffer: bytes.NewBufferString("params")}, nil)
-				c.wkld.parser = m
-			},
-			wantedParams: "params",
-		},
-	}
-
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			// GIVEN
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
-			c := &LoadBalancedWebService{
-				ecsWkld: &ecsWkld{
-					wkld: &wkld{
-						name: aws.StringValue(testLBWebServiceManifest.Name),
-						env:  testEnvName,
-						app:  testAppName,
-						rc: RuntimeConfig{
-							Image: &ECRImage{
-								RepoURL:  testImageRepoURL,
-								ImageTag: testImageTag,
-							},
-							AdditionalTags: map[string]string{
-								"owner": "boss",
-							},
-						},
+	c := &LoadBalancedWebService{
+		ecsWkld: &ecsWkld{
+			wkld: &wkld{
+				name: "frontend",
+				env:  testEnvName,
+				app:  testAppName,
+				rc: RuntimeConfig{
+					Image: &ECRImage{
+						RepoURL:  testImageRepoURL,
+						ImageTag: testImageTag,
 					},
-					tc: testLBWebServiceManifest.TaskConfig,
+					AdditionalTags: map[string]string{
+						"owner": "boss",
+					},
 				},
-				manifest: testLBWebServiceManifest,
-			}
-			tc.mockDependencies(ctrl, c)
-
-			// WHEN
-			params, err := c.SerializedParameters()
-
-			// THEN
-			require.Equal(t, tc.wantedError, err)
-			require.Equal(t, tc.wantedParams, params)
-		})
+			},
+			tc: testLBWebServiceManifest.TaskConfig,
+		},
+		manifest: testLBWebServiceManifest,
 	}
+
+	params, err := c.SerializedParameters()
+	require.NoError(t, err)
+	require.Equal(t, params, `{
+  "Parameters": {
+    "AddonsTemplateURL": "",
+    "AppName": "phonetool",
+    "ContainerImage": "111111111111.dkr.ecr.us-west-2.amazonaws.com/phonetool/frontend:manual-bf3678c",
+    "ContainerPort": "80",
+    "DNSDelegated": "false",
+    "EnvFileARN": "",
+    "EnvName": "test",
+    "HTTPSEnabled": "false",
+    "LogRetention": "30",
+    "RulePath": "frontend",
+    "Stickiness": "false",
+    "TargetContainer": "frontend",
+    "TargetPort": "80",
+    "TaskCPU": "256",
+    "TaskCount": "1",
+    "TaskMemory": "512",
+    "WorkloadName": "frontend"
+  },
+  "Tags": {
+    "copilot-application": "phonetool",
+    "copilot-environment": "test",
+    "copilot-service": "frontend",
+    "owner": "boss"
+  }
+}`)
 }
 
 func TestLoadBalancedWebService_Tags(t *testing.T) {

--- a/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-imported-certs-observability.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-imported-certs-observability.yml
@@ -310,6 +310,7 @@ Resources:
     Properties:
       ServiceToken: !GetAtt UniqueJSONValuesFunction.Arn
       Aliases: !Ref Aliases
+      FilterFor: !Ref ALBWorkloads
   CloudFrontDistribution:
     Metadata:
       'aws:copilot:description': 'A CloudFront distribution for global content delivery'

--- a/internal/pkg/deploy/cloudformation/stack/testdata/stacklocal/cf.params.json
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/stacklocal/cf.params.json
@@ -1,24 +1,24 @@
 {
-  "Parameters" : { 
-    "AppName": "my-app",
-    "EnvName": "test",
-    "WorkloadName": "my-svc",
-    "ContainerImage": "mockImageURL:latest",
+  "Parameters": {
     "AddonsTemplateURL": "",
-    "TaskCPU": "256",
-    "TaskMemory": "512",
-    "TaskCount": "1",
-    "LogRetention": "30",
+    "AppName": "my-app",
+    "ContainerImage": "mockImageURL:latest",
     "ContainerPort": "5000",
     "DNSDelegated": "false",
+    "EnvFileARN": "",
+    "EnvName": "test",
+    "HTTPSEnabled": "true",
+    "LogRetention": "30",
+    "RulePath": "my-svc",
+    "Stickiness": "false",
     "TargetContainer": "my-svc",
     "TargetPort": "5000",
-    "EnvFileARN": "",
-    "RulePath": "my-svc",
-    "HTTPSEnabled": "true",
-    "Stickiness": "false"
+    "TaskCPU": "256",
+    "TaskCount": "1",
+    "TaskMemory": "512",
+    "WorkloadName": "my-svc"
   },
-  "Tags": { 
+  "Tags": {
     "copilot-application": "my-app",
     "copilot-environment": "test",
     "copilot-service": "my-svc"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/job-test.params.json
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/job-test.params.json
@@ -1,18 +1,18 @@
 {
-  "Parameters" : { 
-    "AppName": "my-app",
-    "EnvName": "test",
-    "WorkloadName": "job",
-    "ContainerImage": "alpine",
+  "Parameters": {
     "AddonsTemplateURL": "",
-    "TaskCPU": "256",
-    "TaskMemory": "512",
-    "TaskCount": "1",
+    "AppName": "my-app",
+    "ContainerImage": "alpine",
+    "EnvFileARN": "",
+    "EnvName": "test",
     "LogRetention": "30",
     "Schedule": "cron(0 12 ? * MON *)",
-    "EnvFileARN": ""
+    "TaskCPU": "256",
+    "TaskCount": "1",
+    "TaskMemory": "512",
+    "WorkloadName": "job"
   },
-  "Tags": { 
+  "Tags": {
     "copilot-application": "my-app",
     "copilot-environment": "test",
     "copilot-service": "job"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-grpc-test.params.json
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-grpc-test.params.json
@@ -1,24 +1,24 @@
 {
-  "Parameters" : { 
-    "AppName": "my-app",
-    "EnvName": "test",
-    "WorkloadName": "gRPC",
-    "ContainerImage": "",
+  "Parameters": {
     "AddonsTemplateURL": "",
-    "TaskCPU": "256",
-    "TaskMemory": "512",
-    "TaskCount": "2",
-    "LogRetention": "30",
+    "AppName": "my-app",
+    "ContainerImage": "",
     "ContainerPort": "50051",
     "DNSDelegated": "false",
+    "EnvFileARN": "",
+    "EnvName": "test",
+    "HTTPSEnabled": "true",
+    "LogRetention": "30",
+    "RulePath": "/",
+    "Stickiness": "false",
     "TargetContainer": "gRPC",
     "TargetPort": "50051",
-    "EnvFileARN": "",
-    "RulePath": "/",
-    "HTTPSEnabled": "true",
-    "Stickiness": "false"
+    "TaskCPU": "256",
+    "TaskCount": "2",
+    "TaskMemory": "512",
+    "WorkloadName": "gRPC"
   },
-  "Tags": { 
+  "Tags": {
     "copilot-application": "my-app",
     "copilot-environment": "test",
     "copilot-service": "gRPC"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-dev.params.json
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-dev.params.json
@@ -1,26 +1,26 @@
 {
-  "Parameters" : { 
-    "AppName": "my-app",
-    "EnvName": "dev",
-    "WorkloadName": "fe",
-    "ContainerImage": "",
+  "Parameters": {
     "AddonsTemplateURL": "",
-    "TaskCPU": "256",
-    "TaskMemory": "512",
-    "TaskCount": "5",
-    "LogRetention": "30",
+    "AppName": "my-app",
+    "ContainerImage": "",
     "ContainerPort": "80",
     "DNSDelegated": "true",
+    "EnvFileARN": "",
+    "EnvName": "dev",
+    "HTTPSEnabled": "true",
+    "LogRetention": "30",
+    "NLBAliases": "",
+    "NLBPort": "81",
+    "RulePath": "/",
+    "Stickiness": "false",
     "TargetContainer": "fe",
     "TargetPort": "80",
-    "EnvFileARN": "",
-    "RulePath": "/",
-    "HTTPSEnabled": "true",
-    "Stickiness": "false",
-    "NLBAliases": "",
-    "NLBPort": "81"
+    "TaskCPU": "256",
+    "TaskCount": "5",
+    "TaskMemory": "512",
+    "WorkloadName": "fe"
   },
-  "Tags": { 
+  "Tags": {
     "copilot-application": "my-app",
     "copilot-environment": "dev",
     "copilot-service": "fe"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-prod.params.json
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-prod.params.json
@@ -1,23 +1,23 @@
 {
-  "Parameters" : { 
-    "AppName": "my-app",
-    "EnvName": "prod",
-    "WorkloadName": "fe",
-    "ContainerImage": "",
+  "Parameters": {
     "AddonsTemplateURL": "",
-    "TaskCPU": "256",
-    "TaskMemory": "512",
-    "TaskCount": "5",
-    "LogRetention": "30",
+    "AppName": "my-app",
+    "ContainerImage": "",
     "ContainerPort": "80",
     "DNSDelegated": "true",
+    "EnvFileARN": "",
+    "EnvName": "prod",
+    "LogRetention": "30",
+    "NLBAliases": "nlb.example.com",
+    "NLBPort": "443",
     "TargetContainer": "fe",
     "TargetPort": "80",
-    "EnvFileARN": "",
-    "NLBAliases": "nlb.example.com",
-    "NLBPort": "443"
+    "TaskCPU": "256",
+    "TaskCount": "5",
+    "TaskMemory": "512",
+    "WorkloadName": "fe"
   },
-  "Tags": { 
+  "Tags": {
     "copilot-application": "my-app",
     "copilot-environment": "prod",
     "copilot-service": "fe"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-test.params.json
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-test.params.json
@@ -1,23 +1,23 @@
 {
-  "Parameters" : { 
-    "AppName": "my-app",
-    "EnvName": "test",
-    "WorkloadName": "fe",
-    "ContainerImage": "",
+  "Parameters": {
     "AddonsTemplateURL": "",
-    "TaskCPU": "256",
-    "TaskMemory": "512",
-    "TaskCount": "5",
-    "LogRetention": "30",
+    "AppName": "my-app",
+    "ContainerImage": "",
     "ContainerPort": "80",
     "DNSDelegated": "true",
+    "EnvFileARN": "",
+    "EnvName": "test",
+    "LogRetention": "30",
+    "NLBAliases": "",
+    "NLBPort": "443",
     "TargetContainer": "fe",
     "TargetPort": "80",
-    "EnvFileARN": "",
-    "NLBAliases": "",
-    "NLBPort": "443"
+    "TaskCPU": "256",
+    "TaskCount": "5",
+    "TaskMemory": "512",
+    "WorkloadName": "fe"
   },
-  "Tags": { 
+  "Tags": {
     "copilot-application": "my-app",
     "copilot-environment": "test",
     "copilot-service": "fe"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-prod.params.json
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-prod.params.json
@@ -1,24 +1,24 @@
 {
-  "Parameters" : { 
-    "AppName": "my-app",
-    "EnvName": "prod",
-    "WorkloadName": "fe",
-    "ContainerImage": "",
+  "Parameters": {
     "AddonsTemplateURL": "",
-    "TaskCPU": "256",
-    "TaskMemory": "512",
-    "TaskCount": "3",
-    "LogRetention": "1",
+    "AppName": "my-app",
+    "ContainerImage": "",
     "ContainerPort": "4000",
     "DNSDelegated": "false",
+    "EnvFileARN": "",
+    "EnvName": "prod",
+    "HTTPSEnabled": "true",
+    "LogRetention": "1",
+    "RulePath": "/",
+    "Stickiness": "false",
     "TargetContainer": "fe",
     "TargetPort": "4000",
-    "EnvFileARN": "",
-    "RulePath": "/",
-    "HTTPSEnabled": "true",
-    "Stickiness": "false"
+    "TaskCPU": "256",
+    "TaskCount": "3",
+    "TaskMemory": "512",
+    "WorkloadName": "fe"
   },
-  "Tags": { 
+  "Tags": {
     "copilot-application": "my-app",
     "copilot-environment": "prod",
     "copilot-service": "fe"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-staging.params.json
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-staging.params.json
@@ -1,24 +1,24 @@
 {
-  "Parameters" : { 
-    "AppName": "my-app",
-    "EnvName": "staging",
-    "WorkloadName": "fe",
-    "ContainerImage": "123456789000.dkr.ecr.us-east-1.amazonaws.com/vault/e2e:cicdtest",
+  "Parameters": {
     "AddonsTemplateURL": "",
-    "TaskCPU": "256",
-    "TaskMemory": "512",
-    "TaskCount": "5",
-    "LogRetention": "30",
+    "AppName": "my-app",
+    "ContainerImage": "123456789000.dkr.ecr.us-east-1.amazonaws.com/vault/e2e:cicdtest",
     "ContainerPort": "4000",
     "DNSDelegated": "false",
+    "EnvFileARN": "",
+    "EnvName": "staging",
+    "HTTPSEnabled": "true",
+    "LogRetention": "30",
+    "RulePath": "/",
+    "Stickiness": "false",
     "TargetContainer": "fe",
     "TargetPort": "4000",
-    "EnvFileARN": "",
-    "RulePath": "/",
-    "HTTPSEnabled": "true",
-    "Stickiness": "false"
+    "TaskCPU": "256",
+    "TaskCount": "5",
+    "TaskMemory": "512",
+    "WorkloadName": "fe"
   },
-  "Tags": { 
+  "Tags": {
     "copilot-application": "my-app",
     "copilot-environment": "staging",
     "copilot-service": "fe"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-test.params.json
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-test.params.json
@@ -1,24 +1,24 @@
 {
-  "Parameters" : { 
-    "AppName": "my-app",
-    "EnvName": "test",
-    "WorkloadName": "fe",
-    "ContainerImage": "",
+  "Parameters": {
     "AddonsTemplateURL": "",
-    "TaskCPU": "256",
-    "TaskMemory": "512",
-    "TaskCount": "2",
-    "LogRetention": "30",
+    "AppName": "my-app",
+    "ContainerImage": "",
     "ContainerPort": "4000",
     "DNSDelegated": "false",
+    "EnvFileARN": "",
+    "EnvName": "test",
+    "HTTPSEnabled": "true",
+    "LogRetention": "30",
+    "RulePath": "/",
+    "Stickiness": "false",
     "TargetContainer": "fe",
     "TargetPort": "4000",
-    "EnvFileARN": "",
-    "RulePath": "/",
-    "HTTPSEnabled": "true",
-    "Stickiness": "false"
+    "TaskCPU": "256",
+    "TaskCount": "2",
+    "TaskMemory": "512",
+    "WorkloadName": "fe"
   },
-  "Tags": { 
+  "Tags": {
     "copilot-application": "my-app",
     "copilot-environment": "test",
     "copilot-service": "fe"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/windows-svc-test.params.json
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/windows-svc-test.params.json
@@ -1,24 +1,24 @@
 {
-  "Parameters" : { 
-    "AppName": "my-app",
-    "EnvName": "test",
-    "WorkloadName": "windows-fe",
-    "ContainerImage": "",
+  "Parameters": {
     "AddonsTemplateURL": "",
-    "TaskCPU": "1024",
-    "TaskMemory": "2048",
-    "TaskCount": "1",
-    "LogRetention": "30",
+    "AppName": "my-app",
+    "ContainerImage": "",
     "ContainerPort": "80",
     "DNSDelegated": "false",
+    "EnvFileARN": "",
+    "EnvName": "test",
+    "HTTPSEnabled": "false",
+    "LogRetention": "30",
+    "RulePath": "/",
+    "Stickiness": "false",
     "TargetContainer": "windows-fe",
     "TargetPort": "80",
-    "EnvFileARN": "",
-    "RulePath": "/",
-    "HTTPSEnabled": "false",
-    "Stickiness": "false"
+    "TaskCPU": "1024",
+    "TaskCount": "1",
+    "TaskMemory": "2048",
+    "WorkloadName": "windows-fe"
   },
-  "Tags": { 
+  "Tags": {
     "copilot-application": "my-app",
     "copilot-environment": "test",
     "copilot-service": "windows-fe"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/worker-test.params.json
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/worker-test.params.json
@@ -1,17 +1,17 @@
 {
-  "Parameters" : { 
-    "AppName": "my-app",
-    "EnvName": "test",
-    "WorkloadName": "dogworker",
-    "ContainerImage": "amazon/ecs-example",
+  "Parameters": {
     "AddonsTemplateURL": "",
-    "TaskCPU": "256",
-    "TaskMemory": "512",
-    "TaskCount": "1",
+    "AppName": "my-app",
+    "ContainerImage": "amazon/ecs-example",
+    "EnvFileARN": "",
+    "EnvName": "test",
     "LogRetention": "30",
-    "EnvFileARN": ""
+    "TaskCPU": "256",
+    "TaskCount": "1",
+    "TaskMemory": "512",
+    "WorkloadName": "dogworker"
   },
-  "Tags": { 
+  "Tags": {
     "copilot-application": "my-app",
     "copilot-environment": "test",
     "copilot-service": "dogworker"

--- a/internal/pkg/deploy/cloudformation/stack/workload.go
+++ b/internal/pkg/deploy/cloudformation/stack/workload.go
@@ -202,7 +202,7 @@ func serializeTemplateConfig(parser template.Parser, stack templateConfigurer) (
 
 	str, err := json.MarshalIndent(config, "", "  ")
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("marshal stack parameters to JSON: %v", err)
 	}
 
 	return string(str), nil

--- a/internal/pkg/deploy/cloudformation/stack/workload.go
+++ b/internal/pkg/deploy/cloudformation/stack/workload.go
@@ -4,6 +4,7 @@
 package stack
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 
@@ -15,11 +16,6 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/manifest"
 	"github.com/aws/copilot-cli/internal/pkg/template"
 	"github.com/aws/copilot-cli/internal/pkg/template/override"
-)
-
-// Template rendering configuration common across workloads.
-const (
-	wkldParamsTemplatePath = "workloads/params.json.tmpl"
 )
 
 // Parameter logical IDs common across workloads.
@@ -186,19 +182,30 @@ func serializeTemplateConfig(parser template.Parser, stack templateConfigurer) (
 	if err != nil {
 		return "", err
 	}
-	doc, err := parser.Parse(wkldParamsTemplatePath, struct {
-		Parameters []*cloudformation.Parameter
-		Tags       []*cloudformation.Tag
+
+	tags := stack.Tags()
+
+	config := struct {
+		Parameters map[string]*string `json:"Parameters"`
+		Tags       map[string]*string `json:"Tags,omitempty"`
 	}{
-		Parameters: params,
-		Tags:       stack.Tags(),
-	}, template.WithFuncs(map[string]interface{}{
-		"inc": template.IncFunc,
-	}))
+		Parameters: make(map[string]*string, len(params)),
+		Tags:       make(map[string]*string, len(tags)),
+	}
+
+	for _, param := range params {
+		config.Parameters[aws.StringValue(param.ParameterKey)] = param.ParameterValue
+	}
+	for _, tag := range tags {
+		config.Tags[aws.StringValue(tag.Key)] = tag.Value
+	}
+
+	str, err := json.MarshalIndent(config, "", "  ")
 	if err != nil {
 		return "", err
 	}
-	return doc.String(), nil
+
+	return string(str), nil
 }
 
 func (w *wkld) addonsOutputs() (*template.WorkloadNestedStackOpts, error) {

--- a/internal/pkg/manifest/validate_env.go
+++ b/internal/pkg/manifest/validate_env.go
@@ -50,7 +50,7 @@ func (e EnvironmentConfig) validate() error {
 		cdnCert := e.CDNConfig.Config.Certificate
 		if e.HTTPConfig.Public.Certificates == nil {
 			if cdnCert != nil && !aws.BoolValue(e.CDNConfig.Config.TerminateTLS) {
-				return errors.New("cdn.terminate_tls must be true if cdn.certificate is set without http.public.certificates")
+				return errors.New(`"cdn.terminate_tls" must be true if "cdn.certificate" is set without "http.public.certificates"`)
 			}
 		} else {
 			if cdnCert == nil {

--- a/internal/pkg/manifest/validate_env.go
+++ b/internal/pkg/manifest/validate_env.go
@@ -49,11 +49,8 @@ func (e EnvironmentConfig) validate() error {
 	if e.CDNEnabled() {
 		cdnCert := e.CDNConfig.Config.Certificate
 		if e.HTTPConfig.Public.Certificates == nil {
-			if cdnCert != nil {
-				return &errFieldMustBeSpecified{
-					missingField:      "http.public.certificates",
-					conditionalFields: []string{"cdn.certificate"},
-				}
+			if cdnCert != nil && !aws.BoolValue(e.CDNConfig.Config.TerminateTLS) {
+				return errors.New("cdn.terminate_tls must be true if cdn.certificate is set without http.public.certificates")
 			}
 		} else {
 			if cdnCert == nil {

--- a/internal/pkg/manifest/validate_env_test.go
+++ b/internal/pkg/manifest/validate_env_test.go
@@ -214,7 +214,7 @@ func TestEnvironmentConfig_validate(t *testing.T) {
 				},
 			},
 		},
-		"error if cdn cert specified but public certs not specified": {
+		"error if cdn cert specified, cdn not terminating tls, and public certs not specified": {
 			in: EnvironmentConfig{
 				CDNConfig: EnvironmentCDNConfig{
 					Config: AdvancedCDNConfig{
@@ -222,7 +222,17 @@ func TestEnvironmentConfig_validate(t *testing.T) {
 					},
 				},
 			},
-			wantedError: "\"http.public.certificates\" must be specified if \"cdn.certificate\" is specified",
+			wantedError: "cdn.terminate_tls must be true if cdn.certificate is set without http.public.certificates",
+		},
+		"success if cdn cert specified, cdn terminating tls, and no public certs": {
+			in: EnvironmentConfig{
+				CDNConfig: EnvironmentCDNConfig{
+					Config: AdvancedCDNConfig{
+						Certificate:  aws.String("arn:aws:acm:us-east-1:1111111:certificate/look-like-a-good-arn"),
+						TerminateTLS: aws.Bool(true),
+					},
+				},
+			},
 		},
 		"error if cdn cert not specified but public certs imported": {
 			in: EnvironmentConfig{

--- a/internal/pkg/manifest/validate_env_test.go
+++ b/internal/pkg/manifest/validate_env_test.go
@@ -222,7 +222,7 @@ func TestEnvironmentConfig_validate(t *testing.T) {
 					},
 				},
 			},
-			wantedError: "cdn.terminate_tls must be true if cdn.certificate is set without http.public.certificates",
+			wantedError: `"cdn.terminate_tls" must be true if "cdn.certificate" is set without "http.public.certificates"`,
 		},
 		"success if cdn cert specified, cdn terminating tls, and no public certs": {
 			in: EnvironmentConfig{

--- a/internal/pkg/template/env.go
+++ b/internal/pkg/template/env.go
@@ -121,6 +121,14 @@ type EnvOpts struct {
 	DelegateDNS bool
 }
 
+// HasImportedCerts returns true if any https certificates have been
+// imported to the environment.
+func (e *EnvOpts) HasImportedCerts() bool {
+	return len(e.PublicHTTPConfig.ImportedCertARNs) > 0 ||
+		len(e.PrivateHTTPConfig.ImportedCertARNs) > 0 ||
+		(e.CDNConfig != nil && e.CDNConfig.ImportedCertificate != nil)
+}
+
 // HTTPConfig represents configuration for a Load Balancer.
 type HTTPConfig struct {
 	CIDRPrefixListIDs []string

--- a/internal/pkg/template/templates/environment/partials/cdn-resources.yml
+++ b/internal/pkg/template/templates/environment/partials/cdn-resources.yml
@@ -44,6 +44,7 @@ UniqueAliasesAction:
   Properties:
     ServiceToken: !GetAtt UniqueJSONValuesFunction.Arn
     Aliases: !Ref Aliases
+    FilterFor: !Ref ALBWorkloads
 {{- end}}{{/* endif or .CDNConfig.ImportedCertificate .DelegateDNS */}}
 
 CloudFrontDistribution:

--- a/internal/pkg/template/templates/environment/partials/environment-manager-role.yml
+++ b/internal/pkg/template/templates/environment/partials/environment-manager-role.yml
@@ -22,7 +22,7 @@ EnvironmentManagerRole:
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
-{{- if or .PublicHTTPConfig.ImportedCertARNs .PrivateHTTPConfig.ImportedCertARNs}}
+{{- if .HasImportedCerts}}
         - Sid: ImportedCertificates
           Effect: Allow
           Action: [

--- a/internal/pkg/template/templates/workloads/params.json.tmpl
+++ b/internal/pkg/template/templates/workloads/params.json.tmpl
@@ -1,8 +1,0 @@
-{
-  "Parameters" : { {{$paramsSize := len .Parameters}}{{range $i, $p := .Parameters}}
-    {{if eq (inc $i) $paramsSize}}"{{$p.ParameterKey}}": "{{$p.ParameterValue}}"{{else}}"{{$p.ParameterKey}}": "{{$p.ParameterValue}}",{{end}}{{end}}
-  },{{$n := len .Tags}}{{if gt $n 0}}
-  "Tags": { {{range $i, $t := .Tags}}
-    {{if eq (inc $i) $n}}"{{$t.Key}}": "{{$t.Value}}"{{else}}"{{$t.Key}}": "{{$t.Value}}",{{end}}{{end}}
-  }{{end}}
-}


### PR DESCRIPTION
Also fixes a bug where CDN fails to create if there are any internal ALB services deployed.
Also fixes a bug where on `svc/env package` we don't escape param values

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
