### PR TITLE
chore: fix e2e and integration tests failed by 4166

### DIFF
--- a/internal/pkg/addon/addon_integration_test.go
+++ b/internal/pkg/addon/addon_integration_test.go
@@ -8,7 +8,7 @@ package addon_test
 import (
 	"encoding"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -84,7 +84,7 @@ func TestAddons(t *testing.T) {
 			cfActual := make(map[interface{}]interface{})
 			require.NoError(t, yaml.Unmarshal(actualBytes, cfActual))
 
-			expected, err := ioutil.ReadFile(filepath.Join("testdata", "storage", tc.outFileName))
+			expected, err := os.ReadFile(filepath.Join("testdata", "storage", tc.outFileName))
 			require.NoError(t, err, "should be able to read expected bytes")
 			expectedBytes := []byte(expected)
 			mExpected := make(map[interface{}]interface{})

--- a/internal/pkg/addon/addons.go
+++ b/internal/pkg/addon/addons.go
@@ -111,8 +111,8 @@ func (s *Stack) encode(v any) (string, error) {
 // If the addons directory doesn't exist or no yaml files are found in
 // the addons directory, it returns the empty string and
 // ErrAddonsNotFound.
-func parseTemplate(fnames []string, workloadName string, ws workspaceReader) (*cfnTemplate, error) {
-	templateFiles := filterFiles(fnames, yamlMatcher, nonParamsMatcher)
+func parseTemplate(fNames []string, workloadName string, ws workspaceReader) (*cfnTemplate, error) {
+	templateFiles := filterFiles(fNames, yamlMatcher, nonParamsMatcher)
 	if len(templateFiles) == 0 {
 		return nil, &ErrAddonsNotFound{
 			WlName: workloadName,
@@ -143,8 +143,8 @@ func parseTemplate(fnames []string, workloadName string, ws workspaceReader) (*c
 // If there are addons but no parameters file defined, then returns "" and nil for error.
 // If there are multiple parameters files, then returns "" and cannot define multiple parameter files error.
 // If the addons parameters use the reserved parameter names, then returns "" and a reserved parameter error.
-func parseParameters(fnames []string, workloadName string, ws workspaceReader) (yaml.Node, error) {
-	paramFiles := filterFiles(fnames, paramsMatcher)
+func parseParameters(fNames []string, workloadName string, ws workspaceReader) (yaml.Node, error) {
+	paramFiles := filterFiles(fNames, paramsMatcher)
 	if len(paramFiles) == 0 {
 		return yaml.Node{}, nil
 	}

--- a/internal/pkg/addon/addons_test.go
+++ b/internal/pkg/addon/addons_test.go
@@ -5,7 +5,7 @@ package addon
 
 import (
 	"errors"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -96,11 +96,11 @@ func TestTemplate(t *testing.T) {
 				m.ws.EXPECT().WorkloadAddonsPath(testSvcName).Return("mockPath")
 				m.ws.EXPECT().ListFiles("mockPath").Return([]string{"first.yaml", "invalid-metadata.yaml"}, nil)
 
-				first, _ := ioutil.ReadFile(filepath.Join("testdata", "merge", "first.yaml"))
+				first, _ := os.ReadFile(filepath.Join("testdata", "merge", "first.yaml"))
 				m.ws.EXPECT().WorkloadAddonFilePath(testSvcName, "first.yaml").Return("mockPath")
 				m.ws.EXPECT().ReadFile("mockPath").Return(first, nil)
 
-				second, _ := ioutil.ReadFile(filepath.Join("testdata", "merge", "invalid-metadata.yaml"))
+				second, _ := os.ReadFile(filepath.Join("testdata", "merge", "invalid-metadata.yaml"))
 				m.ws.EXPECT().WorkloadAddonFilePath(testSvcName, "invalid-metadata.yaml").Return("mockPath")
 				m.ws.EXPECT().ReadFile("mockPath").Return(second, nil)
 			},
@@ -112,11 +112,11 @@ func TestTemplate(t *testing.T) {
 				m.ws.EXPECT().WorkloadAddonsPath(testSvcName).Return("mockPath")
 				m.ws.EXPECT().ListFiles("mockPath").Return([]string{"first.yaml", "invalid-parameters.yaml"}, nil)
 
-				first, _ := ioutil.ReadFile(filepath.Join("testdata", "merge", "first.yaml"))
+				first, _ := os.ReadFile(filepath.Join("testdata", "merge", "first.yaml"))
 				m.ws.EXPECT().WorkloadAddonFilePath(testSvcName, "first.yaml").Return("mockPath")
 				m.ws.EXPECT().ReadFile("mockPath").Return(first, nil)
 
-				second, _ := ioutil.ReadFile(filepath.Join("testdata", "merge", "invalid-parameters.yaml"))
+				second, _ := os.ReadFile(filepath.Join("testdata", "merge", "invalid-parameters.yaml"))
 				m.ws.EXPECT().WorkloadAddonFilePath(testSvcName, "invalid-parameters.yaml").Return("mockPath")
 				m.ws.EXPECT().ReadFile("mockPath").Return(second, nil)
 			},
@@ -128,11 +128,11 @@ func TestTemplate(t *testing.T) {
 				m.ws.EXPECT().WorkloadAddonsPath(testSvcName).Return("mockPath")
 				m.ws.EXPECT().ListFiles("mockPath").Return([]string{"first.yaml", "invalid-mappings.yaml"}, nil)
 
-				first, _ := ioutil.ReadFile(filepath.Join("testdata", "merge", "first.yaml"))
+				first, _ := os.ReadFile(filepath.Join("testdata", "merge", "first.yaml"))
 				m.ws.EXPECT().WorkloadAddonFilePath(testSvcName, "first.yaml").Return("mockPath")
 				m.ws.EXPECT().ReadFile("mockPath").Return(first, nil)
 
-				second, _ := ioutil.ReadFile(filepath.Join("testdata", "merge", "invalid-mappings.yaml"))
+				second, _ := os.ReadFile(filepath.Join("testdata", "merge", "invalid-mappings.yaml"))
 				m.ws.EXPECT().WorkloadAddonFilePath(testSvcName, "invalid-mappings.yaml").Return("mockPath")
 				m.ws.EXPECT().ReadFile("mockPath").Return(second, nil)
 			},
@@ -144,11 +144,11 @@ func TestTemplate(t *testing.T) {
 				m.ws.EXPECT().WorkloadAddonsPath(testSvcName).Return("mockPath")
 				m.ws.EXPECT().ListFiles("mockPath").Return([]string{"first.yaml", "invalid-conditions.yaml"}, nil)
 
-				first, _ := ioutil.ReadFile(filepath.Join("testdata", "merge", "first.yaml"))
+				first, _ := os.ReadFile(filepath.Join("testdata", "merge", "first.yaml"))
 				m.ws.EXPECT().WorkloadAddonFilePath(testSvcName, "first.yaml").Return("mockPath")
 				m.ws.EXPECT().ReadFile("mockPath").Return(first, nil)
 
-				second, _ := ioutil.ReadFile(filepath.Join("testdata", "merge", "invalid-conditions.yaml"))
+				second, _ := os.ReadFile(filepath.Join("testdata", "merge", "invalid-conditions.yaml"))
 				m.ws.EXPECT().WorkloadAddonFilePath(testSvcName, "invalid-conditions.yaml").Return("mockPath")
 				m.ws.EXPECT().ReadFile("mockPath").Return(second, nil)
 			},
@@ -160,11 +160,11 @@ func TestTemplate(t *testing.T) {
 				m.ws.EXPECT().WorkloadAddonsPath(testSvcName).Return("mockPath")
 				m.ws.EXPECT().ListFiles("mockPath").Return([]string{"first.yaml", "invalid-resources.yaml"}, nil)
 
-				first, _ := ioutil.ReadFile(filepath.Join("testdata", "merge", "first.yaml"))
+				first, _ := os.ReadFile(filepath.Join("testdata", "merge", "first.yaml"))
 				m.ws.EXPECT().WorkloadAddonFilePath(testSvcName, "first.yaml").Return("mockPath")
 				m.ws.EXPECT().ReadFile("mockPath").Return(first, nil)
 
-				second, _ := ioutil.ReadFile(filepath.Join("testdata", "merge", "invalid-resources.yaml"))
+				second, _ := os.ReadFile(filepath.Join("testdata", "merge", "invalid-resources.yaml"))
 				m.ws.EXPECT().WorkloadAddonFilePath(testSvcName, "invalid-resources.yaml").Return("mockPath")
 				m.ws.EXPECT().ReadFile("mockPath").Return(second, nil)
 			},
@@ -176,11 +176,11 @@ func TestTemplate(t *testing.T) {
 				m.ws.EXPECT().WorkloadAddonsPath(testSvcName).Return("mockPath")
 				m.ws.EXPECT().ListFiles("mockPath").Return([]string{"first.yaml", "invalid-outputs.yaml"}, nil)
 
-				first, _ := ioutil.ReadFile(filepath.Join("testdata", "merge", "first.yaml"))
+				first, _ := os.ReadFile(filepath.Join("testdata", "merge", "first.yaml"))
 				m.ws.EXPECT().WorkloadAddonFilePath(testSvcName, "first.yaml").Return("mockPath")
 				m.ws.EXPECT().ReadFile("mockPath").Return(first, nil)
 
-				second, _ := ioutil.ReadFile(filepath.Join("testdata", "merge", "invalid-outputs.yaml"))
+				second, _ := os.ReadFile(filepath.Join("testdata", "merge", "invalid-outputs.yaml"))
 				m.ws.EXPECT().WorkloadAddonFilePath(testSvcName, "invalid-outputs.yaml").Return("mockPath")
 				m.ws.EXPECT().ReadFile("mockPath").Return(second, nil)
 			},
@@ -192,16 +192,16 @@ func TestTemplate(t *testing.T) {
 				m.ws.EXPECT().WorkloadAddonsPath(testSvcName).Return("mockPath")
 				m.ws.EXPECT().ListFiles("mockPath").Return([]string{"first.yaml", "second.yaml"}, nil)
 
-				first, _ := ioutil.ReadFile(filepath.Join("testdata", "merge", "first.yaml"))
+				first, _ := os.ReadFile(filepath.Join("testdata", "merge", "first.yaml"))
 				m.ws.EXPECT().WorkloadAddonFilePath(testSvcName, "first.yaml").Return("mockPath")
 				m.ws.EXPECT().ReadFile("mockPath").Return(first, nil)
 
-				second, _ := ioutil.ReadFile(filepath.Join("testdata", "merge", "second.yaml"))
+				second, _ := os.ReadFile(filepath.Join("testdata", "merge", "second.yaml"))
 				m.ws.EXPECT().WorkloadAddonFilePath(testSvcName, "second.yaml").Return("mockPath")
 				m.ws.EXPECT().ReadFile("mockPath").Return(second, nil)
 			},
 			wantedTemplate: func() string {
-				wanted, _ := ioutil.ReadFile(filepath.Join("testdata", "merge", "wanted.yaml"))
+				wanted, _ := os.ReadFile(filepath.Join("testdata", "merge", "wanted.yaml"))
 				return string(wanted)
 			}(),
 		},

--- a/internal/pkg/addon/output_test.go
+++ b/internal/pkg/addon/output_test.go
@@ -5,7 +5,7 @@ package addon
 
 import (
 	"errors"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -126,7 +126,7 @@ Outputs:
 			// GIVEN
 			template := tc.template
 			if tc.testdataFileName != "" {
-				content, err := ioutil.ReadFile(filepath.Join("testdata", "outputs", tc.testdataFileName))
+				content, err := os.ReadFile(filepath.Join("testdata", "outputs", tc.testdataFileName))
 				require.NoError(t, err)
 				template = string(content)
 			}

--- a/internal/pkg/aws/cloudformation/parse_test.go
+++ b/internal/pkg/aws/cloudformation/parse_test.go
@@ -4,7 +4,7 @@
 package cloudformation
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -46,7 +46,7 @@ func TestParseTemplateDescriptions(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			// GIVEN
-			body, err := ioutil.ReadFile(filepath.Join("testdata", "parse", tc.testFile))
+			body, err := os.ReadFile(filepath.Join("testdata", "parse", tc.testFile))
 			require.NoError(t, err, tc.testFile, "unexpected error while reading testdata file")
 
 			// WHEN

--- a/internal/pkg/aws/s3/s3_test.go
+++ b/internal/pkg/aws/s3/s3_test.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -39,7 +39,7 @@ func TestS3_Upload(t *testing.T) {
 		"should upload to the s3 bucket": {
 			mockS3ManagerClient: func(m *mocks.Mocks3ManagerAPI) {
 				m.EXPECT().Upload(gomock.Any()).Do(func(in *s3manager.UploadInput, _ ...func(*s3manager.Uploader)) {
-					b, err := ioutil.ReadAll(in.Body)
+					b, err := io.ReadAll(in.Body)
 					require.NoError(t, err)
 					require.Equal(t, "bar", string(b))
 					require.Equal(t, "mockBucket", aws.StringValue(in.Bucket))

--- a/internal/pkg/cli/app_list_test.go
+++ b/internal/pkg/cli/app_list_test.go
@@ -6,7 +6,7 @@ package cli
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/aws/copilot-cli/internal/pkg/cli/mocks"
@@ -29,7 +29,7 @@ func TestListAppOpts_Execute(t *testing.T) {
 		"with applications": {
 			listOpts: listAppOpts{
 				store: mockstore,
-				w:     ioutil.Discard,
+				w:     io.Discard,
 			},
 			mocking: func() {
 				mockstore.
@@ -45,7 +45,7 @@ func TestListAppOpts_Execute(t *testing.T) {
 		"with an error": {
 			listOpts: listAppOpts{
 				store: mockstore,
-				w:     ioutil.Discard,
+				w:     io.Discard,
 			},
 			mocking: func() {
 				mockstore.

--- a/internal/pkg/cli/init.go
+++ b/internal/pkg/cli/init.go
@@ -128,6 +128,12 @@ func newInitOpts(vars initVars) (*initOpts, error) {
 		isSessionFromEnvVars: func() (bool, error) {
 			return sessions.AreCredsFromEnvVars(defaultSess)
 		},
+		existingWorkspace: func() (wsAppManager, error) {
+			return workspace.Use(fs)
+		},
+		newWorkspace: func(appName string) (wsAppManager, error) {
+			return workspace.Create(appName, fs)
+		},
 	}
 	initEnvCmd := &initEnvOpts{
 		initEnvVars: initEnvVars{

--- a/internal/pkg/deploy/cloudformation/stack/backend_svc_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/backend_svc_test.go
@@ -8,7 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -625,11 +625,11 @@ func TestBackendService_TemplateAndParamsGeneration(t *testing.T) {
 			defer ctrl.Finish()
 
 			// parse files
-			manifestBytes, err := ioutil.ReadFile(tc.ManifestPath)
+			manifestBytes, err := os.ReadFile(tc.ManifestPath)
 			require.NoError(t, err)
-			tmplBytes, err := ioutil.ReadFile(tc.TemplatePath)
+			tmplBytes, err := os.ReadFile(tc.TemplatePath)
 			require.NoError(t, err)
-			paramsBytes, err := ioutil.ReadFile(tc.ParamsPath)
+			paramsBytes, err := os.ReadFile(tc.ParamsPath)
 			require.NoError(t, err)
 
 			dynamicMft, err := manifest.UnmarshalWorkload([]byte(manifestBytes))

--- a/internal/pkg/deploy/cloudformation/stack/bb_pipeline_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/bb_pipeline_integration_test.go
@@ -6,7 +6,7 @@
 package stack_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -63,7 +63,7 @@ func TestBB_Pipeline_Template(t *testing.T) {
 	m1 := make(map[interface{}]interface{})
 	require.NoError(t, yaml.Unmarshal(actualInBytes, m1))
 
-	wanted, err := ioutil.ReadFile(filepath.Join("testdata", "pipeline", "bb_template.yaml"))
+	wanted, err := os.ReadFile(filepath.Join("testdata", "pipeline", "bb_template.yaml"))
 	require.NoError(t, err, "should be able to read expected template file")
 	wantedInBytes := []byte(wanted)
 	m2 := make(map[interface{}]interface{})

--- a/internal/pkg/deploy/cloudformation/stack/cc_pipeline_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/cc_pipeline_integration_test.go
@@ -6,7 +6,7 @@
 package stack_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -63,7 +63,7 @@ func TestCC_Pipeline_Template(t *testing.T) {
 	m1 := make(map[interface{}]interface{})
 	require.NoError(t, yaml.Unmarshal(actualInBytes, m1))
 
-	wanted, err := ioutil.ReadFile(filepath.Join("testdata", "pipeline", "cc_template.yaml"))
+	wanted, err := os.ReadFile(filepath.Join("testdata", "pipeline", "cc_template.yaml"))
 	require.NoError(t, err, "should be able to read expected template file")
 	wantedInBytes := []byte(wanted)
 	m2 := make(map[interface{}]interface{})

--- a/internal/pkg/deploy/cloudformation/stack/dd_pipeline_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/dd_pipeline_integration_test.go
@@ -6,7 +6,7 @@
 package stack_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -27,7 +27,7 @@ const (
 // TestDD_Pipeline_Template ensures that the CloudFormation template generated for a pipeline matches our pre-defined template.
 func TestDD_Pipeline_Template(t *testing.T) {
 	path := filepath.Join("testdata", "pipeline", pipelineManifestPath)
-	manifestBytes, err := ioutil.ReadFile(path)
+	manifestBytes, err := os.ReadFile(path)
 	require.NoError(t, err)
 
 	pipelineMft, err := manifest.UnmarshalPipeline([]byte(manifestBytes))
@@ -74,7 +74,7 @@ func TestDD_Pipeline_Template(t *testing.T) {
 	m1 := make(map[any]any)
 	require.NoError(t, yaml.Unmarshal(actualInBytes, m1))
 
-	wanted, err := ioutil.ReadFile(filepath.Join("testdata", "pipeline", pipelineStackPath))
+	wanted, err := os.ReadFile(filepath.Join("testdata", "pipeline", pipelineStackPath))
 	require.NoError(t, err, "should be able to read expected template file")
 	wantedInBytes := []byte(wanted)
 	m2 := make(map[any]any)

--- a/internal/pkg/deploy/cloudformation/stack/gh_pipeline_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/gh_pipeline_integration_test.go
@@ -6,7 +6,7 @@
 package stack_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -62,7 +62,7 @@ func TestGHPipeline_Template(t *testing.T) {
 	m1 := make(map[interface{}]interface{})
 	require.NoError(t, yaml.Unmarshal(actualInBytes, m1))
 
-	wanted, err := ioutil.ReadFile(filepath.Join("testdata", "pipeline", "gh_template.yaml"))
+	wanted, err := os.ReadFile(filepath.Join("testdata", "pipeline", "gh_template.yaml"))
 	require.NoError(t, err, "should be able to read expected template file")
 	wantedInBytes := []byte(wanted)
 	m2 := make(map[interface{}]interface{})

--- a/internal/pkg/deploy/cloudformation/stack/ghv1_pipeline_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/ghv1_pipeline_integration_test.go
@@ -4,7 +4,7 @@
 package stack_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -62,7 +62,7 @@ func TestGHv1Pipeline_Template(t *testing.T) {
 	m1 := make(map[interface{}]interface{})
 	require.NoError(t, yaml.Unmarshal(actualInBytes, m1))
 
-	wanted, err := ioutil.ReadFile(filepath.Join("testdata", "pipeline", "ghv1_template.yml"))
+	wanted, err := os.ReadFile(filepath.Join("testdata", "pipeline", "ghv1_template.yml"))
 	require.NoError(t, err, "should be able to read expected template file")
 	wantedInBytes := []byte(wanted)
 	m2 := make(map[interface{}]interface{})

--- a/internal/pkg/deploy/cloudformation/stack/lb_grpc_web_service_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/lb_grpc_web_service_integration_test.go
@@ -7,7 +7,6 @@ package stack_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -44,7 +43,7 @@ func TestGrpcLoadBalancedWebService_Template(t *testing.T) {
 		},
 	}
 	path := filepath.Join("testdata", "workloads", svcGrpcManifestPath)
-	manifestBytes, err := ioutil.ReadFile(path)
+	manifestBytes, err := os.ReadFile(path)
 	require.NoError(t, err)
 	for name, tc := range testCases {
 		interpolated, err := manifest.NewInterpolator(appName, tc.envName).Interpolate(string(manifestBytes))
@@ -106,7 +105,7 @@ func TestGrpcLoadBalancedWebService_Template(t *testing.T) {
 			mActual := make(map[interface{}]interface{})
 			require.NoError(t, yaml.Unmarshal(actualBytes, mActual))
 
-			expected, err := ioutil.ReadFile(filepath.Join("testdata", "workloads", tc.svcStackPath))
+			expected, err := os.ReadFile(filepath.Join("testdata", "workloads", tc.svcStackPath))
 			require.NoError(t, err, "should be able to read expected bytes")
 			expectedBytes := []byte(expected)
 			mExpected := make(map[interface{}]interface{})
@@ -120,7 +119,7 @@ func TestGrpcLoadBalancedWebService_Template(t *testing.T) {
 			require.NoError(t, err)
 
 			path := filepath.Join("testdata", "workloads", tc.svcParamsPath)
-			wantedCFNParamsBytes, err := ioutil.ReadFile(path)
+			wantedCFNParamsBytes, err := os.ReadFile(path)
 			require.NoError(t, err)
 
 			require.Equal(t, string(wantedCFNParamsBytes), actualParams)

--- a/internal/pkg/deploy/cloudformation/stack/lb_network_web_service_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/lb_network_web_service_integration_test.go
@@ -7,7 +7,6 @@ package stack_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -63,7 +62,7 @@ func TestNetworkLoadBalancedWebService_Template(t *testing.T) {
 		require.NoError(t, os.Setenv("TAG", val))
 	}()
 	path := filepath.Join("testdata", "workloads", nlbSvcManifestPath)
-	manifestBytes, err := ioutil.ReadFile(path)
+	manifestBytes, err := os.ReadFile(path)
 	require.NoError(t, err)
 	for name, tc := range testCases {
 		interpolated, err := manifest.NewInterpolator(appName, tc.envName).Interpolate(string(manifestBytes))
@@ -127,7 +126,7 @@ func TestNetworkLoadBalancedWebService_Template(t *testing.T) {
 			mActual := make(map[interface{}]interface{})
 			require.NoError(t, yaml.Unmarshal(actualBytes, mActual))
 
-			expected, err := ioutil.ReadFile(filepath.Join("testdata", "workloads", tc.svcStackPath))
+			expected, err := os.ReadFile(filepath.Join("testdata", "workloads", tc.svcStackPath))
 			require.NoError(t, err, "should be able to read expected bytes")
 			expectedBytes := []byte(expected)
 			mExpected := make(map[interface{}]interface{})
@@ -141,7 +140,7 @@ func TestNetworkLoadBalancedWebService_Template(t *testing.T) {
 			require.NoError(t, err)
 
 			path := filepath.Join("testdata", "workloads", tc.svcParamsPath)
-			wantedCFNParamsBytes, err := ioutil.ReadFile(path)
+			wantedCFNParamsBytes, err := os.ReadFile(path)
 			require.NoError(t, err)
 
 			require.Equal(t, string(wantedCFNParamsBytes), actualParams)

--- a/internal/pkg/deploy/cloudformation/stack/lb_web_service_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/lb_web_service_integration_test.go
@@ -7,7 +7,6 @@ package stack_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -63,7 +62,7 @@ func TestLoadBalancedWebService_TemplateInteg(t *testing.T) {
 		require.NoError(t, os.Setenv("TAG", val))
 	}()
 	path := filepath.Join("testdata", "workloads", svcManifestPath)
-	manifestBytes, err := ioutil.ReadFile(path)
+	manifestBytes, err := os.ReadFile(path)
 	require.NoError(t, err)
 	for name, tc := range testCases {
 		interpolated, err := manifest.NewInterpolator(appName, tc.envName).Interpolate(string(manifestBytes))
@@ -127,7 +126,7 @@ func TestLoadBalancedWebService_TemplateInteg(t *testing.T) {
 			mActual := make(map[interface{}]interface{})
 			require.NoError(t, yaml.Unmarshal(actualBytes, mActual))
 
-			expected, err := ioutil.ReadFile(filepath.Join("testdata", "workloads", tc.svcStackPath))
+			expected, err := os.ReadFile(filepath.Join("testdata", "workloads", tc.svcStackPath))
 			require.NoError(t, err, "should be able to read expected bytes")
 			expectedBytes := []byte(expected)
 			mExpected := make(map[interface{}]interface{})
@@ -141,7 +140,7 @@ func TestLoadBalancedWebService_TemplateInteg(t *testing.T) {
 			require.NoError(t, err)
 
 			path := filepath.Join("testdata", "workloads", tc.svcParamsPath)
-			wantedCFNParamsBytes, err := ioutil.ReadFile(path)
+			wantedCFNParamsBytes, err := os.ReadFile(path)
 			require.NoError(t, err)
 
 			require.Equal(t, string(wantedCFNParamsBytes), actualParams)

--- a/internal/pkg/deploy/cloudformation/stack/rd_web_svc_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/rd_web_svc_integration_test.go
@@ -7,7 +7,6 @@ package stack_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -42,7 +41,7 @@ func TestRDWS_Template(t *testing.T) {
 	}
 
 	// Read manifest.
-	manifestBytes, err := ioutil.ReadFile(filepath.Join("testdata", "workloads", manifestFileName))
+	manifestBytes, err := os.ReadFile(filepath.Join("testdata", "workloads", manifestFileName))
 	require.NoError(t, err, "read manifest file")
 	mft, err := manifest.UnmarshalWorkload(manifestBytes)
 	require.NoError(t, err, "unmarshal manifest file")
@@ -74,7 +73,7 @@ func TestRDWS_Template(t *testing.T) {
 		require.ErrorAs(t, err, &notFound)
 
 		// Read wanted stack template.
-		wantedTemplate, err := ioutil.ReadFile(filepath.Join("testdata", "workloads", tc.svcStackPath))
+		wantedTemplate, err := os.ReadFile(filepath.Join("testdata", "workloads", tc.svcStackPath))
 		require.NoError(t, err, "read cloudformation stack")
 
 		// Read actual stack template.

--- a/internal/pkg/deploy/cloudformation/stack/scheduled_job_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/scheduled_job_integration_test.go
@@ -8,13 +8,11 @@ package stack_test
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+	"testing"
 
 	"github.com/aws/copilot-cli/internal/pkg/config"
 	"github.com/spf13/afero"
-
-	"io/ioutil"
-	"path/filepath"
-	"testing"
 
 	"gopkg.in/yaml.v3"
 
@@ -37,7 +35,7 @@ const (
 
 func TestScheduledJob_Template(t *testing.T) {
 	path := filepath.Join("testdata", "workloads", jobManifestPath)
-	manifestBytes, err := ioutil.ReadFile(path)
+	manifestBytes, err := os.ReadFile(path)
 	require.NoError(t, err)
 	mft, err := manifest.UnmarshalWorkload(manifestBytes)
 	require.NoError(t, err)
@@ -88,7 +86,7 @@ func TestScheduledJob_Template(t *testing.T) {
 		mActual := make(map[interface{}]interface{})
 		require.NoError(t, yaml.Unmarshal(actualBytes, mActual))
 
-		expected, err := ioutil.ReadFile(filepath.Join("testdata", "workloads", jobStackPath))
+		expected, err := os.ReadFile(filepath.Join("testdata", "workloads", jobStackPath))
 		require.NoError(t, err, "should be able to read expected bytes")
 		expectedBytes := []byte(expected)
 		mExpected := make(map[interface{}]interface{})
@@ -102,7 +100,7 @@ func TestScheduledJob_Template(t *testing.T) {
 		require.NoError(t, err)
 
 		path := filepath.Join("testdata", "workloads", jobParamsPath)
-		wantedCFNParamsBytes, err := ioutil.ReadFile(path)
+		wantedCFNParamsBytes, err := os.ReadFile(path)
 		require.NoError(t, err)
 
 		require.Equal(t, string(wantedCFNParamsBytes), actualParams)

--- a/internal/pkg/deploy/cloudformation/stack/stack_local_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/stack_local_integration_test.go
@@ -7,7 +7,6 @@ package stack_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -40,7 +39,7 @@ func Test_Stack_Local_Integration(t *testing.T) {
 	)
 
 	path := filepath.Join("testdata", "stacklocal", autoScalingManifestPath)
-	wantedManifestBytes, err := ioutil.ReadFile(path)
+	wantedManifestBytes, err := os.ReadFile(path)
 	require.NoError(t, err)
 	mft, err := manifest.UnmarshalWorkload(wantedManifestBytes)
 	require.NoError(t, err)
@@ -88,7 +87,7 @@ func Test_Stack_Local_Integration(t *testing.T) {
 
 	t.Run("CloudFormation template must contain autoscaling resources", func(t *testing.T) {
 		path := filepath.Join("testdata", "stacklocal", wantedAutoScalingCFNTemplatePath)
-		wantedCFNBytes, err := ioutil.ReadFile(path)
+		wantedCFNBytes, err := os.ReadFile(path)
 		require.NoError(t, err)
 
 		require.Contains(t, tpl, string(wantedCFNBytes))
@@ -96,7 +95,7 @@ func Test_Stack_Local_Integration(t *testing.T) {
 
 	t.Run("CloudFormation template must be overridden correctly", func(t *testing.T) {
 		path := filepath.Join("testdata", "stacklocal", wantedOverrideCFNTemplatePath)
-		wantedCFNBytes, err := ioutil.ReadFile(path)
+		wantedCFNBytes, err := os.ReadFile(path)
 		require.NoError(t, err)
 
 		require.Contains(t, tpl, string(wantedCFNBytes))
@@ -107,7 +106,7 @@ func Test_Stack_Local_Integration(t *testing.T) {
 		require.NoError(t, err)
 
 		path := filepath.Join("testdata", "stacklocal", wantedAutoScalingCFNParameterPath)
-		wantedCFNParamsBytes, err := ioutil.ReadFile(path)
+		wantedCFNParamsBytes, err := os.ReadFile(path)
 		require.NoError(t, err)
 
 		require.Equal(t, params, string(wantedCFNParamsBytes))

--- a/internal/pkg/deploy/cloudformation/stack/validate_template_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/validate_template_integration_test.go
@@ -6,6 +6,7 @@
 package stack_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -18,6 +19,7 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation/stack"
 	"github.com/aws/copilot-cli/internal/pkg/manifest"
 	"github.com/aws/copilot-cli/internal/pkg/workspace"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
 )
 
@@ -31,7 +33,14 @@ func TestAutoscalingIntegration_Validate(t *testing.T) {
 	v, ok := content.(*manifest.LoadBalancedWebService)
 	require.Equal(t, ok, true)
 
-	ws, err := workspace.New()
+	// Create in-memory mock file system.
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	fs := afero.NewMemMapFs()
+	_ = fs.MkdirAll(fmt.Sprintf("%s/copilot", wd), 0755)
+	_ = afero.WriteFile(fs, fmt.Sprintf("%s/copilot/.workspace", wd), []byte(fmt.Sprintf("---\napplication: %s", "DavidsApp")), 0644)
+	require.NoError(t, err)
+	ws, err := workspace.Use(fs)
 	require.NoError(t, err)
 
 	_, err = addon.Parse(aws.StringValue(v.Name), ws)
@@ -85,7 +94,14 @@ func TestScheduledJob_Validate(t *testing.T) {
 	v, ok := content.(*manifest.ScheduledJob)
 	require.True(t, ok)
 
-	ws, err := workspace.New()
+	// Create in-memory mock file system.
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	fs := afero.NewMemMapFs()
+	_ = fs.MkdirAll(fmt.Sprintf("%s/copilot", wd), 0755)
+	_ = afero.WriteFile(fs, fmt.Sprintf("%s/copilot/.workspace", wd), []byte(fmt.Sprintf("---\napplication: %s", "DavidsApp")), 0644)
+	require.NoError(t, err)
+	ws, err := workspace.Use(fs)
 	require.NoError(t, err)
 
 	_, err = addon.Parse(aws.StringValue(v.Name), ws)

--- a/internal/pkg/deploy/cloudformation/stack/validate_template_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/validate_template_integration_test.go
@@ -6,7 +6,7 @@
 package stack_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -23,7 +23,7 @@ import (
 
 func TestAutoscalingIntegration_Validate(t *testing.T) {
 	path := filepath.Join("testdata", "stacklocal", autoScalingManifestPath)
-	wantedManifestBytes, err := ioutil.ReadFile(path)
+	wantedManifestBytes, err := os.ReadFile(path)
 	require.NoError(t, err)
 	mft, err := manifest.UnmarshalWorkload(wantedManifestBytes)
 	require.NoError(t, err)
@@ -77,7 +77,7 @@ func TestAutoscalingIntegration_Validate(t *testing.T) {
 
 func TestScheduledJob_Validate(t *testing.T) {
 	path := filepath.Join("testdata", "workloads", jobManifestPath)
-	manifestBytes, err := ioutil.ReadFile(path)
+	manifestBytes, err := os.ReadFile(path)
 	require.NoError(t, err)
 	mft, err := manifest.UnmarshalWorkload(manifestBytes)
 	require.NoError(t, err)

--- a/internal/pkg/deploy/cloudformation/stack/windows_lb_web_service_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/windows_lb_web_service_integration_test.go
@@ -7,7 +7,6 @@ package stack_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -35,7 +34,7 @@ const (
 
 func TestWindowsLoadBalancedWebService_Template(t *testing.T) {
 	path := filepath.Join("testdata", "workloads", windowsSvcManifestPath)
-	manifestBytes, err := ioutil.ReadFile(path)
+	manifestBytes, err := os.ReadFile(path)
 	require.NoError(t, err)
 	mft, err := manifest.UnmarshalWorkload([]byte(manifestBytes))
 	require.NoError(t, err)
@@ -93,7 +92,7 @@ func TestWindowsLoadBalancedWebService_Template(t *testing.T) {
 		mActual := make(map[interface{}]interface{})
 		require.NoError(t, yaml.Unmarshal(actualBytes, mActual))
 
-		expected, err := ioutil.ReadFile(filepath.Join("testdata", "workloads", windowsSvcStackPath))
+		expected, err := os.ReadFile(filepath.Join("testdata", "workloads", windowsSvcStackPath))
 		require.NoError(t, err, "should be able to read expected bytes")
 		expectedBytes := []byte(expected)
 		mExpected := make(map[interface{}]interface{})
@@ -106,7 +105,7 @@ func TestWindowsLoadBalancedWebService_Template(t *testing.T) {
 		require.NoError(t, err)
 
 		path := filepath.Join("testdata", "workloads", windowsSvcParamsPath)
-		wantedCFNParamsBytes, error := ioutil.ReadFile(path)
+		wantedCFNParamsBytes, error := os.ReadFile(path)
 		require.NoError(t, error)
 
 		require.Equal(t, string(wantedCFNParamsBytes), actualParams)

--- a/internal/pkg/deploy/cloudformation/stack/worker_service_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/worker_service_integration_test.go
@@ -7,7 +7,6 @@ package stack_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -36,7 +35,7 @@ const (
 
 func TestWorkerService_Template(t *testing.T) {
 	path := filepath.Join("testdata", "workloads", workerManifestPath)
-	manifestBytes, err := ioutil.ReadFile(path)
+	manifestBytes, err := os.ReadFile(path)
 	require.NoError(t, err)
 	mft, err := manifest.UnmarshalWorkload(manifestBytes)
 	require.NoError(t, err)
@@ -92,7 +91,7 @@ func TestWorkerService_Template(t *testing.T) {
 		mActual := make(map[interface{}]interface{})
 		require.NoError(t, yaml.Unmarshal(actualBytes, mActual))
 
-		expected, err := ioutil.ReadFile(filepath.Join("testdata", "workloads", workerStackPath))
+		expected, err := os.ReadFile(filepath.Join("testdata", "workloads", workerStackPath))
 		require.NoError(t, err, "should be able to read expected bytes")
 		mExpected := make(map[interface{}]interface{})
 
@@ -105,7 +104,7 @@ func TestWorkerService_Template(t *testing.T) {
 		require.NoError(t, err)
 
 		path := filepath.Join("testdata", "workloads", workerParamsPath)
-		wantedCFNParamsBytes, err := ioutil.ReadFile(path)
+		wantedCFNParamsBytes, err := os.ReadFile(path)
 		require.NoError(t, err)
 
 		require.Equal(t, string(wantedCFNParamsBytes), actualParams)

--- a/internal/pkg/docker/dockerengine/dockerengine.go
+++ b/internal/pkg/docker/dockerengine/dockerengine.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	osexec "os/exec"
 	"path/filepath"
@@ -243,7 +242,7 @@ func (c CmdClient) IsEcrCredentialHelperEnabled(uri string) bool {
 	// Look into the default locations
 	pathsToTry := []string{filepath.Join(".docker", "config.json"), ".dockercfg"}
 	for _, path := range pathsToTry {
-		content, err := ioutil.ReadFile(filepath.Join(c.homePath, path))
+		content, err := os.ReadFile(filepath.Join(c.homePath, path))
 		if err != nil {
 			// if we can't read the file keep going
 			continue

--- a/internal/pkg/exec/ssm_plugin_install_latest_binary_darwin.go
+++ b/internal/pkg/exec/ssm_plugin_install_latest_binary_darwin.go
@@ -6,7 +6,6 @@ package exec
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -18,7 +17,7 @@ const (
 // InstallLatestBinary installs the latest ssm plugin.
 func (s SSMPluginCommand) InstallLatestBinary() error {
 	if s.tempDir == "" {
-		dir, err := ioutil.TempDir("", "ssmplugin")
+		dir, err := os.MkdirTemp("", "ssmplugin")
 		if err != nil {
 			return fmt.Errorf("create a temporary directory: %w", err)
 		}

--- a/internal/pkg/exec/ssm_plugin_install_latest_binary_darwin_test.go
+++ b/internal/pkg/exec/ssm_plugin_install_latest_binary_darwin_test.go
@@ -6,7 +6,6 @@ package exec
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -59,7 +58,7 @@ func TestSSMPluginCommand_InstallLatestBinary_darwin(t *testing.T) {
 		},
 	}
 	for name, tc := range tests {
-		mockDir, _ = ioutil.TempDir("", "temp")
+		mockDir, _ = os.MkdirTemp("", "temp")
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			tc.setupMocks(ctrl)

--- a/internal/pkg/manifest/marshal_manifest_integration_test.go
+++ b/internal/pkg/manifest/marshal_manifest_integration_test.go
@@ -6,7 +6,7 @@
 package manifest
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -42,7 +42,7 @@ func TestLoadBalancedWebService_InitialManifestIntegration(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			// GIVEN
 			path := filepath.Join("testdata", tc.wantedTestdata)
-			wantedBytes, err := ioutil.ReadFile(path)
+			wantedBytes, err := os.ReadFile(path)
 			require.NoError(t, err)
 			manifest := NewLoadBalancedWebService(&tc.inProps)
 
@@ -101,7 +101,7 @@ func TestBackendSvc_InitialManifestIntegration(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			// GIVEN
 			path := filepath.Join("testdata", tc.wantedTestdata)
-			wantedBytes, err := ioutil.ReadFile(path)
+			wantedBytes, err := os.ReadFile(path)
 			require.NoError(t, err)
 			manifest := NewBackendService(tc.inProps)
 
@@ -191,7 +191,7 @@ func TestWorkerSvc_InitialManifestIntegration(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			// GIVEN
 			path := filepath.Join("testdata", tc.wantedTestdata)
-			wantedBytes, err := ioutil.ReadFile(path)
+			wantedBytes, err := os.ReadFile(path)
 			require.NoError(t, err)
 			manifest := NewWorkerService(tc.inProps)
 
@@ -278,7 +278,7 @@ func TestScheduledJob_InitialManifestIntegration(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			// GIVEN
 			path := filepath.Join("testdata", tc.wantedTestData)
-			wantedBytes, err := ioutil.ReadFile(path)
+			wantedBytes, err := os.ReadFile(path)
 			require.NoError(t, err)
 			manifest := NewScheduledJob(&tc.inProps)
 
@@ -363,7 +363,7 @@ func TestEnvironment_InitialManifestIntegration(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			// GIVEN
 			path := filepath.Join("testdata", tc.wantedTestData)
-			wantedBytes, err := ioutil.ReadFile(path)
+			wantedBytes, err := os.ReadFile(path)
 			require.NoError(t, err)
 			manifest := NewEnvironment(&tc.inProps)
 
@@ -441,7 +441,7 @@ func TestPipelineManifest_InitialManifest_Integration(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			path := filepath.Join("testdata", tc.wantedTestData)
-			wantedBytes, err := ioutil.ReadFile(path)
+			wantedBytes, err := os.ReadFile(path)
 			require.NoError(t, err)
 
 			manifest, err := NewPipeline("mock-pipeline", tc.inProvider, tc.inStages)

--- a/internal/pkg/template/override/override_test.go
+++ b/internal/pkg/template/override/override_test.go
@@ -5,7 +5,7 @@ package override
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -199,14 +199,14 @@ func Test_CloudFormationTemplate(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			in, err := ioutil.ReadFile(filepath.Join("testdata", "original", tc.inTplFileName))
+			in, err := os.ReadFile(filepath.Join("testdata", "original", tc.inTplFileName))
 			require.NoError(t, err)
 
 			got, gotErr := CloudFormationTemplate(tc.inRules, in)
 			if tc.wantedError != nil {
 				require.EqualError(t, gotErr, tc.wantedError.Error())
 			} else {
-				wantedContent, err := ioutil.ReadFile(filepath.Join("testdata", "outputs", tc.wantedTplFileName))
+				wantedContent, err := os.ReadFile(filepath.Join("testdata", "outputs", tc.wantedTplFileName))
 				require.NoError(t, err)
 
 				require.NoError(t, gotErr)


### PR DESCRIPTION
As well as removing deprecated references

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
