### PR TITLE
chore(workspace): fix `Use` to return an error if the ws has no summary 

### DIFF
--- a/internal/pkg/cli/app_init.go
+++ b/internal/pkg/cli/app_init.go
@@ -138,9 +138,9 @@ https://aws.github.io/copilot-cli/docs/credentials/`)
 		log.Infoln()
 	}
 
-	// When there's a local application.
 	ws, err := o.existingWorkspace()
 	if err == nil {
+		// When there's a local application.
 		summary, err := ws.Summary()
 		if err == nil {
 			if o.name == "" {
@@ -176,8 +176,7 @@ If you'd like to delete the application and all of its resources, run %s.
 			return err
 		}
 	}
-	var errNoWorkspace *workspace.ErrWorkspaceNotFound
-	if !errors.As(err, &errNoWorkspace) {
+	if !workspace.IsEmptyErr(err) {
 		return err
 	}
 

--- a/internal/pkg/workspace/errors.go
+++ b/internal/pkg/workspace/errors.go
@@ -44,11 +44,19 @@ func (e *ErrWorkspaceNotFound) Error() string {
 		e.CurrentDirectory)
 }
 
+func (_ *ErrWorkspaceNotFound) empty() bool {
+	return true
+}
+
 // ErrNoAssociatedApplication means we couldn't locate a workspace summary file.
 type ErrNoAssociatedApplication struct{}
 
 func (e *ErrNoAssociatedApplication) Error() string {
 	return "couldn't find an application associated with this workspace"
+}
+
+func (_ *ErrNoAssociatedApplication) empty() bool {
+	return true
 }
 
 // errHasExistingApplication means we tried to create a workspace that belongs to another application.
@@ -64,4 +72,13 @@ func (e *errHasExistingApplication) Error() string {
 		relPath = e.summaryPath
 	}
 	return fmt.Sprintf("workspace is already registered with application %s under %s", e.existingAppName, relPath)
+}
+
+// IsEmptyErr returns true if the error is related to an empty workspace.
+func IsEmptyErr(err error) bool {
+	type empty interface {
+		empty() bool
+	}
+	var emptyWs empty
+	return errors.As(err, &emptyWs)
 }

--- a/internal/pkg/workspace/errors.go
+++ b/internal/pkg/workspace/errors.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+
+	"github.com/aws/copilot-cli/internal/pkg/term/color"
 )
 
 // ErrNoPipelineInWorkspace means there was no pipeline manifest in the workspace dir.
@@ -44,9 +46,13 @@ func (e *ErrWorkspaceNotFound) Error() string {
 		e.CurrentDirectory)
 }
 
