### PR TITLE
fix: NLB use case for service connect

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-test.stack.yml
@@ -95,9 +95,10 @@ Resources: # If a bucket URL is specified, that means the template exists.
               awslogs-stream-prefix: copilot
           PortMappings:
             - ContainerPort: !Ref ContainerPort
-              Name: target
+              Name: ALBTarget
             - ContainerPort: 443
               Protocol: tcp
+              Name: NLBTarget
   ExecutionRole:
     Metadata:
       'aws:copilot:description': 'An IAM Role for the Fargate agent to make AWS API calls on your behalf'

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-test.stack.yml
@@ -109,7 +109,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
               SourceVolume: persistence
           PortMappings:
             - ContainerPort: !Ref ContainerPort
-              Name: target
+              Name: ALBTarget
       Volumes:
         - Name: persistence
   ExecutionRole:

--- a/internal/pkg/template/templates/workloads/partials/cf/workload-container.yml
+++ b/internal/pkg/template/templates/workloads/partials/cf/workload-container.yml
@@ -32,7 +32,7 @@
     {{- if and .ServiceConnect .SCFeatureFlag}} # remove when release
     {{/* Multiple exposed port is not supported yet. Therefore, if the target container is the sidecar, the target port must be the one and only one port that the container exposes. */}}
     {{- if eq .HTTPTargetContainer.Name .WorkloadName}}
-      Name: target
+      Name: ALBTarget
     {{- end}}
     {{- end}}
 {{- if .NLB}} {{ $nlbListener := .NLB.Listener }} 
@@ -40,6 +40,9 @@
   {{/*No need to add additional port if the target port is the same as image port*/}}
     - ContainerPort: {{$nlbListener.TargetPort}}
       Protocol: {{if eq $nlbListener.Protocol "UDP"}}udp{{else}}tcp{{end}}
+      {{- if and .ServiceConnect .SCFeatureFlag }} # remove when release
+      Name: NLBTarget
+      {{- end}}
   {{- end}}
 {{- end}}
 {{- end}} {{/* end if eq .WorkloadType "Load Balanced Web Service"*/}}


### PR DESCRIPTION
<!-- Provide summary of changes -->
This PR adds `Name` parameter to the port mapping in the NLB use case which will be releasing as a part of Service Connect feature.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
