### PR TITLE
chore: add sc to svc show

### DIFF
--- a/internal/pkg/aws/ecs/mocks/mock_ecs.go
+++ b/internal/pkg/aws/ecs/mocks/mock_ecs.go
@@ -7,7 +7,7 @@ package mocks
 import (
 	reflect "reflect"
 
-	ecs "github.com/aws/copilot-cli/internal/pkg/ecssdk"
+	ecssdk "github.com/aws/copilot-cli/internal/pkg/ecssdk"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -35,10 +35,10 @@ func (m *Mockapi) EXPECT() *MockapiMockRecorder {
 }
 
 // DescribeClusters mocks base method.
-func (m *Mockapi) DescribeClusters(input *ecs.DescribeClustersInput) (*ecs.DescribeClustersOutput, error) {
+func (m *Mockapi) DescribeClusters(input *ecssdk.DescribeClustersInput) (*ecssdk.DescribeClustersOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeClusters", input)
-	ret0, _ := ret[0].(*ecs.DescribeClustersOutput)
+	ret0, _ := ret[0].(*ecssdk.DescribeClustersOutput)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -50,10 +50,10 @@ func (mr *MockapiMockRecorder) DescribeClusters(input interface{}) *gomock.Call 
 }
 
 // DescribeServices mocks base method.
-func (m *Mockapi) DescribeServices(input *ecs.DescribeServicesInput) (*ecs.DescribeServicesOutput, error) {
+func (m *Mockapi) DescribeServices(input *ecssdk.DescribeServicesInput) (*ecssdk.DescribeServicesOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeServices", input)
-	ret0, _ := ret[0].(*ecs.DescribeServicesOutput)
+	ret0, _ := ret[0].(*ecssdk.DescribeServicesOutput)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -65,10 +65,10 @@ func (mr *MockapiMockRecorder) DescribeServices(input interface{}) *gomock.Call 
 }
 
 // DescribeTaskDefinition mocks base method.
-func (m *Mockapi) DescribeTaskDefinition(input *ecs.DescribeTaskDefinitionInput) (*ecs.DescribeTaskDefinitionOutput, error) {
+func (m *Mockapi) DescribeTaskDefinition(input *ecssdk.DescribeTaskDefinitionInput) (*ecssdk.DescribeTaskDefinitionOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeTaskDefinition", input)
-	ret0, _ := ret[0].(*ecs.DescribeTaskDefinitionOutput)
+	ret0, _ := ret[0].(*ecssdk.DescribeTaskDefinitionOutput)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -80,10 +80,10 @@ func (mr *MockapiMockRecorder) DescribeTaskDefinition(input interface{}) *gomock
 }
 
 // DescribeTasks mocks base method.
-func (m *Mockapi) DescribeTasks(input *ecs.DescribeTasksInput) (*ecs.DescribeTasksOutput, error) {
+func (m *Mockapi) DescribeTasks(input *ecssdk.DescribeTasksInput) (*ecssdk.DescribeTasksOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeTasks", input)
-	ret0, _ := ret[0].(*ecs.DescribeTasksOutput)
+	ret0, _ := ret[0].(*ecssdk.DescribeTasksOutput)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -95,10 +95,10 @@ func (mr *MockapiMockRecorder) DescribeTasks(input interface{}) *gomock.Call {
 }
 
 // ExecuteCommand mocks base method.
-func (m *Mockapi) ExecuteCommand(input *ecs.ExecuteCommandInput) (*ecs.ExecuteCommandOutput, error) {
+func (m *Mockapi) ExecuteCommand(input *ecssdk.ExecuteCommandInput) (*ecssdk.ExecuteCommandOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ExecuteCommand", input)
-	ret0, _ := ret[0].(*ecs.ExecuteCommandOutput)
+	ret0, _ := ret[0].(*ecssdk.ExecuteCommandOutput)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -110,10 +110,10 @@ func (mr *MockapiMockRecorder) ExecuteCommand(input interface{}) *gomock.Call {
 }
 
 // ListTasks mocks base method.
-func (m *Mockapi) ListTasks(input *ecs.ListTasksInput) (*ecs.ListTasksOutput, error) {
+func (m *Mockapi) ListTasks(input *ecssdk.ListTasksInput) (*ecssdk.ListTasksOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListTasks", input)
-	ret0, _ := ret[0].(*ecs.ListTasksOutput)
+	ret0, _ := ret[0].(*ecssdk.ListTasksOutput)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -125,10 +125,10 @@ func (mr *MockapiMockRecorder) ListTasks(input interface{}) *gomock.Call {
 }
 
 // RunTask mocks base method.
-func (m *Mockapi) RunTask(input *ecs.RunTaskInput) (*ecs.RunTaskOutput, error) {
+func (m *Mockapi) RunTask(input *ecssdk.RunTaskInput) (*ecssdk.RunTaskOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RunTask", input)
-	ret0, _ := ret[0].(*ecs.RunTaskOutput)
+	ret0, _ := ret[0].(*ecssdk.RunTaskOutput)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -140,10 +140,10 @@ func (mr *MockapiMockRecorder) RunTask(input interface{}) *gomock.Call {
 }
 
 // StopTask mocks base method.
-func (m *Mockapi) StopTask(input *ecs.StopTaskInput) (*ecs.StopTaskOutput, error) {
+func (m *Mockapi) StopTask(input *ecssdk.StopTaskInput) (*ecssdk.StopTaskOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StopTask", input)
-	ret0, _ := ret[0].(*ecs.StopTaskOutput)
+	ret0, _ := ret[0].(*ecssdk.StopTaskOutput)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -155,10 +155,10 @@ func (mr *MockapiMockRecorder) StopTask(input interface{}) *gomock.Call {
 }
 
 // UpdateService mocks base method.
-func (m *Mockapi) UpdateService(input *ecs.UpdateServiceInput) (*ecs.UpdateServiceOutput, error) {
+func (m *Mockapi) UpdateService(input *ecssdk.UpdateServiceInput) (*ecssdk.UpdateServiceOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateService", input)
-	ret0, _ := ret[0].(*ecs.UpdateServiceOutput)
+	ret0, _ := ret[0].(*ecssdk.UpdateServiceOutput)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -170,7 +170,7 @@ func (mr *MockapiMockRecorder) UpdateService(input interface{}) *gomock.Call {
 }
 
 // WaitUntilTasksRunning mocks base method.
-func (m *Mockapi) WaitUntilTasksRunning(input *ecs.DescribeTasksInput) error {
+func (m *Mockapi) WaitUntilTasksRunning(input *ecssdk.DescribeTasksInput) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitUntilTasksRunning", input)
 	ret0, _ := ret[0].(error)
@@ -207,7 +207,7 @@ func (m *MockssmSessionStarter) EXPECT() *MockssmSessionStarterMockRecorder {
 }
 
 // StartSession mocks base method.
-func (m *MockssmSessionStarter) StartSession(ssmSession *ecs.Session) error {
+func (m *MockssmSessionStarter) StartSession(ssmSession *ecssdk.Session) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartSession", ssmSession)
 	ret0, _ := ret[0].(error)

--- a/internal/pkg/aws/ecs/service.go
+++ b/internal/pkg/aws/ecs/service.go
@@ -80,14 +80,13 @@ func (s *Service) ServiceConnectAliases() []string {
 	if scConfig == nil || !aws.BoolValue(scConfig.Enabled) {
 		return nil
 	}
-	ns := aws.StringValue(scConfig.Namespace)
 	var aliases []string
 	for _, service := range scConfig.Services {
 		defaultName := aws.StringValue(service.PortName)
 		if aws.StringValue(service.DiscoveryName) != "" {
 			defaultName = aws.StringValue(service.DiscoveryName)
 		}
-		defaultAlias := fmt.Sprintf("%s.%s", defaultName, ns)
+		defaultAlias := fmt.Sprintf("%s.%s", defaultName, aws.StringValue(scConfig.Namespace))
 		if len(service.ClientAliases) == 0 {
 			aliases = append(aliases, defaultAlias)
 			continue

--- a/internal/pkg/describe/backend_service.go
+++ b/internal/pkg/describe/backend_service.go
@@ -104,8 +104,8 @@ func (d *BackendServiceDescriber) Describe() (HumanJSONStringer, error) {
 
 	var routes []*WebServiceRoute
 	var configs []*ECSServiceConfig
-	var sdEndpoints serviceDiscoveries
-	var scEndpoints serviceConnects
+	sdEndpoints := make(serviceDiscoveries)
+	scEndpoints := make(serviceConnects)
 	var envVars []*containerEnvVar
 	var secrets []*secret
 	for _, env := range environments {
@@ -213,21 +213,6 @@ func (d *BackendServiceDescriber) Manifest(env string) ([]byte, error) {
 // backendSvcDesc contains serialized parameters for a backend service.
 type backendSvcDesc struct {
 	ecsSvcDesc
-}
-
-type ecsSvcDesc struct {
-	Service          string               `json:"service"`
-	Type             string               `json:"type"`
-	App              string               `json:"application"`
-	Configurations   ecsConfigurations    `json:"configurations"`
-	Routes           []*WebServiceRoute   `json:"routes"`
-	ServiceDiscovery serviceDiscoveries   `json:"serviceDiscovery"`
-	ServiceConnect   serviceConnects      `json:"serviceConnect,omitempty"`
-	Variables        containerEnvVars     `json:"variables"`
-	Secrets          secrets              `json:"secrets,omitempty"`
-	Resources        deployedSvcResources `json:"resources,omitempty"`
-
-	environments []string `json:"-"`
 }
 
 // JSONString returns the stringified backendService struct with json format.

--- a/internal/pkg/describe/backend_service.go
+++ b/internal/pkg/describe/backend_service.go
@@ -134,10 +134,10 @@ func (d *BackendServiceDescriber) Describe() (HumanJSONStringer, error) {
 		port := blankContainerPort
 		if isReachableWithinVPC(svcParams) {
 			port = svcParams[cfnstack.WorkloadTargetPortParamKey]
-			if err := sdEndpoints.collectServiceDiscoveryEndpoints(envDescr, d.svc, env, port); err != nil {
+			if err := sdEndpoints.collectEndpoints(envDescr, d.svc, env, port); err != nil {
 				return nil, err
 			}
-			if err := scEndpoints.collectServiceConnectEndpoints(svcDescr, env); err != nil {
+			if err := scEndpoints.collectEndpoints(svcDescr, env); err != nil {
 				return nil, err
 			}
 		}

--- a/internal/pkg/describe/backend_service.go
+++ b/internal/pkg/describe/backend_service.go
@@ -262,7 +262,7 @@ func (w *backendSvcDesc) HumanString() string {
 		}
 	}
 	if len(w.ServiceConnect) > 0 || len(w.ServiceDiscovery) > 0 {
-		fmt.Fprint(writer, color.Bold.Sprint("\nService Endpoint\n\n"))
+		fmt.Fprint(writer, color.Bold.Sprint("\nInternal Service Endpoint\n\n"))
 		writer.Flush()
 		endpoints := serviceEndpoints{
 			discoveries: w.ServiceDiscovery,

--- a/internal/pkg/describe/backend_service_test.go
+++ b/internal/pkg/describe/backend_service_test.go
@@ -568,10 +568,10 @@ Configurations
 
 Internal Service Endpoint
 
-  Environment  Endpoint                              Type
-  -----------  --------                              ----
-  prod         http://my-svc.prod.my-app.local:5000  Service Discovery
-  test         http://my-svc.test.my-app.local:5000  Service Discovery
+  Endpoint                              Environment  Type
+  --------                              -----------  ----
+  http://my-svc.test.my-app.local:5000  test         Service Discovery
+  http://my-svc.prod.my-app.local:5000  prod         Service Discovery
 
 Variables
 

--- a/internal/pkg/describe/backend_service_test.go
+++ b/internal/pkg/describe/backend_service_test.go
@@ -310,14 +310,14 @@ func TestBackendServiceDescriber_Describe(t *testing.T) {
 							Tasks: "2",
 						},
 					},
-					ServiceDiscovery: []*ServiceDiscovery{
+					ServiceDiscovery: serviceDiscoveries{
 						{
 							Environment: []string{"test"},
-							Namespace:   "jobs.test.phonetool.local:5000",
+							Endpoint:    "jobs.test.phonetool.local:5000",
 						},
 						{
 							Environment: []string{"prod"},
-							Namespace:   "jobs.prod.phonetool.local:5000",
+							Endpoint:    "jobs.prod.phonetool.local:5000",
 						},
 					},
 					Variables: []*containerEnvVar{
@@ -462,13 +462,13 @@ func TestBackendServiceDescriber_Describe(t *testing.T) {
 					ServiceDiscovery: serviceDiscoveries{
 						{
 							Environment: []string{"test"},
-							Namespace:   "jobs.test.phonetool.local:5000",
+							Endpoint:    "jobs.test.phonetool.local:5000",
 						},
 					},
 					ServiceConnect: serviceConnects{
 						{
 							Environment: []string{"test"},
-							DNSName:     "jobs",
+							Endpoint:    "jobs",
 						},
 					},
 					Variables: []*containerEnvVar{
@@ -595,7 +595,7 @@ Resources
   prod
     AWS::EC2::SecurityGroupIngress  ContainerSecurityGroupIngressFromPublicALB
 `,
-			wantedJSONString: "{\"service\":\"my-svc\",\"type\":\"Backend Service\",\"application\":\"my-app\",\"configurations\":[{\"environment\":\"test\",\"port\":\"80\",\"cpu\":\"256\",\"memory\":\"512\",\"platform\":\"LINUX/X86_64\",\"tasks\":\"1\"},{\"environment\":\"prod\",\"port\":\"5000\",\"cpu\":\"512\",\"memory\":\"1024\",\"platform\":\"LINUX/ARM64\",\"tasks\":\"3\"}],\"routes\":null,\"serviceDiscovery\":[{\"environment\":[\"test\"],\"namespace\":\"http://my-svc.test.my-app.local:5000\"},{\"environment\":[\"prod\"],\"namespace\":\"http://my-svc.prod.my-app.local:5000\"}],\"variables\":[{\"environment\":\"prod\",\"name\":\"COPILOT_ENVIRONMENT_NAME\",\"value\":\"prod\",\"container\":\"container\"},{\"environment\":\"test\",\"name\":\"COPILOT_ENVIRONMENT_NAME\",\"value\":\"test\",\"container\":\"container\"}],\"secrets\":[{\"name\":\"GITHUB_WEBHOOK_SECRET\",\"container\":\"container\",\"environment\":\"test\",\"valueFrom\":\"GH_WEBHOOK_SECRET\"},{\"name\":\"SOME_OTHER_SECRET\",\"container\":\"container\",\"environment\":\"prod\",\"valueFrom\":\"SHHHHH\"}],\"resources\":{\"prod\":[{\"type\":\"AWS::EC2::SecurityGroupIngress\",\"physicalID\":\"ContainerSecurityGroupIngressFromPublicALB\"}],\"test\":[{\"type\":\"AWS::EC2::SecurityGroup\",\"physicalID\":\"sg-0758ed6b233743530\"}]}}\n",
+			wantedJSONString: "{\"service\":\"my-svc\",\"type\":\"Backend Service\",\"application\":\"my-app\",\"configurations\":[{\"environment\":\"test\",\"port\":\"80\",\"cpu\":\"256\",\"memory\":\"512\",\"platform\":\"LINUX/X86_64\",\"tasks\":\"1\"},{\"environment\":\"prod\",\"port\":\"5000\",\"cpu\":\"512\",\"memory\":\"1024\",\"platform\":\"LINUX/ARM64\",\"tasks\":\"3\"}],\"routes\":null,\"serviceDiscovery\":[{\"environment\":[\"test\"],\"endpoint\":\"http://my-svc.test.my-app.local:5000\"},{\"environment\":[\"prod\"],\"endpoint\":\"http://my-svc.prod.my-app.local:5000\"}],\"variables\":[{\"environment\":\"prod\",\"name\":\"COPILOT_ENVIRONMENT_NAME\",\"value\":\"prod\",\"container\":\"container\"},{\"environment\":\"test\",\"name\":\"COPILOT_ENVIRONMENT_NAME\",\"value\":\"test\",\"container\":\"container\"}],\"secrets\":[{\"name\":\"GITHUB_WEBHOOK_SECRET\",\"container\":\"container\",\"environment\":\"test\",\"valueFrom\":\"GH_WEBHOOK_SECRET\"},{\"name\":\"SOME_OTHER_SECRET\",\"container\":\"container\",\"environment\":\"prod\",\"valueFrom\":\"SHHHHH\"}],\"resources\":{\"prod\":[{\"type\":\"AWS::EC2::SecurityGroupIngress\",\"physicalID\":\"ContainerSecurityGroupIngressFromPublicALB\"}],\"test\":[{\"type\":\"AWS::EC2::SecurityGroup\",\"physicalID\":\"sg-0758ed6b233743530\"}]}}\n",
 		},
 	}
 
@@ -655,14 +655,14 @@ Resources
 					ValueFrom:   "SHHHHH",
 				},
 			}
-			sds := []*ServiceDiscovery{
+			sds := serviceDiscoveries{
 				{
 					Environment: []string{"test"},
-					Namespace:   "http://my-svc.test.my-app.local:5000",
+					Endpoint:    "http://my-svc.test.my-app.local:5000",
 				},
 				{
 					Environment: []string{"prod"},
-					Namespace:   "http://my-svc.prod.my-app.local:5000",
+					Endpoint:    "http://my-svc.prod.my-app.local:5000",
 				},
 			}
 			resources := map[string][]*stack.Resource{

--- a/internal/pkg/describe/backend_service_test.go
+++ b/internal/pkg/describe/backend_service_test.go
@@ -566,7 +566,7 @@ Configurations
   test         1         0.25        512           LINUX/X86_64  80
   prod         3         0.5         1024          LINUX/ARM64   5000
 
-Service Endpoint
+Internal Service Endpoint
 
   Environment  Endpoint                              Type
   -----------  --------                              ----

--- a/internal/pkg/describe/backend_service_test.go
+++ b/internal/pkg/describe/backend_service_test.go
@@ -311,15 +311,10 @@ func TestBackendServiceDescriber_Describe(t *testing.T) {
 						},
 					},
 					ServiceDiscovery: serviceDiscoveries{
-						{
-							Environment: []string{"test"},
-							Endpoint:    "jobs.test.phonetool.local:5000",
-						},
-						{
-							Environment: []string{"prod"},
-							Endpoint:    "jobs.prod.phonetool.local:5000",
-						},
+						"jobs.test.phonetool.local:5000": []string{"test"},
+						"jobs.prod.phonetool.local:5000": []string{"prod"},
 					},
+					ServiceConnect: serviceConnects{},
 					Variables: []*containerEnvVar{
 						{
 							envVar: &envVar{
@@ -460,16 +455,10 @@ func TestBackendServiceDescriber_Describe(t *testing.T) {
 						},
 					},
 					ServiceDiscovery: serviceDiscoveries{
-						{
-							Environment: []string{"test"},
-							Endpoint:    "jobs.test.phonetool.local:5000",
-						},
+						"jobs.test.phonetool.local:5000": []string{"test"},
 					},
 					ServiceConnect: serviceConnects{
-						{
-							Environment: []string{"test"},
-							Endpoint:    "jobs",
-						},
+						"jobs": []string{"test"},
 					},
 					Variables: []*containerEnvVar{
 						{
@@ -570,8 +559,8 @@ Internal Service Endpoint
 
   Endpoint                              Environment  Type
   --------                              -----------  ----
-  http://my-svc.test.my-app.local:5000  test         Service Discovery
   http://my-svc.prod.my-app.local:5000  prod         Service Discovery
+  http://my-svc.test.my-app.local:5000  test         Service Discovery
 
 Variables
 
@@ -595,7 +584,7 @@ Resources
   prod
     AWS::EC2::SecurityGroupIngress  ContainerSecurityGroupIngressFromPublicALB
 `,
-			wantedJSONString: "{\"service\":\"my-svc\",\"type\":\"Backend Service\",\"application\":\"my-app\",\"configurations\":[{\"environment\":\"test\",\"port\":\"80\",\"cpu\":\"256\",\"memory\":\"512\",\"platform\":\"LINUX/X86_64\",\"tasks\":\"1\"},{\"environment\":\"prod\",\"port\":\"5000\",\"cpu\":\"512\",\"memory\":\"1024\",\"platform\":\"LINUX/ARM64\",\"tasks\":\"3\"}],\"routes\":null,\"serviceDiscovery\":[{\"environment\":[\"test\"],\"endpoint\":\"http://my-svc.test.my-app.local:5000\"},{\"environment\":[\"prod\"],\"endpoint\":\"http://my-svc.prod.my-app.local:5000\"}],\"variables\":[{\"environment\":\"prod\",\"name\":\"COPILOT_ENVIRONMENT_NAME\",\"value\":\"prod\",\"container\":\"container\"},{\"environment\":\"test\",\"name\":\"COPILOT_ENVIRONMENT_NAME\",\"value\":\"test\",\"container\":\"container\"}],\"secrets\":[{\"name\":\"GITHUB_WEBHOOK_SECRET\",\"container\":\"container\",\"environment\":\"test\",\"valueFrom\":\"GH_WEBHOOK_SECRET\"},{\"name\":\"SOME_OTHER_SECRET\",\"container\":\"container\",\"environment\":\"prod\",\"valueFrom\":\"SHHHHH\"}],\"resources\":{\"prod\":[{\"type\":\"AWS::EC2::SecurityGroupIngress\",\"physicalID\":\"ContainerSecurityGroupIngressFromPublicALB\"}],\"test\":[{\"type\":\"AWS::EC2::SecurityGroup\",\"physicalID\":\"sg-0758ed6b233743530\"}]}}\n",
+			wantedJSONString: "{\"service\":\"my-svc\",\"type\":\"Backend Service\",\"application\":\"my-app\",\"configurations\":[{\"environment\":\"test\",\"port\":\"80\",\"cpu\":\"256\",\"memory\":\"512\",\"platform\":\"LINUX/X86_64\",\"tasks\":\"1\"},{\"environment\":\"prod\",\"port\":\"5000\",\"cpu\":\"512\",\"memory\":\"1024\",\"platform\":\"LINUX/ARM64\",\"tasks\":\"3\"}],\"routes\":null,\"serviceDiscovery\":[{\"environment\":[\"prod\"],\"endpoint\":\"http://my-svc.prod.my-app.local:5000\"},{\"environment\":[\"test\"],\"endpoint\":\"http://my-svc.test.my-app.local:5000\"}],\"variables\":[{\"environment\":\"prod\",\"name\":\"COPILOT_ENVIRONMENT_NAME\",\"value\":\"prod\",\"container\":\"container\"},{\"environment\":\"test\",\"name\":\"COPILOT_ENVIRONMENT_NAME\",\"value\":\"test\",\"container\":\"container\"}],\"secrets\":[{\"name\":\"GITHUB_WEBHOOK_SECRET\",\"container\":\"container\",\"environment\":\"test\",\"valueFrom\":\"GH_WEBHOOK_SECRET\"},{\"name\":\"SOME_OTHER_SECRET\",\"container\":\"container\",\"environment\":\"prod\",\"valueFrom\":\"SHHHHH\"}],\"resources\":{\"prod\":[{\"type\":\"AWS::EC2::SecurityGroupIngress\",\"physicalID\":\"ContainerSecurityGroupIngressFromPublicALB\"}],\"test\":[{\"type\":\"AWS::EC2::SecurityGroup\",\"physicalID\":\"sg-0758ed6b233743530\"}]}}\n",
 		},
 	}
 
@@ -656,14 +645,8 @@ Resources
 				},
 			}
 			sds := serviceDiscoveries{
-				{
-					Environment: []string{"test"},
-					Endpoint:    "http://my-svc.test.my-app.local:5000",
-				},
-				{
-					Environment: []string{"prod"},
-					Endpoint:    "http://my-svc.prod.my-app.local:5000",
-				},
+				"http://my-svc.test.my-app.local:5000": []string{"test"},
+				"http://my-svc.prod.my-app.local:5000": []string{"prod"},
 			}
 			resources := map[string][]*stack.Resource{
 				"test": {

--- a/internal/pkg/describe/backend_service_test.go
+++ b/internal/pkg/describe/backend_service_test.go
@@ -58,12 +58,12 @@ func TestBackendServiceDescriber_Describe(t *testing.T) {
 					m.storeSvc.EXPECT().ListEnvironmentsDeployedTo(testApp, testSvc).Return([]string{testEnv}, nil),
 					m.ecsDescriber.EXPECT().ServiceStackResources().Return(nil, nil),
 					m.ecsDescriber.EXPECT().Params().Return(map[string]string{
-						cfnstack.WorkloadContainerPortParamKey: "80",
-						cfnstack.WorkloadTaskCountParamKey:     "1",
-						cfnstack.WorkloadTaskMemoryParamKey:    "512",
-						cfnstack.WorkloadTaskCPUParamKey:       "256",
+						cfnstack.WorkloadTargetPortParamKey: "80",
+						cfnstack.WorkloadTaskCountParamKey:  "1",
+						cfnstack.WorkloadTaskMemoryParamKey: "512",
+						cfnstack.WorkloadTaskCPUParamKey:    "256",
 					}, nil),
-					m.envDescriber.EXPECT().ServiceDiscoveryEndpoint().Return("", errors.New("some error")),
+					m.envDescriber.EXPECT().ServiceDiscoveryEndpoint().Return("", mockErr),
 				)
 			},
 			wantedError: fmt.Errorf("retrieve service URI: retrieve service discovery endpoint for environment test: some error"),
@@ -71,10 +71,10 @@ func TestBackendServiceDescriber_Describe(t *testing.T) {
 		"return error if fail to retrieve service connect dns names": {
 			setupMocks: func(m lbWebSvcDescriberMocks) {
 				params := map[string]string{
-					cfnstack.WorkloadContainerPortParamKey: "5000",
-					cfnstack.WorkloadTaskCountParamKey:     "1",
-					cfnstack.WorkloadTaskCPUParamKey:       "256",
-					cfnstack.WorkloadTaskMemoryParamKey:    "512",
+					cfnstack.WorkloadTargetPortParamKey: "5000",
+					cfnstack.WorkloadTaskCountParamKey:  "1",
+					cfnstack.WorkloadTaskCPUParamKey:    "256",
+					cfnstack.WorkloadTaskMemoryParamKey: "512",
 				}
 				gomock.InOrder(
 					m.storeSvc.EXPECT().ListEnvironmentsDeployedTo(testApp, testSvc).Return([]string{testEnv}, nil),
@@ -91,10 +91,10 @@ func TestBackendServiceDescriber_Describe(t *testing.T) {
 		"return error if fail to retrieve platform": {
 			setupMocks: func(m lbWebSvcDescriberMocks) {
 				params := map[string]string{
-					cfnstack.WorkloadContainerPortParamKey: "5000",
-					cfnstack.WorkloadTaskCountParamKey:     "1",
-					cfnstack.WorkloadTaskCPUParamKey:       "256",
-					cfnstack.WorkloadTaskMemoryParamKey:    "512",
+					cfnstack.WorkloadTargetPortParamKey: "5000",
+					cfnstack.WorkloadTaskCountParamKey:  "1",
+					cfnstack.WorkloadTaskCPUParamKey:    "256",
+					cfnstack.WorkloadTaskMemoryParamKey: "512",
 				}
 				gomock.InOrder(
 					m.storeSvc.EXPECT().ListEnvironmentsDeployedTo(testApp, testSvc).Return([]string{testEnv}, nil),
@@ -112,10 +112,10 @@ func TestBackendServiceDescriber_Describe(t *testing.T) {
 		"return error if fail to retrieve environment variables": {
 			setupMocks: func(m lbWebSvcDescriberMocks) {
 				params := map[string]string{
-					cfnstack.WorkloadContainerPortParamKey: "5000",
-					cfnstack.WorkloadTaskCountParamKey:     "1",
-					cfnstack.WorkloadTaskCPUParamKey:       "256",
-					cfnstack.WorkloadTaskMemoryParamKey:    "512",
+					cfnstack.WorkloadTargetPortParamKey: "5000",
+					cfnstack.WorkloadTaskCountParamKey:  "1",
+					cfnstack.WorkloadTaskCPUParamKey:    "256",
+					cfnstack.WorkloadTaskMemoryParamKey: "512",
 				}
 				gomock.InOrder(
 					m.storeSvc.EXPECT().ListEnvironmentsDeployedTo(testApp, testSvc).Return([]string{testEnv}, nil),
@@ -137,10 +137,10 @@ func TestBackendServiceDescriber_Describe(t *testing.T) {
 		"return error if fail to retrieve secrets": {
 			setupMocks: func(m lbWebSvcDescriberMocks) {
 				params := map[string]string{
-					cfnstack.WorkloadContainerPortParamKey: "80",
-					cfnstack.WorkloadTaskCountParamKey:     "1",
-					cfnstack.WorkloadTaskCPUParamKey:       "256",
-					cfnstack.WorkloadTaskMemoryParamKey:    "512",
+					cfnstack.WorkloadTargetPortParamKey: "80",
+					cfnstack.WorkloadTaskCountParamKey:  "1",
+					cfnstack.WorkloadTaskCPUParamKey:    "256",
+					cfnstack.WorkloadTaskMemoryParamKey: "512",
 				}
 				gomock.InOrder(
 					m.storeSvc.EXPECT().ListEnvironmentsDeployedTo(testApp, testSvc).Return([]string{testEnv}, nil),
@@ -170,22 +170,22 @@ func TestBackendServiceDescriber_Describe(t *testing.T) {
 			shouldOutputResources: true,
 			setupMocks: func(m lbWebSvcDescriberMocks) {
 				testParams := map[string]string{
-					cfnstack.WorkloadContainerPortParamKey: "5000",
-					cfnstack.WorkloadTaskCountParamKey:     "1",
-					cfnstack.WorkloadTaskCPUParamKey:       "256",
-					cfnstack.WorkloadTaskMemoryParamKey:    "512",
+					cfnstack.WorkloadTargetPortParamKey: "5000",
+					cfnstack.WorkloadTaskCountParamKey:  "1",
+					cfnstack.WorkloadTaskCPUParamKey:    "256",
+					cfnstack.WorkloadTaskMemoryParamKey: "512",
 				}
 				prodParams := map[string]string{
-					cfnstack.WorkloadContainerPortParamKey: "5000",
-					cfnstack.WorkloadTaskCountParamKey:     "2",
-					cfnstack.WorkloadTaskCPUParamKey:       "512",
-					cfnstack.WorkloadTaskMemoryParamKey:    "1024",
+					cfnstack.WorkloadTargetPortParamKey: "5000",
+					cfnstack.WorkloadTaskCountParamKey:  "2",
+					cfnstack.WorkloadTaskCPUParamKey:    "512",
+					cfnstack.WorkloadTaskMemoryParamKey: "1024",
 				}
 				mockParams := map[string]string{
-					cfnstack.WorkloadContainerPortParamKey: "-1",
-					cfnstack.WorkloadTaskCountParamKey:     "2",
-					cfnstack.WorkloadTaskCPUParamKey:       "512",
-					cfnstack.WorkloadTaskMemoryParamKey:    "1024",
+					cfnstack.WorkloadTargetPortParamKey: "-1",
+					cfnstack.WorkloadTaskCountParamKey:  "2",
+					cfnstack.WorkloadTaskCPUParamKey:    "512",
+					cfnstack.WorkloadTaskMemoryParamKey: "1024",
 				}
 				gomock.InOrder(
 					m.storeSvc.EXPECT().ListEnvironmentsDeployedTo(testApp, testSvc).Return([]string{testEnv, prodEnv, mockEnv}, nil),
@@ -388,11 +388,11 @@ func TestBackendServiceDescriber_Describe(t *testing.T) {
 			shouldOutputResources: true,
 			setupMocks: func(m lbWebSvcDescriberMocks) {
 				params := map[string]string{
-					cfnstack.WorkloadContainerPortParamKey: "5000",
-					cfnstack.WorkloadTaskCountParamKey:     "1",
-					cfnstack.WorkloadTaskCPUParamKey:       "256",
-					cfnstack.WorkloadTaskMemoryParamKey:    "512",
-					cfnstack.WorkloadRulePathParamKey:      "mySvc",
+					cfnstack.WorkloadTargetPortParamKey: "5000",
+					cfnstack.WorkloadTaskCountParamKey:  "1",
+					cfnstack.WorkloadTaskCPUParamKey:    "256",
+					cfnstack.WorkloadTaskMemoryParamKey: "512",
+					cfnstack.WorkloadRulePathParamKey:   "mySvc",
 				}
 				resources := []*describeStack.Resource{
 					{

--- a/internal/pkg/describe/lb_web_service.go
+++ b/internal/pkg/describe/lb_web_service.go
@@ -372,50 +372,14 @@ type serviceEndpoints struct {
 }
 
 func (s serviceEndpoints) humanString(w io.Writer) {
-	headers := []string{"Environment", "Endpoint", "Type"}
+	headers := []string{"Endpoint", "Environment", "Type"}
 	fmt.Fprintf(w, "  %s\n", strings.Join(headers, "\t"))
 	fmt.Fprintf(w, "  %s\n", strings.Join(underline(headers), "\t"))
-	scEnvToEndpoints := make(map[string]map[string]struct{})
 	for _, sc := range s.connects {
-		envs := strings.Join(sc.Environment, ", ")
-		if _, ok := scEnvToEndpoints[envs]; !ok {
-			scEnvToEndpoints[envs] = make(map[string]struct{})
-		}
-		scEnvToEndpoints[envs][sc.DNSName] = struct{}{}
+		fmt.Fprintf(w, "  %s\t%s\t%s\n", sc.DNSName, strings.Join(sc.Environment, ", "), "Service Connect")
 	}
-	var scEnvs []string
-	for env := range scEnvToEndpoints {
-		scEnvs = append(scEnvs, env)
-	}
-	sort.SliceStable(scEnvs, func(i int, j int) bool { return scEnvs[i] < scEnvs[j] })
-	for _, env := range scEnvs {
-		var endpoints []string
-		for endpoint := range scEnvToEndpoints[env] {
-			endpoints = append(endpoints, endpoint)
-		}
-		sort.SliceStable(endpoints, func(i int, j int) bool { return endpoints[i] < endpoints[j] })
-		fmt.Fprintf(w, "  %s\t%s\t%s\n", env, strings.Join(endpoints, ", "), "Service Connect")
-	}
-	sdEnvToEndpoints := make(map[string]map[string]struct{})
 	for _, sd := range s.discoveries {
-		envs := strings.Join(sd.Environment, ", ")
-		if _, ok := sdEnvToEndpoints[envs]; !ok {
-			sdEnvToEndpoints[envs] = make(map[string]struct{})
-		}
-		sdEnvToEndpoints[envs][sd.Namespace] = struct{}{}
-	}
-	var sdEnvs []string
-	for env := range sdEnvToEndpoints {
-		sdEnvs = append(sdEnvs, env)
-	}
-	sort.SliceStable(sdEnvs, func(i int, j int) bool { return sdEnvs[i] < sdEnvs[j] })
-	for _, env := range sdEnvs {
-		var endpoints []string
-		for endpoint := range sdEnvToEndpoints[env] {
-			endpoints = append(endpoints, endpoint)
-		}
-		sort.SliceStable(endpoints, func(i int, j int) bool { return endpoints[i] < endpoints[j] })
-		fmt.Fprintf(w, "  %s\t%s\t%s\n", env, strings.Join(endpoints, ", "), "Service Discovery")
+		fmt.Fprintf(w, "  %s\t%s\t%s\n", sd.Namespace, strings.Join(sd.Environment, ", "), "Service Discovery")
 	}
 }
 

--- a/internal/pkg/describe/lb_web_service.go
+++ b/internal/pkg/describe/lb_web_service.go
@@ -315,9 +315,9 @@ func (sds *serviceDiscoveries) collectServiceDiscoveryEndpoints(descr envDescrib
 
 func (sds *serviceDiscoveries) appendServiceDiscovery(sd serviceDiscovery, env string) {
 	exist := false
-	for _, s := range *sds {
-		if s.Namespace == sd.String() {
-			s.Environment = append(s.Environment, env)
+	for _, svcDiscovery := range *sds {
+		if svcDiscovery.Namespace == sd.String() {
+			svcDiscovery.Environment = append(svcDiscovery.Environment, env)
 			exist = true
 		}
 	}
@@ -351,9 +351,9 @@ func (scs *serviceConnects) collectServiceConnectEndpoints(descr ecsDescriber, e
 
 func (scs *serviceConnects) appendServiceConnect(dnsName string, env string) {
 	exist := false
-	for _, s := range *scs {
-		if s.DNSName == dnsName {
-			s.Environment = append(s.Environment, env)
+	for _, svcConnect := range *scs {
+		if svcConnect.DNSName == dnsName {
+			svcConnect.Environment = append(svcConnect.Environment, env)
 			exist = true
 		}
 	}
@@ -454,7 +454,7 @@ func (w *webSvcDesc) HumanString() string {
 		fmt.Fprintf(writer, "  %s\t%s\n", route.Environment, route.URL)
 	}
 	if len(w.ServiceConnect) > 0 || len(w.ServiceDiscovery) > 0 {
-		fmt.Fprint(writer, color.Bold.Sprint("\nService Endpoint\n\n"))
+		fmt.Fprint(writer, color.Bold.Sprint("\nInternal Service Endpoint\n\n"))
 		writer.Flush()
 		endpoints := serviceEndpoints{
 			discoveries: w.ServiceDiscovery,

--- a/internal/pkg/describe/lb_web_service.go
+++ b/internal/pkg/describe/lb_web_service.go
@@ -310,11 +310,11 @@ func (sds *serviceDiscoveries) collectEndpoints(descr envDescriber, svc, env, po
 		Port:     port,
 		Endpoint: endpoint,
 	}
-	(*internalEndpoints)(sds).appendInternalEndpoints(sd.String(), env)
+	(*internalEndpoints)(sds).append(sd.String(), env)
 	return nil
 }
 
-func (ies *internalEndpoints) appendInternalEndpoints(endpoint string, env string) {
+func (ies *internalEndpoints) append(endpoint string, env string) {
 	for _, ie := range *ies {
 		if ie.Endpoint == endpoint {
 			ie.Environment = append(ie.Environment, env)
@@ -325,7 +325,6 @@ func (ies *internalEndpoints) appendInternalEndpoints(endpoint string, env strin
 		Environment: []string{env},
 		Endpoint:    endpoint,
 	})
-	return
 }
 
 type serviceConnects internalEndpoints
@@ -336,7 +335,7 @@ func (scs *serviceConnects) collectEndpoints(descr ecsDescriber, env string) err
 		return fmt.Errorf("retrieve service connect DNS names: %w", err)
 	}
 	for _, dnsName := range scDNSNames {
-		(*internalEndpoints)(scs).appendInternalEndpoints(dnsName, env)
+		(*internalEndpoints)(scs).append(dnsName, env)
 	}
 	return nil
 }

--- a/internal/pkg/describe/lb_web_service_test.go
+++ b/internal/pkg/describe/lb_web_service_test.go
@@ -539,7 +539,7 @@ Routes
   test         http://my-pr-Publi.us-west-2.elb.amazonaws.com/frontend
   prod         http://my-pr-Publi.us-west-2.elb.amazonaws.com/backend
 
-Service Endpoint
+Internal Service Endpoint
 
   Environment  Endpoint                              Type
   -----------  --------                              ----

--- a/internal/pkg/describe/lb_web_service_test.go
+++ b/internal/pkg/describe/lb_web_service_test.go
@@ -541,12 +541,11 @@ Routes
 
 Internal Service Endpoint
 
-  Environment  Endpoint                              Type
-  -----------  --------                              ----
-  prod         api, my-svc:5000                      Service Connect
-  test         my-svc                                Service Connect
-  prod         http://my-svc.prod.my-app.local:5000  Service Discovery
-  test         http://my-svc.test.my-app.local:5000  Service Discovery
+  Endpoint                              Environment  Type
+  --------                              -----------  ----
+  my-svc                                test, prod   Service Connect
+  http://my-svc.test.my-app.local:5000  test         Service Discovery
+  http://my-svc.prod.my-app.local:5000  prod         Service Discovery
 
 Variables
 
@@ -571,7 +570,7 @@ Resources
   prod
     AWS::EC2::SecurityGroupIngress  ContainerSecurityGroupIngressFromPublicALB
 `,
-			wantedJSONString: "{\"service\":\"my-svc\",\"type\":\"Load Balanced Web Service\",\"application\":\"my-app\",\"configurations\":[{\"environment\":\"test\",\"port\":\"80\",\"cpu\":\"256\",\"memory\":\"512\",\"platform\":\"LINUX/X86_64\",\"tasks\":\"1\"},{\"environment\":\"prod\",\"port\":\"5000\",\"cpu\":\"512\",\"memory\":\"1024\",\"platform\":\"LINUX/ARM64\",\"tasks\":\"3\"}],\"routes\":[{\"environment\":\"test\",\"url\":\"http://my-pr-Publi.us-west-2.elb.amazonaws.com/frontend\"},{\"environment\":\"prod\",\"url\":\"http://my-pr-Publi.us-west-2.elb.amazonaws.com/backend\"}],\"serviceDiscovery\":[{\"environment\":[\"test\"],\"namespace\":\"http://my-svc.test.my-app.local:5000\"},{\"environment\":[\"prod\"],\"namespace\":\"http://my-svc.prod.my-app.local:5000\"}],\"serviceConnect\":[{\"environment\":[\"test\"],\"dnsName\":\"my-svc\"},{\"environment\":[\"prod\"],\"dnsName\":\"my-svc:5000\"},{\"environment\":[\"prod\"],\"dnsName\":\"api\"}],\"variables\":[{\"environment\":\"test\",\"name\":\"COPILOT_ENVIRONMENT_NAME\",\"value\":\"test\",\"container\":\"containerA\"},{\"environment\":\"prod\",\"name\":\"COPILOT_ENVIRONMENT_NAME\",\"value\":\"prod\",\"container\":\"containerB\"},{\"environment\":\"prod\",\"name\":\"DIFFERENT_ENV_VAR\",\"value\":\"prod\",\"container\":\"containerB\"}],\"secrets\":[{\"name\":\"GITHUB_WEBHOOK_SECRET\",\"container\":\"containerA\",\"environment\":\"test\",\"valueFrom\":\"GH_WEBHOOK_SECRET\"},{\"name\":\"SOME_OTHER_SECRET\",\"container\":\"containerB\",\"environment\":\"prod\",\"valueFrom\":\"SHHHHH\"}],\"resources\":{\"prod\":[{\"type\":\"AWS::EC2::SecurityGroupIngress\",\"physicalID\":\"ContainerSecurityGroupIngressFromPublicALB\"}],\"test\":[{\"type\":\"AWS::EC2::SecurityGroup\",\"physicalID\":\"sg-0758ed6b233743530\"}]}}\n",
+			wantedJSONString: "{\"service\":\"my-svc\",\"type\":\"Load Balanced Web Service\",\"application\":\"my-app\",\"configurations\":[{\"environment\":\"test\",\"port\":\"80\",\"cpu\":\"256\",\"memory\":\"512\",\"platform\":\"LINUX/X86_64\",\"tasks\":\"1\"},{\"environment\":\"prod\",\"port\":\"5000\",\"cpu\":\"512\",\"memory\":\"1024\",\"platform\":\"LINUX/ARM64\",\"tasks\":\"3\"}],\"routes\":[{\"environment\":\"test\",\"url\":\"http://my-pr-Publi.us-west-2.elb.amazonaws.com/frontend\"},{\"environment\":\"prod\",\"url\":\"http://my-pr-Publi.us-west-2.elb.amazonaws.com/backend\"}],\"serviceDiscovery\":[{\"environment\":[\"test\"],\"namespace\":\"http://my-svc.test.my-app.local:5000\"},{\"environment\":[\"prod\"],\"namespace\":\"http://my-svc.prod.my-app.local:5000\"}],\"serviceConnect\":[{\"environment\":[\"test\",\"prod\"],\"dnsName\":\"my-svc\"}],\"variables\":[{\"environment\":\"test\",\"name\":\"COPILOT_ENVIRONMENT_NAME\",\"value\":\"test\",\"container\":\"containerA\"},{\"environment\":\"prod\",\"name\":\"COPILOT_ENVIRONMENT_NAME\",\"value\":\"prod\",\"container\":\"containerB\"},{\"environment\":\"prod\",\"name\":\"DIFFERENT_ENV_VAR\",\"value\":\"prod\",\"container\":\"containerB\"}],\"secrets\":[{\"name\":\"GITHUB_WEBHOOK_SECRET\",\"container\":\"containerA\",\"environment\":\"test\",\"valueFrom\":\"GH_WEBHOOK_SECRET\"},{\"name\":\"SOME_OTHER_SECRET\",\"container\":\"containerB\",\"environment\":\"prod\",\"valueFrom\":\"SHHHHH\"}],\"resources\":{\"prod\":[{\"type\":\"AWS::EC2::SecurityGroupIngress\",\"physicalID\":\"ContainerSecurityGroupIngressFromPublicALB\"}],\"test\":[{\"type\":\"AWS::EC2::SecurityGroup\",\"physicalID\":\"sg-0758ed6b233743530\"}]}}\n",
 		},
 	}
 
@@ -661,16 +660,8 @@ Resources
 			}
 			scs := serviceConnects{
 				{
-					Environment: []string{"test"},
+					Environment: []string{"test", "prod"},
 					DNSName:     "my-svc",
-				},
-				{
-					Environment: []string{"prod"},
-					DNSName:     "my-svc:5000",
-				},
-				{
-					Environment: []string{"prod"},
-					DNSName:     "api",
 				},
 			}
 			resources := map[string][]*stack.Resource{

--- a/internal/pkg/describe/lb_web_service_test.go
+++ b/internal/pkg/describe/lb_web_service_test.go
@@ -409,17 +409,17 @@ func TestLBWebServiceDescriber_Describe(t *testing.T) {
 					ServiceDiscovery: serviceDiscoveries{
 						{
 							Environment: []string{"test"},
-							Namespace:   "jobs.test.phonetool.local:80",
+							Endpoint:    "jobs.test.phonetool.local:80",
 						},
 						{
 							Environment: []string{"prod"},
-							Namespace:   "jobs.prod.phonetool.local:5000",
+							Endpoint:    "jobs.prod.phonetool.local:5000",
 						},
 					},
 					ServiceConnect: serviceConnects{
 						{
 							Environment: []string{"test", "prod"},
-							DNSName:     testSvc,
+							Endpoint:    testSvc,
 						},
 					},
 					Variables: []*containerEnvVar{
@@ -570,7 +570,7 @@ Resources
   prod
     AWS::EC2::SecurityGroupIngress  ContainerSecurityGroupIngressFromPublicALB
 `,
-			wantedJSONString: "{\"service\":\"my-svc\",\"type\":\"Load Balanced Web Service\",\"application\":\"my-app\",\"configurations\":[{\"environment\":\"test\",\"port\":\"80\",\"cpu\":\"256\",\"memory\":\"512\",\"platform\":\"LINUX/X86_64\",\"tasks\":\"1\"},{\"environment\":\"prod\",\"port\":\"5000\",\"cpu\":\"512\",\"memory\":\"1024\",\"platform\":\"LINUX/ARM64\",\"tasks\":\"3\"}],\"routes\":[{\"environment\":\"test\",\"url\":\"http://my-pr-Publi.us-west-2.elb.amazonaws.com/frontend\"},{\"environment\":\"prod\",\"url\":\"http://my-pr-Publi.us-west-2.elb.amazonaws.com/backend\"}],\"serviceDiscovery\":[{\"environment\":[\"test\"],\"namespace\":\"http://my-svc.test.my-app.local:5000\"},{\"environment\":[\"prod\"],\"namespace\":\"http://my-svc.prod.my-app.local:5000\"}],\"serviceConnect\":[{\"environment\":[\"test\",\"prod\"],\"dnsName\":\"my-svc\"}],\"variables\":[{\"environment\":\"test\",\"name\":\"COPILOT_ENVIRONMENT_NAME\",\"value\":\"test\",\"container\":\"containerA\"},{\"environment\":\"prod\",\"name\":\"COPILOT_ENVIRONMENT_NAME\",\"value\":\"prod\",\"container\":\"containerB\"},{\"environment\":\"prod\",\"name\":\"DIFFERENT_ENV_VAR\",\"value\":\"prod\",\"container\":\"containerB\"}],\"secrets\":[{\"name\":\"GITHUB_WEBHOOK_SECRET\",\"container\":\"containerA\",\"environment\":\"test\",\"valueFrom\":\"GH_WEBHOOK_SECRET\"},{\"name\":\"SOME_OTHER_SECRET\",\"container\":\"containerB\",\"environment\":\"prod\",\"valueFrom\":\"SHHHHH\"}],\"resources\":{\"prod\":[{\"type\":\"AWS::EC2::SecurityGroupIngress\",\"physicalID\":\"ContainerSecurityGroupIngressFromPublicALB\"}],\"test\":[{\"type\":\"AWS::EC2::SecurityGroup\",\"physicalID\":\"sg-0758ed6b233743530\"}]}}\n",
+			wantedJSONString: "{\"service\":\"my-svc\",\"type\":\"Load Balanced Web Service\",\"application\":\"my-app\",\"configurations\":[{\"environment\":\"test\",\"port\":\"80\",\"cpu\":\"256\",\"memory\":\"512\",\"platform\":\"LINUX/X86_64\",\"tasks\":\"1\"},{\"environment\":\"prod\",\"port\":\"5000\",\"cpu\":\"512\",\"memory\":\"1024\",\"platform\":\"LINUX/ARM64\",\"tasks\":\"3\"}],\"routes\":[{\"environment\":\"test\",\"url\":\"http://my-pr-Publi.us-west-2.elb.amazonaws.com/frontend\"},{\"environment\":\"prod\",\"url\":\"http://my-pr-Publi.us-west-2.elb.amazonaws.com/backend\"}],\"serviceDiscovery\":[{\"environment\":[\"test\"],\"endpoint\":\"http://my-svc.test.my-app.local:5000\"},{\"environment\":[\"prod\"],\"endpoint\":\"http://my-svc.prod.my-app.local:5000\"}],\"serviceConnect\":[{\"environment\":[\"test\",\"prod\"],\"endpoint\":\"my-svc\"}],\"variables\":[{\"environment\":\"test\",\"name\":\"COPILOT_ENVIRONMENT_NAME\",\"value\":\"test\",\"container\":\"containerA\"},{\"environment\":\"prod\",\"name\":\"COPILOT_ENVIRONMENT_NAME\",\"value\":\"prod\",\"container\":\"containerB\"},{\"environment\":\"prod\",\"name\":\"DIFFERENT_ENV_VAR\",\"value\":\"prod\",\"container\":\"containerB\"}],\"secrets\":[{\"name\":\"GITHUB_WEBHOOK_SECRET\",\"container\":\"containerA\",\"environment\":\"test\",\"valueFrom\":\"GH_WEBHOOK_SECRET\"},{\"name\":\"SOME_OTHER_SECRET\",\"container\":\"containerB\",\"environment\":\"prod\",\"valueFrom\":\"SHHHHH\"}],\"resources\":{\"prod\":[{\"type\":\"AWS::EC2::SecurityGroupIngress\",\"physicalID\":\"ContainerSecurityGroupIngressFromPublicALB\"}],\"test\":[{\"type\":\"AWS::EC2::SecurityGroup\",\"physicalID\":\"sg-0758ed6b233743530\"}]}}\n",
 		},
 	}
 
@@ -651,17 +651,17 @@ Resources
 			sds := serviceDiscoveries{
 				{
 					Environment: []string{"test"},
-					Namespace:   "http://my-svc.test.my-app.local:5000",
+					Endpoint:    "http://my-svc.test.my-app.local:5000",
 				},
 				{
 					Environment: []string{"prod"},
-					Namespace:   "http://my-svc.prod.my-app.local:5000",
+					Endpoint:    "http://my-svc.prod.my-app.local:5000",
 				},
 			}
 			scs := serviceConnects{
 				{
 					Environment: []string{"test", "prod"},
-					DNSName:     "my-svc",
+					Endpoint:    "my-svc",
 				},
 			}
 			resources := map[string][]*stack.Resource{

--- a/internal/pkg/describe/lb_web_service_test.go
+++ b/internal/pkg/describe/lb_web_service_test.go
@@ -407,20 +407,11 @@ func TestLBWebServiceDescriber_Describe(t *testing.T) {
 						},
 					},
 					ServiceDiscovery: serviceDiscoveries{
-						{
-							Environment: []string{"test"},
-							Endpoint:    "jobs.test.phonetool.local:80",
-						},
-						{
-							Environment: []string{"prod"},
-							Endpoint:    "jobs.prod.phonetool.local:5000",
-						},
+						"jobs.test.phonetool.local:80":   []string{"test"},
+						"jobs.prod.phonetool.local:5000": []string{"prod"},
 					},
 					ServiceConnect: serviceConnects{
-						{
-							Environment: []string{"test", "prod"},
-							Endpoint:    testSvc,
-						},
+						testSvc: []string{"test", "prod"},
 					},
 					Variables: []*containerEnvVar{
 						{
@@ -544,8 +535,8 @@ Internal Service Endpoint
   Endpoint                              Environment  Type
   --------                              -----------  ----
   my-svc                                test, prod   Service Connect
-  http://my-svc.test.my-app.local:5000  test         Service Discovery
   http://my-svc.prod.my-app.local:5000  prod         Service Discovery
+  http://my-svc.test.my-app.local:5000  test         Service Discovery
 
 Variables
 
@@ -570,7 +561,7 @@ Resources
   prod
     AWS::EC2::SecurityGroupIngress  ContainerSecurityGroupIngressFromPublicALB
 `,
-			wantedJSONString: "{\"service\":\"my-svc\",\"type\":\"Load Balanced Web Service\",\"application\":\"my-app\",\"configurations\":[{\"environment\":\"test\",\"port\":\"80\",\"cpu\":\"256\",\"memory\":\"512\",\"platform\":\"LINUX/X86_64\",\"tasks\":\"1\"},{\"environment\":\"prod\",\"port\":\"5000\",\"cpu\":\"512\",\"memory\":\"1024\",\"platform\":\"LINUX/ARM64\",\"tasks\":\"3\"}],\"routes\":[{\"environment\":\"test\",\"url\":\"http://my-pr-Publi.us-west-2.elb.amazonaws.com/frontend\"},{\"environment\":\"prod\",\"url\":\"http://my-pr-Publi.us-west-2.elb.amazonaws.com/backend\"}],\"serviceDiscovery\":[{\"environment\":[\"test\"],\"endpoint\":\"http://my-svc.test.my-app.local:5000\"},{\"environment\":[\"prod\"],\"endpoint\":\"http://my-svc.prod.my-app.local:5000\"}],\"serviceConnect\":[{\"environment\":[\"test\",\"prod\"],\"endpoint\":\"my-svc\"}],\"variables\":[{\"environment\":\"test\",\"name\":\"COPILOT_ENVIRONMENT_NAME\",\"value\":\"test\",\"container\":\"containerA\"},{\"environment\":\"prod\",\"name\":\"COPILOT_ENVIRONMENT_NAME\",\"value\":\"prod\",\"container\":\"containerB\"},{\"environment\":\"prod\",\"name\":\"DIFFERENT_ENV_VAR\",\"value\":\"prod\",\"container\":\"containerB\"}],\"secrets\":[{\"name\":\"GITHUB_WEBHOOK_SECRET\",\"container\":\"containerA\",\"environment\":\"test\",\"valueFrom\":\"GH_WEBHOOK_SECRET\"},{\"name\":\"SOME_OTHER_SECRET\",\"container\":\"containerB\",\"environment\":\"prod\",\"valueFrom\":\"SHHHHH\"}],\"resources\":{\"prod\":[{\"type\":\"AWS::EC2::SecurityGroupIngress\",\"physicalID\":\"ContainerSecurityGroupIngressFromPublicALB\"}],\"test\":[{\"type\":\"AWS::EC2::SecurityGroup\",\"physicalID\":\"sg-0758ed6b233743530\"}]}}\n",
+			wantedJSONString: "{\"service\":\"my-svc\",\"type\":\"Load Balanced Web Service\",\"application\":\"my-app\",\"configurations\":[{\"environment\":\"test\",\"port\":\"80\",\"cpu\":\"256\",\"memory\":\"512\",\"platform\":\"LINUX/X86_64\",\"tasks\":\"1\"},{\"environment\":\"prod\",\"port\":\"5000\",\"cpu\":\"512\",\"memory\":\"1024\",\"platform\":\"LINUX/ARM64\",\"tasks\":\"3\"}],\"routes\":[{\"environment\":\"test\",\"url\":\"http://my-pr-Publi.us-west-2.elb.amazonaws.com/frontend\"},{\"environment\":\"prod\",\"url\":\"http://my-pr-Publi.us-west-2.elb.amazonaws.com/backend\"}],\"serviceDiscovery\":[{\"environment\":[\"prod\"],\"endpoint\":\"http://my-svc.prod.my-app.local:5000\"},{\"environment\":[\"test\"],\"endpoint\":\"http://my-svc.test.my-app.local:5000\"}],\"serviceConnect\":[{\"environment\":[\"test\",\"prod\"],\"endpoint\":\"my-svc\"}],\"variables\":[{\"environment\":\"test\",\"name\":\"COPILOT_ENVIRONMENT_NAME\",\"value\":\"test\",\"container\":\"containerA\"},{\"environment\":\"prod\",\"name\":\"COPILOT_ENVIRONMENT_NAME\",\"value\":\"prod\",\"container\":\"containerB\"},{\"environment\":\"prod\",\"name\":\"DIFFERENT_ENV_VAR\",\"value\":\"prod\",\"container\":\"containerB\"}],\"secrets\":[{\"name\":\"GITHUB_WEBHOOK_SECRET\",\"container\":\"containerA\",\"environment\":\"test\",\"valueFrom\":\"GH_WEBHOOK_SECRET\"},{\"name\":\"SOME_OTHER_SECRET\",\"container\":\"containerB\",\"environment\":\"prod\",\"valueFrom\":\"SHHHHH\"}],\"resources\":{\"prod\":[{\"type\":\"AWS::EC2::SecurityGroupIngress\",\"physicalID\":\"ContainerSecurityGroupIngressFromPublicALB\"}],\"test\":[{\"type\":\"AWS::EC2::SecurityGroup\",\"physicalID\":\"sg-0758ed6b233743530\"}]}}\n",
 		},
 	}
 
@@ -649,20 +640,11 @@ Resources
 				},
 			}
 			sds := serviceDiscoveries{
-				{
-					Environment: []string{"test"},
-					Endpoint:    "http://my-svc.test.my-app.local:5000",
-				},
-				{
-					Environment: []string{"prod"},
-					Endpoint:    "http://my-svc.prod.my-app.local:5000",
-				},
+				"http://my-svc.test.my-app.local:5000": []string{"test"},
+				"http://my-svc.prod.my-app.local:5000": []string{"prod"},
 			}
 			scs := serviceConnects{
-				{
-					Environment: []string{"test", "prod"},
-					Endpoint:    "my-svc",
-				},
+				"my-svc": []string{"test", "prod"},
 			}
 			resources := map[string][]*stack.Resource{
 				"test": {

--- a/internal/pkg/describe/lb_web_service_test.go
+++ b/internal/pkg/describe/lb_web_service_test.go
@@ -36,18 +36,18 @@ func TestLBWebServiceDescriber_Describe(t *testing.T) {
 		prodSvcPath       = "*"
 	)
 	mockParams := map[string]string{
-		cfnstack.WorkloadContainerPortParamKey: "80",
-		cfnstack.WorkloadTaskCountParamKey:     "1",
-		cfnstack.WorkloadTaskCPUParamKey:       "256",
-		cfnstack.WorkloadTaskMemoryParamKey:    "512",
-		cfnstack.WorkloadRulePathParamKey:      testSvcPath,
+		cfnstack.WorkloadTargetPortParamKey: "80",
+		cfnstack.WorkloadTaskCountParamKey:  "1",
+		cfnstack.WorkloadTaskCPUParamKey:    "256",
+		cfnstack.WorkloadTaskMemoryParamKey: "512",
+		cfnstack.WorkloadRulePathParamKey:   testSvcPath,
 	}
 	mockProdParams := map[string]string{
-		cfnstack.WorkloadContainerPortParamKey: "5000",
-		cfnstack.WorkloadTaskCountParamKey:     "2",
-		cfnstack.WorkloadTaskCPUParamKey:       "512",
-		cfnstack.WorkloadTaskMemoryParamKey:    "1024",
-		cfnstack.WorkloadRulePathParamKey:      prodSvcPath,
+		cfnstack.WorkloadTargetPortParamKey: "5000",
+		cfnstack.WorkloadTaskCountParamKey:  "2",
+		cfnstack.WorkloadTaskCPUParamKey:    "512",
+		cfnstack.WorkloadTaskMemoryParamKey: "1024",
+		cfnstack.WorkloadRulePathParamKey:   prodSvcPath,
 	}
 	mockErr := errors.New("some error")
 	testCases := map[string]struct {

--- a/internal/pkg/describe/mocks/mock_service.go
+++ b/internal/pkg/describe/mocks/mock_service.go
@@ -203,6 +203,21 @@ func (m *MockecsClient) EXPECT() *MockecsClientMockRecorder {
 	return m.recorder
 }
 
+// Service mocks base method.
+func (m *MockecsClient) Service(app, env, svc string) (*ecs.Service, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Service", app, env, svc)
+	ret0, _ := ret[0].(*ecs.Service)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Service indicates an expected call of Service.
+func (mr *MockecsClientMockRecorder) Service(app, env, svc interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Service", reflect.TypeOf((*MockecsClient)(nil).Service), app, env, svc)
+}
+
 // TaskDefinition mocks base method.
 func (m *MockecsClient) TaskDefinition(app, env, svc string) (*ecs.TaskDefinition, error) {
 	m.ctrl.T.Helper()
@@ -450,6 +465,21 @@ func (m *MockecsDescriber) Secrets() ([]*ecs.ContainerSecret, error) {
 func (mr *MockecsDescriberMockRecorder) Secrets() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Secrets", reflect.TypeOf((*MockecsDescriber)(nil).Secrets))
+}
+
+// ServiceConnectDNSNames mocks base method.
+func (m *MockecsDescriber) ServiceConnectDNSNames() ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ServiceConnectDNSNames")
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ServiceConnectDNSNames indicates an expected call of ServiceConnectDNSNames.
+func (mr *MockecsDescriberMockRecorder) ServiceConnectDNSNames() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceConnectDNSNames", reflect.TypeOf((*MockecsDescriber)(nil).ServiceConnectDNSNames))
 }
 
 // ServiceStackResources mocks base method.

--- a/internal/pkg/describe/service.go
+++ b/internal/pkg/describe/service.go
@@ -500,6 +500,10 @@ func (e *endpointToEnvs) marshalJSON() ([]byte, error) {
 	return json.Marshal(&internalEndpoints)
 }
 
+func (e *endpointToEnvs) add(endpoint string, env string) {
+	(*e)[endpoint] = append((*e)[endpoint], env)
+}
+
 type serviceDiscoveries endpointToEnvs
 
 // MarshalJSON overrides the default JSON marshaling logic for the serviceDiscoveries
@@ -520,10 +524,6 @@ func (sds *serviceDiscoveries) collectEndpoints(descr envDescriber, svc, env, po
 	}
 	(*endpointToEnvs)(sds).add(sd.String(), env)
 	return nil
-}
-
-func (e *endpointToEnvs) add(endpoint string, env string) {
-	(*e)[endpoint] = append((*e)[endpoint], env)
 }
 
 type serviceConnects endpointToEnvs

--- a/internal/pkg/describe/service.go
+++ b/internal/pkg/describe/service.go
@@ -48,6 +48,7 @@ type DeployedEnvServicesLister interface {
 
 type ecsClient interface {
 	TaskDefinition(app, env, svc string) (*awsecs.TaskDefinition, error)
+	Service(app, env, svc string) (*awsecs.Service, error)
 }
 
 type apprunnerClient interface {
@@ -63,7 +64,7 @@ type workloadStackDescriber interface {
 
 type ecsDescriber interface {
 	workloadStackDescriber
-
+	ServiceConnectDNSNames() ([]string, error)
 	Platform() (*awsecs.ContainerPlatform, error)
 	EnvVars() ([]*awsecs.ContainerEnvVar, error)
 	Secrets() ([]*awsecs.ContainerSecret, error)
@@ -261,6 +262,15 @@ func (d *ecsServiceDescriber) Platform() (*awsecs.ContainerPlatform, error) {
 		}, nil
 	}
 	return platform, nil
+}
+
+// ServiceConnectDNSNames returns the service connect dns names of a service.
+func (d *ecsServiceDescriber) ServiceConnectDNSNames() ([]string, error) {
+	service, err := d.ecsClient.Service(d.app, d.env, d.service)
+	if err != nil {
+		return nil, fmt.Errorf("get service %s: %w", d.service, err)
+	}
+	return service.ServiceConnectAliases(), nil
 }
 
 // ServiceARN retrieves the ARN of the app runner service.

--- a/internal/pkg/describe/service.go
+++ b/internal/pkg/describe/service.go
@@ -480,15 +480,14 @@ func underline(headings []string) []string {
 	return lines
 }
 
-type internalEndpoint struct {
-	Environment []string `json:"environment"`
-	Endpoint    string   `json:"endpoint"`
-}
-
 // endpointToEnvs is a mapping of endpoint to environments.
 type endpointToEnvs map[string][]string
 
 func (e *endpointToEnvs) marshalJSON() ([]byte, error) {
+	type internalEndpoint struct {
+		Environment []string `json:"environment"`
+		Endpoint    string   `json:"endpoint"`
+	}
 	var internalEndpoints []internalEndpoint
 	for endpoint := range *e {
 		internalEndpoints = append(internalEndpoints, internalEndpoint{
@@ -500,8 +499,8 @@ func (e *endpointToEnvs) marshalJSON() ([]byte, error) {
 	return json.Marshal(&internalEndpoints)
 }
 
-func (e *endpointToEnvs) add(endpoint string, env string) {
-	(*e)[endpoint] = append((*e)[endpoint], env)
+func (e endpointToEnvs) add(endpoint string, env string) {
+	e[endpoint] = append(e[endpoint], env)
 }
 
 type serviceDiscoveries endpointToEnvs

--- a/internal/pkg/describe/service_test.go
+++ b/internal/pkg/describe/service_test.go
@@ -288,6 +288,84 @@ func TestServiceDescriber_EnvVars(t *testing.T) {
 	}
 }
 
+func TestServiceDescriber_ServiceConnectDNSNames(t *testing.T) {
+	const (
+		testApp = "phonetool"
+		testSvc = "svc"
+		testEnv = "test"
+	)
+	testCases := map[string]struct {
+		setupMocks func(mocks ecsSvcDescriberMocks)
+
+		wantedDNSNames []string
+		wantedError    error
+	}{
+		"returns error if fails to get ECS service": {
+			setupMocks: func(m ecsSvcDescriberMocks) {
+				m.mockECSClient.EXPECT().Service(testApp, testEnv, testSvc).Return(nil, errors.New("some error"))
+			},
+
+			wantedError: errors.New("get service svc: some error"),
+		},
+		"success": {
+			setupMocks: func(m ecsSvcDescriberMocks) {
+				m.mockECSClient.EXPECT().Service(testApp, testEnv, testSvc).Return(&awsecs.Service{
+					Deployments: []*ecsapi.Deployment{
+						{
+							ServiceConnectConfiguration: &ecsapi.ServiceConnectConfiguration{
+								Enabled:   aws.Bool(true),
+								Namespace: aws.String("foobar.com"),
+								Services: []*ecsapi.ServiceConnectService{
+									{
+										PortName: aws.String("frontend"),
+									},
+								},
+							},
+						},
+					},
+				}, nil)
+			},
+
+			wantedDNSNames: []string{"frontend.foobar.com"},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// GIVEN
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockecsClient := mocks.NewMockecsClient(ctrl)
+			mocks := ecsSvcDescriberMocks{
+				mockECSClient: mockecsClient,
+			}
+
+			tc.setupMocks(mocks)
+
+			d := &ecsServiceDescriber{
+				serviceStackDescriber: &serviceStackDescriber{
+					app:     testApp,
+					service: testSvc,
+					env:     testEnv,
+				},
+				ecsClient: mockecsClient,
+			}
+
+			// WHEN
+			actual, err := d.ServiceConnectDNSNames()
+
+			// THEN
+			if tc.wantedError != nil {
+				require.EqualError(t, err, tc.wantedError.Error())
+			} else {
+				require.NoError(t, err)
+				require.ElementsMatch(t, tc.wantedDNSNames, actual)
+			}
+		})
+	}
+}
+
 func TestServiceDescriber_Secrets(t *testing.T) {
 	const (
 		testApp = "phonetool"

--- a/internal/pkg/describe/uri.go
+++ b/internal/pkg/describe/uri.go
@@ -192,8 +192,8 @@ func (d *BackendServiceDescriber) URI(envName string) (URI, error) {
 	if err != nil {
 		return URI{}, fmt.Errorf("get stack parameters for environment %s: %w", envName, err)
 	}
-	port := svcStackParams[stack.WorkloadContainerPortParamKey]
-	if port == stack.NoExposedContainerPort {
+	port := svcStackParams[stack.WorkloadTargetPortParamKey]
+	if !isReachableWithinVPC(svcStackParams) {
 		return URI{
 			URI:        BlankServiceDiscoveryURI,
 			AccessType: URIAccessTypeNone,

--- a/internal/pkg/describe/uri.go
+++ b/internal/pkg/describe/uri.go
@@ -192,7 +192,6 @@ func (d *BackendServiceDescriber) URI(envName string) (URI, error) {
 	if err != nil {
 		return URI{}, fmt.Errorf("get stack parameters for environment %s: %w", envName, err)
 	}
-	port := svcStackParams[stack.WorkloadTargetPortParamKey]
 	if !isReachableWithinVPC(svcStackParams) {
 		return URI{
 			URI:        BlankServiceDiscoveryURI,
@@ -205,7 +204,7 @@ func (d *BackendServiceDescriber) URI(envName string) (URI, error) {
 	}
 	s := serviceDiscovery{
 		Service:  d.svc,
-		Port:     port,
+		Port:     svcStackParams[stack.WorkloadTargetPortParamKey],
 		Endpoint: endpoint,
 	}
 	return URI{

--- a/internal/pkg/describe/uri_test.go
+++ b/internal/pkg/describe/uri_test.go
@@ -372,7 +372,7 @@ func TestBackendServiceDescriber_URI(t *testing.T) {
 			setupMocks: func(m lbWebSvcDescriberMocks) {
 				m.ecsDescriber.EXPECT().ServiceStackResources().Return(nil, nil)
 				m.ecsDescriber.EXPECT().Params().Return(map[string]string{
-					stack.WorkloadContainerPortParamKey: stack.NoExposedContainerPort, // No port is set for the backend service.
+					stack.WorkloadTargetPortParamKey: stack.NoExposedContainerPort, // No port is set for the backend service.
 				}, nil)
 			},
 			wantedURI: BlankServiceDiscoveryURI,
@@ -381,7 +381,7 @@ func TestBackendServiceDescriber_URI(t *testing.T) {
 			setupMocks: func(m lbWebSvcDescriberMocks) {
 				m.ecsDescriber.EXPECT().ServiceStackResources().Return(nil, nil)
 				m.ecsDescriber.EXPECT().Params().Return(map[string]string{
-					stack.WorkloadContainerPortParamKey: "8080",
+					stack.WorkloadTargetPortParamKey: "8080",
 				}, nil)
 				m.envDescriber.EXPECT().ServiceDiscoveryEndpoint().Return("test.app.local", nil)
 			},

--- a/internal/pkg/describe/worker_service_test.go
+++ b/internal/pkg/describe/worker_service_test.go
@@ -56,10 +56,9 @@ func TestWorkerServiceDescriber_Describe(t *testing.T) {
 				gomock.InOrder(
 					m.storeSvc.EXPECT().ListEnvironmentsDeployedTo(testApp, testSvc).Return([]string{testEnv}, nil),
 					m.ecsDescriber.EXPECT().Params().Return(map[string]string{
-						cfnstack.WorkloadContainerPortParamKey: "-",
-						cfnstack.WorkloadTaskCountParamKey:     "1",
-						cfnstack.WorkloadTaskCPUParamKey:       "256",
-						cfnstack.WorkloadTaskMemoryParamKey:    "512",
+						cfnstack.WorkloadTaskCountParamKey:  "1",
+						cfnstack.WorkloadTaskCPUParamKey:    "256",
+						cfnstack.WorkloadTaskMemoryParamKey: "512",
 					}, nil),
 					m.ecsDescriber.EXPECT().Platform().Return(nil, errors.New("some error")),
 				)
@@ -71,10 +70,9 @@ func TestWorkerServiceDescriber_Describe(t *testing.T) {
 				gomock.InOrder(
 					m.storeSvc.EXPECT().ListEnvironmentsDeployedTo(testApp, testSvc).Return([]string{testEnv}, nil),
 					m.ecsDescriber.EXPECT().Params().Return(map[string]string{
-						cfnstack.WorkloadContainerPortParamKey: "-",
-						cfnstack.WorkloadTaskCountParamKey:     "1",
-						cfnstack.WorkloadTaskMemoryParamKey:    "512",
-						cfnstack.WorkloadTaskCPUParamKey:       "256",
+						cfnstack.WorkloadTaskCountParamKey:  "1",
+						cfnstack.WorkloadTaskMemoryParamKey: "512",
+						cfnstack.WorkloadTaskCPUParamKey:    "256",
 					}, nil),
 					m.ecsDescriber.EXPECT().Platform().Return(&ecs.ContainerPlatform{
 						OperatingSystem: "LINUX",
@@ -91,10 +89,9 @@ func TestWorkerServiceDescriber_Describe(t *testing.T) {
 					m.storeSvc.EXPECT().ListEnvironmentsDeployedTo(testApp, testSvc).Return([]string{testEnv}, nil),
 
 					m.ecsDescriber.EXPECT().Params().Return(map[string]string{
-						cfnstack.WorkloadContainerPortParamKey: "-",
-						cfnstack.WorkloadTaskCountParamKey:     "1",
-						cfnstack.WorkloadTaskCPUParamKey:       "256",
-						cfnstack.WorkloadTaskMemoryParamKey:    "512",
+						cfnstack.WorkloadTaskCountParamKey:  "1",
+						cfnstack.WorkloadTaskCPUParamKey:    "256",
+						cfnstack.WorkloadTaskMemoryParamKey: "512",
 					}, nil),
 					m.ecsDescriber.EXPECT().Platform().Return(&ecs.ContainerPlatform{
 						OperatingSystem: "LINUX",
@@ -119,10 +116,9 @@ func TestWorkerServiceDescriber_Describe(t *testing.T) {
 					m.storeSvc.EXPECT().ListEnvironmentsDeployedTo(testApp, testSvc).Return([]string{testEnv, prodEnv, mockEnv}, nil),
 
 					m.ecsDescriber.EXPECT().Params().Return(map[string]string{
-						cfnstack.WorkloadContainerPortParamKey: "-",
-						cfnstack.WorkloadTaskCountParamKey:     "1",
-						cfnstack.WorkloadTaskCPUParamKey:       "256",
-						cfnstack.WorkloadTaskMemoryParamKey:    "512",
+						cfnstack.WorkloadTaskCountParamKey:  "1",
+						cfnstack.WorkloadTaskCPUParamKey:    "256",
+						cfnstack.WorkloadTaskMemoryParamKey: "512",
 					}, nil),
 					m.ecsDescriber.EXPECT().Platform().Return(&ecs.ContainerPlatform{
 						OperatingSystem: "LINUX",
@@ -143,10 +139,9 @@ func TestWorkerServiceDescriber_Describe(t *testing.T) {
 						},
 					}, nil),
 					m.ecsDescriber.EXPECT().Params().Return(map[string]string{
-						cfnstack.WorkloadContainerPortParamKey: "-",
-						cfnstack.WorkloadTaskCountParamKey:     "2",
-						cfnstack.WorkloadTaskCPUParamKey:       "512",
-						cfnstack.WorkloadTaskMemoryParamKey:    "1024",
+						cfnstack.WorkloadTaskCountParamKey:  "2",
+						cfnstack.WorkloadTaskCPUParamKey:    "512",
+						cfnstack.WorkloadTaskMemoryParamKey: "1024",
 					}, nil),
 					m.ecsDescriber.EXPECT().Platform().Return(&ecs.ContainerPlatform{
 						OperatingSystem: "LINUX",
@@ -167,10 +162,9 @@ func TestWorkerServiceDescriber_Describe(t *testing.T) {
 						},
 					}, nil),
 					m.ecsDescriber.EXPECT().Params().Return(map[string]string{
-						cfnstack.WorkloadContainerPortParamKey: "-",
-						cfnstack.WorkloadTaskCountParamKey:     "2",
-						cfnstack.WorkloadTaskCPUParamKey:       "512",
-						cfnstack.WorkloadTaskMemoryParamKey:    "1024",
+						cfnstack.WorkloadTaskCountParamKey:  "2",
+						cfnstack.WorkloadTaskCPUParamKey:    "512",
+						cfnstack.WorkloadTaskMemoryParamKey: "1024",
 					}, nil),
 					m.ecsDescriber.EXPECT().Platform().Return(&ecs.ContainerPlatform{
 						OperatingSystem: "LINUX",

--- a/internal/pkg/ecs/ecs_test.go
+++ b/internal/pkg/ecs/ecs_test.go
@@ -329,7 +329,7 @@ func TestClient_DescribeService(t *testing.T) {
 	}
 }
 
-func TestClient_LastUpdatedAt(t *testing.T) {
+func TestClient_Service(t *testing.T) {
 	const (
 		mockApp     = "mockApp"
 		mockEnv     = "mockEnv"
@@ -339,6 +339,99 @@ func TestClient_LastUpdatedAt(t *testing.T) {
 		mockService = "mockService"
 	)
 	mockError := errors.New("some error")
+	getRgInput := map[string]string{
+		deploy.AppTagKey:     mockApp,
+		deploy.EnvTagKey:     mockEnv,
+		deploy.ServiceTagKey: mockSvc,
+	}
+
+	tests := map[string]struct {
+		setupMocks func(mocks clientMocks)
+
+		wantedError error
+		wanted      *ecs.Service
+	}{
+		"error if fail to describe ECS service": {
+			setupMocks: func(m clientMocks) {
+				gomock.InOrder(
+					m.resourceGetter.EXPECT().GetResourcesByTags(serviceResourceType, getRgInput).
+						Return([]*resourcegroups.Resource{
+							{ARN: mockSvcARN},
+						}, nil),
+					m.ecsClient.EXPECT().Service(mockCluster, mockService).Return(nil, mockError),
+				)
+			},
+			wantedError: fmt.Errorf("get ECS service mockService: some error"),
+		},
+		"err if failed to get the ECS service": {
+			setupMocks: func(m clientMocks) {
+				gomock.InOrder(
+					m.resourceGetter.EXPECT().GetResourcesByTags(serviceResourceType, getRgInput).
+						Return([]*resourcegroups.Resource{
+							{ARN: mockSvcARN},
+						}, nil),
+					m.ecsClient.EXPECT().Service(mockCluster, mockService).Return(nil, mockError),
+				)
+			},
+			wantedError: fmt.Errorf("get ECS service mockService: some error"),
+		},
+		"success": {
+			setupMocks: func(m clientMocks) {
+				gomock.InOrder(
+					m.resourceGetter.EXPECT().GetResourcesByTags(serviceResourceType, getRgInput).
+						Return([]*resourcegroups.Resource{
+							{ARN: mockSvcARN},
+						}, nil),
+					m.ecsClient.EXPECT().Service(mockCluster, mockService).Return(&ecs.Service{}, nil),
+				)
+			},
+			wanted: &ecs.Service{},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			// GIVEN
+			mockRgGetter := mocks.NewMockresourceGetter(ctrl)
+			mockECSClient := mocks.NewMockecsClient(ctrl)
+			mocks := clientMocks{
+				resourceGetter: mockRgGetter,
+				ecsClient:      mockECSClient,
+			}
+
+			test.setupMocks(mocks)
+
+			client := Client{
+				rgGetter:  mockRgGetter,
+				ecsClient: mockECSClient,
+			}
+
+			// WHEN
+			get, err := client.Service(mockApp, mockEnv, mockSvc)
+
+			// THEN
+			if test.wantedError != nil {
+				require.EqualError(t, err, test.wantedError.Error())
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, get, test.wanted)
+			}
+		})
+	}
+}
+
+func TestClient_LastUpdatedAt(t *testing.T) {
+	const (
+		mockApp     = "mockApp"
+		mockEnv     = "mockEnv"
+		mockSvc     = "mockSvc"
+		mockSvcARN  = "arn:aws:ecs:us-west-2:1234567890:service/mockCluster/mockService"
+		mockCluster = "mockCluster"
+		mockService = "mockService"
+	)
 	mockTime := time.Unix(1494505756, 0)
 	mockBeforeTime := time.Unix(1494505750, 0)
 	getRgInput := map[string]string{
@@ -353,18 +446,6 @@ func TestClient_LastUpdatedAt(t *testing.T) {
 		wantedError error
 		wanted      time.Time
 	}{
-		"error if fail to describe ECS service": {
-			setupMocks: func(m clientMocks) {
-				gomock.InOrder(
-					m.resourceGetter.EXPECT().GetResourcesByTags(serviceResourceType, getRgInput).
-						Return([]*resourcegroups.Resource{
-							{ARN: mockSvcARN},
-						}, nil),
-					m.ecsClient.EXPECT().Service(mockCluster, mockService).Return(nil, mockError),
-				)
-			},
-			wantedError: fmt.Errorf("get ECS service mockService: some error"),
-		},
 		"succeed": {
 			setupMocks: func(m clientMocks) {
 				gomock.InOrder(


### PR DESCRIPTION
<!-- Provide summary of changes -->
### Sample Output
```
Service Endpoint

  Endpoint                              Environment  Type
  --------                              -----------  ----
  my-svc                                test         Service Connect
  api                                   prod         Service Connect
  http://my-svc.test.my-app.local:5000  test         Service Discovery
  http://my-svc.prod.my-app.local:5000  prod         Service Discovery
```
Note that service discovery section for human output is now gone.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