-func (_ *ErrWorkspaceNotFound) empty() bool {
-	return true
+// RecommendActions suggests steps clients can take to mitigate the copilot/ directory not found error.
+func (_ *ErrWorkspaceNotFound) RecommendActions() string {
+	return fmt.Sprintf("Run %s to create an application.", color.HighlightCode("copilot app init"))
 }
+
+// empty denotes that this error represents an empty workspace.
+func (_ *ErrWorkspaceNotFound) empty() {}
 
 // ErrNoAssociatedApplication means we couldn't locate a workspace summary file.
 type ErrNoAssociatedApplication struct{}
@@ -55,9 +61,14 @@ func (e *ErrNoAssociatedApplication) Error() string {
 	return "couldn't find an application associated with this workspace"
 }
 
-func (_ *ErrNoAssociatedApplication) empty() bool {
-	return true
+// RecommendActions suggests steps clients can take to mitigate the .workspace file not found error.
+func (_ *ErrNoAssociatedApplication) RecommendActions() string {
+	return fmt.Sprintf(`The "copilot" directory is not associated with an application.
+Run %s to create or use an application.`, color.HighlightCode("copilot app init"))
 }
+
+// empty denotes that this error represents an empty workspace.
+func (_ *ErrNoAssociatedApplication) empty() {}
 
 // errHasExistingApplication means we tried to create a workspace that belongs to another application.
 type errHasExistingApplication struct {
@@ -76,9 +87,8 @@ func (e *errHasExistingApplication) Error() string {
 
 // IsEmptyErr returns true if the error is related to an empty workspace.
 func IsEmptyErr(err error) bool {
-	type empty interface {
-		empty() bool
+	var emptyWs interface {
+		empty()
 	}
-	var emptyWs empty
 	return errors.As(err, &emptyWs)
 }

--- a/internal/pkg/workspace/errors_test.go
+++ b/internal/pkg/workspace/errors_test.go
@@ -1,0 +1,41 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package workspace
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsEmptyErr(t *testing.T) {
+	testCases := map[string]struct {
+		err    error
+		wanted bool
+	}{
+		"should return true when ErrWorkspaceNotFound": {
+			err:    &ErrWorkspaceNotFound{},
+			wanted: true,
+		},
+		"should return true when ErrNoAssociatedApplication": {
+			err:    &ErrNoAssociatedApplication{},
+			wanted: true,
+		},
+		"should return true when an empty workspace error is wrapped": {
+			err:    fmt.Errorf("burrito: %w", &ErrNoAssociatedApplication{}),
+			wanted: true,
+		},
+		"should return false when a random error": {
+			err: errors.New("unexpected"),
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.wanted, IsEmptyErr(tc.err))
+		})
+	}
+}

--- a/internal/pkg/workspace/workspace.go
+++ b/internal/pkg/workspace/workspace.go
@@ -66,6 +66,7 @@ type Workspace struct {
 	workingDirAbs string
 	copilotDirAbs string
 
+	// These fields should be accessed via the Summary method and not directly.
 	summary       *Summary
 	summaryErr    error
 	summarizeOnce sync.Once

--- a/internal/pkg/workspace/workspace.go
+++ b/internal/pkg/workspace/workspace.go
@@ -58,7 +58,7 @@ const (
 // Summary is a description of what's associated with this workspace.
 type Summary struct {
 	Application string `yaml:"application"` // Name of the application.
-	Path        string // absolute path to the summary file.
+	Path        string `yaml:"-"`           // absolute path to the summary file.
 }
 
 // Workspace typically represents a Git repository where the user has its infrastructure-as-code files as well as source files.

--- a/internal/pkg/workspace/workspace.go
+++ b/internal/pkg/workspace/workspace.go
@@ -4,21 +4,22 @@
 // Package workspace contains functionality to manage a user's local workspace. This includes
 // creating an application directory, reading and writing a summary file to associate the workspace with the application,
 // and managing infrastructure-as-code files. The typical workspace will be structured like:
-//  .
-//  ├── copilot                        (application directory)
-//  │   ├── .workspace                 (workspace summary)
-//  │   ├── my-service
-//  │   │   └── manifest.yml           (service manifest)
-//  |   |   environments
-//  |   |   └── test
-//  │   │       └── manifest.yml       (environment manifest for the environment test)
-//  │   ├── buildspec.yml              (legacy buildspec for the pipeline's build stage)
-//  │   ├── pipeline.yml               (legacy pipeline manifest)
-//  │   ├── pipelines
-//  │   │   ├── pipeline-app-beta
-//  │   │   │   ├── buildspec.yml      (buildspec for the pipeline 'pipeline-app-beta')
-//  │   ┴   ┴   └── manifest.yml       (pipeline manifest for the pipeline 'pipeline-app-beta')
-//  └── my-service-src                 (customer service code)
+//
+//	.
+//	├── copilot                        (application directory)
+//	│   ├── .workspace                 (workspace summary)
+//	│   ├── my-service
+//	│   │   └── manifest.yml           (service manifest)
+//	|   |   environments
+//	|   |   └── test
+//	│   │       └── manifest.yml       (environment manifest for the environment test)
+//	│   ├── buildspec.yml              (legacy buildspec for the pipeline's build stage)
+//	│   ├── pipeline.yml               (legacy pipeline manifest)
+//	│   ├── pipelines
+//	│   │   ├── pipeline-app-beta
+//	│   │   │   ├── buildspec.yml      (buildspec for the pipeline 'pipeline-app-beta')
+//	│   ┴   ┴   └── manifest.yml       (pipeline manifest for the pipeline 'pipeline-app-beta')
+//	└── my-service-src                 (customer service code)
 package workspace
 
 import (
@@ -28,6 +29,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"sync"
 
 	"github.com/aws/copilot-cli/internal/pkg/term/log"
 
@@ -56,16 +58,20 @@ const (
 // Summary is a description of what's associated with this workspace.
 type Summary struct {
 	Application string `yaml:"application"` // Name of the application.
-
-	Path string // absolute path to the summary file.
+	Path        string // absolute path to the summary file.
 }
 
 // Workspace typically represents a Git repository where the user has its infrastructure-as-code files as well as source files.
 type Workspace struct {
 	workingDirAbs string
 	copilotDirAbs string
-	fs            *afero.Afero
-	logger        func(format string, args ...interface{})
+
+	summary       *Summary
+	summaryErr    error
+	summarizeOnce sync.Once
+
+	fs     *afero.Afero
+	logger func(format string, args ...interface{})
 }
 
 // Use returns an existing workspace, searching for a copilot/ directory from the current wd,
@@ -85,6 +91,10 @@ func Use(fs afero.Fs) (*Workspace, error) {
 		return nil, err
 	}
 	ws.copilotDirAbs = copilotDirPath
+	if _, err := ws.Summary(); err != nil {
+		// If there is an issue retrieving the summary, then the workspace is not usable.
+		return nil, err
+	}
 	return ws, nil
 }
 
@@ -134,7 +144,8 @@ func Create(appName string, fs afero.Fs) (*Workspace, error) {
 		return nil, err
 	}
 	ws.copilotDirAbs = copilotDirAbs
-	if err := ws.writeSummary(appName); err != nil {
+	ws.summary, ws.summaryErr = ws.writeSummary(appName)
+	if ws.summaryErr != nil {
 		return nil, err
 	}
 
@@ -143,19 +154,23 @@ func Create(appName string, fs afero.Fs) (*Workspace, error) {
 
 // Summary returns a summary of the workspace. The method assumes that the workspace exists and the path is known.
 func (ws *Workspace) Summary() (*Summary, error) {
-	summaryPath := filepath.Join(ws.copilotDirAbs, SummaryFileName) // Assume `copilotDirAbs` is always present.
-	summaryFileExists, _ := ws.fs.Exists(summaryPath)               // If an err occurs, return no applications.
-	if summaryFileExists {
-		value, err := ws.fs.ReadFile(summaryPath)
-		if err != nil {
-			return nil, err
+	ws.summarizeOnce.Do(func() {
+		summaryPath := filepath.Join(ws.copilotDirAbs, SummaryFileName) // Assume `copilotDirAbs` is always present.
+		if ok, _ := ws.fs.Exists(summaryPath); !ok {
+			ws.summaryErr = &ErrNoAssociatedApplication{}
+			return
 		}
-		wsSummary := Summary{
+		f, err := ws.fs.ReadFile(summaryPath)
+		if err != nil {
+			ws.summaryErr = err
+			return
+		}
+		ws.summary = &Summary{
 			Path: summaryPath,
 		}
-		return &wsSummary, yaml.Unmarshal(value, &wsSummary)
-	}
-	return nil, &ErrNoAssociatedApplication{}
+		ws.summaryErr = yaml.Unmarshal(f, ws.summary)
+	})
+	return ws.summary, ws.summaryErr
 }
 
 // ListServices returns the names of the services in the workspace.
@@ -480,18 +495,18 @@ func (ws *Workspace) pipelineManifestLegacyPath() string {
 	return filepath.Join(ws.copilotDirAbs, legacyPipelineFileName)
 }
 
-func (ws *Workspace) writeSummary(appName string) error {
+func (ws *Workspace) writeSummary(appName string) (*Summary, error) {
 	summaryPath := ws.summaryPath()
-	workspaceSummary := Summary{
+	summary := Summary{
 		Application: appName,
+		Path:        summaryPath,
 	}
 
-	serializedWorkspaceSummary, err := yaml.Marshal(workspaceSummary)
-
+	serializedWorkspaceSummary, err := yaml.Marshal(summary)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return ws.fs.WriteFile(summaryPath, serializedWorkspaceSummary, 0644)
+	return &summary, ws.fs.WriteFile(summaryPath, serializedWorkspaceSummary, 0644)
 }
 
 func (ws *Workspace) pipelinesDirPath() string {

--- a/internal/pkg/workspace/workspace_test.go
+++ b/internal/pkg/workspace/workspace_test.go
@@ -266,7 +266,7 @@ func TestWorkspace_Use(t *testing.T) {
 			},
 			expectedCopilotDirAbs: fmt.Sprintf("%s/copilot", parent),
 		},
-		"returns the existing workspace that does not have a workspace summary": {
+		"returns an ErrNoAssociatedApplication error when there is existing copilot/ directory that does not have a workspace summary": {
 			appName: "DavidsApp",
 			mockFileSystem: func() afero.Fs {
 				fs := afero.NewMemMapFs()
@@ -274,6 +274,7 @@ func TestWorkspace_Use(t *testing.T) {
 				return fs
 			},
 			expectedCopilotDirAbs: fmt.Sprintf("%s/copilot", wd),
+			expectedError:         &ErrNoAssociatedApplication{},
 		},
 		"ErrWorkspaceNotFound if there is no workspace": {
 			mockFileSystem: func() afero.Fs {


### PR DESCRIPTION
Currently, running `copilot app init` in an empty workspace results in the creation of a .workspace file with an empty "" app name. This is because `Use` did not error on empty workspace and incorrectly assumed that an empty `copilot/` directory was a valid workspace which resulted in the app name to be empty.
Instead, we want to prompt for an app name when the workspace is empty.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
