### PR TITLE
fix: access logs bucket policy applied after ALB update

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-default-access-log-config.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-default-access-log-config.yml
@@ -710,6 +710,8 @@ Resources:
       IpProtocol: -1
       SourceSecurityGroupId: !Ref PublicHTTPSLoadBalancerSecurityGroup
   ELBAccessLogsBucket:
+    Metadata:
+      "aws:copilot:description": "A S3 bucket for the Load Balancer's access logs"
     Type: AWS::S3::Bucket
     Condition: CreateALB
     Properties:
@@ -770,6 +772,7 @@ Resources:
     Metadata:
       'aws:copilot:description': 'An Application Load Balancer to distribute public traffic to your services'
     Condition: CreateALB
+    DependsOn: ELBAccessLogsBucketPolicy
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
       LoadBalancerAttributes:

--- a/internal/pkg/template/templates/environment/cf.yml
+++ b/internal/pkg/template/templates/environment/cf.yml
@@ -300,6 +300,9 @@ Resources:
     Metadata:
       'aws:copilot:description': 'An Application Load Balancer to distribute public traffic to your services'
     Condition: CreateALB
+    {{- if .PublicHTTPConfig.ELBAccessLogs.ShouldCreateBucket}}
+    DependsOn: ELBAccessLogsBucketPolicy
+    {{- end}}
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
       {{- if .PublicHTTPConfig.ELBAccessLogs }}

--- a/internal/pkg/template/templates/environment/partials/elb-access-logs.yml
+++ b/internal/pkg/template/templates/environment/partials/elb-access-logs.yml
@@ -27,6 +27,8 @@ ELBAccessLogsBucketPolicy:
           Principal:
             AWS: !Join [ "", [ !Sub 'arn:${AWS::Partition}:iam::', !FindInMap [ RegionalConfigs, !Ref 'AWS::Region', ElbAccountId ], ":root" ] ]
 ELBAccessLogsBucket:
+  Metadata:
+    'aws:copilot:description': 'A S3 bucket for the Load Balancer's access logs'
   Type: AWS::S3::Bucket
   Condition: CreateALB
   Properties:

--- a/internal/pkg/template/templates/environment/partials/elb-access-logs.yml
+++ b/internal/pkg/template/templates/environment/partials/elb-access-logs.yml
@@ -28,7 +28,7 @@ ELBAccessLogsBucketPolicy:
             AWS: !Join [ "", [ !Sub 'arn:${AWS::Partition}:iam::', !FindInMap [ RegionalConfigs, !Ref 'AWS::Region', ElbAccountId ], ":root" ] ]
 ELBAccessLogsBucket:
   Metadata:
-    'aws:copilot:description': 'A S3 bucket for the Load Balancer's access logs'
+    "aws:copilot:description": "A S3 bucket for the Load Balancer's access logs"
   Type: AWS::S3::Bucket
   Condition: CreateALB
   Properties:


### PR DESCRIPTION
Previously, turning on [access logs](https://aws.github.io/copilot-cli/docs/manifest/environment/#http-public-access-logs) for the ALB would result in the error like:
```
Access Denied for bucket: app-env-elbaccesslogsbucket-1234. Please check S3bucket permission (Service: AmazonElasticLoadBalancing; Status Code: 400; Error Code: InvalidConfigurationRequest; Request ID: id; Proxy: null)
```

This is because Cloudformation would update the ALB's settings _before_ creating the bucket policy that allows the ALB to send logs to the bucket.

Now, we add an explicit dependency to the ALB on the bucket policy if access logs is enabled so that the policy is created/applied before attempting to put objects in the bucket. 

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
