### PR TITLE
docs: remove warning about internal ALB limitation--no longer needs to be new service

### DIFF
--- a/site/content/docs/developing/internal-albs.en.md
+++ b/site/content/docs/developing/internal-albs.en.md
@@ -29,9 +29,6 @@ network:
     placement: private
 ```
 
-!!!attention
-    Currently, you must use a new Backend Service that has not yet been deployed. Very soon, you will be able to add internal load balancers to existing Backend Services!
-
 ## Advanced Configuration
 
 ### Subnet Placement

--- a/site/content/docs/developing/internal-albs.ja.md
+++ b/site/content/docs/developing/internal-albs.ja.md
@@ -25,9 +25,6 @@ network:
     placement: private
 ```
 
-!!!attention
-    現時点では、まだデプロイされていない新しい Backend Service を利用する必要があります。近いうちに、内部ロードバランサーを既存の Backend Service に追加できる様になります！
-
 ## 高度な設定
 
 ### サブネット配置


### PR DESCRIPTION
🎉  It is now possible to add an internal ALB to a backend service that has already been deployed! Users need only add the required fields in their manifest, then rerun `copilot svc deploy`. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
