### PR TITLE
chore: fix cloudfront e2e test

### DIFF
--- a/e2e/cloudfront/cloudfront_suite_test.go
+++ b/e2e/cloudfront/cloudfront_suite_test.go
@@ -43,7 +43,8 @@ var _ = BeforeSuite(func() {
 	err = os.Setenv("DOMAINNAME", domainName)
 	Expect(err).NotTo(HaveOccurred())
 	staticPath = "static/index.html"
-	sess := session.New()
+	sess, err := session.NewSession()
+	Expect(err).NotTo(HaveOccurred())
 	s3Client = s3.New(sess)
 	s3Manager = s3manager.NewUploader(sess)
 })

--- a/e2e/cloudfront/cloudfront_suite_test.go
+++ b/e2e/cloudfront/cloudfront_suite_test.go
@@ -10,10 +10,10 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/aws/copilot-cli/e2e/internal/client"
-	"github.com/aws/copilot-cli/internal/pkg/aws/sessions"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -43,8 +43,7 @@ var _ = BeforeSuite(func() {
 	err = os.Setenv("DOMAINNAME", domainName)
 	Expect(err).NotTo(HaveOccurred())
 	staticPath = "static/index.html"
-	sess, err := sessions.ImmutableProvider().Default()
-	Expect(err).NotTo(HaveOccurred())
+	sess := session.New()
 	s3Client = s3.New(sess)
 	s3Manager = s3manager.NewUploader(sess)
 })


### PR DESCRIPTION
<!-- Provide summary of changes -->
Currently failed because of 
```
# github.com/aws/copilot-cli/e2e/cloudfront
cloudfront_suite_test.go:16:2: no required module provides package github.com/aws/copilot-cli/internal/pkg/aws/sessions; to add it:
    go get github.com/aws/copilot-cli/internal/pkg/aws/sessions
```
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
