### PR TITLE
chore: set tasks fewer than `spot_from` to fargate cp when `min` and `spot_from` equal

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/transformers.go
+++ b/internal/pkg/deploy/cloudformation/stack/transformers.go
@@ -205,11 +205,14 @@ func convertCapacityProviders(a manifest.AdvancedCount) []*template.CapacityProv
 	// Scaling with spot
 	spotFrom := aws.IntValue(rc.SpotFrom)
 	min := aws.IntValue(rc.Min)
-	// If spotFrom value is greater than or equal to the autoscaling min, 
+	// If spotFrom value is greater than or equal to the autoscaling min,
 	// then the base value on the Fargate capacity provider must be set
 	// to one less than spotFrom
 	if spotFrom >= min {
 		base := spotFrom - 1
+		if base < 0 {
+			base = 0
+		}
 		fgCapacity := &template.CapacityProviderStrategy{
 			Base:             aws.Int(base),
 			Weight:           aws.Int(0),

--- a/internal/pkg/deploy/cloudformation/stack/transformers.go
+++ b/internal/pkg/deploy/cloudformation/stack/transformers.go
@@ -206,7 +206,7 @@ func convertCapacityProviders(a manifest.AdvancedCount) []*template.CapacityProv
 	spotFrom := aws.IntValue(rc.SpotFrom)
 	min := aws.IntValue(rc.Min)
 	// If spotFrom value is greater than or equal to the autoscaling min, 
-	// then the base value on the Fargate Capacity provider must be set
+	// then the base value on the Fargate capacity provider must be set
 	// to one less than spotFrom
 	if spotFrom >= min {
 		base := spotFrom - 1

--- a/internal/pkg/deploy/cloudformation/stack/transformers.go
+++ b/internal/pkg/deploy/cloudformation/stack/transformers.go
@@ -198,17 +198,17 @@ func convertCapacityProviders(a manifest.AdvancedCount) []*template.CapacityProv
 		CapacityProvider: capacityProviderFargateSpot,
 	})
 	rc := a.Range.RangeConfig
-	// Return if only spot is specifed as count
+	// Return if only spot is specified as count
 	if rc.SpotFrom == nil {
 		return cps
 	}
 	// Scaling with spot
 	spotFrom := aws.IntValue(rc.SpotFrom)
 	min := aws.IntValue(rc.Min)
-	// If spotFrom value is not equal to the autoscaling min, then
-	// the base value on the Fargate Capacity provider must be set
+	// If spotFrom value is greater than or equal to the autoscaling min, 
+	// then the base value on the Fargate Capacity provider must be set
 	// to one less than spotFrom
-	if spotFrom > min {
+	if spotFrom >= min {
 		base := spotFrom - 1
 		fgCapacity := &template.CapacityProviderStrategy{
 			Base:             aws.Int(base),

--- a/internal/pkg/deploy/cloudformation/stack/transformers_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/transformers_test.go
@@ -404,6 +404,11 @@ func Test_convertCapacityProviders(t *testing.T) {
 					Weight:           aws.Int(1),
 					CapacityProvider: capacityProviderFargateSpot,
 				},
+				{
+					Base:             aws.Int(0),
+					Weight:           aws.Int(0),
+					CapacityProvider: capacityProviderFargate,
+				},
 			},
 		},
 		"with scaling into spot": {
@@ -424,6 +429,29 @@ func Test_convertCapacityProviders(t *testing.T) {
 				},
 				{
 					Base:             aws.Int(spotFrom - 1),
+					Weight:           aws.Int(0),
+					CapacityProvider: capacityProviderFargate,
+				},
+			},
+		},
+		"with min equaling spot_from": {
+			input: manifest.AdvancedCount{
+				Range: manifest.Range{
+					RangeConfig: manifest.RangeConfig{
+						Min:      aws.Int(2),
+						Max:      aws.Int(10),
+						SpotFrom: aws.Int(2),
+					},
+				},
+			},
+
+			expected: []*template.CapacityProviderStrategy{
+				{
+					Weight:           aws.Int(1),
+					CapacityProvider: capacityProviderFargateSpot,
+				},
+				{
+					Base:             aws.Int(1),
 					Weight:           aws.Int(0),
 					CapacityProvider: capacityProviderFargate,
 				},

--- a/internal/pkg/manifest/errors.go
+++ b/internal/pkg/manifest/errors.go
@@ -137,6 +137,16 @@ http:
 `
 }
 
+type errRangeValueLessThanZero struct {
+	min int
+	max int
+	spotFrom int
+}
+
+func (e *errRangeValueLessThanZero) Error() string{
+	return fmt.Sprintf("min value %d, max value %d, and spot_from value %d must all be positive", e.min, e.max, e.spotFrom)
+}
+
 type errMinGreaterThanMax struct {
 	min int
 	max int

--- a/internal/pkg/manifest/validate.go
+++ b/internal/pkg/manifest/validate.go
@@ -1080,7 +1080,14 @@ func (r RangeConfig) validate() error {
 			missingField: "min/max",
 		}
 	}
-	min, max := aws.IntValue(r.Min), aws.IntValue(r.Max)
+	min, max, spotFrom := aws.IntValue(r.Min), aws.IntValue(r.Max), aws.IntValue(r.SpotFrom)
+	if min < 0 || max < 0 || spotFrom < 0 {
+		return &errRangeValueLessThanZero{
+			min: min,
+			max: max,
+			spotFrom: spotFrom,
+		}
+	}
 	if min <= max {
 		return nil
 	}

--- a/internal/pkg/manifest/validate_test.go
+++ b/internal/pkg/manifest/validate_test.go
@@ -2105,6 +2105,14 @@ func TestRangeConfig_validate(t *testing.T) {
 			},
 			wantedError: fmt.Errorf("min value 2 cannot be greater than max value 1"),
 		},
+		"error if spot_from value is negative": {
+			RangeConfig: RangeConfig{
+				Min: aws.Int(2),
+				Max: aws.Int(10),
+				SpotFrom: aws.Int(-3),
+			},
+			wantedError: fmt.Errorf("min value 2, max value 10, and spot_from value -3 must all be positive"),
+		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
Addresses: https://gitter.im/aws/copilot-cli?at=637244e418f21c023bb057cc

Previously, the logic to scale into Fargate Spot only applied if the `spot_from` value was greater than the `min` value. So in edge case of users having equal values greater than 1 for those fields, as in the case linked to above, all of the tasks would have Fargate Spot as their capacity provider, rather than the `spot_from` value determining the threshold for Fargate vs Fargate Spot. This kind of config is somewhat atypical, as the `min` value isn't guaranteed if that number task has Fargate Spot as a capacity provider, but if users do set up their scaling this way, at least we are honoring the `spot_from` value.

With this change:
`min: 3` and `spot_from: 3` --> 2 Fargate, 1 Spot
`min: 2` and `spot_from: 2` --> 1 Fargate, 1 Spot
`min: 1` and `spot_from: 1` --> 0 Fargate, 1 Spot
`min: 0` and `spot_from: 0` --> 0 Fargate, 1 Spot

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
