### PR TITLE
chore: implement new api for the `workspace` package

### DIFF
--- a/internal/pkg/addon/addons.go
+++ b/internal/pkg/addon/addons.go
@@ -49,8 +49,7 @@ type Stack struct {
 // files found there. If no addons are found, Parse returns a nil
 // Stack and ErrAddonsNotFound.
 func Parse(workloadName string, ws workspaceReader) (*Stack, error) {
-	path := ws.WorkloadAddonsPath(workloadName)
-	fNames, err := ws.ListFiles(path)
+	fNames, err := ws.ListFiles(ws.WorkloadAddonsPath(workloadName))
 	if err != nil {
 		return nil, &ErrAddonsNotFound{
 			WlName:    workloadName,

--- a/internal/pkg/addon/addons.go
+++ b/internal/pkg/addon/addons.go
@@ -31,8 +31,8 @@ var (
 )
 
 type workspaceReader interface {
-	WorkloadAddonsPath(name string) (string, error)
-	WorkloadAddonFilePath(wkldName, fName string) (string, error)
+	WorkloadAddonsPath(name string) string
+	WorkloadAddonFilePath(wkldName, fName string) string
 	ListFiles(dirPath string) ([]string, error)
 	ReadFile(fPath string) ([]byte, error)
 }
@@ -49,13 +49,7 @@ type Stack struct {
 // files found there. If no addons are found, Parse returns a nil
 // Stack and ErrAddonsNotFound.
 func Parse(workloadName string, ws workspaceReader) (*Stack, error) {
-	path, err := ws.WorkloadAddonsPath(workloadName)
-	if err != nil {
-		return nil, &ErrAddonsNotFound{
-			WlName:    workloadName,
-			ParentErr: err,
-		}
-	}
+	path := ws.WorkloadAddonsPath(workloadName)
 	fNames, err := ws.ListFiles(path)
 	if err != nil {
 		return nil, &ErrAddonsNotFound{
@@ -128,10 +122,7 @@ func parseTemplate(fnames []string, workloadName string, ws workspaceReader) (*c
 
 	mergedTemplate := newCFNTemplate("merged")
 	for _, fname := range templateFiles {
-		path, err := ws.WorkloadAddonFilePath(workloadName, fname)
-		if err != nil {
-			return nil, fmt.Errorf("get addon %s file path under %s: %w", fname, workloadName, err)
-		}
+		path := ws.WorkloadAddonFilePath(workloadName, fname)
 		out, err := ws.ReadFile(path)
 		if err != nil {
 			return nil, fmt.Errorf("read addon %s under %s: %w", fname, workloadName, err)
@@ -162,10 +153,7 @@ func parseParameters(fnames []string, workloadName string, ws workspaceReader) (
 		return yaml.Node{}, fmt.Errorf("defining %s is not allowed under %s addons/", english.WordSeries(parameterFileNames, "and"), workloadName)
 	}
 	paramFile := paramFiles[0]
-	path, err := ws.WorkloadAddonFilePath(workloadName, paramFile)
-	if err != nil {
-		return yaml.Node{}, fmt.Errorf("get parameter file %s path under %s addons/: %w", paramFile, workloadName, err)
-	}
+	path := ws.WorkloadAddonFilePath(workloadName, paramFile)
 	raw, err := ws.ReadFile(path)
 	if err != nil {
 		return yaml.Node{}, fmt.Errorf("read parameter file %s under %s addons/: %w", paramFile, workloadName, err)

--- a/internal/pkg/addon/addons_test.go
+++ b/internal/pkg/addon/addons_test.go
@@ -27,20 +27,10 @@ func TestTemplate(t *testing.T) {
 		wantedTemplate string
 		wantedErr      error
 	}{
-		"return err if unable to get the path to the workload addons directory": {
-			workloadName: testSvcName,
-			setupMocks: func(m addonMocks) {
-				m.ws.EXPECT().WorkloadAddonsPath(testSvcName).Return("", errors.New("some error"))
-			},
-			wantedErr: &ErrAddonsNotFound{
-				WlName:    testSvcName,
-				ParentErr: errors.New("some error"),
-			},
-		},
 		"return ErrAddonsNotFound if addons doesn't exist in a service": {
 			workloadName: testSvcName,
 			setupMocks: func(m addonMocks) {
-				m.ws.EXPECT().WorkloadAddonsPath(testSvcName).Return("mockPath", nil)
+				m.ws.EXPECT().WorkloadAddonsPath(testSvcName).Return("mockPath")
 				m.ws.EXPECT().ListFiles("mockPath").Return(nil, testErr)
 			},
 			wantedErr: &ErrAddonsNotFound{
@@ -51,7 +41,7 @@ func TestTemplate(t *testing.T) {
 		"return ErrAddonsNotFound if addons doesn't exist in a job": {
 			workloadName: testJobName,
 			setupMocks: func(m addonMocks) {
-				m.ws.EXPECT().WorkloadAddonsPath(testJobName).Return("mockPath", nil)
+				m.ws.EXPECT().WorkloadAddonsPath(testJobName).Return("mockPath")
 				m.ws.EXPECT().ListFiles("mockPath").Return(nil, testErr)
 			},
 			wantedErr: &ErrAddonsNotFound{
@@ -62,7 +52,7 @@ func TestTemplate(t *testing.T) {
 		"return ErrAddonsNotFound if addons directory is empty in a service": {
 			workloadName: testSvcName,
 			setupMocks: func(m addonMocks) {
-				m.ws.EXPECT().WorkloadAddonsPath(testSvcName).Return("mockPath", nil)
+				m.ws.EXPECT().WorkloadAddonsPath(testSvcName).Return("mockPath")
 				m.ws.EXPECT().ListFiles("mockPath").Return([]string{}, nil)
 			},
 			wantedErr: &ErrAddonsNotFound{
@@ -73,7 +63,7 @@ func TestTemplate(t *testing.T) {
 		"return ErrAddonsNotFound if addons directory does not contain yaml files in a service": {
 			workloadName: testSvcName,
 			setupMocks: func(m addonMocks) {
-				m.ws.EXPECT().WorkloadAddonsPath(testSvcName).Return("mockPath", nil)
+				m.ws.EXPECT().WorkloadAddonsPath(testSvcName).Return("mockPath")
 				m.ws.EXPECT().ListFiles("mockPath").Return([]string{"gitkeep"}, nil)
 			},
 			wantedErr: &ErrAddonsNotFound{
@@ -84,7 +74,7 @@ func TestTemplate(t *testing.T) {
 		"ignore addons.parameters.yml files": {
 			workloadName: testSvcName,
 			setupMocks: func(m addonMocks) {
-				m.ws.EXPECT().WorkloadAddonsPath(testSvcName).Return("mockPath", nil)
+				m.ws.EXPECT().WorkloadAddonsPath(testSvcName).Return("mockPath")
 				m.ws.EXPECT().ListFiles("mockPath").Return([]string{"addons.parameters.yml", "addons.parameters.yaml"}, nil)
 			},
 			wantedErr: &ErrAddonsNotFound{
@@ -95,7 +85,7 @@ func TestTemplate(t *testing.T) {
 		"print correct error message for ErrAddonsNotFound": {
 			workloadName: testJobName,
 			setupMocks: func(m addonMocks) {
-				m.ws.EXPECT().WorkloadAddonsPath(testJobName).Return("mockPath", nil)
+				m.ws.EXPECT().WorkloadAddonsPath(testJobName).Return("mockPath")
 				m.ws.EXPECT().ListFiles("mockPath").Return(nil, testErr)
 			},
 			wantedErr: errors.New("read addons directory for resizer: some error"),
@@ -103,15 +93,15 @@ func TestTemplate(t *testing.T) {
 		"return err on invalid Metadata fields": {
 			workloadName: testSvcName,
 			setupMocks: func(m addonMocks) {
-				m.ws.EXPECT().WorkloadAddonsPath(testSvcName).Return("mockPath", nil)
+				m.ws.EXPECT().WorkloadAddonsPath(testSvcName).Return("mockPath")
 				m.ws.EXPECT().ListFiles("mockPath").Return([]string{"first.yaml", "invalid-metadata.yaml"}, nil)
 
 				first, _ := ioutil.ReadFile(filepath.Join("testdata", "merge", "first.yaml"))
-				m.ws.EXPECT().WorkloadAddonFilePath(testSvcName, "first.yaml").Return("mockPath", nil)
+				m.ws.EXPECT().WorkloadAddonFilePath(testSvcName, "first.yaml").Return("mockPath")
 				m.ws.EXPECT().ReadFile("mockPath").Return(first, nil)
 
 				second, _ := ioutil.ReadFile(filepath.Join("testdata", "merge", "invalid-metadata.yaml"))
-				m.ws.EXPECT().WorkloadAddonFilePath(testSvcName, "invalid-metadata.yaml").Return("mockPath", nil)
+				m.ws.EXPECT().WorkloadAddonFilePath(testSvcName, "invalid-metadata.yaml").Return("mockPath")
 				m.ws.EXPECT().ReadFile("mockPath").Return(second, nil)
 			},
 			wantedErr: errors.New(`metadata key "Services" defined in "first.yaml" at Ln 4, Col 7 is different than in "invalid-metadata.yaml" at Ln 3, Col 5`),
@@ -119,15 +109,15 @@ func TestTemplate(t *testing.T) {
 		"returns err on invalid Parameters fields": {
 			workloadName: testSvcName,
 			setupMocks: func(m addonMocks) {
-				m.ws.EXPECT().WorkloadAddonsPath(testSvcName).Return("mockPath", nil)
+				m.ws.EXPECT().WorkloadAddonsPath(testSvcName).Return("mockPath")
 				m.ws.EXPECT().ListFiles("mockPath").Return([]string{"first.yaml", "invalid-parameters.yaml"}, nil)
 
 				first, _ := ioutil.ReadFile(filepath.Join("testdata", "merge", "first.yaml"))
-				m.ws.EXPECT().WorkloadAddonFilePath(testSvcName, "first.yaml").Return("mockPath", nil)
+				m.ws.EXPECT().WorkloadAddonFilePath(testSvcName, "first.yaml").Return("mockPath")
 				m.ws.EXPECT().ReadFile("mockPath").Return(first, nil)
 
 				second, _ := ioutil.ReadFile(filepath.Join("testdata", "merge", "invalid-parameters.yaml"))
-				m.ws.EXPECT().WorkloadAddonFilePath(testSvcName, "invalid-parameters.yaml").Return("mockPath", nil)
+				m.ws.EXPECT().WorkloadAddonFilePath(testSvcName, "invalid-parameters.yaml").Return("mockPath")
 				m.ws.EXPECT().ReadFile("mockPath").Return(second, nil)
 			},
 			wantedErr: errors.New(`parameter logical ID "Name" defined in "first.yaml" at Ln 15, Col 9 is different than in "invalid-parameters.yaml" at Ln 3, Col 7`),
@@ -135,15 +125,15 @@ func TestTemplate(t *testing.T) {
 		"returns err on invalid Mappings fields": {
 			workloadName: testSvcName,
 			setupMocks: func(m addonMocks) {
-				m.ws.EXPECT().WorkloadAddonsPath(testSvcName).Return("mockPath", nil)
+				m.ws.EXPECT().WorkloadAddonsPath(testSvcName).Return("mockPath")
 				m.ws.EXPECT().ListFiles("mockPath").Return([]string{"first.yaml", "invalid-mappings.yaml"}, nil)
 
 				first, _ := ioutil.ReadFile(filepath.Join("testdata", "merge", "first.yaml"))
-				m.ws.EXPECT().WorkloadAddonFilePath(testSvcName, "first.yaml").Return("mockPath", nil)
+				m.ws.EXPECT().WorkloadAddonFilePath(testSvcName, "first.yaml").Return("mockPath")
 				m.ws.EXPECT().ReadFile("mockPath").Return(first, nil)
 
 				second, _ := ioutil.ReadFile(filepath.Join("testdata", "merge", "invalid-mappings.yaml"))
-				m.ws.EXPECT().WorkloadAddonFilePath(testSvcName, "invalid-mappings.yaml").Return("mockPath", nil)
+				m.ws.EXPECT().WorkloadAddonFilePath(testSvcName, "invalid-mappings.yaml").Return("mockPath")
 				m.ws.EXPECT().ReadFile("mockPath").Return(second, nil)
 			},
 			wantedErr: errors.New(`mapping "MyTableDynamoDBSettings.test" defined in "first.yaml" at Ln 21, Col 13 is different than in "invalid-mappings.yaml" at Ln 4, Col 7`),
@@ -151,15 +141,15 @@ func TestTemplate(t *testing.T) {
 		"returns err on invalid Conditions fields": {
 			workloadName: testSvcName,
 			setupMocks: func(m addonMocks) {
-				m.ws.EXPECT().WorkloadAddonsPath(testSvcName).Return("mockPath", nil)
+				m.ws.EXPECT().WorkloadAddonsPath(testSvcName).Return("mockPath")
 				m.ws.EXPECT().ListFiles("mockPath").Return([]string{"first.yaml", "invalid-conditions.yaml"}, nil)
 
 				first, _ := ioutil.ReadFile(filepath.Join("testdata", "merge", "first.yaml"))
-				m.ws.EXPECT().WorkloadAddonFilePath(testSvcName, "first.yaml").Return("mockPath", nil)
+				m.ws.EXPECT().WorkloadAddonFilePath(testSvcName, "first.yaml").Return("mockPath")
 				m.ws.EXPECT().ReadFile("mockPath").Return(first, nil)
 
 				second, _ := ioutil.ReadFile(filepath.Join("testdata", "merge", "invalid-conditions.yaml"))
-				m.ws.EXPECT().WorkloadAddonFilePath(testSvcName, "invalid-conditions.yaml").Return("mockPath", nil)
+				m.ws.EXPECT().WorkloadAddonFilePath(testSvcName, "invalid-conditions.yaml").Return("mockPath")
 				m.ws.EXPECT().ReadFile("mockPath").Return(second, nil)
 			},
 			wantedErr: errors.New(`condition "IsProd" defined in "first.yaml" at Ln 28, Col 13 is different than in "invalid-conditions.yaml" at Ln 2, Col 13`),
@@ -167,15 +157,15 @@ func TestTemplate(t *testing.T) {
 		"returns err on invalid Resources fields": {
 			workloadName: testSvcName,
 			setupMocks: func(m addonMocks) {
-				m.ws.EXPECT().WorkloadAddonsPath(testSvcName).Return("mockPath", nil)
+				m.ws.EXPECT().WorkloadAddonsPath(testSvcName).Return("mockPath")
 				m.ws.EXPECT().ListFiles("mockPath").Return([]string{"first.yaml", "invalid-resources.yaml"}, nil)
 
 				first, _ := ioutil.ReadFile(filepath.Join("testdata", "merge", "first.yaml"))
-				m.ws.EXPECT().WorkloadAddonFilePath(testSvcName, "first.yaml").Return("mockPath", nil)
+				m.ws.EXPECT().WorkloadAddonFilePath(testSvcName, "first.yaml").Return("mockPath")
 				m.ws.EXPECT().ReadFile("mockPath").Return(first, nil)
 
 				second, _ := ioutil.ReadFile(filepath.Join("testdata", "merge", "invalid-resources.yaml"))
-				m.ws.EXPECT().WorkloadAddonFilePath(testSvcName, "invalid-resources.yaml").Return("mockPath", nil)
+				m.ws.EXPECT().WorkloadAddonFilePath(testSvcName, "invalid-resources.yaml").Return("mockPath")
 				m.ws.EXPECT().ReadFile("mockPath").Return(second, nil)
 			},
 			wantedErr: errors.New(`resource "MyTable" defined in "first.yaml" at Ln 34, Col 9 is different than in "invalid-resources.yaml" at Ln 3, Col 5`),
@@ -183,15 +173,15 @@ func TestTemplate(t *testing.T) {
 		"returns err on invalid Outputs fields": {
 			workloadName: testSvcName,
 			setupMocks: func(m addonMocks) {
-				m.ws.EXPECT().WorkloadAddonsPath(testSvcName).Return("mockPath", nil)
+				m.ws.EXPECT().WorkloadAddonsPath(testSvcName).Return("mockPath")
 				m.ws.EXPECT().ListFiles("mockPath").Return([]string{"first.yaml", "invalid-outputs.yaml"}, nil)
 
 				first, _ := ioutil.ReadFile(filepath.Join("testdata", "merge", "first.yaml"))
-				m.ws.EXPECT().WorkloadAddonFilePath(testSvcName, "first.yaml").Return("mockPath", nil)
+				m.ws.EXPECT().WorkloadAddonFilePath(testSvcName, "first.yaml").Return("mockPath")
 				m.ws.EXPECT().ReadFile("mockPath").Return(first, nil)
 
 				second, _ := ioutil.ReadFile(filepath.Join("testdata", "merge", "invalid-outputs.yaml"))
-				m.ws.EXPECT().WorkloadAddonFilePath(testSvcName, "invalid-outputs.yaml").Return("mockPath", nil)
+				m.ws.EXPECT().WorkloadAddonFilePath(testSvcName, "invalid-outputs.yaml").Return("mockPath")
 				m.ws.EXPECT().ReadFile("mockPath").Return(second, nil)
 			},
 			wantedErr: errors.New(`output "MyTableAccessPolicy" defined in "first.yaml" at Ln 85, Col 9 is different than in "invalid-outputs.yaml" at Ln 3, Col 5`),
@@ -199,15 +189,15 @@ func TestTemplate(t *testing.T) {
 		"merge fields successfully": {
 			workloadName: testSvcName,
 			setupMocks: func(m addonMocks) {
-				m.ws.EXPECT().WorkloadAddonsPath(testSvcName).Return("mockPath", nil)
+				m.ws.EXPECT().WorkloadAddonsPath(testSvcName).Return("mockPath")
 				m.ws.EXPECT().ListFiles("mockPath").Return([]string{"first.yaml", "second.yaml"}, nil)
 
 				first, _ := ioutil.ReadFile(filepath.Join("testdata", "merge", "first.yaml"))
-				m.ws.EXPECT().WorkloadAddonFilePath(testSvcName, "first.yaml").Return("mockPath", nil)
+				m.ws.EXPECT().WorkloadAddonFilePath(testSvcName, "first.yaml").Return("mockPath")
 				m.ws.EXPECT().ReadFile("mockPath").Return(first, nil)
 
 				second, _ := ioutil.ReadFile(filepath.Join("testdata", "merge", "second.yaml"))
-				m.ws.EXPECT().WorkloadAddonFilePath(testSvcName, "second.yaml").Return("mockPath", nil)
+				m.ws.EXPECT().WorkloadAddonFilePath(testSvcName, "second.yaml").Return("mockPath")
 				m.ws.EXPECT().ReadFile("mockPath").Return(second, nil)
 			},
 			wantedTemplate: func() string {
@@ -254,7 +244,7 @@ func TestParameters(t *testing.T) {
 	}{
 		"returns ErrAddonsNotFound if there is no addons/ directory defined": {
 			setupMocks: func(m addonMocks) {
-				m.ws.EXPECT().WorkloadAddonsPath("api").Return("mockPath", nil)
+				m.ws.EXPECT().WorkloadAddonsPath("api").Return("mockPath")
 				m.ws.EXPECT().ListFiles("mockPath").Return(nil, errors.New("some error"))
 			},
 			wantedErr: (&ErrAddonsNotFound{
@@ -264,50 +254,50 @@ func TestParameters(t *testing.T) {
 		},
 		"returns empty string and nil if there are no parameter files under addons/": {
 			setupMocks: func(m addonMocks) {
-				m.ws.EXPECT().WorkloadAddonsPath("api").Return("mockPath", nil)
+				m.ws.EXPECT().WorkloadAddonsPath("api").Return("mockPath")
 				m.ws.EXPECT().ListFiles("mockPath").Return([]string{"database.yaml"}, nil)
-				m.ws.EXPECT().WorkloadAddonFilePath("api", "database.yaml").Return("mockPath", nil)
+				m.ws.EXPECT().WorkloadAddonFilePath("api", "database.yaml").Return("mockPath")
 				m.ws.EXPECT().ReadFile("mockPath").Return(nil, nil)
 			},
 		},
 		"returns an error if there are multiple parameter files defined under addons/": {
 			setupMocks: func(m addonMocks) {
-				m.ws.EXPECT().WorkloadAddonsPath("api").Return("mockPath", nil)
+				m.ws.EXPECT().WorkloadAddonsPath("api").Return("mockPath")
 				m.ws.EXPECT().ListFiles("mockPath").Return([]string{"database.yml", "addons.parameters.yml", "addons.parameters.yaml"}, nil)
-				m.ws.EXPECT().WorkloadAddonFilePath("api", "database.yml").Return("mockPath", nil)
+				m.ws.EXPECT().WorkloadAddonFilePath("api", "database.yml").Return("mockPath")
 				m.ws.EXPECT().ReadFile("mockPath").Return(nil, nil)
 			},
 			wantedErr: "defining addons.parameters.yaml and addons.parameters.yml is not allowed under api addons/",
 		},
 		"returns an error if cannot read parameter file under addons/": {
 			setupMocks: func(m addonMocks) {
-				m.ws.EXPECT().WorkloadAddonsPath("api").Return("mockPath", nil)
+				m.ws.EXPECT().WorkloadAddonsPath("api").Return("mockPath")
 				m.ws.EXPECT().ListFiles("mockPath").Return([]string{"template.yml", "addons.parameters.yml"}, nil)
-				m.ws.EXPECT().WorkloadAddonFilePath("api", "template.yml").Return("mockPath", nil)
+				m.ws.EXPECT().WorkloadAddonFilePath("api", "template.yml").Return("mockPath")
 				m.ws.EXPECT().ReadFile("mockPath").Return(nil, nil)
-				m.ws.EXPECT().WorkloadAddonFilePath("api", "addons.parameters.yml").Return("mockPath", nil)
+				m.ws.EXPECT().WorkloadAddonFilePath("api", "addons.parameters.yml").Return("mockPath")
 				m.ws.EXPECT().ReadFile("mockPath").Return(nil, errors.New("some error"))
 			},
 			wantedErr: "read parameter file addons.parameters.yml under api addons/: some error",
 		},
 		"returns an error if there are no 'Parameters' field defined in a parameters file": {
 			setupMocks: func(m addonMocks) {
-				m.ws.EXPECT().WorkloadAddonsPath("api").Return("mockPath", nil)
+				m.ws.EXPECT().WorkloadAddonsPath("api").Return("mockPath")
 				m.ws.EXPECT().ListFiles("mockPath").Return([]string{"template.yaml", "addons.parameters.yml"}, nil)
-				m.ws.EXPECT().WorkloadAddonFilePath("api", "template.yaml").Return("mockPath", nil)
+				m.ws.EXPECT().WorkloadAddonFilePath("api", "template.yaml").Return("mockPath")
 				m.ws.EXPECT().ReadFile("mockPath").Return(nil, nil)
-				m.ws.EXPECT().WorkloadAddonFilePath("api", "addons.parameters.yml").Return("mockPath", nil)
+				m.ws.EXPECT().WorkloadAddonFilePath("api", "addons.parameters.yml").Return("mockPath")
 				m.ws.EXPECT().ReadFile("mockPath").Return([]byte(""), nil)
 			},
 			wantedErr: "must define field 'Parameters' in file addons.parameters.yml under api addons/",
 		},
 		"returns an error if reserved parameter fields is redefined in a parameters file": {
 			setupMocks: func(m addonMocks) {
-				m.ws.EXPECT().WorkloadAddonsPath("api").Return("mockPath", nil)
+				m.ws.EXPECT().WorkloadAddonsPath("api").Return("mockPath")
 				m.ws.EXPECT().ListFiles("mockPath").Return([]string{"template.yaml", "addons.parameters.yml"}, nil)
-				m.ws.EXPECT().WorkloadAddonFilePath("api", "template.yaml").Return("mockPath", nil)
+				m.ws.EXPECT().WorkloadAddonFilePath("api", "template.yaml").Return("mockPath")
 				m.ws.EXPECT().ReadFile("mockPath").Return(nil, nil)
-				m.ws.EXPECT().WorkloadAddonFilePath("api", "addons.parameters.yml").Return("mockPath", nil)
+				m.ws.EXPECT().WorkloadAddonFilePath("api", "addons.parameters.yml").Return("mockPath")
 				m.ws.EXPECT().ReadFile("mockPath").Return([]byte(`
 Parameters:
   App: !Ref AppName
@@ -322,11 +312,11 @@ Parameters:
 		},
 		"returns the content of Parameters on success": {
 			setupMocks: func(m addonMocks) {
-				m.ws.EXPECT().WorkloadAddonsPath("api").Return("mockPath", nil)
+				m.ws.EXPECT().WorkloadAddonsPath("api").Return("mockPath")
 				m.ws.EXPECT().ListFiles("mockPath").Return([]string{"template.yaml", "addons.parameters.yaml"}, nil)
-				m.ws.EXPECT().WorkloadAddonFilePath("api", "template.yaml").Return("mockPath", nil)
+				m.ws.EXPECT().WorkloadAddonFilePath("api", "template.yaml").Return("mockPath")
 				m.ws.EXPECT().ReadFile("mockPath").Return(nil, nil)
-				m.ws.EXPECT().WorkloadAddonFilePath("api", "addons.parameters.yaml").Return("mockPath", nil)
+				m.ws.EXPECT().WorkloadAddonFilePath("api", "addons.parameters.yaml").Return("mockPath")
 				m.ws.EXPECT().ReadFile("mockPath").Return([]byte(`
 Parameters:
   EventsQueue: 

--- a/internal/pkg/addon/mocks/mock_addons.go
+++ b/internal/pkg/addon/mocks/mock_addons.go
@@ -64,12 +64,11 @@ func (mr *MockworkspaceReaderMockRecorder) ReadFile(fPath interface{}) *gomock.C
 }
 
 // WorkloadAddonFilePath mocks base method.
-func (m *MockworkspaceReader) WorkloadAddonFilePath(wkldName, fName string) (string, error) {
+func (m *MockworkspaceReader) WorkloadAddonFilePath(wkldName, fName string) string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WorkloadAddonFilePath", wkldName, fName)
 	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	return ret0
 }
 
 // WorkloadAddonFilePath indicates an expected call of WorkloadAddonFilePath.
@@ -79,12 +78,11 @@ func (mr *MockworkspaceReaderMockRecorder) WorkloadAddonFilePath(wkldName, fName
 }
 
 // WorkloadAddonsPath mocks base method.
-func (m *MockworkspaceReader) WorkloadAddonsPath(name string) (string, error) {
+func (m *MockworkspaceReader) WorkloadAddonsPath(name string) string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WorkloadAddonsPath", name)
 	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	return ret0
 }
 
 // WorkloadAddonsPath indicates an expected call of WorkloadAddonsPath.

--- a/internal/pkg/cli/app_delete.go
+++ b/internal/pkg/cli/app_delete.go
@@ -70,18 +70,10 @@ type deleteAppOpts struct {
 }
 
 func newDeleteAppOpts(vars deleteAppVars) (*deleteAppOpts, error) {
-	workingDir, err := os.Getwd()
-	if err != nil {
-		return nil, fmt.Errorf("get working directory: %w", err)
-	}
-	ws, err := workspace.Use(afero.NewOsFs(), workingDir)
+	ws, err := workspace.Use(afero.NewOsFs())
 	if err != nil {
 		return nil, err
 	}
-	if err != nil {
-		return nil, fmt.Errorf("new workspace: %w", err)
-	}
-
 	provider := sessions.ImmutableProvider(sessions.UserAgentExtras("app delete"))
 	defaultSession, err := provider.Default()
 	if err != nil {

--- a/internal/pkg/cli/app_delete.go
+++ b/internal/pkg/cli/app_delete.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/aws/identity"
 	rg "github.com/aws/copilot-cli/internal/pkg/aws/resourcegroups"
 	"github.com/aws/copilot-cli/internal/pkg/deploy"
+	"github.com/spf13/afero"
 
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/copilot-cli/internal/pkg/aws/s3"
@@ -69,7 +70,15 @@ type deleteAppOpts struct {
 }
 
 func newDeleteAppOpts(vars deleteAppVars) (*deleteAppOpts, error) {
-	ws, err := workspace.New()
+	fs := &afero.Afero{Fs: afero.NewOsFs()}
+	workingDir, err := os.Getwd()
+	if err != nil {
+		return nil, fmt.Errorf("get working directory: %w", err)
+	}
+	ws, err := workspace.Use(fs, workingDir)
+	if err != nil {
+		return nil, err
+	}
 	if err != nil {
 		return nil, fmt.Errorf("new workspace: %w", err)
 	}

--- a/internal/pkg/cli/app_delete.go
+++ b/internal/pkg/cli/app_delete.go
@@ -70,12 +70,11 @@ type deleteAppOpts struct {
 }
 
 func newDeleteAppOpts(vars deleteAppVars) (*deleteAppOpts, error) {
-	fs := &afero.Afero{Fs: afero.NewOsFs()}
 	workingDir, err := os.Getwd()
 	if err != nil {
 		return nil, fmt.Errorf("get working directory: %w", err)
 	}
-	ws, err := workspace.Use(fs, workingDir)
+	ws, err := workspace.Use(afero.NewOsFs(), workingDir)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/cli/app_init.go
+++ b/internal/pkg/cli/app_init.go
@@ -90,7 +90,7 @@ func newInitAppOpts(vars initAppVars) (*initAppOpts, error) {
 			return sessions.AreCredsFromEnvVars(sess)
 		},
 		existingWorkspace: func() (wsAppManager, error) {
-			return workspace.Use(&afero.Afero{Fs: fs}, workingDir)
+			return workspace.Use(fs, workingDir)
 		},
 		newWorkspace: func(appName string) (wsAppManager, error) {
 			return workspace.Create(appName, &afero.Afero{Fs: fs}, workingDir)

--- a/internal/pkg/cli/app_init.go
+++ b/internal/pkg/cli/app_init.go
@@ -61,18 +61,12 @@ type initAppOpts struct {
 
 	// Cached variables.
 	cachedHostedZoneID string
-	workingDir         string
-	fs                 afero.Fs
 }
 
 func newInitAppOpts(vars initAppVars) (*initAppOpts, error) {
 	sess, err := sessions.ImmutableProvider(sessions.UserAgentExtras("app init")).Default()
 	if err != nil {
 		return nil, fmt.Errorf("default session: %w", err)
-	}
-	workingDir, err := os.Getwd()
-	if err != nil {
-		return nil, fmt.Errorf("get working directory: %w", err)
 	}
 	fs := afero.NewOsFs()
 	identity := identity.New(sess)
@@ -90,13 +84,11 @@ func newInitAppOpts(vars initAppVars) (*initAppOpts, error) {
 			return sessions.AreCredsFromEnvVars(sess)
 		},
 		existingWorkspace: func() (wsAppManager, error) {
-			return workspace.Use(fs, workingDir)
+			return workspace.Use(fs)
 		},
 		newWorkspace: func(appName string) (wsAppManager, error) {
-			return workspace.Create(appName, &afero.Afero{Fs: fs}, workingDir)
+			return workspace.Create(appName, fs)
 		},
-		fs:         fs,
-		workingDir: workingDir,
 	}, nil
 }
 

--- a/internal/pkg/cli/cli.go
+++ b/internal/pkg/cli/cli.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/dustin/go-humanize/english"
+	"github.com/spf13/afero"
 
 	"github.com/aws/copilot-cli/internal/pkg/term/log"
 
@@ -30,7 +31,12 @@ const (
 // tryReadingAppName retrieves the application's name from the workspace if it exists and returns it.
 // If there is an error while retrieving the workspace summary, returns the empty string.
 func tryReadingAppName() string {
-	ws, err := workspace.New()
+	fs := &afero.Afero{Fs: afero.NewOsFs()}
+	workingDir, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	ws, err := workspace.Use(fs, workingDir)
 	if err != nil {
 		return ""
 	}

--- a/internal/pkg/cli/cli.go
+++ b/internal/pkg/cli/cli.go
@@ -31,12 +31,7 @@ const (
 // tryReadingAppName retrieves the application's name from the workspace if it exists and returns it.
 // If there is an error while retrieving the workspace summary, returns the empty string.
 func tryReadingAppName() string {
-	fs := &afero.Afero{Fs: afero.NewOsFs()}
-	workingDir, err := os.Getwd()
-	if err != nil {
-		return ""
-	}
-	ws, err := workspace.Use(fs, workingDir)
+	ws, err := workspace.Use(afero.NewOsFs())
 	if err != nil {
 		return ""
 	}

--- a/internal/pkg/cli/deploy.go
+++ b/internal/pkg/cli/deploy.go
@@ -5,7 +5,6 @@ package cli
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -55,11 +54,7 @@ func newDeployOpts(vars deployWkldVars) (*deployOpts, error) {
 		return nil, fmt.Errorf("default session: %v", err)
 	}
 	store := config.NewSSMStore(identity.New(defaultSess), ssm.New(defaultSess), aws.StringValue(defaultSess.Config.Region))
-	workingDir, err := os.Getwd()
-	if err != nil {
-		return nil, fmt.Errorf("get working directory: %w", err)
-	}
-	ws, err := workspace.Use(afero.NewOsFs(), workingDir)
+	ws, err := workspace.Use(afero.NewOsFs())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/cli/deploy.go
+++ b/internal/pkg/cli/deploy.go
@@ -55,12 +55,11 @@ func newDeployOpts(vars deployWkldVars) (*deployOpts, error) {
 		return nil, fmt.Errorf("default session: %v", err)
 	}
 	store := config.NewSSMStore(identity.New(defaultSess), ssm.New(defaultSess), aws.StringValue(defaultSess.Config.Region))
-	fs := &afero.Afero{Fs: afero.NewOsFs()}
 	workingDir, err := os.Getwd()
 	if err != nil {
 		return nil, fmt.Errorf("get working directory: %w", err)
 	}
-	ws, err := workspace.Use(fs, workingDir)
+	ws, err := workspace.Use(afero.NewOsFs(), workingDir)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/cli/deploy/svc.go
+++ b/internal/pkg/cli/deploy/svc.go
@@ -199,7 +199,6 @@ func newWorkloadDeployer(in *WorkloadDeployerInput) (*workloadDeployer, error) {
 	if err != nil {
 		return nil, err
 	}
-	workspacePath := ws.Path()
 	defaultSession, err := in.SessionProvider.Default()
 	if err != nil {
 		return nil, fmt.Errorf("create default: %w", err)
@@ -255,7 +254,7 @@ func newWorkloadDeployer(in *WorkloadDeployerInput) (*workloadDeployer, error) {
 		env:                in.Env,
 		imageTag:           in.ImageTag,
 		resources:          resources,
-		workspacePath:      workspacePath,
+		workspacePath:      ws.Path(),
 		fs:                 &afero.Afero{Fs: afero.NewOsFs()},
 		s3Client:           s3.New(envSession),
 		addons:             addons,

--- a/internal/pkg/cli/deploy/svc.go
+++ b/internal/pkg/cli/deploy/svc.go
@@ -204,10 +204,7 @@ func newWorkloadDeployer(in *WorkloadDeployerInput) (*workloadDeployer, error) {
 	if err != nil {
 		return nil, err
 	}
-	workspacePath, err := ws.Path()
-	if err != nil {
-		return nil, fmt.Errorf("get workspace path: %w", err)
-	}
+	workspacePath := ws.Path()
 	defaultSession, err := in.SessionProvider.Default()
 	if err != nil {
 		return nil, fmt.Errorf("create default: %w", err)

--- a/internal/pkg/cli/deploy/svc.go
+++ b/internal/pkg/cli/deploy/svc.go
@@ -195,9 +195,14 @@ type WorkloadDeployerInput struct {
 
 // newWorkloadDeployer is the constructor for workloadDeployer.
 func newWorkloadDeployer(in *WorkloadDeployerInput) (*workloadDeployer, error) {
-	ws, err := workspace.New()
+	fs := &afero.Afero{Fs: afero.NewOsFs()}
+	workingDir, err := os.Getwd()
 	if err != nil {
-		return nil, fmt.Errorf("new workspace: %w", err)
+		return nil, fmt.Errorf("get working directory: %w", err)
+	}
+	ws, err := workspace.Use(fs, workingDir)
+	if err != nil {
+		return nil, err
 	}
 	workspacePath, err := ws.Path()
 	if err != nil {

--- a/internal/pkg/cli/deploy/svc.go
+++ b/internal/pkg/cli/deploy/svc.go
@@ -195,12 +195,7 @@ type WorkloadDeployerInput struct {
 
 // newWorkloadDeployer is the constructor for workloadDeployer.
 func newWorkloadDeployer(in *WorkloadDeployerInput) (*workloadDeployer, error) {
-	fs := &afero.Afero{Fs: afero.NewOsFs()}
-	workingDir, err := os.Getwd()
-	if err != nil {
-		return nil, fmt.Errorf("get working directory: %w", err)
-	}
-	ws, err := workspace.Use(fs, workingDir)
+	ws, err := workspace.Use(afero.NewOsFs())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/cli/env_deploy.go
+++ b/internal/pkg/cli/env_deploy.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/term/prompt"
 	"github.com/aws/copilot-cli/internal/pkg/term/selector"
 	"github.com/aws/copilot-cli/internal/pkg/workspace"
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
 
@@ -59,9 +60,14 @@ func newEnvDeployOpts(vars deployEnvVars) (*deployEnvOpts, error) {
 		return nil, err
 	}
 	store := config.NewSSMStore(identity.New(defaultSess), ssm.New(defaultSess), aws.StringValue(defaultSess.Config.Region))
-	ws, err := workspace.New()
+	fs := &afero.Afero{Fs: afero.NewOsFs()}
+	workingDir, err := os.Getwd()
 	if err != nil {
-		return nil, fmt.Errorf("new workspace: %w", err)
+		return nil, fmt.Errorf("get working directory: %w", err)
+	}
+	ws, err := workspace.Use(fs, workingDir)
+	if err != nil {
+		return nil, err
 	}
 	opts := &deployEnvOpts{
 		deployEnvVars: vars,

--- a/internal/pkg/cli/env_deploy.go
+++ b/internal/pkg/cli/env_deploy.go
@@ -60,12 +60,11 @@ func newEnvDeployOpts(vars deployEnvVars) (*deployEnvOpts, error) {
 		return nil, err
 	}
 	store := config.NewSSMStore(identity.New(defaultSess), ssm.New(defaultSess), aws.StringValue(defaultSess.Config.Region))
-	fs := &afero.Afero{Fs: afero.NewOsFs()}
 	workingDir, err := os.Getwd()
 	if err != nil {
 		return nil, fmt.Errorf("get working directory: %w", err)
 	}
-	ws, err := workspace.Use(fs, workingDir)
+	ws, err := workspace.Use(afero.NewOsFs(), workingDir)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/cli/env_deploy.go
+++ b/internal/pkg/cli/env_deploy.go
@@ -60,11 +60,7 @@ func newEnvDeployOpts(vars deployEnvVars) (*deployEnvOpts, error) {
 		return nil, err
 	}
 	store := config.NewSSMStore(identity.New(defaultSess), ssm.New(defaultSess), aws.StringValue(defaultSess.Config.Region))
-	workingDir, err := os.Getwd()
-	if err != nil {
-		return nil, fmt.Errorf("get working directory: %w", err)
-	}
-	ws, err := workspace.Use(afero.NewOsFs(), workingDir)
+	ws, err := workspace.Use(afero.NewOsFs())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/cli/env_init.go
+++ b/internal/pkg/cli/env_init.go
@@ -194,12 +194,11 @@ func newInitEnvOpts(vars initEnvVars) (*initEnvOpts, error) {
 
 	prompter := prompt.New()
 
-	fs := &afero.Afero{Fs: afero.NewOsFs()}
 	workingDir, err := os.Getwd()
 	if err != nil {
 		return nil, fmt.Errorf("get working directory: %w", err)
 	}
-	ws, err := workspace.Use(fs, workingDir)
+	ws, err := workspace.Use(afero.NewOsFs(), workingDir)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/cli/env_init.go
+++ b/internal/pkg/cli/env_init.go
@@ -186,19 +186,12 @@ func newInitEnvOpts(vars initEnvVars) (*initEnvOpts, error) {
 		return nil, err
 	}
 	store := config.NewSSMStore(identity.New(defaultSession), ssm.New(defaultSession), aws.StringValue(defaultSession.Config.Region))
-
 	cfg, err := profile.NewConfig()
 	if err != nil {
 		return nil, fmt.Errorf("read named profiles: %w", err)
 	}
-
 	prompter := prompt.New()
-
-	workingDir, err := os.Getwd()
-	if err != nil {
-		return nil, fmt.Errorf("get working directory: %w", err)
-	}
-	ws, err := workspace.Use(afero.NewOsFs(), workingDir)
+	ws, err := workspace.Use(afero.NewOsFs())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/cli/env_init.go
+++ b/internal/pkg/cli/env_init.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/manifest"
 	"github.com/aws/copilot-cli/internal/pkg/workspace"
 	"github.com/dustin/go-humanize/english"
+	"github.com/spf13/afero"
 
 	"github.com/aws/aws-sdk-go/service/ssm"
 
@@ -193,9 +194,14 @@ func newInitEnvOpts(vars initEnvVars) (*initEnvOpts, error) {
 
 	prompter := prompt.New()
 
-	ws, err := workspace.New()
+	fs := &afero.Afero{Fs: afero.NewOsFs()}
+	workingDir, err := os.Getwd()
 	if err != nil {
-		return nil, fmt.Errorf("create workspace: %w", err)
+		return nil, fmt.Errorf("get working directory: %w", err)
+	}
+	ws, err := workspace.Use(fs, workingDir)
+	if err != nil {
+		return nil, err
 	}
 	return &initEnvOpts{
 		initEnvVars:  vars,

--- a/internal/pkg/cli/env_package.go
+++ b/internal/pkg/cli/env_package.go
@@ -79,7 +79,7 @@ func newPackageEnvOpts(vars packageEnvVars) (*packageEnvOpts, error) {
 		return nil, fmt.Errorf("default session: %v", err)
 	}
 
-	fs := &afero.Afero{Fs: afero.NewOsFs()}
+	fs := afero.NewOsFs()
 	workingDir, err := os.Getwd()
 	if err != nil {
 		return nil, fmt.Errorf("get working directory: %w", err)

--- a/internal/pkg/cli/env_package.go
+++ b/internal/pkg/cli/env_package.go
@@ -80,11 +80,7 @@ func newPackageEnvOpts(vars packageEnvVars) (*packageEnvOpts, error) {
 	}
 
 	fs := afero.NewOsFs()
-	workingDir, err := os.Getwd()
-	if err != nil {
-		return nil, fmt.Errorf("get working directory: %w", err)
-	}
-	ws, err := workspace.Use(fs, workingDir)
+	ws, err := workspace.Use(fs)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/cli/init.go
+++ b/internal/pkg/cli/init.go
@@ -93,11 +93,7 @@ type initOpts struct {
 
 func newInitOpts(vars initVars) (*initOpts, error) {
 	fs := afero.NewOsFs()
-	workingDir, err := os.Getwd()
-	if err != nil {
-		return nil, fmt.Errorf("get working directory: %w", err)
-	}
-	ws, err := workspace.Use(fs, workingDir)
+	ws, err := workspace.Use(fs)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/cli/init.go
+++ b/internal/pkg/cli/init.go
@@ -92,7 +92,12 @@ type initOpts struct {
 }
 
 func newInitOpts(vars initVars) (*initOpts, error) {
-	ws, err := workspace.New()
+	fs := &afero.Afero{Fs: afero.NewOsFs()}
+	workingDir, err := os.Getwd()
+	if err != nil {
+		return nil, fmt.Errorf("get working directory: %w", err)
+	}
+	ws, err := workspace.Use(fs, workingDir)
 	if err != nil {
 		return nil, err
 	}
@@ -120,7 +125,6 @@ func newInitOpts(vars initVars) (*initOpts, error) {
 			name: vars.appName,
 		},
 		store:    configStore,
-		ws:       ws,
 		prompt:   prompt,
 		identity: id,
 		cfn:      deployer,
@@ -197,7 +201,6 @@ func newInitOpts(vars initVars) (*initOpts, error) {
 	deployJobCmd.newJobDeployer = func() (workloadDeployer, error) {
 		return newJobDeployer(deployJobCmd)
 	}
-	fs := &afero.Afero{Fs: afero.NewOsFs()}
 	cmd := exec.NewCmd()
 	return &initOpts{
 		initVars:     vars,

--- a/internal/pkg/cli/init.go
+++ b/internal/pkg/cli/init.go
@@ -92,7 +92,7 @@ type initOpts struct {
 }
 
 func newInitOpts(vars initVars) (*initOpts, error) {
-	fs := &afero.Afero{Fs: afero.NewOsFs()}
+	fs := afero.NewOsFs()
 	workingDir, err := os.Getwd()
 	if err != nil {
 		return nil, fmt.Errorf("get working directory: %w", err)

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -240,7 +240,7 @@ type environmentManifestWriter interface {
 }
 
 type workspacePathGetter interface {
-	Path() (string, error)
+	Path() string
 }
 
 type wsPipelineManifestReader interface {

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -316,7 +316,6 @@ type wsPipelineGetter interface {
 }
 
 type wsAppManager interface {
-	Create(appName string) error
 	Summary() (*workspace.Summary, error)
 }
 

--- a/internal/pkg/cli/job_deploy.go
+++ b/internal/pkg/cli/job_deploy.go
@@ -5,7 +5,6 @@ package cli
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -59,12 +58,7 @@ func newJobDeployOpts(vars deployWkldVars) (*deployJobOpts, error) {
 		return nil, err
 	}
 	store := config.NewSSMStore(identity.New(defaultSess), ssm.New(defaultSess), aws.StringValue(defaultSess.Config.Region))
-
-	workingDir, err := os.Getwd()
-	if err != nil {
-		return nil, fmt.Errorf("get working directory: %w", err)
-	}
-	ws, err := workspace.Use(afero.NewOsFs(), workingDir)
+	ws, err := workspace.Use(afero.NewOsFs())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/cli/job_deploy.go
+++ b/internal/pkg/cli/job_deploy.go
@@ -60,12 +60,11 @@ func newJobDeployOpts(vars deployWkldVars) (*deployJobOpts, error) {
 	}
 	store := config.NewSSMStore(identity.New(defaultSess), ssm.New(defaultSess), aws.StringValue(defaultSess.Config.Region))
 
-	fs := &afero.Afero{Fs: afero.NewOsFs()}
 	workingDir, err := os.Getwd()
 	if err != nil {
 		return nil, fmt.Errorf("get working directory: %w", err)
 	}
-	ws, err := workspace.Use(fs, workingDir)
+	ws, err := workspace.Use(afero.NewOsFs(), workingDir)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/cli/job_init.go
+++ b/internal/pkg/cli/job_init.go
@@ -82,9 +82,14 @@ type initJobOpts struct {
 }
 
 func newInitJobOpts(vars initJobVars) (*initJobOpts, error) {
-	ws, err := workspace.New()
+	fs := &afero.Afero{Fs: afero.NewOsFs()}
+	workingDir, err := os.Getwd()
 	if err != nil {
-		return nil, fmt.Errorf("workspace cannot be created: %w", err)
+		return nil, fmt.Errorf("get working directory: %w", err)
+	}
+	ws, err := workspace.Use(fs, workingDir)
+	if err != nil {
+		return nil, err
 	}
 
 	p := sessions.ImmutableProvider(sessions.UserAgentExtras("job init"))
@@ -93,9 +98,6 @@ func newInitJobOpts(vars initJobVars) (*initJobOpts, error) {
 		return nil, err
 	}
 	store := config.NewSSMStore(identity.New(sess), ssm.New(sess), aws.StringValue(sess.Config.Region))
-
-	fs := &afero.Afero{Fs: afero.NewOsFs()}
-
 	jobInitter := &initialize.WorkloadInitializer{
 		Store:    store,
 		Ws:       ws,

--- a/internal/pkg/cli/job_init.go
+++ b/internal/pkg/cli/job_init.go
@@ -82,7 +82,7 @@ type initJobOpts struct {
 }
 
 func newInitJobOpts(vars initJobVars) (*initJobOpts, error) {
-	fs := &afero.Afero{Fs: afero.NewOsFs()}
+	fs := afero.NewOsFs()
 	workingDir, err := os.Getwd()
 	if err != nil {
 		return nil, fmt.Errorf("get working directory: %w", err)

--- a/internal/pkg/cli/job_init.go
+++ b/internal/pkg/cli/job_init.go
@@ -83,11 +83,7 @@ type initJobOpts struct {
 
 func newInitJobOpts(vars initJobVars) (*initJobOpts, error) {
 	fs := afero.NewOsFs()
-	workingDir, err := os.Getwd()
-	if err != nil {
-		return nil, fmt.Errorf("get working directory: %w", err)
-	}
-	ws, err := workspace.Use(fs, workingDir)
+	ws, err := workspace.Use(fs)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/cli/job_list.go
+++ b/internal/pkg/cli/job_list.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/aws/copilot-cli/internal/pkg/aws/identity"
 	"github.com/aws/copilot-cli/internal/pkg/aws/sessions"
+	"github.com/spf13/afero"
 
 	"github.com/aws/copilot-cli/internal/pkg/cli/list"
 	"github.com/aws/copilot-cli/internal/pkg/config"
@@ -42,7 +43,12 @@ func newListJobOpts(vars listWkldVars) (*listJobOpts, error) {
 	if err != nil {
 		return nil, err
 	}
-	ws, err := workspace.New()
+	fs := &afero.Afero{Fs: afero.NewOsFs()}
+	workingDir, err := os.Getwd()
+	if err != nil {
+		return nil, fmt.Errorf("get working directory: %w", err)
+	}
+	ws, err := workspace.Use(fs, workingDir)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/cli/job_list.go
+++ b/internal/pkg/cli/job_list.go
@@ -43,12 +43,7 @@ func newListJobOpts(vars listWkldVars) (*listJobOpts, error) {
 	if err != nil {
 		return nil, err
 	}
-	fs := &afero.Afero{Fs: afero.NewOsFs()}
-	workingDir, err := os.Getwd()
-	if err != nil {
-		return nil, fmt.Errorf("get working directory: %w", err)
-	}
-	ws, err := workspace.Use(fs, workingDir)
+	ws, err := workspace.Use(afero.NewOsFs())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/cli/job_package.go
+++ b/internal/pkg/cli/job_package.go
@@ -59,12 +59,11 @@ func newPackageJobOpts(vars packageJobVars) (*packageJobOpts, error) {
 	}
 	store := config.NewSSMStore(identity.New(defaultSess), ssm.New(defaultSess), aws.StringValue(defaultSess.Config.Region))
 
-	fs := &afero.Afero{Fs: afero.NewOsFs()}
 	workingDir, err := os.Getwd()
 	if err != nil {
 		return nil, fmt.Errorf("get working directory: %w", err)
 	}
-	ws, err := workspace.Use(fs, workingDir)
+	ws, err := workspace.Use(afero.NewOsFs(), workingDir)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/cli/job_package.go
+++ b/internal/pkg/cli/job_package.go
@@ -59,9 +59,14 @@ func newPackageJobOpts(vars packageJobVars) (*packageJobOpts, error) {
 	}
 	store := config.NewSSMStore(identity.New(defaultSess), ssm.New(defaultSess), aws.StringValue(defaultSess.Config.Region))
 
-	ws, err := workspace.New()
+	fs := &afero.Afero{Fs: afero.NewOsFs()}
+	workingDir, err := os.Getwd()
 	if err != nil {
-		return nil, fmt.Errorf("new workspace: %w", err)
+		return nil, fmt.Errorf("get working directory: %w", err)
+	}
+	ws, err := workspace.Use(fs, workingDir)
+	if err != nil {
+		return nil, err
 	}
 	prompter := prompt.New()
 	opts := &packageJobOpts{

--- a/internal/pkg/cli/job_package.go
+++ b/internal/pkg/cli/job_package.go
@@ -91,7 +91,7 @@ func newPackageJobOpts(vars packageJobVars) (*packageJobOpts, error) {
 			newInterpolator:   newManifestInterpolator,
 			paramsWriter:      discardFile{},
 			addonsWriter:      discardFile{},
-			fs:                &afero.Afero{Fs: fs},
+			fs:                fs,
 			sessProvider:      sessProvider,
 			newStackGenerator: newWorkloadStackGenerator,
 		}

--- a/internal/pkg/cli/job_package.go
+++ b/internal/pkg/cli/job_package.go
@@ -58,12 +58,8 @@ func newPackageJobOpts(vars packageJobVars) (*packageJobOpts, error) {
 		return nil, err
 	}
 	store := config.NewSSMStore(identity.New(defaultSess), ssm.New(defaultSess), aws.StringValue(defaultSess.Config.Region))
-
-	workingDir, err := os.Getwd()
-	if err != nil {
-		return nil, fmt.Errorf("get working directory: %w", err)
-	}
-	ws, err := workspace.Use(afero.NewOsFs(), workingDir)
+	fs := afero.NewOsFs()
+	ws, err := workspace.Use(fs)
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +91,7 @@ func newPackageJobOpts(vars packageJobVars) (*packageJobOpts, error) {
 			newInterpolator:   newManifestInterpolator,
 			paramsWriter:      discardFile{},
 			addonsWriter:      discardFile{},
-			fs:                &afero.Afero{Fs: afero.NewOsFs()},
+			fs:                &afero.Afero{Fs: fs},
 			sessProvider:      sessProvider,
 			newStackGenerator: newWorkloadStackGenerator,
 		}

--- a/internal/pkg/cli/job_run.go
+++ b/internal/pkg/cli/job_run.go
@@ -5,7 +5,6 @@ package cli
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/aws/copilot-cli/internal/pkg/workspace"
 	"github.com/spf13/afero"
@@ -55,11 +54,7 @@ func newJobRunOpts(vars jobRunVars) (*jobRunOpts, error) {
 		return nil, err
 	}
 	configStore := config.NewSSMStore(identity.New(defaultSess), ssm.New(defaultSess), aws.StringValue(defaultSess.Config.Region))
-	workingDir, err := os.Getwd()
-	if err != nil {
-		return nil, fmt.Errorf("get working directory: %w", err)
-	}
-	ws, err := workspace.Use(afero.NewOsFs(), workingDir)
+	ws, err := workspace.Use(afero.NewOsFs())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/cli/job_run.go
+++ b/internal/pkg/cli/job_run.go
@@ -5,8 +5,10 @@ package cli
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/aws/copilot-cli/internal/pkg/workspace"
+	"github.com/spf13/afero"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -53,9 +55,14 @@ func newJobRunOpts(vars jobRunVars) (*jobRunOpts, error) {
 		return nil, err
 	}
 	configStore := config.NewSSMStore(identity.New(defaultSess), ssm.New(defaultSess), aws.StringValue(defaultSess.Config.Region))
-	ws, err := workspace.New()
+	fs := &afero.Afero{Fs: afero.NewOsFs()}
+	workingDir, err := os.Getwd()
 	if err != nil {
-		return nil, fmt.Errorf("new workspace: %w", err)
+		return nil, fmt.Errorf("get working directory: %w", err)
+	}
+	ws, err := workspace.Use(fs, workingDir)
+	if err != nil {
+		return nil, err
 	}
 	prompter := prompt.New()
 

--- a/internal/pkg/cli/job_run.go
+++ b/internal/pkg/cli/job_run.go
@@ -55,12 +55,11 @@ func newJobRunOpts(vars jobRunVars) (*jobRunOpts, error) {
 		return nil, err
 	}
 	configStore := config.NewSSMStore(identity.New(defaultSess), ssm.New(defaultSess), aws.StringValue(defaultSess.Config.Region))
-	fs := &afero.Afero{Fs: afero.NewOsFs()}
 	workingDir, err := os.Getwd()
 	if err != nil {
 		return nil, fmt.Errorf("get working directory: %w", err)
 	}
-	ws, err := workspace.Use(fs, workingDir)
+	ws, err := workspace.Use(afero.NewOsFs(), workingDir)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -2299,12 +2299,11 @@ func (m *MockworkspacePathGetter) EXPECT() *MockworkspacePathGetterMockRecorder 
 }
 
 // Path mocks base method.
-func (m *MockworkspacePathGetter) Path() (string, error) {
+func (m *MockworkspacePathGetter) Path() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Path")
 	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	return ret0
 }
 
 // Path indicates an expected call of Path.
@@ -2731,12 +2730,11 @@ func (mr *MockwsJobDirReaderMockRecorder) ListJobs() *gomock.Call {
 }
 
 // Path mocks base method.
-func (m *MockwsJobDirReader) Path() (string, error) {
+func (m *MockwsJobDirReader) Path() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Path")
 	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	return ret0
 }
 
 // Path indicates an expected call of Path.
@@ -2859,12 +2857,11 @@ func (mr *MockwsWlDirReaderMockRecorder) ListWorkloads() *gomock.Call {
 }
 
 // Path mocks base method.
-func (m *MockwsWlDirReader) Path() (string, error) {
+func (m *MockwsWlDirReader) Path() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Path")
 	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	return ret0
 }
 
 // Path indicates an expected call of Path.

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -3130,20 +3130,6 @@ func (m *MockwsAppManager) EXPECT() *MockwsAppManagerMockRecorder {
 	return m.recorder
 }
 
-// Create mocks base method.
-func (m *MockwsAppManager) Create(appName string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Create", appName)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Create indicates an expected call of Create.
-func (mr *MockwsAppManagerMockRecorder) Create(appName interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockwsAppManager)(nil).Create), appName)
-}
-
 // Summary mocks base method.
 func (m *MockwsAppManager) Summary() (*workspace.Summary, error) {
 	m.ctrl.T.Helper()

--- a/internal/pkg/cli/pipeline_delete.go
+++ b/internal/pkg/cli/pipeline_delete.go
@@ -77,12 +77,7 @@ type deletePipelineOpts struct {
 }
 
 func newDeletePipelineOpts(vars deletePipelineVars) (*deletePipelineOpts, error) {
-	fs := &afero.Afero{Fs: afero.NewOsFs()}
-	workingDir, err := os.Getwd()
-	if err != nil {
-		return nil, fmt.Errorf("get working directory: %w", err)
-	}
-	ws, err := workspace.Use(fs, workingDir)
+	ws, err := workspace.Use(afero.NewOsFs())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/cli/pipeline_delete.go
+++ b/internal/pkg/cli/pipeline_delete.go
@@ -26,6 +26,7 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/term/prompt"
 	"github.com/aws/copilot-cli/internal/pkg/term/selector"
 	"github.com/aws/copilot-cli/internal/pkg/workspace"
+	"github.com/spf13/afero"
 
 	"github.com/spf13/cobra"
 )
@@ -76,9 +77,14 @@ type deletePipelineOpts struct {
 }
 
 func newDeletePipelineOpts(vars deletePipelineVars) (*deletePipelineOpts, error) {
-	ws, err := workspace.New()
+	fs := &afero.Afero{Fs: afero.NewOsFs()}
+	workingDir, err := os.Getwd()
 	if err != nil {
-		return nil, fmt.Errorf("new workspace client: %w", err)
+		return nil, fmt.Errorf("get working directory: %w", err)
+	}
+	ws, err := workspace.Use(fs, workingDir)
+	if err != nil {
+		return nil, err
 	}
 
 	defaultSess, err := sessions.ImmutableProvider(sessions.UserAgentExtras("pipeline delete")).Default()

--- a/internal/pkg/cli/pipeline_deploy.go
+++ b/internal/pkg/cli/pipeline_deploy.go
@@ -98,12 +98,11 @@ func newDeployPipelineOpts(vars deployPipelineVars) (*deployPipelineOpts, error)
 
 	prompter := prompt.New()
 
-	fs := &afero.Afero{Fs: afero.NewOsFs()}
 	workingDir, err := os.Getwd()
 	if err != nil {
 		return nil, fmt.Errorf("get working directory: %w", err)
 	}
-	ws, err := workspace.Use(fs, workingDir)
+	ws, err := workspace.Use(afero.NewOsFs(), workingDir)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/cli/pipeline_deploy.go
+++ b/internal/pkg/cli/pipeline_deploy.go
@@ -97,12 +97,7 @@ func newDeployPipelineOpts(vars deployPipelineVars) (*deployPipelineOpts, error)
 	store := config.NewSSMStore(identity.New(defaultSession), ssm.New(defaultSession), aws.StringValue(defaultSession.Config.Region))
 
 	prompter := prompt.New()
-
-	workingDir, err := os.Getwd()
-	if err != nil {
-		return nil, fmt.Errorf("get working directory: %w", err)
-	}
-	ws, err := workspace.Use(afero.NewOsFs(), workingDir)
+	ws, err := workspace.Use(afero.NewOsFs())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/cli/pipeline_deploy.go
+++ b/internal/pkg/cli/pipeline_deploy.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 
 	"github.com/aws/aws-sdk-go/service/ssm"
+	"github.com/spf13/afero"
 
 	"github.com/aws/copilot-cli/internal/pkg/aws/cloudformation"
 	cs "github.com/aws/copilot-cli/internal/pkg/aws/codestar"
@@ -97,9 +98,14 @@ func newDeployPipelineOpts(vars deployPipelineVars) (*deployPipelineOpts, error)
 
 	prompter := prompt.New()
 
-	ws, err := workspace.New()
+	fs := &afero.Afero{Fs: afero.NewOsFs()}
+	workingDir, err := os.Getwd()
 	if err != nil {
-		return nil, fmt.Errorf("new workspace client: %w", err)
+		return nil, fmt.Errorf("get working directory: %w", err)
+	}
+	ws, err := workspace.Use(fs, workingDir)
+	if err != nil {
+		return nil, err
 	}
 
 	wsAppName := tryReadingAppName()

--- a/internal/pkg/cli/pipeline_init.go
+++ b/internal/pkg/cli/pipeline_init.go
@@ -201,7 +201,6 @@ type initPipelineOpts struct {
 
 	// Cached variables
 	wsAppName    string
-	fs           *afero.Afero
 	buffer       bytes.Buffer
 	envConfigs   []*config.Environment
 	manifestPath string // relative path to pipeline's manifest.yml file
@@ -244,7 +243,6 @@ func newInitPipelineOpts(vars initPipelineVars) (*initPipelineOpts, error) {
 		prompt:           prompter,
 		sel:              selector.NewAppEnvSelector(prompter, ssmStore),
 		runner:           exec.NewCmd(),
-		fs:               &afero.Afero{Fs: afero.NewOsFs()},
 		wsAppName:        wsAppName,
 		pipelineLister:   deploy.NewPipelineStore(rg.New(defaultSession)),
 	}, nil

--- a/internal/pkg/cli/pipeline_init.go
+++ b/internal/pkg/cli/pipeline_init.go
@@ -214,11 +214,7 @@ type artifactBucket struct {
 }
 
 func newInitPipelineOpts(vars initPipelineVars) (*initPipelineOpts, error) {
-	workingDir, err := os.Getwd()
-	if err != nil {
-		return nil, fmt.Errorf("get working directory: %w", err)
-	}
-	ws, err := workspace.Use(afero.NewOsFs(), workingDir)
+	ws, err := workspace.Use(afero.NewOsFs())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/cli/pipeline_init.go
+++ b/internal/pkg/cli/pipeline_init.go
@@ -214,9 +214,14 @@ type artifactBucket struct {
 }
 
 func newInitPipelineOpts(vars initPipelineVars) (*initPipelineOpts, error) {
-	ws, err := workspace.New()
+	fs := &afero.Afero{Fs: afero.NewOsFs()}
+	workingDir, err := os.Getwd()
 	if err != nil {
-		return nil, fmt.Errorf("new workspace client: %w", err)
+		return nil, fmt.Errorf("get working directory: %w", err)
+	}
+	ws, err := workspace.Use(fs, workingDir)
+	if err != nil {
+		return nil, err
 	}
 
 	p := sessions.ImmutableProvider(sessions.UserAgentExtras("pipeline init"))

--- a/internal/pkg/cli/pipeline_init.go
+++ b/internal/pkg/cli/pipeline_init.go
@@ -214,12 +214,11 @@ type artifactBucket struct {
 }
 
 func newInitPipelineOpts(vars initPipelineVars) (*initPipelineOpts, error) {
-	fs := &afero.Afero{Fs: afero.NewOsFs()}
 	workingDir, err := os.Getwd()
 	if err != nil {
 		return nil, fmt.Errorf("get working directory: %w", err)
 	}
-	ws, err := workspace.Use(fs, workingDir)
+	ws, err := workspace.Use(afero.NewOsFs(), workingDir)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/cli/pipeline_init_test.go
+++ b/internal/pkg/cli/pipeline_init_test.go
@@ -20,7 +20,6 @@ import (
 	templatemocks "github.com/aws/copilot-cli/internal/pkg/template/mocks"
 	"github.com/aws/copilot-cli/internal/pkg/workspace"
 	"github.com/golang/mock/gomock"
-	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
 )
 
@@ -867,9 +866,6 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 			if tc.setupMocks != nil {
 				tc.setupMocks(mocks)
 			}
-
-			memFs := &afero.Afero{Fs: afero.NewMemMapFs()}
-
 			opts := &initPipelineOpts{
 				initPipelineVars: initPipelineVars{
 					name:              tc.inName,
@@ -885,7 +881,6 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 				sessProvider:   mocks.sessProvider,
 				store:          mocks.store,
 				cfnClient:      mocks.cfnClient,
-				fs:             memFs,
 				buffer:         tc.buffer,
 				envConfigs:     tc.inEnvConfigs,
 			}

--- a/internal/pkg/cli/pipeline_list.go
+++ b/internal/pkg/cli/pipeline_list.go
@@ -60,12 +60,7 @@ type listPipelineOpts struct {
 type newPipelineDescriberFunc func(pipeline deploy.Pipeline) (describer, error)
 
 func newListPipelinesOpts(vars listPipelineVars) (*listPipelineOpts, error) {
-	fs := &afero.Afero{Fs: afero.NewOsFs()}
-	workingDir, err := os.Getwd()
-	if err != nil {
-		return nil, fmt.Errorf("get working directory: %w", err)
-	}
-	ws, err := workspace.Use(fs, workingDir)
+	ws, err := workspace.Use(afero.NewOsFs())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/cli/pipeline_list.go
+++ b/internal/pkg/cli/pipeline_list.go
@@ -20,6 +20,7 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/deploy"
 	"github.com/aws/copilot-cli/internal/pkg/describe"
 	"github.com/aws/copilot-cli/internal/pkg/workspace"
+	"github.com/spf13/afero"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/aws/copilot-cli/internal/pkg/aws/sessions"
@@ -59,7 +60,12 @@ type listPipelineOpts struct {
 type newPipelineDescriberFunc func(pipeline deploy.Pipeline) (describer, error)
 
 func newListPipelinesOpts(vars listPipelineVars) (*listPipelineOpts, error) {
-	ws, err := workspace.New()
+	fs := &afero.Afero{Fs: afero.NewOsFs()}
+	workingDir, err := os.Getwd()
+	if err != nil {
+		return nil, fmt.Errorf("get working directory: %w", err)
+	}
+	ws, err := workspace.Use(fs, workingDir)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/cli/pipeline_show.go
+++ b/internal/pkg/cli/pipeline_show.go
@@ -6,7 +6,6 @@ package cli
 import (
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/aws/copilot-cli/internal/pkg/deploy"
 	"github.com/aws/copilot-cli/internal/pkg/term/color"
@@ -61,12 +60,7 @@ type showPipelineOpts struct {
 }
 
 func newShowPipelineOpts(vars showPipelineVars) (*showPipelineOpts, error) {
-	fs := &afero.Afero{Fs: afero.NewOsFs()}
-	workingDir, err := os.Getwd()
-	if err != nil {
-		return nil, fmt.Errorf("get working directory: %w", err)
-	}
-	ws, err := workspace.Use(fs, workingDir)
+	ws, err := workspace.Use(afero.NewOsFs())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/cli/pipeline_show.go
+++ b/internal/pkg/cli/pipeline_show.go
@@ -6,9 +6,11 @@ package cli
 import (
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/aws/copilot-cli/internal/pkg/deploy"
 	"github.com/aws/copilot-cli/internal/pkg/term/color"
+	"github.com/spf13/afero"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ssm"
@@ -59,9 +61,14 @@ type showPipelineOpts struct {
 }
 
 func newShowPipelineOpts(vars showPipelineVars) (*showPipelineOpts, error) {
-	ws, err := workspace.New()
+	fs := &afero.Afero{Fs: afero.NewOsFs()}
+	workingDir, err := os.Getwd()
 	if err != nil {
-		return nil, fmt.Errorf("new workspace client: %w", err)
+		return nil, fmt.Errorf("get working directory: %w", err)
+	}
+	ws, err := workspace.Use(fs, workingDir)
+	if err != nil {
+		return nil, err
 	}
 
 	defaultSession, err := sessions.ImmutableProvider(sessions.UserAgentExtras("pipeline show")).Default()

--- a/internal/pkg/cli/pipeline_status.go
+++ b/internal/pkg/cli/pipeline_status.go
@@ -6,9 +6,11 @@ package cli
 import (
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/aws/copilot-cli/internal/pkg/deploy"
 	"github.com/aws/copilot-cli/internal/pkg/term/color"
+	"github.com/spf13/afero"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ssm"
@@ -58,9 +60,14 @@ type pipelineStatusOpts struct {
 }
 
 func newPipelineStatusOpts(vars pipelineStatusVars) (*pipelineStatusOpts, error) {
-	ws, err := workspace.New()
+	fs := &afero.Afero{Fs: afero.NewOsFs()}
+	workingDir, err := os.Getwd()
 	if err != nil {
-		return nil, fmt.Errorf("new workspace client: %w", err)
+		return nil, fmt.Errorf("get working directory: %w", err)
+	}
+	ws, err := workspace.Use(fs, workingDir)
+	if err != nil {
+		return nil, err
 	}
 
 	session, err := sessions.ImmutableProvider(sessions.UserAgentExtras("pipeline status")).Default()

--- a/internal/pkg/cli/pipeline_status.go
+++ b/internal/pkg/cli/pipeline_status.go
@@ -6,7 +6,6 @@ package cli
 import (
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/aws/copilot-cli/internal/pkg/deploy"
 	"github.com/aws/copilot-cli/internal/pkg/term/color"
@@ -60,12 +59,7 @@ type pipelineStatusOpts struct {
 }
 
 func newPipelineStatusOpts(vars pipelineStatusVars) (*pipelineStatusOpts, error) {
-	fs := &afero.Afero{Fs: afero.NewOsFs()}
-	workingDir, err := os.Getwd()
-	if err != nil {
-		return nil, fmt.Errorf("get working directory: %w", err)
-	}
-	ws, err := workspace.Use(fs, workingDir)
+	ws, err := workspace.Use(afero.NewOsFs())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/cli/secret_init.go
+++ b/internal/pkg/cli/secret_init.go
@@ -87,12 +87,12 @@ func newSecretInitOpts(vars secretInitVars) (*secretInitOpts, error) {
 	if err != nil {
 		return nil, err
 	}
-	fs := &afero.Afero{Fs: afero.NewOsFs()}
+	fs := afero.NewOsFs()
 	workingDir, err := os.Getwd()
 	if err != nil {
 		return nil, fmt.Errorf("get working directory: %w", err)
 	}
-	ws, err := workspace.Use(fs, workingDir)
+	ws, err := workspace.Use(afero.NewOsFs(), workingDir)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/cli/secret_init.go
+++ b/internal/pkg/cli/secret_init.go
@@ -6,7 +6,6 @@ package cli
 import (
 	"errors"
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 
@@ -88,11 +87,7 @@ func newSecretInitOpts(vars secretInitVars) (*secretInitOpts, error) {
 		return nil, err
 	}
 	fs := afero.NewOsFs()
-	workingDir, err := os.Getwd()
-	if err != nil {
-		return nil, fmt.Errorf("get working directory: %w", err)
-	}
-	ws, err := workspace.Use(afero.NewOsFs(), workingDir)
+	ws, err := workspace.Use(afero.NewOsFs())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/cli/storage_init.go
+++ b/internal/pkg/cli/storage_init.go
@@ -196,7 +196,7 @@ func newStorageInitOpts(vars initStorageVars) (*initStorageOpts, error) {
 		return nil, err
 	}
 
-	fs := &afero.Afero{Fs: afero.NewOsFs()}
+	fs := afero.NewOsFs()
 	workingDir, err := os.Getwd()
 	if err != nil {
 		return nil, fmt.Errorf("get working directory: %w", err)

--- a/internal/pkg/cli/storage_init.go
+++ b/internal/pkg/cli/storage_init.go
@@ -7,7 +7,6 @@ import (
 	"encoding"
 	"errors"
 	"fmt"
-	"os"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ssm"
@@ -197,11 +196,7 @@ func newStorageInitOpts(vars initStorageVars) (*initStorageOpts, error) {
 	}
 
 	fs := afero.NewOsFs()
-	workingDir, err := os.Getwd()
-	if err != nil {
-		return nil, fmt.Errorf("get working directory: %w", err)
-	}
-	ws, err := workspace.Use(fs, workingDir)
+	ws, err := workspace.Use(fs)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -5,7 +5,6 @@ package cli
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -74,11 +73,7 @@ type deploySvcOpts struct {
 }
 
 func newSvcDeployOpts(vars deployWkldVars) (*deploySvcOpts, error) {
-	workingDir, err := os.Getwd()
-	if err != nil {
-		return nil, fmt.Errorf("get working directory: %w", err)
-	}
-	ws, err := workspace.Use(afero.NewOsFs(), workingDir)
+	ws, err := workspace.Use(afero.NewOsFs())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -74,12 +74,11 @@ type deploySvcOpts struct {
 }
 
 func newSvcDeployOpts(vars deployWkldVars) (*deploySvcOpts, error) {
-	fs := &afero.Afero{Fs: afero.NewOsFs()}
 	workingDir, err := os.Getwd()
 	if err != nil {
 		return nil, fmt.Errorf("get working directory: %w", err)
 	}
-	ws, err := workspace.Use(fs, workingDir)
+	ws, err := workspace.Use(afero.NewOsFs(), workingDir)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -5,6 +5,7 @@ package cli
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -15,6 +16,7 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/aws/tags"
 	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation/stack"
 	"github.com/aws/copilot-cli/internal/pkg/template"
+	"github.com/spf13/afero"
 
 	"github.com/spf13/cobra"
 
@@ -72,9 +74,14 @@ type deploySvcOpts struct {
 }
 
 func newSvcDeployOpts(vars deployWkldVars) (*deploySvcOpts, error) {
-	ws, err := workspace.New()
+	fs := &afero.Afero{Fs: afero.NewOsFs()}
+	workingDir, err := os.Getwd()
 	if err != nil {
-		return nil, fmt.Errorf("new workspace: %w", err)
+		return nil, fmt.Errorf("get working directory: %w", err)
+	}
+	ws, err := workspace.Use(fs, workingDir)
+	if err != nil {
+		return nil, err
 	}
 
 	sessProvider := sessions.ImmutableProvider(sessions.UserAgentExtras("svc deploy"))

--- a/internal/pkg/cli/svc_init.go
+++ b/internal/pkg/cli/svc_init.go
@@ -157,11 +157,7 @@ type initSvcOpts struct {
 
 func newInitSvcOpts(vars initSvcVars) (*initSvcOpts, error) {
 	fs := afero.NewOsFs()
-	workingDir, err := os.Getwd()
-	if err != nil {
-		return nil, fmt.Errorf("get working directory: %w", err)
-	}
-	ws, err := workspace.Use(fs, workingDir)
+	ws, err := workspace.Use(fs)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/cli/svc_init.go
+++ b/internal/pkg/cli/svc_init.go
@@ -156,7 +156,7 @@ type initSvcOpts struct {
 }
 
 func newInitSvcOpts(vars initSvcVars) (*initSvcOpts, error) {
-	fs := &afero.Afero{Fs: afero.NewOsFs()}
+	fs := afero.NewOsFs()
 	workingDir, err := os.Getwd()
 	if err != nil {
 		return nil, fmt.Errorf("get working directory: %w", err)

--- a/internal/pkg/cli/svc_init.go
+++ b/internal/pkg/cli/svc_init.go
@@ -156,9 +156,14 @@ type initSvcOpts struct {
 }
 
 func newInitSvcOpts(vars initSvcVars) (*initSvcOpts, error) {
-	ws, err := workspace.New()
+	fs := &afero.Afero{Fs: afero.NewOsFs()}
+	workingDir, err := os.Getwd()
 	if err != nil {
-		return nil, fmt.Errorf("workspace cannot be created: %w", err)
+		return nil, fmt.Errorf("get working directory: %w", err)
+	}
+	ws, err := workspace.Use(fs, workingDir)
+	if err != nil {
+		return nil, err
 	}
 
 	sessProvider := sessions.ImmutableProvider(sessions.UserAgentExtras("svc init"))
@@ -183,7 +188,7 @@ func newInitSvcOpts(vars initSvcVars) (*initSvcOpts, error) {
 	opts := &initSvcOpts{
 		initSvcVars:  vars,
 		store:        store,
-		fs:           &afero.Afero{Fs: afero.NewOsFs()},
+		fs:           fs,
 		init:         initSvc,
 		prompt:       prompter,
 		sel:          selector.NewWorkspaceSelector(prompter, ws),

--- a/internal/pkg/cli/svc_list.go
+++ b/internal/pkg/cli/svc_list.go
@@ -36,12 +36,7 @@ type listSvcOpts struct {
 }
 
 func newListSvcOpts(vars listWkldVars) (*listSvcOpts, error) {
-	fs := &afero.Afero{Fs: afero.NewOsFs()}
-	workingDir, err := os.Getwd()
-	if err != nil {
-		return nil, fmt.Errorf("get working directory: %w", err)
-	}
-	ws, err := workspace.Use(fs, workingDir)
+	ws, err := workspace.Use(afero.NewOsFs())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/cli/svc_list.go
+++ b/internal/pkg/cli/svc_list.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/aws/copilot-cli/internal/pkg/aws/identity"
 	"github.com/aws/copilot-cli/internal/pkg/aws/sessions"
+	"github.com/spf13/afero"
 
 	"github.com/aws/copilot-cli/internal/pkg/cli/list"
 	"github.com/aws/copilot-cli/internal/pkg/config"
@@ -35,7 +36,12 @@ type listSvcOpts struct {
 }
 
 func newListSvcOpts(vars listWkldVars) (*listSvcOpts, error) {
-	ws, err := workspace.New()
+	fs := &afero.Afero{Fs: afero.NewOsFs()}
+	workingDir, err := os.Getwd()
+	if err != nil {
+		return nil, fmt.Errorf("get working directory: %w", err)
+	}
+	ws, err := workspace.Use(fs, workingDir)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/cli/svc_package.go
+++ b/internal/pkg/cli/svc_package.go
@@ -72,9 +72,14 @@ type packageSvcOpts struct {
 }
 
 func newPackageSvcOpts(vars packageSvcVars) (*packageSvcOpts, error) {
-	ws, err := workspace.New()
+	fs := &afero.Afero{Fs: afero.NewOsFs()}
+	workingDir, err := os.Getwd()
 	if err != nil {
-		return nil, fmt.Errorf("new workspace: %w", err)
+		return nil, fmt.Errorf("get working directory: %w", err)
+	}
+	ws, err := workspace.Use(fs, workingDir)
+	if err != nil {
+		return nil, err
 	}
 
 	sessProvider := sessions.ImmutableProvider(sessions.UserAgentExtras("svc package"))
@@ -89,7 +94,7 @@ func newPackageSvcOpts(vars packageSvcVars) (*packageSvcOpts, error) {
 		packageSvcVars:    vars,
 		store:             store,
 		ws:                ws,
-		fs:                &afero.Afero{Fs: afero.NewOsFs()},
+		fs:                fs,
 		unmarshal:         manifest.UnmarshalWorkload,
 		runner:            exec.NewCmd(),
 		sel:               selector.NewLocalWorkloadSelector(prompter, store, ws),

--- a/internal/pkg/cli/svc_package.go
+++ b/internal/pkg/cli/svc_package.go
@@ -73,11 +73,7 @@ type packageSvcOpts struct {
 
 func newPackageSvcOpts(vars packageSvcVars) (*packageSvcOpts, error) {
 	fs := afero.NewOsFs()
-	workingDir, err := os.Getwd()
-	if err != nil {
-		return nil, fmt.Errorf("get working directory: %w", err)
-	}
-	ws, err := workspace.Use(fs, workingDir)
+	ws, err := workspace.Use(fs)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/cli/svc_package.go
+++ b/internal/pkg/cli/svc_package.go
@@ -72,7 +72,7 @@ type packageSvcOpts struct {
 }
 
 func newPackageSvcOpts(vars packageSvcVars) (*packageSvcOpts, error) {
-	fs := &afero.Afero{Fs: afero.NewOsFs()}
+	fs := afero.NewOsFs()
 	workingDir, err := os.Getwd()
 	if err != nil {
 		return nil, fmt.Errorf("get working directory: %w", err)

--- a/internal/pkg/cli/task_delete.go
+++ b/internal/pkg/cli/task_delete.go
@@ -75,12 +75,7 @@ type deleteTaskOpts struct {
 }
 
 func newDeleteTaskOpts(vars deleteTaskVars) (*deleteTaskOpts, error) {
-	fs := afero.NewOsFs()
-	workingDir, err := os.Getwd()
-	if err != nil {
-		return nil, fmt.Errorf("get working directory: %w", err)
-	}
-	ws, err := workspace.Use(fs, workingDir)
+	ws, err := workspace.Use(afero.NewOsFs())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/cli/task_delete.go
+++ b/internal/pkg/cli/task_delete.go
@@ -75,7 +75,7 @@ type deleteTaskOpts struct {
 }
 
 func newDeleteTaskOpts(vars deleteTaskVars) (*deleteTaskOpts, error) {
-	fs := &afero.Afero{Fs: afero.NewOsFs()}
+	fs := afero.NewOsFs()
 	workingDir, err := os.Getwd()
 	if err != nil {
 		return nil, fmt.Errorf("get working directory: %w", err)

--- a/internal/pkg/cli/task_delete.go
+++ b/internal/pkg/cli/task_delete.go
@@ -9,6 +9,7 @@ import (
 	"os"
 
 	"github.com/aws/copilot-cli/internal/pkg/aws/s3"
+	"github.com/spf13/afero"
 
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/aws/copilot-cli/internal/pkg/aws/identity"
@@ -74,9 +75,14 @@ type deleteTaskOpts struct {
 }
 
 func newDeleteTaskOpts(vars deleteTaskVars) (*deleteTaskOpts, error) {
-	ws, err := workspace.New()
+	fs := &afero.Afero{Fs: afero.NewOsFs()}
+	workingDir, err := os.Getwd()
 	if err != nil {
-		return nil, fmt.Errorf("new workspace: %w", err)
+		return nil, fmt.Errorf("get working directory: %w", err)
+	}
+	ws, err := workspace.Use(fs, workingDir)
+	if err != nil {
+		return nil, err
 	}
 
 	sessProvider := sessions.ImmutableProvider(sessions.UserAgentExtras("task delete"))

--- a/internal/pkg/deploy/cloudformation/stack/lb_grpc_web_service_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/lb_grpc_web_service_integration_test.go
@@ -8,10 +8,12 @@ package stack_test
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"testing"
 
+	"github.com/spf13/afero"
 	"gopkg.in/yaml.v3"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -60,9 +62,15 @@ func TestGrpcLoadBalancedWebService_Template(t *testing.T) {
 		v, ok := content.(*manifest.LoadBalancedWebService)
 		require.True(t, ok)
 
-		ws, err := workspace.New()
+		// Create in-memory mock file system.
+		wd, err := os.Getwd()
+		require.NoError(t, err)
+		fs := afero.NewMemMapFs()
+		_ = fs.MkdirAll(fmt.Sprintf("%s/copilot", wd), 0755)
+		_ = afero.WriteFile(fs, fmt.Sprintf("%s/copilot/.workspace", wd), []byte(fmt.Sprintf("---\napplication: %s", "DavidsApp")), 0644)
 		require.NoError(t, err)
 
+		ws, err := workspace.Use(fs)
 		_, err = addon.Parse(aws.StringValue(v.Name), ws)
 		var notFound *addon.ErrAddonsNotFound
 		require.ErrorAs(t, err, &notFound)

--- a/internal/pkg/deploy/cloudformation/stack/lb_network_web_service_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/lb_network_web_service_integration_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation/stack"
 	"github.com/aws/copilot-cli/internal/pkg/manifest"
 	"github.com/aws/copilot-cli/internal/pkg/workspace"
+	"github.com/spf13/afero"
 
 	"github.com/stretchr/testify/require"
 )
@@ -80,7 +81,15 @@ func TestNetworkLoadBalancedWebService_Template(t *testing.T) {
 		v, ok := content.(*manifest.LoadBalancedWebService)
 		require.True(t, ok)
 
-		ws, err := workspace.New()
+		// Create in-memory mock file system.
+		wd, err := os.Getwd()
+		require.NoError(t, err)
+		fs := afero.NewMemMapFs()
+		_ = fs.MkdirAll(fmt.Sprintf("%s/copilot", wd), 0755)
+		_ = afero.WriteFile(fs, fmt.Sprintf("%s/copilot/.workspace", wd), []byte(fmt.Sprintf("---\napplication: %s", "DavidsApp")), 0644)
+		require.NoError(t, err)
+
+		ws, err := workspace.Use(fs)
 		require.NoError(t, err)
 
 		_, err = addon.Parse(aws.StringValue(v.Name), ws)

--- a/internal/pkg/deploy/cloudformation/stack/lb_web_service_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/lb_web_service_integration_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/config"
 	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation/stack"
 	"github.com/aws/copilot-cli/internal/pkg/workspace"
+	"github.com/spf13/afero"
 	"gopkg.in/yaml.v3"
 
 	"github.com/aws/copilot-cli/internal/pkg/manifest"
@@ -80,7 +81,15 @@ func TestLoadBalancedWebService_TemplateInteg(t *testing.T) {
 		v, ok := content.(*manifest.LoadBalancedWebService)
 		require.True(t, ok)
 
-		ws, err := workspace.New()
+		// Create in-memory mock file system.
+		wd, err := os.Getwd()
+		require.NoError(t, err)
+		fs := afero.NewMemMapFs()
+		_ = fs.MkdirAll(fmt.Sprintf("%s/copilot", wd), 0755)
+		_ = afero.WriteFile(fs, fmt.Sprintf("%s/copilot/.workspace", wd), []byte(fmt.Sprintf("---\napplication: %s", "DavidsApp")), 0644)
+		require.NoError(t, err)
+
+		ws, err := workspace.Use(fs)
 		require.NoError(t, err)
 
 		_, err = addon.Parse(aws.StringValue(v.Name), ws)

--- a/internal/pkg/deploy/cloudformation/stack/rd_web_svc_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/rd_web_svc_integration_test.go
@@ -6,7 +6,9 @@
 package stack_test
 
 import (
+	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -19,6 +21,7 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation/stack"
 	"github.com/aws/copilot-cli/internal/pkg/manifest"
 	"github.com/aws/copilot-cli/internal/pkg/workspace"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
 )
 
@@ -55,7 +58,15 @@ func TestRDWS_Template(t *testing.T) {
 		v, ok := content.(*manifest.RequestDrivenWebService)
 		require.True(t, ok)
 
-		ws, err := workspace.New()
+		// Create in-memory mock file system.
+		wd, err := os.Getwd()
+		require.NoError(t, err)
+		fs := afero.NewMemMapFs()
+		_ = fs.MkdirAll(fmt.Sprintf("%s/copilot", wd), 0755)
+		_ = afero.WriteFile(fs, fmt.Sprintf("%s/copilot/.workspace", wd), []byte(fmt.Sprintf("---\napplication: %s", "DavidsApp")), 0644)
+		require.NoError(t, err)
+
+		ws, err := workspace.Use(fs)
 		require.NoError(t, err)
 
 		_, err = addon.Parse(aws.StringValue(v.Name), ws)

--- a/internal/pkg/deploy/cloudformation/stack/scheduled_job_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/scheduled_job_integration_test.go
@@ -6,7 +6,12 @@
 package stack_test
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/aws/copilot-cli/internal/pkg/config"
+	"github.com/spf13/afero"
+
 	"io/ioutil"
 	"path/filepath"
 	"testing"
@@ -47,7 +52,15 @@ func TestScheduledJob_Template(t *testing.T) {
 	v, ok := content.(*manifest.ScheduledJob)
 	require.True(t, ok)
 
-	ws, err := workspace.New()
+	// Create in-memory mock file system.
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	fs := afero.NewMemMapFs()
+	_ = fs.MkdirAll(fmt.Sprintf("%s/copilot", wd), 0755)
+	_ = afero.WriteFile(fs, fmt.Sprintf("%s/copilot/.workspace", wd), []byte(fmt.Sprintf("---\napplication: %s", "DavidsApp")), 0644)
+	require.NoError(t, err)
+
+	ws, err := workspace.Use(fs)
 	require.NoError(t, err)
 
 	_, err = addon.Parse(aws.StringValue(v.Name), ws)

--- a/internal/pkg/deploy/cloudformation/stack/windows_lb_web_service_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/windows_lb_web_service_integration_test.go
@@ -8,6 +8,7 @@ package stack_test
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"testing"
@@ -18,6 +19,7 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/config"
 	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation/stack"
 	"github.com/aws/copilot-cli/internal/pkg/workspace"
+	"github.com/spf13/afero"
 	"gopkg.in/yaml.v3"
 
 	"github.com/aws/copilot-cli/internal/pkg/manifest"
@@ -48,7 +50,15 @@ func TestWindowsLoadBalancedWebService_Template(t *testing.T) {
 	v, ok := content.(*manifest.LoadBalancedWebService)
 	require.True(t, ok)
 
-	ws, err := workspace.New()
+	// Create in-memory mock file system.
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	fs := afero.NewMemMapFs()
+	_ = fs.MkdirAll(fmt.Sprintf("%s/copilot", wd), 0755)
+	_ = afero.WriteFile(fs, fmt.Sprintf("%s/copilot/.workspace", wd), []byte(fmt.Sprintf("---\napplication: %s", "DavidsApp")), 0644)
+	require.NoError(t, err)
+
+	ws, err := workspace.Use(fs)
 	require.NoError(t, err)
 
 	_, err = addon.Parse(aws.StringValue(v.Name), ws)

--- a/internal/pkg/workspace/errors.go
+++ b/internal/pkg/workspace/errors.go
@@ -44,10 +44,10 @@ func (e *ErrWorkspaceNotFound) Error() string {
 		e.CurrentDirectory)
 }
 
-// errNoAssociatedApplication means we couldn't locate a workspace summary file.
-type errNoAssociatedApplication struct{}
+// ErrNoAssociatedApplication means we couldn't locate a workspace summary file.
+type ErrNoAssociatedApplication struct{}
 
-func (e *errNoAssociatedApplication) Error() string {
+func (e *ErrNoAssociatedApplication) Error() string {
 	return "couldn't find an application associated with this workspace"
 }
 

--- a/internal/pkg/workspace/workspace.go
+++ b/internal/pkg/workspace/workspace.go
@@ -92,7 +92,7 @@ func Use(fs afero.Fs) (*Workspace, error) {
 	return ws, nil
 }
 
-// Create creates a new *Workspace in the current working directory for appName if it doesn't already exist.
+// Create creates a new Workspace in the current working directory for appName with summary if it doesn't already exist.
 func Create(appName string, fs afero.Fs) (*Workspace, error) {
 	workingDirAbs, err := os.Getwd()
 	if err != nil {
@@ -533,10 +533,6 @@ func (ws *Workspace) Rel(path string) (string, error) {
 
 // copilotDirPath tries to find the current app's copilot directory from the workspace working directory.
 func (ws *Workspace) copilotDirPath() (string, error) {
-	if ws.copilotDirAbs != "" {
-		return ws.copilotDirAbs, nil
-	}
-
 	// Are we in the application's copilot directory already?
 	//
 	// Note: This code checks for *any* directory named "copilot", but this might not work
@@ -544,8 +540,7 @@ func (ws *Workspace) copilotDirPath() (string, error) {
 	// to name "copilot". It's not clear if there's a good way to avoid that problem, though it
 	// doesn't seem to be a terribly likely issue.
 	if filepath.Base(ws.workingDirAbs) == CopilotDirName {
-		ws.copilotDirAbs = ws.workingDirAbs
-		return ws.copilotDirAbs, nil
+		return ws.workingDirAbs, nil
 	}
 
 	// We might be in the application directory or in a subdirectory of the application
@@ -561,8 +556,7 @@ func (ws *Workspace) copilotDirPath() (string, error) {
 			return "", err
 		}
 		if inCurrentDirPath {
-			ws.copilotDirAbs = currentDirectoryPath
-			return ws.copilotDirAbs, nil
+			return currentDirectoryPath, nil
 		}
 		searchingDir = filepath.Dir(searchingDir)
 	}

--- a/internal/pkg/workspace/workspace.go
+++ b/internal/pkg/workspace/workspace.go
@@ -88,26 +88,6 @@ func Use(fs *afero.Afero, workingDirAbs string) (*Workspace, error) {
 	return ws, nil
 }
 
-// New returns a workspace, used for reading and writing to user's local workspace.
-func New() (*Workspace, error) {
-	fs := afero.NewOsFs()
-	fsUtils := &afero.Afero{Fs: fs}
-	logger := log.Infof
-
-	workingDirAbs, err := os.Getwd()
-	if err != nil {
-		return nil, err
-	}
-
-	ws := Workspace{
-		workingDirAbs: workingDirAbs,
-		fs:            fsUtils,
-		logger:        logger,
-	}
-
-	return &ws, nil
-}
-
 // Create creates a new *Workspace in the current working directory for appName if it doesn't already exist.
 func Create(appName string, fs *afero.Afero, workingDirAbs string) (*Workspace, error) {
 	ws := &Workspace{
@@ -155,38 +135,6 @@ func Create(appName string, fs *afero.Afero, workingDirAbs string) (*Workspace, 
 	}
 
 	return ws, nil
-}
-
-// Create creates the copilot directory (if it doesn't already exist) in the current working directory,
-// and saves a summary with the application name.
-func (ws *Workspace) Create(appName string) error {
-	// Create an application directory, if one doesn't exist
-	if _, err := ws.createCopilotDir(); err != nil {
-		return err
-	}
-
-	// Grab an existing workspace summary, if one exists.
-	summary, err := ws.Summary()
-	if err == nil {
-		// If a summary exists, but is registered to a different application, throw an error.
-		if summary.Application != appName {
-			return &errHasExistingApplication{
-				existingAppName: summary.Application,
-				basePath:        ws.workingDirAbs,
-				summaryPath:     summary.Path,
-			}
-		}
-		// Otherwise our work is all done.
-		return nil
-	}
-
-	// If there isn't an existing workspace summary, create it.
-	var notFound *ErrNoAssociatedApplication
-	if errors.As(err, &notFound) {
-		return ws.writeSummary(appName)
-	}
-
-	return err
 }
 
 // Summary returns a summary of the workspace. The method assumes that the workspace exists and the path is known.

--- a/internal/pkg/workspace/workspace.go
+++ b/internal/pkg/workspace/workspace.go
@@ -138,7 +138,7 @@ func Create(appName string, fs *afero.Afero, workingDirAbs string) (*Workspace, 
 			// Otherwise our work is all done.
 			return ws, nil
 		}
-		var notFound *errNoAssociatedApplication
+		var notFound *ErrNoAssociatedApplication
 		if !errors.As(err, &notFound) {
 			return nil, err
 		}
@@ -181,7 +181,7 @@ func (ws *Workspace) Create(appName string) error {
 	}
 
 	// If there isn't an existing workspace summary, create it.
-	var notFound *errNoAssociatedApplication
+	var notFound *ErrNoAssociatedApplication
 	if errors.As(err, &notFound) {
 		return ws.writeSummary(appName)
 	}
@@ -203,7 +203,7 @@ func (ws *Workspace) Summary() (*Summary, error) {
 		}
 		return &wsSummary, yaml.Unmarshal(value, &wsSummary)
 	}
-	return nil, &errNoAssociatedApplication{}
+	return nil, &ErrNoAssociatedApplication{}
 }
 
 // ListServices returns the names of the services in the workspace.

--- a/internal/pkg/workspace/workspace.go
+++ b/internal/pkg/workspace/workspace.go
@@ -72,6 +72,22 @@ type Workspace struct {
 	logger        func(format string, args ...interface{})
 }
 
+// Use returns an existing workspace, searching for a copilot/ directory from the current wd,
+// up to 5 levels above. It returns ErrWorkspaceNotFound if no copilot/ directory is found.
+func Use(fs *afero.Afero, workingDirAbs string) (*Workspace, error) {
+	ws := &Workspace{
+		workingDirAbs: workingDirAbs,
+		fs:            fs,
+		logger:        log.Infof,
+	}
+	copilotDirPath, err := ws.copilotDirPath()
+	if err != nil {
+		return nil, err
+	}
+	ws.copilotDirAbs = copilotDirPath
+	return ws, nil
+}
+
 // New returns a workspace, used for reading and writing to user's local workspace.
 func New() (*Workspace, error) {
 	fs := afero.NewOsFs()

--- a/internal/pkg/workspace/workspace.go
+++ b/internal/pkg/workspace/workspace.go
@@ -124,13 +124,10 @@ func (ws *Workspace) Create(appName string) error {
 	return err
 }
 
-// Summary returns a summary of the workspace - including the application name.
+// Summary returns a summary of the workspace. The method assumes that the workspace exists and the path is known.
 func (ws *Workspace) Summary() (*Summary, error) {
-	summaryPath, err := ws.summaryPath()
-	if err != nil {
-		return nil, err
-	}
-	summaryFileExists, _ := ws.fs.Exists(summaryPath) // If an err occurs, return no applications.
+	summaryPath := filepath.Join(ws.copilotDirAbs, SummaryFileName) // Assume `copilotDirAbs` is always present.
+	summaryFileExists, _ := ws.fs.Exists(summaryPath)               // If an err occurs, return no applications.
 	if summaryFileExists {
 		value, err := ws.fs.ReadFile(summaryPath)
 		if err != nil {

--- a/internal/pkg/workspace/workspace.go
+++ b/internal/pkg/workspace/workspace.go
@@ -74,7 +74,11 @@ type Workspace struct {
 
 // Use returns an existing workspace, searching for a copilot/ directory from the current wd,
 // up to 5 levels above. It returns ErrWorkspaceNotFound if no copilot/ directory is found.
-func Use(fs afero.Fs, workingDirAbs string) (*Workspace, error) {
+func Use(fs afero.Fs) (*Workspace, error) {
+	workingDirAbs, err := os.Getwd()
+	if err != nil {
+		return nil, fmt.Errorf("get working directory: %w", err)
+	}
 	ws := &Workspace{
 		workingDirAbs: workingDirAbs,
 		fs:            &afero.Afero{Fs: fs},
@@ -89,7 +93,11 @@ func Use(fs afero.Fs, workingDirAbs string) (*Workspace, error) {
 }
 
 // Create creates a new *Workspace in the current working directory for appName if it doesn't already exist.
-func Create(appName string, fs afero.Fs, workingDirAbs string) (*Workspace, error) {
+func Create(appName string, fs afero.Fs) (*Workspace, error) {
+	workingDirAbs, err := os.Getwd()
+	if err != nil {
+		return nil, fmt.Errorf("get working directory: %w", err)
+	}
 	ws := &Workspace{
 		workingDirAbs: workingDirAbs,
 		fs:            &afero.Afero{Fs: fs},

--- a/internal/pkg/workspace/workspace.go
+++ b/internal/pkg/workspace/workspace.go
@@ -74,10 +74,10 @@ type Workspace struct {
 
 // Use returns an existing workspace, searching for a copilot/ directory from the current wd,
 // up to 5 levels above. It returns ErrWorkspaceNotFound if no copilot/ directory is found.
-func Use(fs *afero.Afero, workingDirAbs string) (*Workspace, error) {
+func Use(fs afero.Fs, workingDirAbs string) (*Workspace, error) {
 	ws := &Workspace{
 		workingDirAbs: workingDirAbs,
-		fs:            fs,
+		fs:            &afero.Afero{Fs: fs},
 		logger:        log.Infof,
 	}
 	copilotDirPath, err := ws.copilotDirPath()
@@ -89,10 +89,10 @@ func Use(fs *afero.Afero, workingDirAbs string) (*Workspace, error) {
 }
 
 // Create creates a new *Workspace in the current working directory for appName if it doesn't already exist.
-func Create(appName string, fs *afero.Afero, workingDirAbs string) (*Workspace, error) {
+func Create(appName string, fs afero.Fs, workingDirAbs string) (*Workspace, error) {
 	ws := &Workspace{
 		workingDirAbs: workingDirAbs,
-		fs:            fs,
+		fs:            &afero.Afero{Fs: fs},
 		logger:        log.Infof,
 	}
 

--- a/internal/pkg/workspace/workspace.go
+++ b/internal/pkg/workspace/workspace.go
@@ -96,7 +96,7 @@ func New() (*Workspace, error) {
 // and saves a summary with the application name.
 func (ws *Workspace) Create(appName string) error {
 	// Create an application directory, if one doesn't exist
-	if err := ws.createCopilotDir(); err != nil {
+	if _, err := ws.createCopilotDir(); err != nil {
 		return err
 	}
 
@@ -536,13 +536,16 @@ func (ws *Workspace) summaryPath() (string, error) {
 	return workspaceSummaryPath, nil
 }
 
-func (ws *Workspace) createCopilotDir() error {
+func (ws *Workspace) createCopilotDir() (string, error) {
 	// First check to see if a manifest directory already exists
 	existingWorkspace, _ := ws.copilotDirPath()
 	if existingWorkspace != "" {
-		return nil
+		return existingWorkspace, nil
 	}
-	return ws.fs.Mkdir(CopilotDirName, 0755)
+	if err := ws.fs.Mkdir(CopilotDirName, 0755); err != nil {
+		return "", err
+	}
+	return filepath.Join(ws.workingDirAbs, CopilotDirName), nil
 }
 
 // Path returns the absolute path to the workspace.

--- a/internal/pkg/workspace/workspace.go
+++ b/internal/pkg/workspace/workspace.go
@@ -569,11 +569,7 @@ func (ws *Workspace) copilotDirPath() (string, error) {
 
 // write flushes the data to a file under the copilot directory joined by path elements.
 func (ws *Workspace) write(data []byte, elem ...string) (string, error) {
-	copilotPath, err := ws.copilotDirPath()
-	if err != nil {
-		return "", err
-	}
-	pathElems := append([]string{copilotPath}, elem...)
+	pathElems := append([]string{ws.copilotDirAbs}, elem...)
 	filename := filepath.Join(pathElems...)
 
 	if err := ws.fs.MkdirAll(filepath.Dir(filename), 0755 /* -rwxr-xr-x */); err != nil {
@@ -594,11 +590,7 @@ func (ws *Workspace) write(data []byte, elem ...string) (string, error) {
 
 // read returns the contents of the file under the copilot directory joined by path elements.
 func (ws *Workspace) read(elem ...string) ([]byte, error) {
-	copilotPath, err := ws.copilotDirPath()
-	if err != nil {
-		return nil, err
-	}
-	pathElems := append([]string{copilotPath}, elem...)
+	pathElems := append([]string{ws.copilotDirAbs}, elem...)
 	filename := filepath.Join(pathElems...)
 	exist, err := ws.fs.Exists(filename)
 	if err != nil {

--- a/internal/pkg/workspace/workspace_test.go
+++ b/internal/pkg/workspace/workspace_test.go
@@ -144,7 +144,7 @@ func TestWorkspace_Summary(t *testing.T) {
 			mockFileSystem: func(fs afero.Fs) {
 				fs.MkdirAll("test/copilot", 0755)
 			},
-			expectedError: &errNoAssociatedApplication{},
+			expectedError: &ErrNoAssociatedApplication{},
 		},
 	}
 	for name, tc := range testCases {

--- a/internal/pkg/workspace/workspace_test.go
+++ b/internal/pkg/workspace/workspace_test.go
@@ -210,8 +210,7 @@ func TestWorkspace_Create(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			// Set up filesystem.
-			fs := &afero.Afero{Fs: tc.mockFileSystem()}
-			gotWS, err := Create(tc.appName, fs, tc.workingDir)
+			gotWS, err := Create(tc.appName, tc.mockFileSystem(), tc.workingDir)
 			if tc.expectedError == nil {
 				// an operation not permitted error means
 				// we tried to write to the filesystem, but
@@ -222,7 +221,7 @@ func TestWorkspace_Create(t *testing.T) {
 				require.Equal(t, tc.expectedCopilotDirAbs, gotWS.copilotDirAbs)
 
 				// Validate that the workspace dir is created.
-				exist, err := fs.Exists(tc.expectedCopilotDirAbs)
+				exist, err := gotWS.fs.Exists(tc.expectedCopilotDirAbs)
 				require.NoError(t, err)
 				require.True(t, exist)
 
@@ -299,8 +298,7 @@ func TestWorkspace_Use(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			// Set up filesystem.
-			fs := &afero.Afero{Fs: tc.mockFileSystem()}
-			gotWS, err := Use(fs, tc.workingDir)
+			gotWS, err := Use(tc.mockFileSystem(), tc.workingDir)
 			if tc.expectedError == nil {
 				// an operation not permitted error means
 				// we tried to write to the filesystem, but
@@ -311,7 +309,7 @@ func TestWorkspace_Use(t *testing.T) {
 				require.Equal(t, tc.expectedCopilotDirAbs, gotWS.copilotDirAbs)
 
 				// Validate that the workspace dir is there.
-				exist, err := fs.Exists(tc.expectedCopilotDirAbs)
+				exist, err := gotWS.fs.Exists(tc.expectedCopilotDirAbs)
 				require.NoError(t, err)
 				require.True(t, exist)
 

--- a/internal/pkg/workspace/workspace_test.go
+++ b/internal/pkg/workspace/workspace_test.go
@@ -148,7 +148,6 @@ func TestWorkspace_Create(t *testing.T) {
 	parent := filepath.Dir(wd)
 	testCases := map[string]struct {
 		appName        string
-		workingDir     string
 		mockFileSystem func() afero.Fs
 
 		expectedError         error
@@ -207,7 +206,7 @@ func TestWorkspace_Create(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			// Set up filesystem.
-			gotWS, err := Create(tc.appName, tc.mockFileSystem(), tc.workingDir)
+			gotWS, err := Create(tc.appName, tc.mockFileSystem())
 			if tc.expectedError == nil {
 				// an operation not permitted error means
 				// we tried to write to the filesystem, but
@@ -240,7 +239,6 @@ func TestWorkspace_Use(t *testing.T) {
 	parent := filepath.Dir(wd)
 	testCases := map[string]struct {
 		appName        string
-		workingDir     string
 		mockFileSystem func() afero.Fs
 
 		expectedError         error
@@ -293,7 +291,7 @@ func TestWorkspace_Use(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			// Set up filesystem.
-			gotWS, err := Use(tc.mockFileSystem(), tc.workingDir)
+			gotWS, err := Use(tc.mockFileSystem())
 			if tc.expectedError == nil {
 				// an operation not permitted error means
 				// we tried to write to the filesystem, but

--- a/internal/pkg/workspace/workspace_test.go
+++ b/internal/pkg/workspace/workspace_test.go
@@ -144,7 +144,7 @@ func TestWorkspace_Summary(t *testing.T) {
 			mockFileSystem: func(fs afero.Fs) {
 				fs.MkdirAll("test/copilot", 0755)
 			},
-			expectedError: fmt.Errorf("couldn't find an application associated with this workspace"),
+			expectedError: &errNoAssociatedApplication{},
 		},
 	}
 	for name, tc := range testCases {


### PR DESCRIPTION
This PR implements a new API for the `workspace` package. With the new API, a workspace client that gets returned to the caller always have the `copilotDirAbs` field in it. This means that the method calls can assume non-empty value of that field.
This addresses the proposal made in https://github.com/aws/copilot-cli/pull/4147#discussion_r1017019403

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
