### PR TITLE
chore: appinit sub command in init

### DIFF
--- a/internal/pkg/cli/app_init.go
+++ b/internal/pkg/cli/app_init.go
@@ -71,7 +71,7 @@ func newInitAppOpts(vars initAppVars) (*initAppOpts, error) {
 	}
 	fs := afero.NewOsFs()
 	identity := identity.New(sess)
-	iam := iam.New(sess)
+	iamClient := iam.New(sess)
 	return &initAppOpts{
 		initAppVars:      vars,
 		identity:         identity,
@@ -81,8 +81,8 @@ func newInitAppOpts(vars initAppVars) (*initAppOpts, error) {
 		cfn:              cloudformation.New(sess, cloudformation.WithProgressTracker(os.Stderr)),
 		prompt:           prompt.New(),
 		prog:             termprogress.NewSpinner(log.DiagnosticWriter),
-		iam:              iam,
-		iamRoleManager:   iam,
+		iam:              iamClient,
+		iamRoleManager:   iamClient,
 		isSessionFromEnvVars: func() (bool, error) {
 			return sessions.AreCredsFromEnvVars(sess)
 		},

--- a/internal/pkg/cli/init.go
+++ b/internal/pkg/cli/init.go
@@ -110,7 +110,7 @@ func newInitOpts(vars initVars) (*initOpts, error) {
 	spin := termprogress.NewSpinner(log.DiagnosticWriter)
 	id := identity.New(defaultSess)
 	deployer := cloudformation.New(defaultSess, cloudformation.WithProgressTracker(os.Stderr))
-	iam := iam.New(defaultSess)
+	iamClient := iam.New(defaultSess)
 	initAppCmd := &initAppOpts{
 		initAppVars: initAppVars{
 			name: vars.appName,
@@ -129,8 +129,8 @@ func newInitOpts(vars initVars) (*initOpts, error) {
 		newWorkspace: func(appName string) (wsAppManager, error) {
 			return workspace.Create(appName, fs)
 		},
-		iam:            iam,
-		iamRoleManager: iam,
+		iam:            iamClient,
+		iamRoleManager: iamClient,
 	}
 	initEnvCmd := &initEnvOpts{
 		initEnvVars: initEnvVars{

--- a/internal/pkg/cli/init.go
+++ b/internal/pkg/cli/init.go
@@ -10,6 +10,7 @@ import (
 	"os"
 
 	awscfn "github.com/aws/copilot-cli/internal/pkg/aws/cloudformation"
+	"github.com/aws/copilot-cli/internal/pkg/aws/iam"
 	"github.com/aws/copilot-cli/internal/pkg/docker/dockerfile"
 
 	"github.com/aws/copilot-cli/internal/pkg/deploy"
@@ -109,6 +110,7 @@ func newInitOpts(vars initVars) (*initOpts, error) {
 	spin := termprogress.NewSpinner(log.DiagnosticWriter)
 	id := identity.New(defaultSess)
 	deployer := cloudformation.New(defaultSess, cloudformation.WithProgressTracker(os.Stderr))
+	iam := iam.New(defaultSess)
 	if err != nil {
 		return nil, err
 	}
@@ -130,6 +132,8 @@ func newInitOpts(vars initVars) (*initOpts, error) {
 		newWorkspace: func(appName string) (wsAppManager, error) {
 			return workspace.Create(appName, fs)
 		},
+		iam:            iam,
+		iamRoleManager: iam,
 	}
 	initEnvCmd := &initEnvOpts{
 		initEnvVars: initEnvVars{

--- a/internal/pkg/cli/init.go
+++ b/internal/pkg/cli/init.go
@@ -111,9 +111,6 @@ func newInitOpts(vars initVars) (*initOpts, error) {
 	id := identity.New(defaultSess)
 	deployer := cloudformation.New(defaultSess, cloudformation.WithProgressTracker(os.Stderr))
 	iam := iam.New(defaultSess)
-	if err != nil {
-		return nil, err
-	}
 	initAppCmd := &initAppOpts{
 		initAppVars: initAppVars{
 			name: vars.appName,


### PR DESCRIPTION
<!-- Provide summary of changes -->
Currently, when you run `copilot init` it errors out because iam and iamRoleManager are not initialized.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
