### PR TITLE
chore: remove extra word from worker service manifest

### DIFF
--- a/internal/pkg/manifest/testdata/worker-svc-nosubscribe.yml
+++ b/internal/pkg/manifest/testdata/worker-svc-nosubscribe.yml
@@ -21,7 +21,7 @@ exec: true     # Enable running commands in your container.
 
 
 # You can register to topics from other services.
-# The events can be be received from an SQS queue via the env var $COPILOT_QUEUE_URI.
+# The events can be received from an SQS queue via the env var $COPILOT_QUEUE_URI.
 # subscribe:
 #   topics: 
 #     - name: topic-from-another-service

--- a/internal/pkg/manifest/testdata/worker-svc-subscribe.yml
+++ b/internal/pkg/manifest/testdata/worker-svc-subscribe.yml
@@ -20,7 +20,7 @@ exec: true     # Enable running commands in your container.
   # readonly_fs: true       # Limit to read-only access to mounted root filesystems.
 
 
-# The events can be be received from an SQS queue via the env var $COPILOT_QUEUE_URI.
+# The events can be received from an SQS queue via the env var $COPILOT_QUEUE_URI.
 subscribe:
   topics:
     - name: testTopic

--- a/internal/pkg/manifest/testdata/worker-svc-with-default-fifo-queue.yml
+++ b/internal/pkg/manifest/testdata/worker-svc-with-default-fifo-queue.yml
@@ -20,7 +20,7 @@ exec: true     # Enable running commands in your container.
   # readonly_fs: true       # Limit to read-only access to mounted root filesystems.
 
 
-# The events can be be received from an SQS queue via the env var $COPILOT_QUEUE_URI.
+# The events can be received from an SQS queue via the env var $COPILOT_QUEUE_URI.
 subscribe:
   topics:
     - name: testTopic

--- a/internal/pkg/template/templates/workloads/services/worker/manifest.yml
+++ b/internal/pkg/template/templates/workloads/services/worker/manifest.yml
@@ -42,7 +42,7 @@ exec: true     # Enable running commands in your container.
 {{- end}}
 
 {{if .Subscribe}}{{- if .Subscribe.Topics}}
-# The events can be be received from an SQS queue via the env var $COPILOT_QUEUE_URI.
+# The events can be received from an SQS queue via the env var $COPILOT_QUEUE_URI.
 subscribe:
   topics:
 {{- range $topic := .Subscribe.Topics}}
@@ -58,7 +58,7 @@ subscribe:
   {{- end }}
 {{- else}}
 # You can register to topics from other services.
-# The events can be be received from an SQS queue via the env var $COPILOT_QUEUE_URI.
+# The events can be received from an SQS queue via the env var $COPILOT_QUEUE_URI.
 # subscribe:
 #   topics: 
 #     - name: topic-from-another-service


### PR DESCRIPTION


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
