### PR TITLE
chore: cli stack

### DIFF
--- a/internal/pkg/cli/deploy/env.go
+++ b/internal/pkg/cli/deploy/env.go
@@ -79,7 +79,7 @@ type envDeployer struct {
 	appCFN                   appResourcesGetter
 	envDeployer              environmentDeployer
 	patcher                  patcher
-	newStackSerializer       func(input *deploy.CreateEnvironmentInput, forceUpdateID string, prevParams []*awscfn.Parameter) stackSerializer
+	newStack                 func(input *deploy.CreateEnvironmentInput, forceUpdateID string, prevParams []*awscfn.Parameter) Stack
 	envDescriber             envDescriber
 	lbDescriber              lbDescriber
 	newServiceStackDescriber func(string) stackDescriber
@@ -134,7 +134,7 @@ func NewEnvDeployer(in *NewEnvDeployerInput) (*envDeployer, error) {
 			TemplatePatcher: cfnClient,
 			Env:             in.Env,
 		},
-		newStackSerializer: func(in *deploy.CreateEnvironmentInput, lastForceUpdateID string, oldParams []*awscfn.Parameter) stackSerializer {
+		newStack: func(in *deploy.CreateEnvironmentInput, lastForceUpdateID string, oldParams []*awscfn.Parameter) Stack {
 			return cfnstack.NewEnvConfigFromExistingStack(in, lastForceUpdateID, oldParams)
 		},
 		envDescriber: envDescriber,
@@ -339,7 +339,7 @@ func (d *envDeployer) GenerateCloudFormationTemplate(in *DeployEnvironmentInput)
 	if err != nil {
 		return nil, fmt.Errorf("retrieve environment stack force update ID: %w", err)
 	}
-	stack := d.newStackSerializer(stackInput, lastForceUpdateID, oldParams)
+	stack := d.newStack(stackInput, lastForceUpdateID, oldParams)
 	tpl, err := stack.Template()
 	if err != nil {
 		return nil, fmt.Errorf("generate stack template: %w", err)

--- a/internal/pkg/cli/deploy/env_test.go
+++ b/internal/pkg/cli/deploy/env_test.go
@@ -244,7 +244,7 @@ func TestEnvDeployer_GenerateCloudFormationTemplate(t *testing.T) {
 				},
 				appCFN:      m.appCFN,
 				envDeployer: m.envDeployer,
-				newStackSerializer: func(_ *deploy.CreateEnvironmentInput, _ string, _ []*awscfn.Parameter) stackSerializer {
+				newStack: func(_ *deploy.CreateEnvironmentInput, _ string, _ []*awscfn.Parameter) Stack {
 					return m.stackSerializer
 				},
 			}

--- a/internal/pkg/cli/deploy/job.go
+++ b/internal/pkg/cli/deploy/job.go
@@ -9,7 +9,6 @@ import (
 	awscloudformation "github.com/aws/copilot-cli/internal/pkg/aws/cloudformation"
 	awsecs "github.com/aws/copilot-cli/internal/pkg/aws/ecs"
 	"github.com/aws/copilot-cli/internal/pkg/aws/partitions"
-	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation"
 	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation/stack"
 	"github.com/aws/copilot-cli/internal/pkg/deploy/upload/customresource"
 	"github.com/aws/copilot-cli/internal/pkg/manifest"
@@ -51,43 +50,11 @@ func NewJobDeployer(in *WorkloadDeployerInput) (*jobDeployer, error) {
 }
 
 // UploadArtifacts uploads the deployment artifacts such as the container image, custom resources, addons and env files.
-func (d *jobDeployer) UploadArtifacts() (*UploadArtifactsOutput, error) {
+func (d *jobDeployer) UploadArtifacts() error {
 	return d.uploadArtifacts(d.customResources)
 }
 
-// GenerateCloudFormationTemplate generates a CloudFormation template and parameters for a workload.
-func (d *jobDeployer) GenerateCloudFormationTemplate(in *GenerateCloudFormationTemplateInput) (
-	*GenerateCloudFormationTemplateOutput, error) {
-	output, err := d.stackConfiguration(&in.StackRuntimeConfiguration)
-	if err != nil {
-		return nil, err
-	}
-	return d.generateCloudFormationTemplate(output.conf)
-}
-
-// DeployWorkload deploys a job using CloudFormation.
-func (d *jobDeployer) DeployWorkload(in *DeployWorkloadInput) (ActionRecommender, error) {
-	opts := []awscloudformation.StackOption{
-		awscloudformation.WithRoleARN(d.env.ExecutionRoleARN),
-	}
-	if in.DisableRollback {
-		opts = append(opts, awscloudformation.WithDisableRollback())
-	}
-	stackConfigOutput, err := d.stackConfiguration(&in.StackRuntimeConfiguration)
-	if err != nil {
-		return nil, err
-	}
-	if err := d.deployer.DeployService(stackConfigOutput.conf, d.resources.S3Bucket, opts...); err != nil {
-		return nil, fmt.Errorf("deploy job: %w", err)
-	}
-	return nil, nil
-}
-
-type jobStackConfigurationOutput struct {
-	conf cloudformation.StackConfiguration
-}
-
-func (d *jobDeployer) stackConfiguration(in *StackRuntimeConfiguration) (*jobStackConfigurationOutput, error) {
+func (d *jobDeployer) Stack(in StackRuntimeConfiguration) (Stack, error) {
 	rc, err := d.runtimeConfig(in)
 	if err != nil {
 		return nil, err
@@ -103,7 +70,18 @@ func (d *jobDeployer) stackConfiguration(in *StackRuntimeConfiguration) (*jobSta
 	if err != nil {
 		return nil, fmt.Errorf("create stack configuration: %w", err)
 	}
-	return &jobStackConfigurationOutput{
-		conf: conf,
-	}, nil
+	return conf, nil
+}
+
+func (d *jobDeployer) Deploy(stack Stack, deployOpts DeployOpts) error {
+	opts := []awscloudformation.StackOption{
+		awscloudformation.WithRoleARN(d.env.ExecutionRoleARN),
+	}
+	if deployOpts.DisableRollback {
+		opts = append(opts, awscloudformation.WithDisableRollback())
+	}
+	if err := d.deployer.DeployService(stack, d.resources.S3Bucket, opts...); err != nil {
+		return fmt.Errorf("deploy job: %w", err)
+	}
+	return nil
 }

--- a/internal/pkg/cli/deploy/svc.go
+++ b/internal/pkg/cli/deploy/svc.go
@@ -12,7 +12,6 @@ import (
 
 	"golang.org/x/mod/semver"
 
-	sdkcfn "github.com/aws/aws-sdk-go/service/cloudformation"
 	awscloudformation "github.com/aws/copilot-cli/internal/pkg/aws/cloudformation"
 	"github.com/aws/copilot-cli/internal/pkg/deploy"
 	"github.com/aws/copilot-cli/internal/pkg/term/color"
@@ -21,13 +20,6 @@ import (
 
 type uploader interface {
 	Upload(bucket, key string, data io.Reader) (string, error)
-}
-
-type stackSerializer interface {
-	templater
-	SerializedParameters() (string, error)
-	Parameters() ([]*sdkcfn.Parameter, error)
-	Tags() []*sdkcfn.Tag
 }
 
 type versionGetter interface {

--- a/internal/pkg/cli/deploy/workload.go
+++ b/internal/pkg/cli/deploy/workload.go
@@ -254,7 +254,8 @@ type Stack interface {
 }
 
 // TODO
-func (w *workloadDeployer) AddonStack() (Stack, error) {
+func (w *workloadDeployer) AddonsStack() (Stack, error) {
+	return w.addons, nil
 	if w.addons == nil {
 		return nil, nil
 	}

--- a/internal/pkg/cli/deploy/workload.go
+++ b/internal/pkg/cli/deploy/workload.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
-	sdkcfn "github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/aws/copilot-cli/internal/pkg/addon"
 	awscloudformation "github.com/aws/copilot-cli/internal/pkg/aws/cloudformation"
@@ -61,8 +60,7 @@ type templater interface {
 }
 
 type stackBuilder interface {
-	templater
-	Parameters() (string, error)
+	Stack
 	Package(addon.PackageConfig) error
 }
 
@@ -247,34 +245,18 @@ type StackInput struct {
 type Stack interface {
 	StackName() string
 	Template() (string, error)
-	Parameters() ([]*sdkcfn.Parameter, error)
-	Tags() []*sdkcfn.Tag
-
+	Parameters() (map[string]*string, error)
+	Tags() map[string]string
 	SerializedParameters() (string, error)
 }
 
 // TODO
 func (w *workloadDeployer) AddonsStack() (Stack, error) {
 	return w.addons, nil
-	if w.addons == nil {
-		return nil, nil
-	}
-
-	return nil, nil
-	// return w.addons, nil
 }
 
 func (w *workloadDeployer) RecommendActions() []string {
 	return nil
-}
-
-// AddonsTemplate returns this workload's addon template.
-func (w *workloadDeployer) AddonsTemplate() (string, error) {
-	if w.addons == nil {
-		return "", nil
-	}
-
-	return w.addons.Template()
 }
 
 type forceDeployInput struct {

--- a/internal/pkg/cli/deploy/workload_test.go
+++ b/internal/pkg/cli/deploy/workload_test.go
@@ -1159,8 +1159,8 @@ func TestWorkloadDeployer_DeployWorkload(t *testing.T) {
 				},
 			}
 
-			_, gotErr := deployer.DeployWorkload(&DeployWorkloadInput{
-				Options: Options{
+			_, gotErr := deployer.DeployWorkload(&DeployInput{
+				DeployOpts: DeployOpts{
 					ForceNewUpdate:  tc.inForceDeploy,
 					DisableRollback: tc.inDisableRollback,
 				},

--- a/internal/pkg/cli/flag.go
+++ b/internal/pkg/cli/flag.go
@@ -28,6 +28,7 @@ const (
 	forceFlag      = "force"
 	noRollbackFlag = "no-rollback"
 	manifestFlag   = "manifest"
+	diffFlag       = "diff"
 
 	// Command specific flags.
 	dockerFileFlag        = "dockerfile"
@@ -229,6 +230,9 @@ production environment.`
 	manifestFlagDescription    = "Optional. Output the manifest file used for the deployment."
 	svcManifestFlagDescription = `Optional. Name of the environment in which the service was deployed;
 output the manifest file used for that deployment.`
+	diffFlagPackageDescription = "Optional. Output the diff between the deployed stack and the packaged stack."
+	diffFlagDeployDescription  = `Optional. Acknowledge the diff between the deployed stack
+and the packaged stack before deployment.`
 
 	imageTagFlagDescription     = `Optional. The container image tag.`
 	resourceTagsFlagDescription = `Optional. Labels with a key and value separated by commas.

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -631,18 +631,16 @@ type interpolator interface {
 }
 
 type workloadDeployer interface {
-	UploadArtifacts() (*clideploy.UploadArtifactsOutput, error)
-	DeployWorkload(in *clideploy.DeployWorkloadInput) (clideploy.ActionRecommender, error)
+	UploadArtifacts() error
+	Stack(clideploy.StackRuntimeConfiguration) (clideploy.Stack, error)
+	Deploy(clideploy.Stack, clideploy.DeployOpts) error
 	IsServiceAvailableInRegion(region string) (bool, error)
-}
+	RecommendActions() []string
 
-type workloadStackGenerator interface {
-	UploadArtifacts() (*clideploy.UploadArtifactsOutput, error)
-	GenerateCloudFormationTemplate(in *clideploy.GenerateCloudFormationTemplateInput) (
-		*clideploy.GenerateCloudFormationTemplateOutput, error)
+	// TODO ?
+	// AddonsStack() (clideploy.Stack, error)
 	AddonsTemplate() (string, error)
 }
-
 type runner interface {
 	Run() error
 }

--- a/internal/pkg/cli/job_deploy.go
+++ b/internal/pkg/cli/job_deploy.go
@@ -179,7 +179,7 @@ func (o *deployJobOpts) Execute() error {
 	if err != nil {
 		return fmt.Errorf("upload deploy resources for job %s: %w", o.name, err)
 	}
-	if _, err = deployer.DeployWorkload(&deploy.DeployWorkloadInput{
+	if _, err = deployer.DeployWorkload(&deploy.DeployInput{
 		StackRuntimeConfiguration: deploy.StackRuntimeConfiguration{
 			ImageDigest:        uploadOut.ImageDigest,
 			EnvFileARN:         uploadOut.EnvFileARN,
@@ -188,7 +188,7 @@ func (o *deployJobOpts) Execute() error {
 			Tags:               tags.Merge(o.targetApp.Tags, o.resourceTags),
 			CustomResourceURLs: uploadOut.CustomResourceURLs,
 		},
-		Options: deploy.Options{
+		DeployOpts: deploy.DeployOpts{
 			DisableRollback: o.disableRollback,
 		},
 	}); err != nil {

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -6637,7 +6637,7 @@ func (m *MockworkloadDeployer) EXPECT() *MockworkloadDeployerMockRecorder {
 }
 
 // DeployWorkload mocks base method.
-func (m *MockworkloadDeployer) DeployWorkload(in *deploy.DeployWorkloadInput) (deploy.ActionRecommender, error) {
+func (m *MockworkloadDeployer) DeployWorkload(in *deploy.DeployInput) (deploy.ActionRecommender, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeployWorkload", in)
 	ret0, _ := ret[0].(deploy.ActionRecommender)
@@ -6720,7 +6720,7 @@ func (mr *MockworkloadStackGeneratorMockRecorder) AddonsTemplate() *gomock.Call 
 }
 
 // GenerateCloudFormationTemplate mocks base method.
-func (m *MockworkloadStackGenerator) GenerateCloudFormationTemplate(in *deploy.GenerateCloudFormationTemplateInput) (*deploy.GenerateCloudFormationTemplateOutput, error) {
+func (m *MockworkloadStackGenerator) GenerateCloudFormationTemplate(in *deploy.StackInput) (*deploy.GenerateCloudFormationTemplateOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GenerateCloudFormationTemplate", in)
 	ret0, _ := ret[0].(*deploy.GenerateCloudFormationTemplateOutput)

--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -8,37 +8,25 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/ssm"
-	"github.com/aws/copilot-cli/internal/pkg/aws/identity"
 	"github.com/aws/copilot-cli/internal/pkg/aws/tags"
 	"github.com/aws/copilot-cli/internal/pkg/deploy"
-	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation/stack"
 	"github.com/aws/copilot-cli/internal/pkg/template"
-	"github.com/spf13/afero"
 
 	"github.com/spf13/cobra"
 
-	"github.com/aws/copilot-cli/internal/pkg/aws/sessions"
 	clideploy "github.com/aws/copilot-cli/internal/pkg/cli/deploy"
-	"github.com/aws/copilot-cli/internal/pkg/config"
 	"github.com/aws/copilot-cli/internal/pkg/describe"
 	"github.com/aws/copilot-cli/internal/pkg/exec"
 	"github.com/aws/copilot-cli/internal/pkg/manifest"
 	"github.com/aws/copilot-cli/internal/pkg/term/color"
 	"github.com/aws/copilot-cli/internal/pkg/term/log"
 	termprogress "github.com/aws/copilot-cli/internal/pkg/term/progress"
-	"github.com/aws/copilot-cli/internal/pkg/term/prompt"
-	"github.com/aws/copilot-cli/internal/pkg/term/selector"
-	"github.com/aws/copilot-cli/internal/pkg/workspace"
 )
 
 type deployWkldVars struct {
-	appName         string
-	name            string
-	envName         string
-	imageTag        string
+	packageSvcVars
+
 	resourceTags    map[string]string
 	forceNewUpdate  bool // NOTE: this variable is not applicable for a job workload currently.
 	disableRollback bool
@@ -50,206 +38,92 @@ type deployWkldVars struct {
 type deploySvcOpts struct {
 	deployWkldVars
 
-	store                store
-	ws                   wsWlDirReader
-	unmarshal            func([]byte) (manifest.DynamicWorkload, error)
-	newInterpolator      func(app, env string) interpolator
-	cmd                  execRunner
-	sessProvider         *sessions.Provider
-	newSvcDeployer       func() (workloadDeployer, error)
-	envFeaturesDescriber versionCompatibilityChecker
-
-	spinner progress
-	sel     wsSelector
-	prompt  prompter
+	// deps
+	packageSvcOpts packageSvcOpts
+	cmd            execRunner
+	spinner        progress
 
 	// cached variables
-	targetApp         *config.Application
-	targetEnv         *config.Environment
-	envSess           *session.Session
-	svcType           string
-	appliedDynamicMft manifest.DynamicWorkload
-	rootUserARN       string
-	deployRecs        clideploy.ActionRecommender
+	deployRecs []string
 }
 
 func newSvcDeployOpts(vars deployWkldVars) (*deploySvcOpts, error) {
-	ws, err := workspace.Use(afero.NewOsFs())
+	packageSvcOpts, err := newPackageSvcOpts(vars.packageSvcVars, "svc deploy")
 	if err != nil {
 		return nil, err
 	}
 
-	sessProvider := sessions.ImmutableProvider(sessions.UserAgentExtras("svc deploy"))
-	defaultSession, err := sessProvider.Default()
-	if err != nil {
-		return nil, err
-	}
-
-	store := config.NewSSMStore(identity.New(defaultSession), ssm.New(defaultSession), aws.StringValue(defaultSession.Config.Region))
-	prompter := prompt.New()
-
-	opts := &deploySvcOpts{
+	return &deploySvcOpts{
 		deployWkldVars: vars,
-
-		store:           store,
-		ws:              ws,
-		unmarshal:       manifest.UnmarshalWorkload,
-		spinner:         termprogress.NewSpinner(log.DiagnosticWriter),
-		sel:             selector.NewLocalWorkloadSelector(prompter, store, ws),
-		prompt:          prompter,
-		newInterpolator: newManifestInterpolator,
-		cmd:             exec.NewCmd(),
-		sessProvider:    sessProvider,
-	}
-	opts.newSvcDeployer = func() (workloadDeployer, error) {
-		// NOTE: Defined as a struct member to facilitate unit testing.
-		return newSvcDeployer(opts)
-	}
-	return opts, err
-}
-
-func newSvcDeployer(o *deploySvcOpts) (workloadDeployer, error) {
-	targetApp, err := o.getTargetApp()
-	if err != nil {
-		return nil, err
-	}
-	raw, err := o.ws.ReadWorkloadManifest(o.name)
-	if err != nil {
-		return nil, fmt.Errorf("read manifest file for %s: %w", o.name, err)
-	}
-	content := o.appliedDynamicMft.Manifest()
-	var deployer workloadDeployer
-	in := clideploy.WorkloadDeployerInput{
-		SessionProvider:  o.sessProvider,
-		Name:             o.name,
-		App:              targetApp,
-		Env:              o.targetEnv,
-		ImageTag:         o.imageTag,
-		Mft:              content,
-		RawMft:           raw,
-		EnvVersionGetter: o.envFeaturesDescriber,
-	}
-	switch t := content.(type) {
-	case *manifest.LoadBalancedWebService:
-		deployer, err = clideploy.NewLBWSDeployer(&in)
-	case *manifest.BackendService:
-		deployer, err = clideploy.NewBackendDeployer(&in)
-	case *manifest.RequestDrivenWebService:
-		deployer, err = clideploy.NewRDWSDeployer(&in)
-	case *manifest.WorkerService:
-		deployer, err = clideploy.NewWorkerSvcDeployer(&in)
-	default:
-		return nil, fmt.Errorf("unknown manifest type %T while creating the CloudFormation stack", t)
-	}
-	if err != nil {
-		return nil, fmt.Errorf("initiate workload deployer: %w", err)
-	}
-	return deployer, nil
-}
-
-func newManifestInterpolator(app, env string) interpolator {
-	return manifest.NewInterpolator(app, env)
+		packageSvcOpts: *packageSvcOpts,
+		spinner:        termprogress.NewSpinner(log.DiagnosticWriter),
+		cmd:            exec.NewCmd(),
+	}, nil
 }
 
 // Validate returns an error for any invalid optional flags.
 func (o *deploySvcOpts) Validate() error {
-	return nil
+	return o.packageSvcOpts.Validate()
 }
 
 // Ask prompts for and validates any required flags.
 func (o *deploySvcOpts) Ask() error {
-	if o.appName != "" {
-		if _, err := o.getTargetApp(); err != nil {
-			return err
-		}
-	} else {
-		// NOTE: This command is required to be executed under a workspace. We don't prompt for it.
-		return errNoAppInWorkspace
-	}
+	// TODO fix prompts to not say "package"
+	/*
+	   func (o *deploySvcOpts) validateOrAskSvcName() error {
+	   	name, err := o.sel.Service("Select a service in your workspace", "")
+	   	return nil
+	   }
 
-	if err := o.validateOrAskSvcName(); err != nil {
-		return err
-	}
-
-	if err := o.validateOrAskEnvName(); err != nil {
-		return err
-	}
-	return nil
+	   func (o *deploySvcOpts) validateOrAskEnvName() error {
+	   	name, err := o.sel.Environment("Select an environment", "", o.appName)
+	   	return nil
+	   }
+	*/
+	return o.packageSvcOpts.Ask()
 }
 
 // Execute builds and pushes the container image for the service,
 func (o *deploySvcOpts) Execute() error {
-	if !o.clientConfigured {
-		if err := o.configureClients(); err != nil {
-			return err
-		}
-	}
-	mft, err := workloadManifest(&workloadManifestInput{
-		name:         o.name,
-		appName:      o.appName,
-		envName:      o.envName,
-		interpolator: o.newInterpolator(o.appName, o.envName),
-		ws:           o.ws,
-		unmarshal:    o.unmarshal,
-		sess:         o.envSess,
-	})
+	deployer, err := o.packageSvcOpts.Deployer()
 	if err != nil {
 		return err
-	}
-	o.appliedDynamicMft = mft
-	if err := validateWorkloadManifestCompatibilityWithEnv(o.ws, o.envFeaturesDescriber, mft, o.envName); err != nil {
-		return err
-	}
-	deployer, err := o.newSvcDeployer()
-	if err != nil {
-		return err
-	}
-	serviceInRegion, err := deployer.IsServiceAvailableInRegion(o.targetEnv.Region)
-	if err != nil {
-		return fmt.Errorf("check if %s is available in region %s: %w", o.svcType, o.targetEnv.Region, err)
 	}
 
-	if !serviceInRegion {
-		log.Warningf(`%s might not be available in region %s; proceed with caution.
-`, o.svcType, o.targetEnv.Region)
+	if err := deployer.UploadArtifacts(); err != nil {
+		return fmt.Errorf("upload artifacts: %w", err)
 	}
-	uploadOut, err := deployer.UploadArtifacts()
+
+	// generate stacks
+	stack, err := deployer.Stack(clideploy.StackRuntimeConfiguration{
+		RootUserARN: o.packageSvcOpts.rootUserARN,
+		Tags:        tags.Merge(o.packageSvcOpts.targetApp.Tags, o.resourceTags),
+	})
 	if err != nil {
-		return fmt.Errorf("upload deploy resources for service %s: %w", o.name, err)
+		return fmt.Errorf("generate stack: %w", err)
 	}
-	targetApp, err := o.getTargetApp()
-	if err != nil {
-		return err
-	}
-	deployRecs, err := deployer.DeployWorkload(&clideploy.DeployWorkloadInput{
-		StackRuntimeConfiguration: clideploy.StackRuntimeConfiguration{
-			ImageDigest:        uploadOut.ImageDigest,
-			EnvFileARN:         uploadOut.EnvFileARN,
-			AddonsURL:          uploadOut.AddonsURL,
-			RootUserARN:        o.rootUserARN,
-			Tags:               tags.Merge(targetApp.Tags, o.resourceTags),
-			CustomResourceURLs: uploadOut.CustomResourceURLs,
-		},
-		Options: clideploy.Options{
-			ForceNewUpdate:  o.forceNewUpdate,
-			DisableRollback: o.disableRollback,
-		},
+
+	err = deployer.Deploy(stack, clideploy.DeployOpts{
+		ForceNewUpdate:  o.forceNewUpdate,
+		DisableRollback: o.disableRollback,
 	})
 	if err != nil {
 		if o.disableRollback {
-			stackName := stack.NameForService(o.targetApp.Name, o.targetEnv.Name, o.name)
-			rollbackCmd := fmt.Sprintf("aws cloudformation rollback-stack --stack-name %s --role-arn %s", stackName, o.targetEnv.ExecutionRoleARN)
+			// stackName := stack.NameForService(o.packageSvcOpts.targetApp.Name, o.packageSvcOpts.targetEnv.Name, o.name)
+			stackName := "TODO"
+			rollbackCmd := fmt.Sprintf("aws cloudformation rollback-stack --stack-name %s --role-arn %s", stackName, o.packageSvcOpts.targetEnv.ExecutionRoleARN)
 			log.Infof(`It seems like you have disabled automatic stack rollback for this deployment. To debug, you can:
-* Run %s to inspect the service log.
-* Visit the AWS console to inspect the errors.
-After fixing the deployment, you can:
-1. Run %s to rollback the deployment.
-2. Run %s to make a new deployment.
+	* Run %s to inspect the service log.
+	* Visit the AWS console to inspect the errors.
+	After fixing the deployment, you can:
+	1. Run %s to rollback the deployment.
+	2. Run %s to make a new deployment.
 `, color.HighlightCode("copilot svc logs"), color.HighlightCode(rollbackCmd), color.HighlightCode("copilot svc deploy"))
 		}
 		return fmt.Errorf("deploy service %s to environment %s: %w", o.name, o.envName, err)
 	}
-	o.deployRecs = deployRecs
+
+	o.deployRecs = deployer.RecommendActions()
 	log.Successf("Deployed service %s.\n", color.HighlightUserInput(o.name))
 	return nil
 }
@@ -262,100 +136,9 @@ func (o *deploySvcOpts) RecommendActions() error {
 		return err
 	}
 	recommendations = append(recommendations, uriRecs...)
-	if o.deployRecs != nil {
-		recommendations = append(recommendations, o.deployRecs.RecommendedActions()...)
-	}
+	recommendations = append(recommendations, o.deployRecs...)
 	recommendations = append(recommendations, o.publishRecommendedActions()...)
 	logRecommendedActions(recommendations)
-	return nil
-}
-
-func (o *deploySvcOpts) validateSvcName() error {
-	names, err := o.ws.ListServices()
-	if err != nil {
-		return fmt.Errorf("list services in the workspace: %w", err)
-	}
-	for _, name := range names {
-		if o.name == name {
-			return nil
-		}
-	}
-	return fmt.Errorf("service %s not found in the workspace", color.HighlightUserInput(o.name))
-}
-
-func (o *deploySvcOpts) validateEnvName() error {
-	if _, err := o.store.GetEnvironment(o.appName, o.envName); err != nil {
-		return fmt.Errorf("get environment %s configuration: %w", o.envName, err)
-	}
-	return nil
-}
-
-func (o *deploySvcOpts) validateOrAskSvcName() error {
-	if o.name != "" {
-		return o.validateSvcName()
-	}
-
-	name, err := o.sel.Service("Select a service in your workspace", "")
-	if err != nil {
-		return fmt.Errorf("select service: %w", err)
-	}
-	o.name = name
-	return nil
-}
-
-func (o *deploySvcOpts) validateOrAskEnvName() error {
-	if o.envName != "" {
-		return o.validateEnvName()
-	}
-
-	name, err := o.sel.Environment("Select an environment", "", o.appName)
-	if err != nil {
-		return fmt.Errorf("select environment: %w", err)
-	}
-	o.envName = name
-	return nil
-}
-
-func (o *deploySvcOpts) configureClients() error {
-	o.imageTag = imageTagFromGit(o.cmd, o.imageTag) // Best effort assign git tag.
-	env, err := o.store.GetEnvironment(o.appName, o.envName)
-	if err != nil {
-		return fmt.Errorf("get environment %s configuration: %w", o.envName, err)
-	}
-	o.targetEnv = env
-	svc, err := o.store.GetService(o.appName, o.name)
-	if err != nil {
-		return fmt.Errorf("get service %s configuration: %w", o.name, err)
-	}
-	o.svcType = svc.Type
-
-	// client to retrieve an application's resources created with CloudFormation.
-	defaultSess, err := o.sessProvider.Default()
-	if err != nil {
-		return fmt.Errorf("create default session: %w", err)
-	}
-	envSess, err := o.sessProvider.FromRole(env.ManagerRoleARN, env.Region)
-	if err != nil {
-		return err
-	}
-	o.envSess = envSess
-
-	// client to retrieve caller identity.
-	caller, err := identity.New(defaultSess).Get()
-	if err != nil {
-		return fmt.Errorf("get identity: %w", err)
-	}
-	o.rootUserARN = caller.RootUserARN
-
-	envDescriber, err := describe.NewEnvDescriber(describe.NewEnvDescriberConfig{
-		App:         o.appName,
-		Env:         o.envName,
-		ConfigStore: o.store,
-	})
-	if err != nil {
-		return err
-	}
-	o.envFeaturesDescriber = envDescriber
 	return nil
 }
 
@@ -489,18 +272,6 @@ func (o *deploySvcOpts) publishRecommendedActions() []string {
 	}
 }
 
-func (o *deploySvcOpts) getTargetApp() (*config.Application, error) {
-	if o.targetApp != nil {
-		return o.targetApp, nil
-	}
-	app, err := o.store.GetApplication(o.appName)
-	if err != nil {
-		return nil, fmt.Errorf("get application %s configuration: %w", o.appName, err)
-	}
-	o.targetApp = app
-	return o.targetApp, nil
-}
-
 type errFeatureIncompatibleWithEnvironment struct {
 	ws             wsEnvironmentsLister
 	missingFeature string
@@ -564,6 +335,7 @@ func buildSvcDeployCmd() *cobra.Command {
 	cmd.Flags().StringToStringVar(&vars.resourceTags, resourceTagsFlag, nil, resourceTagsFlagDescription)
 	cmd.Flags().BoolVar(&vars.forceNewUpdate, forceFlag, false, forceFlagDescription)
 	cmd.Flags().BoolVar(&vars.disableRollback, noRollbackFlag, false, noRollbackFlagDescription)
+	cmd.Flags().BoolVar(&vars.showDiff, diffFlag, false, noRollbackFlagDescription)
 
 	return cmd
 }

--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -68,18 +68,6 @@ func (o *deploySvcOpts) Validate() error {
 
 // Ask prompts for and validates any required flags.
 func (o *deploySvcOpts) Ask() error {
-	// TODO fix prompts to not say "package"
-	/*
-	   func (o *deploySvcOpts) validateOrAskSvcName() error {
-	   	name, err := o.sel.Service("Select a service in your workspace", "")
-	   	return nil
-	   }
-
-	   func (o *deploySvcOpts) validateOrAskEnvName() error {
-	   	name, err := o.sel.Environment("Select an environment", "", o.appName)
-	   	return nil
-	   }
-	*/
 	return o.packageSvcOpts.Ask()
 }
 
@@ -220,7 +208,7 @@ func (o *deploySvcOpts) uriRecommendedActions() ([]string, error) {
 	type reachable interface {
 		Port() (uint16, bool)
 	}
-	mft, ok := o.appliedDynamicMft.Manifest().(reachable)
+	mft, ok := o.packageSvcOpts.appliedDynamicMft.Manifest().(reachable)
 	if !ok {
 		return nil, nil
 	}
@@ -228,7 +216,7 @@ func (o *deploySvcOpts) uriRecommendedActions() ([]string, error) {
 		return nil, nil
 	}
 
-	describer, err := describe.NewReachableService(o.appName, o.name, o.store)
+	describer, err := describe.NewReachableService(o.appName, o.name, o.packageSvcOpts.store)
 	if err != nil {
 		return nil, err
 	}
@@ -256,7 +244,7 @@ func (o *deploySvcOpts) publishRecommendedActions() []string {
 	type publisher interface {
 		Publish() []manifest.Topic
 	}
-	mft, ok := o.appliedDynamicMft.Manifest().(publisher)
+	mft, ok := o.packageSvcOpts.appliedDynamicMft.Manifest().(publisher)
 	if !ok {
 		return nil
 	}
@@ -331,7 +319,7 @@ func buildSvcDeployCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&vars.appName, appFlag, appFlagShort, tryReadingAppName(), appFlagDescription)
 	cmd.Flags().StringVarP(&vars.name, nameFlag, nameFlagShort, "", svcFlagDescription)
 	cmd.Flags().StringVarP(&vars.envName, envFlag, envFlagShort, "", envFlagDescription)
-	cmd.Flags().StringVar(&vars.imageTag, imageTagFlag, "", imageTagFlagDescription)
+	cmd.Flags().StringVar(&vars.tag, imageTagFlag, "", imageTagFlagDescription)
 	cmd.Flags().StringToStringVar(&vars.resourceTags, resourceTagsFlag, nil, resourceTagsFlagDescription)
 	cmd.Flags().BoolVar(&vars.forceNewUpdate, forceFlag, false, forceFlagDescription)
 	cmd.Flags().BoolVar(&vars.disableRollback, noRollbackFlag, false, noRollbackFlagDescription)

--- a/internal/pkg/cli/svc_package_test.go
+++ b/internal/pkg/cli/svc_package_test.go
@@ -202,7 +202,7 @@ count: 1`
 				m.generator.EXPECT().UploadArtifacts().Return(&deploy.UploadArtifactsOutput{
 					ImageDigest: aws.String(mockDigest),
 				}, nil)
-				m.generator.EXPECT().GenerateCloudFormationTemplate(&deploy.GenerateCloudFormationTemplateInput{
+				m.generator.EXPECT().GenerateCloudFormationTemplate(&deploy.StackInput{
 					StackRuntimeConfiguration: deploy.StackRuntimeConfiguration{
 						ImageDigest: aws.String(mockDigest),
 						RootUserARN: mockARN,
@@ -243,7 +243,7 @@ count: 1`
 					},
 				}
 				m.envFeaturesDescriber.EXPECT().AvailableFeatures().Return([]string{}, nil)
-				m.generator.EXPECT().GenerateCloudFormationTemplate(&deploy.GenerateCloudFormationTemplateInput{
+				m.generator.EXPECT().GenerateCloudFormationTemplate(&deploy.StackInput{
 					StackRuntimeConfiguration: deploy.StackRuntimeConfiguration{
 						RootUserARN: mockARN,
 					},

--- a/internal/pkg/deploy/cloudformation/cloudformation.go
+++ b/internal/pkg/deploy/cloudformation/cloudformation.go
@@ -50,8 +50,8 @@ var (
 type StackConfiguration interface {
 	StackName() string
 	Template() (string, error)
-	Parameters() ([]*sdkcloudformation.Parameter, error)
-	Tags() []*sdkcloudformation.Tag
+	Parameters() (map[string]*string, error)
+	Tags() map[string]string
 	SerializedParameters() (string, error)
 }
 

--- a/internal/pkg/deploy/cloudformation/stack/scheduled_job.go
+++ b/internal/pkg/deploy/cloudformation/stack/scheduled_job.go
@@ -14,7 +14,6 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/config"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/copilot-cli/internal/pkg/manifest"
 	"github.com/aws/copilot-cli/internal/pkg/template"
 	"github.com/aws/copilot-cli/internal/pkg/template/override"
@@ -203,8 +202,8 @@ func (j *ScheduledJob) Template() (string, error) {
 }
 
 // Parameters returns the list of CloudFormation parameters used by the template.
-func (j *ScheduledJob) Parameters() ([]*cloudformation.Parameter, error) {
-	wkldParams, err := j.ecsWkld.Parameters()
+func (j *ScheduledJob) Parameters() (map[string]*string, error) {
+	params, err := j.ecsWkld.Parameters()
 	if err != nil {
 		return nil, err
 	}
@@ -212,16 +211,9 @@ func (j *ScheduledJob) Parameters() ([]*cloudformation.Parameter, error) {
 	if err != nil {
 		return nil, err
 	}
-	return append(wkldParams, []*cloudformation.Parameter{
-		{
-			ParameterKey:   aws.String(ScheduledJobScheduleParamKey),
-			ParameterValue: aws.String(schedule),
-		},
-		{
-			ParameterKey:   aws.String(WorkloadEnvFileARNParamKey),
-			ParameterValue: aws.String(j.rc.EnvFileARN),
-		},
-	}...), nil
+
+	params[ScheduledJobScheduleParamKey] = aws.String(schedule)
+	return params, nil
 }
 
 // SerializedParameters returns the CloudFormation stack's parameters serialized to a JSON document.
@@ -277,7 +269,8 @@ func (j *ScheduledJob) awsSchedule() (string, error) {
 
 // toRate converts a cron "@every" directive to a rate expression defined in minutes.
 // example input: @every 1h30m
-//        output: rate(90 minutes)
+//
+//	output: rate(90 minutes)
 func toRate(duration string) (string, error) {
 	d, err := time.ParseDuration(duration)
 	if err != nil {
@@ -302,9 +295,10 @@ func toRate(duration string) (string, error) {
 // toFixedSchedule converts cron predefined schedules into AWS-flavored cron expressions.
 // (https://godoc.org/github.com/robfig/cron#hdr-Predefined_schedules)
 // Example input: @daily
-//        output: cron(0 0 * * ? *)
-//         input: @annually
-//        output: cron(0 0 1 1 ? *)
+//
+//	output: cron(0 0 * * ? *)
+//	 input: @annually
+//	output: cron(0 0 1 1 ? *)
 func toFixedSchedule(schedule string) (string, error) {
 	switch {
 	case strings.HasPrefix(schedule, hourly):
@@ -337,7 +331,8 @@ func awsCronFieldSpecified(input string) bool {
 // BOTH DOM and DOW cannot be specified
 // DOW numbers run 1-7, not 0-6
 // Example input: 0 9 * * 1-5 (at 9 am, Monday-Friday)
-//              : cron(0 9 ? * 2-6 *) (adds required ? operator, increments DOW to 1-index, adds year)
+//
+//	: cron(0 9 ? * 2-6 *) (adds required ? operator, increments DOW to 1-index, adds year)
 func toAWSCron(schedule string) (string, error) {
 	const (
 		MIN = iota

--- a/internal/pkg/deploy/cloudformation/stack/worker_svc.go
+++ b/internal/pkg/deploy/cloudformation/stack/worker_svc.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/copilot-cli/internal/pkg/config"
 	"github.com/aws/copilot-cli/internal/pkg/manifest"
 	"github.com/aws/copilot-cli/internal/pkg/template"
@@ -165,15 +164,8 @@ func (s *WorkerService) Template() (string, error) {
 }
 
 // Parameters returns the list of CloudFormation parameters used by the template.
-func (s *WorkerService) Parameters() ([]*cloudformation.Parameter, error) {
-	wkldParams, err := s.ecsWkld.Parameters()
-	if err != nil {
-		return nil, err
-	}
-	return append(wkldParams, &cloudformation.Parameter{
-		ParameterKey:   aws.String(WorkloadEnvFileARNParamKey),
-		ParameterValue: aws.String(s.rc.EnvFileARN),
-	}), nil
+func (s *WorkerService) Parameters() (map[string]*string, error) {
+	return s.ecsWkld.Parameters()
 }
 
 // SerializedParameters returns the CloudFormation stack's parameters serialized to a JSON document.

--- a/internal/pkg/deploy/cloudformation/stack/workload.go
+++ b/internal/pkg/deploy/cloudformation/stack/workload.go
@@ -102,7 +102,8 @@ func (i ECRImage) GetLocation() string {
 
 type addons interface {
 	Template() (string, error)
-	Parameters() (string, error)
+	SerializedParameters() (string, error)
+	Parameters() (map[string]*string, error)
 }
 
 type location interface {


### PR DESCRIPTION
This (incomplete) PR refactors the `cli` and `cli/deploy` packages to make the `addon` and `main` stacks visible to the `cli` package. The idea is to combine similar functionality between `package` and `deploy` commands to follow the same pattern of generate stack -> do something with it (deploy or print). This makes it so that we can add steps _after_ generating the stack but _before_ doing the command task, like printing a diff or overriding a template.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
