### PR TITLE
chore: aurora v2 use correct port for db cluster

### DIFF
--- a/internal/pkg/addon/testdata/storage/aurora.yml
+++ b/internal/pkg/addon/testdata/storage/aurora.yml
@@ -108,6 +108,7 @@ Resources:
       DBSubnetGroupName: !Ref auroraDBSubnetGroup
       VpcSecurityGroupIds:
         - !Ref auroraDBClusterSecurityGroup
+      Port: 3306
       ServerlessV2ScalingConfiguration:
         # Replace "All" below with "!Ref Env" to set different autoscaling limits per environment.
         MinCapacity:

--- a/internal/pkg/template/templates/addons/aurora/rdws/serverlessv2.yml
+++ b/internal/pkg/template/templates/addons/aurora/rdws/serverlessv2.yml
@@ -135,6 +135,7 @@ Resources:
       {{- end}}
       DBClusterParameterGroupName: {{- if .ParameterGroup}} {{.ParameterGroup}} {{- else}} !Ref {{logicalIDSafe .ClusterName}}DBClusterParameterGroup {{- end}}
       DBSubnetGroupName: !Ref {{logicalIDSafe .ClusterName}}DBSubnetGroup
+      Port: {{if eq .Engine "MySQL"}}3306{{else}}5432{{end}}
       VpcSecurityGroupIds:
         - !Ref {{logicalIDSafe .ClusterName}}DBClusterSecurityGroup
       ServerlessV2ScalingConfiguration:

--- a/internal/pkg/template/templates/addons/aurora/serverlessv2.yml
+++ b/internal/pkg/template/templates/addons/aurora/serverlessv2.yml
@@ -124,6 +124,7 @@ Resources:
       {{- end}}
       DBClusterParameterGroupName: {{- if .ParameterGroup}} {{.ParameterGroup}} {{- else}} !Ref {{logicalIDSafe .ClusterName}}DBClusterParameterGroup {{- end}}
       DBSubnetGroupName: !Ref {{logicalIDSafe .ClusterName}}DBSubnetGroup
+      Port: {{if eq .Engine "MySQL"}}3306{{else}}5432{{end}}
       VpcSecurityGroupIds:
         - !Ref {{logicalIDSafe .ClusterName}}DBClusterSecurityGroup
       ServerlessV2ScalingConfiguration:


### PR DESCRIPTION
<!-- Provide summary of changes -->
> The serverless engine mode only applies for Aurora Serverless v1 DB clusters.

https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBCluster.html

```
Port
The port number on which the DB instances in the DB cluster accept connections.

Default:

When EngineMode is provisioned, 3306 (for both Aurora MySQL and Aurora PostgreSQL)

When EngineMode is serverless:

3306 when Engine is aurora or aurora-mysql

5432 when Engine is aurora-postgresql
```
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbcluster.html#cfn-rds-dbcluster-port

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
