### PR TITLE
chore(manifest): make cdn static path to be required

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/env.go
+++ b/internal/pkg/deploy/cloudformation/stack/env.go
@@ -45,8 +45,7 @@ const (
 
 const (
 	// DefaultVPCCIDR is the default CIDR used for a manged VPC.
-	DefaultVPCCIDR       = "10.0.0.0/16"
-	defaultCDNStaticPath = "*"
+	DefaultVPCCIDR = "10.0.0.0/16"
 )
 
 var (
@@ -451,11 +450,8 @@ func (e *Env) cdnConfig() *template.CDNConfig {
 	if !mftConfig.Static.IsEmpty() {
 		config.Static = &template.CDNStaticAssetConfig{
 			Location: mftConfig.Static.Location,
-			Path:     defaultCDNStaticPath,
+			Path:     mftConfig.Static.Path,
 			Alias:    mftConfig.Static.Alias,
-		}
-		if mftConfig.Static.Path != nil {
-			config.Static.Path = aws.StringValue(mftConfig.Static.Path)
 		}
 	}
 	return config

--- a/internal/pkg/deploy/cloudformation/stack/env_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/env_integration_test.go
@@ -37,6 +37,7 @@ cdn:
   static_assets:
     location: cf-s3-ecs-demo-bucket.s3.us-west-2.amazonaws.com
     alias: example.com
+    path: static/*
 http:
   public:
     ingress:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-cloudfront-observability.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-cloudfront-observability.yml
@@ -11,6 +11,7 @@ Metadata:
       static_assets:
         location: cf-s3-ecs-demo-bucket.s3.us-west-2.amazonaws.com
         alias: example.com
+        path: static/*
     http:
       public:
         ingress:
@@ -366,7 +367,7 @@ Resources:
             ViewerProtocolPolicy: allow-all
             CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6 # See https://go.aws/3bJid3k
             TargetOriginId: !Sub 'copilot-${AppName}-${EnvironmentName}-s3'
-            PathPattern: '*'
+            PathPattern: 'static/*'
         ViewerCertificate:
           AcmCertificateArn: viewer-cert
           MinimumProtocolVersion: TLSv1

--- a/internal/pkg/manifest/env.go
+++ b/internal/pkg/manifest/env.go
@@ -273,14 +273,14 @@ func (cfg *EnvironmentCDNConfig) UnmarshalYAML(value *yaml.Node) error {
 
 // CDNStaticConfig represents the static config for CDN.
 type CDNStaticConfig struct {
-	Location string  `yaml:"location,omitempty"`
-	Alias    string  `yaml:"alias,omitempty"`
-	Path     *string `yaml:"path,omitempty"`
+	Location string `yaml:"location,omitempty"`
+	Alias    string `yaml:"alias,omitempty"`
+	Path     string `yaml:"path,omitempty"`
 }
 
 // IsEmpty returns true if CDNStaticConfig is not configured.
 func (cfg CDNStaticConfig) IsEmpty() bool {
-	return cfg.Location == "" && cfg.Alias == "" && cfg.Path == nil
+	return cfg.Location == "" && cfg.Alias == "" && cfg.Path == ""
 }
 
 // IsEmpty returns true if environmentVPCConfig is not configured.

--- a/internal/pkg/manifest/env_test.go
+++ b/internal/pkg/manifest/env_test.go
@@ -919,7 +919,7 @@ func TestCDNStaticConfig_IsEmpty(t *testing.T) {
 		},
 		"not empty": {
 			in: CDNStaticConfig{
-				Path: aws.String("something"),
+				Path: "something",
 			},
 			wanted: false,
 		},

--- a/internal/pkg/manifest/validate_env.go
+++ b/internal/pkg/manifest/validate_env.go
@@ -421,6 +421,11 @@ func (cfg CDNStaticConfig) validate() error {
 			missingField: "location",
 		}
 	}
+	if cfg.Path == "" {
+		return &errFieldMustBeSpecified{
+			missingField: "path",
+		}
+	}
 	return nil
 }
 

--- a/internal/pkg/manifest/validate_env_test.go
+++ b/internal/pkg/manifest/validate_env_test.go
@@ -866,7 +866,7 @@ func TestCDNConfiguration_validate(t *testing.T) {
 			in: EnvironmentCDNConfig{
 				Config: AdvancedCDNConfig{
 					Static: CDNStaticConfig{
-						Path: aws.String("something"),
+						Path: "something",
 					},
 				},
 			},
@@ -907,7 +907,7 @@ func TestCDNStaticConfig_validate(t *testing.T) {
 		},
 		"invalid if alias is not specified": {
 			in: CDNStaticConfig{
-				Path: aws.String("something"),
+				Path: "something",
 			},
 			wantedError: fmt.Errorf(`"alias" must be specified`),
 		},
@@ -917,10 +917,18 @@ func TestCDNStaticConfig_validate(t *testing.T) {
 			},
 			wantedError: fmt.Errorf(`"location" must be specified`),
 		},
+		"invalid if path is not specified": {
+			in: CDNStaticConfig{
+				Alias:    "example.com",
+				Location: "s3url",
+			},
+			wantedError: fmt.Errorf(`"path" must be specified`),
+		},
 		"success": {
 			in: CDNStaticConfig{
 				Alias:    "example.com",
 				Location: "static",
+				Path:     "something",
 			},
 		},
 	}


### PR DESCRIPTION
<!-- Provide summary of changes -->
Making cdn static path to be required because ALB is the default cache behavior and if we give `*` as a default value for path, it means all the traffic will be routed to the static pattern (a possible use case but not a sane default).
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
