### PR TITLE
docs(ja): fix broken link and broken rendering

### DIFF
--- a/site/content/blogs/release-v123.ja.md
+++ b/site/content/blogs/release-v123.ja.md
@@ -56,8 +56,8 @@ Environment 内にトラフィックを送りたい場合は、Manifest に [`ne
 
 <a id="support-aurora-serverless-v2-in-storage-init"></a>
 
-## [`storage init`] (../docs/commands/storage-init.ja.md)で Aurora Serverless v2 をサポート
-[Aurora Serverless v2 は 今年の初めに一般利用を開始](https://aws.amazon.com/about-aws/whats-new/2022/04/amazon-aurora-serverless-v2/)しており、
+## [`storage init`](../docs/commands/storage-init.ja.md)で Aurora Serverless v2 をサポート
+[Aurora Serverless v2 は今年の初めに一般利用を開始](https://aws.amazon.com/about-aws/whats-new/2022/04/amazon-aurora-serverless-v2/)しており、
 現在、Copilot のストレージオプションとしてサポートされています。
 
 以前は、次のコマンドを実行し、

--- a/site/content/docs/developing/svc-to-svc-communication.ja.md
+++ b/site/content/docs/developing/svc-to-svc-communication.ja.md
@@ -1,6 +1,6 @@
 # サービス間通信
 
-## Service Connect が<span class="version" > v1.24.0 </span>で追加
+## Service Connect <span class="version" > v1.24.0 </span>
 
 [ECS Service Connect](https://docs.aws.amazon.com/ja_jp/AmazonECS/latest/developerguide/service-connect.html) を使うとクライアント Service が負荷分散された弾力的な方法で、ダウンストリームの Service に接続できます。さらに分かりやすいエイリアスを指定することで、Service をクライアントに公開する方法を簡単にします。Copilot における Service Connect は、作成した各 Service にデフォルトで次の様なプライベートエイリアスを付与します：`http://<your service name>` 。
 

--- a/site/content/docs/manifest/rd-web-service.ja.md
+++ b/site/content/docs/manifest/rd-web-service.ja.md
@@ -224,6 +224,7 @@ AWS App Runner リソースとして渡される AWS タグを表すキー・値
 既存のオートスケーリング設定の名前を指定します。
 ```yaml
 count: high-availability/3
+```
 <div class="separator"></div>
 
 <a id="environments" href="#environments" class="field">`environments`</a> <span class="type">Map</span>  


### PR DESCRIPTION
<!-- Provide summary of changes -->
Fix two points:
- [Link of `storage init`](https://aws.github.io/copilot-cli/ja/blogs/release-v123/#storage-init-docscommandsstorage-initjamd-aurora-serverless-v2) is broken
- [Rendering of Request-Driven Web Service Manifest's count field](https://aws.github.io/copilot-cli/ja/docs/manifest/rd-web-service/#count) is broken

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
