### PR TITLE
chore(sessions): add UserAgentExtras method to Provider

### DIFF
--- a/internal/pkg/aws/sessions/sessions.go
+++ b/internal/pkg/aws/sessions/sessions.go
@@ -70,6 +70,14 @@ func UserAgentExtras(extras ...string) func(*Provider) {
 	}
 }
 
+// UserAgentExtras adds additional User-Agent extras to cached sessions and any new sessions.
+func (p *Provider) UserAgentExtras(extras ...string) {
+	p.userAgentExtras = append(p.userAgentExtras, extras...)
+	if p.defaultSess != nil {
+		p.defaultSess.Handlers.Build.SwapNamed(p.userAgentHandler())
+	}
+}
+
 // Default returns a session configured against the "default" AWS profile.
 // Default assumes that a region must be present with a session, otherwise it returns an error.
 func (p *Provider) Default() (*session.Session, error) {

--- a/internal/pkg/aws/sessions/sessions_test.go
+++ b/internal/pkg/aws/sessions/sessions_test.go
@@ -6,10 +6,11 @@ package sessions
 import (
 	"context"
 	"errors"
-	"github.com/aws/copilot-cli/internal/pkg/aws/sessions/mocks"
-	"github.com/golang/mock/gomock"
 	"os"
 	"testing"
+
+	"github.com/aws/copilot-cli/internal/pkg/aws/sessions/mocks"
+	"github.com/golang/mock/gomock"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"


### PR DESCRIPTION
I couldn't find a way to write a unit test that ensures the user-agent will have the extras on new requests.
However, I tested the method manually in `copilot app show` and I can see the new extras added on requests.

Related #4208 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
