### PR TITLE
docs(ja): fix yaml rendering for blog release v 1.24 in Japanese

### DIFF
--- a/site/content/blogs/release-v124.ja.md
+++ b/site/content/blogs/release-v124.ja.md
@@ -24,18 +24,18 @@ Copilot v1.24 では、いくつかの新機能と改良が施されています
 count: high-availability/3
 ```
 - **VPC フローログのログ保持期間の指定**: デフォルトでは 14 日間です。
- ```yaml
+```yaml
 network:
   vpc:
     flow_logs: on
- ```
+```
  または、保持期間を変更できます。
- ```yaml
+```yaml
 network:
   vpc:
     flow_logs:
       retention: 30
- ```
+```
 
 
 ???+ note "AWS Copilot とは?"


### PR DESCRIPTION
<!-- Provide summary of changes -->
Fix yaml rendering issue of AWS Copilot v1.24 release blog in Japanese. 
Apply [this](https://github.com/aws/copilot-cli/pull/4300) for Japanese documentation.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
