### PR TITLE
chore: validate addons parameters before deployment

### DIFF
--- a/internal/pkg/addon/addons.go
+++ b/internal/pkg/addon/addons.go
@@ -245,7 +245,7 @@ func validateParameters(neededNode yaml.Node, passedNode yaml.Node, reservedKeys
 	if err := neededNode.Decode(needed); err != nil {
 		return fmt.Errorf("decode \"Parameters\" section of the template file: %w", err)
 	}
-	// The reserved keys should present/be absent in the template/parameters file.
+	// The reserved keys should be present/absent in the template/parameters file.
 	for _, k := range reservedKeys {
 		if _, ok := needed[k]; !ok {
 			return fmt.Errorf("required parameter %q is missing from the template", k)

--- a/internal/pkg/addon/addons.go
+++ b/internal/pkg/addon/addons.go
@@ -255,7 +255,7 @@ func validateParameters(neededNode yaml.Node, passedNode yaml.Node, reservedKeys
 		}
 		passed[k] = yaml.Node{}
 	}
-	for k, _ := range passed {
+	for k := range passed {
 		if _, ok := needed[k]; !ok {
 			return fmt.Errorf("template does not require the parameter %q in parameters file", k)
 		}

--- a/internal/pkg/addon/testdata/merge/env/first.yaml
+++ b/internal/pkg/addon/testdata/merge/env/first.yaml
@@ -1,0 +1,83 @@
+Metadata:
+  Version: 1
+  Services:
+    - api
+    - fe
+
+Parameters:
+  App:
+    Type: String
+    Description: Your application's name.
+  Env:
+    Type: String
+    Description: The environment name your service, job, or workflow is being deployed to.
+
+Mappings:
+  MyTableDynamoDBSettings:
+    test:
+      RCU: 5
+      WCU: 5
+    prod:
+      RCU: 50
+      WCU: 25
+
+Conditions:
+  IsProd: !Equals [!Ref Env, prod]
+
+Transform: AWS::Serverless-2016-10-31
+
+Resources:
+  MyTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: !Sub '${App}-${Env}-mytable'
+      AttributeDefinitions:
+        - AttributeName: id
+          AttributeType: S
+      KeySchema:
+        - AttributeName: id
+          KeyType: HASH
+      ProvisionedThroughput:
+        ReadCapacityUnits:
+          Fn::FindInMap: [MyTableDynamoDBSettings, Ref: Env, RCU]
+        WriteCapacityUnits:
+          Fn::FindInMap: [MyTableDynamoDBSettings, Ref: Env, WCU]
+  
+  MyTableAccessPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: !Sub
+        - Grants CRUD access to MyTable
+        - { Table: !Ref MyTable }
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: DDBActions
+            Effect: Allow
+            Action:
+              - dynamodb:BatchGet*
+              - dynamodb:DescribeStream
+              - dynamodb:DescribeTable
+              - dynamodb:Get*
+              - dynamodb:Query
+              - dynamodb:Scan
+              - dynamodb:BatchWrite*
+              - dynamodb:Create*
+              - dynamodb:Delete*
+              - dynamodb:Update*
+              - dynamodb:PutItem
+            Resource: !Sub ${ MyTable.Arn}
+          - Sid: DDBLSIActions
+            Action:
+              - dynamodb:Query
+              - dynamodb:Scan
+            Effect: Allow
+            Resource: !Sub ${ MyTable.Arn}/index/*
+
+Outputs:
+  MyTableName:
+    Description: "The name of this DynamoDB."
+    Value: !Ref MyTable
+  MyTableAccessPolicy:
+    Description: "The IAM::ManagedPolicy to attach to the task role."
+    Value: !Ref MyTableAccessPolicy

--- a/internal/pkg/addon/testdata/merge/env/second.yaml
+++ b/internal/pkg/addon/testdata/merge/env/second.yaml
@@ -1,0 +1,113 @@
+# The indentation and the exact line where a field appears should be ignored.
+Metadata:
+  Databases:
+    users: Database for users.
+    payments: Database for payments.
+
+  # The HeadComment -- comments preceding the node -- should be ignored.
+  Version: 1 #  The LineComment -- comment at the end of the node -- should be ignored.
+  # The FootComments -- comments after the node -- should be ignored.
+  # Continuation of foot comment.
+
+  # Different Styles of definition a node should be ignored (single quote, double quote, flow, ...)
+  Services: ['api', "fe"]
+
+Parameters:
+  # Different indentation and order should not matter.
+  Env:
+    Type: String
+    Description: The environment name your service, job, or workflow is being deployed to.
+  App: # Line comment is ignored.
+      Type: String
+      Description: Your application's name.
+  IsProd:
+    Type: String
+    Default: "false"
+  InstanceType:
+    Type: 'AWS::SSM::Parameter::Value<String>'
+    Default: mini
+
+Mappings:
+  MyTableDynamoDBSettings:
+    prod: # Another ignored comment.
+      # Comments and position should not matter.
+
+      RCU: 50
+      WCU: 25
+    test:
+      RCU: 5
+      WCU: 5
+    gamma:
+      RCU: 10
+      WCU: 10
+  MyLambdaSettings:
+    test:
+      MemorySize: 512
+    prod:
+      MemorySize: 1024
+
+Conditions:
+  IsTest:
+    !Not [!Equals [ !Ref Env, "prod" ]]
+  IsProd:
+    !Equals [!Ref Env, prod]
+  ExportOutputs: !Or
+    - !Condition IsProd
+    - !Condition IsTest
+
+Transform:
+  - Name: 'AWS::Include'
+    Parameters:
+      Location: 's3://MyAmazonS3BucketName/MyFileName.yaml'
+  - 'AWS::Serverless-2016-10-31'
+  - MyMacro
+
+Resources:
+  MyBucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    Properties:
+      AccessControl: Private
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      BucketName: !Sub '${App}-${Env}-mybucket'
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+  
+  MyBucketAccessPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: !Sub
+        - Grants CRUD access to MyBucket
+        - { Bucket: !Ref MyBucket }
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: S3ObjectActions
+            Effect: Allow
+            Action:
+              - s3:GetObject
+              - s3:PutObject
+              - s3:PutObjectACL
+              - s3:PutObjectTagging
+              - s3:DeleteObject
+              - s3:RestoreObject
+            Resource: !Sub ${MyBucket.Arn}/*
+          - Sid: S3ListAction
+            Effect: Allow
+            Action: s3:ListBucket
+            Resource: !Sub ${MyBucket.Arn}
+
+Outputs:
+  MyBucketName:
+    Description: "The name of a user-defined bucket."
+    Value: !Ref MyBucketName
+  MyBucketAccessPolicy:
+    Description: "The IAM::ManagedPolicy to attach to the task role"
+    Value: !Ref MyBucketAccessPolicy
+  MyTableName:
+    Description: "The name of this DynamoDB."
+    Value: !Ref MyTable

--- a/internal/pkg/addon/testdata/merge/env/wanted.yaml
+++ b/internal/pkg/addon/testdata/merge/env/wanted.yaml
@@ -13,9 +13,6 @@ Parameters:
   Env:
     Type: String
     Description: The environment name your service, job, or workflow is being deployed to.
-  Name:
-    Type: String
-    Description: The name of the service, job, or workflow being deployed.
   IsProd:
     Type: String
     Default: "false"
@@ -54,7 +51,7 @@ Resources:
   MyTable:
     Type: AWS::DynamoDB::Table
     Properties:
-      TableName: !Sub '${App}-${Env}-${Name}-mytable'
+      TableName: !Sub '${App}-${Env}-mytable'
       AttributeDefinitions:
         - AttributeName: id
           AttributeType: S
@@ -105,7 +102,7 @@ Resources:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: AES256
-      BucketName: !Sub '${App}-${Env}-${Name}-mybucket'
+      BucketName: !Sub '${App}-${Env}-mybucket'
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
         BlockPublicPolicy: true

--- a/internal/pkg/addon/testdata/merge/second.yaml
+++ b/internal/pkg/addon/testdata/merge/second.yaml
@@ -28,6 +28,7 @@ Parameters:
       Default: "false"
     InstanceType:
       Type: 'AWS::SSM::Parameter::Value<String>'
+      Default: mini
 
 Mappings:
   MyTableDynamoDBSettings:


### PR DESCRIPTION
This PR validates the parameters in addon templates, as well as the customized parameters, before the CFN deployment. 

With the wrong addons parameter config, the CFN deployment fails nevertheless. With this PR, Copilot will error out earlier so that users don't have to wait until the deployment to know.

Note that this validation happens for both the workload addon, and the environment addon.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
