### PR TITLE
docs: update copyright year to 2023

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,7 @@ site_url: 'https://aws.github.io/copilot-cli/'
 repo_name: 'aws/copilot-cli'
 repo_url: 'https://github.com/aws/copilot-cli'
 edit_uri: 'edit/mainline/site/content'
-copyright: 'Copyright &copy; 2022 Amazon'
+copyright: 'Copyright &copy; 2023 Amazon'
 docs_dir: 'site/content'
 site_dir: 'docs'
 extra_css:


### PR DESCRIPTION
It's now officially the new year


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
