### PR TITLE
chore: update recommended actions for missing credentials

### DIFF
--- a/internal/pkg/aws/sessions/errors.go
+++ b/internal/pkg/aws/sessions/errors.go
@@ -39,16 +39,11 @@ func (e *errCredRetrieval) Error() string {
 // RecommendActions returns recommended actions to be taken after the error.
 // Implements main.actionRecommender interface.
 func (e *errCredRetrieval) RecommendActions() string {
-	notice := "It looks like your credential settings are misconfigured or missing"
+	notice := "It looks like AWS credentials are misconfigured or missing"
 	if e.profile != "" {
-		notice = fmt.Sprintf("It looks like your profile [%s] is misconfigured or missing", e.profile)
+		notice = fmt.Sprintf("It looks like AWS profile [%s] is misconfigured or missing", e.profile)
 	}
 	return fmt.Sprintf(`%s:
-https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
-- We recommend including your credentials in the shared credentials file.
-- Alternatively, you can also set credentials through 
-	* Environment Variables
-	* EC2 Instance Metadata (credentials only)
 More information: https://aws.github.io/copilot-cli/docs/credentials/`, notice)
 }
 


### PR DESCRIPTION
This removes link to AWS Go SDK and uses only link to AWS Copilot docs

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
