### PR TITLE
chore: write `addons.parameters.yml` for env aurora that works for managed VPC

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/env.go
+++ b/internal/pkg/deploy/cloudformation/stack/env.go
@@ -5,7 +5,6 @@ package stack
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
@@ -33,8 +32,6 @@ const (
 	envParamAppRunnerPrivateWorkloadsKey   = "AppRunnerPrivateWorkloads"
 	envParamCreateHTTPSListenerKey         = "CreateHTTPSListener"
 	envParamCreateInternalHTTPSListenerKey = "CreateInternalHTTPSListener"
-	envParamImportVPCIDKey                 = "ImportedVPCID"
-	envParamImportPrivateSubnetsKey        = "ImportedPrivateSubnets"
 )
 
 // Output keys.
@@ -195,12 +192,6 @@ func (e *Env) Parameters() ([]*cloudformation.Parameter, error) {
 	if len(e.importPrivateCertARNs()) != 0 {
 		internalHTTPSListener = "true"
 	}
-	var importedVPCID string
-	var importedPrivateSubnets string
-	if vpc := e.in.Mft.Network.VPC.ImportedVPC(); vpc != nil {
-		importedVPCID = vpc.ID
-		importedPrivateSubnets = strings.Join(vpc.PrivateSubnetIDs, ",")
-	}
 	currParams := []*cloudformation.Parameter{
 		{
 			ParameterKey:   aws.String(envParamAppNameKey),
@@ -257,14 +248,6 @@ func (e *Env) Parameters() ([]*cloudformation.Parameter, error) {
 		{
 			ParameterKey:   aws.String(envParamAppRunnerPrivateWorkloadsKey),
 			ParameterValue: aws.String(""),
-		},
-		{
-			ParameterKey:   aws.String(envParamImportVPCIDKey),
-			ParameterValue: aws.String(importedVPCID),
-		},
-		{
-			ParameterKey:   aws.String(envParamImportPrivateSubnetsKey),
-			ParameterValue: aws.String(importedPrivateSubnets),
 		},
 	}
 	if e.prevParams == nil {

--- a/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-basic-manifest.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-basic-manifest.yml
@@ -36,12 +36,7 @@ Parameters:
     AllowedValues: [true, false]
   ServiceDiscoveryEndpoint:
     Type: String
-  ImportedVPCID:
-    Type: String
-  ImportedPrivateSubnets:
-    Type: String
 Conditions:
-  IsVPCImported: !Not [!Equals [!Ref ImportedVPCID, ""]]
   CreateALB:
     !Not [!Equals [ !Ref ALBWorkloads, "" ]]
   CreateInternalALB:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-cloudfront-observability.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-cloudfront-observability.yml
@@ -62,12 +62,7 @@ Parameters:
     AllowedValues: [true, false]
   ServiceDiscoveryEndpoint:
     Type: String
-  ImportedVPCID:
-    Type: String
-  ImportedPrivateSubnets:
-    Type: String
 Conditions:
-  IsVPCImported: !Not [!Equals [!Ref ImportedVPCID, ""]]
   CreateALB:
     !Not [!Equals [ !Ref ALBWorkloads, "" ]]
   DelegateDNS:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-custom-security-group.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-custom-security-group.yml
@@ -58,12 +58,7 @@ Parameters:
     AllowedValues: [true, false]
   ServiceDiscoveryEndpoint:
     Type: String
-  ImportedVPCID:
-    Type: String
-  ImportedPrivateSubnets:
-    Type: String
 Conditions:
-  IsVPCImported: !Not [!Equals [!Ref ImportedVPCID, ""]]
   CreateALB:
     !Not [!Equals [ !Ref ALBWorkloads, "" ]]
   DelegateDNS:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-default-access-log-config.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-default-access-log-config.yml
@@ -39,12 +39,7 @@ Parameters:
     AllowedValues: [true, false]
   ServiceDiscoveryEndpoint:
     Type: String
-  ImportedVPCID:
-    Type: String
-  ImportedPrivateSubnets:
-    Type: String
 Conditions:
-  IsVPCImported: !Not [!Equals [!Ref ImportedVPCID, ""]]
   CreateALB:
     !Not [!Equals [ !Ref ALBWorkloads, "" ]]
   CreateInternalALB:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-defaultvpc-flowlogs.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-defaultvpc-flowlogs.yml
@@ -41,12 +41,7 @@ Parameters:
     AllowedValues: [true, false]
   ServiceDiscoveryEndpoint:
     Type: String
-  ImportedVPCID:
-    Type: String
-  ImportedPrivateSubnets:
-    Type: String
 Conditions:
-  IsVPCImported: !Not [!Equals [!Ref ImportedVPCID, ""]]
   CreateALB:
     !Not [!Equals [ !Ref ALBWorkloads, "" ]]
   CreateInternalALB:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-imported-certs-sslpolicy-custom-empty-security-group.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-imported-certs-sslpolicy-custom-empty-security-group.yml
@@ -48,12 +48,7 @@ Parameters:
     AllowedValues: [true, false]
   ServiceDiscoveryEndpoint:
     Type: String
-  ImportedVPCID:
-    Type: String
-  ImportedPrivateSubnets:
-    Type: String
 Conditions:
-  IsVPCImported: !Not [!Equals [!Ref ImportedVPCID, ""]]
   CreateALB:
     !Not [!Equals [ !Ref ALBWorkloads, "" ]]
   DelegateDNS:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-importedvpc-flowlogs.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-importedvpc-flowlogs.yml
@@ -48,12 +48,7 @@ Parameters:
     AllowedValues: [true, false]
   ServiceDiscoveryEndpoint:
     Type: String
-  ImportedVPCID:
-    Type: String
-  ImportedPrivateSubnets:
-    Type: String
 Conditions:
-  IsVPCImported: !Not [!Equals [!Ref ImportedVPCID, ""]]
   CreateALB:
     !Not [!Equals [ !Ref ALBWorkloads, "" ]]
   CreateInternalALB:

--- a/internal/pkg/template/templates/addons/aurora/env/addons.parameters.yml
+++ b/internal/pkg/template/templates/addons/aurora/env/addons.parameters.yml
@@ -1,9 +1,3 @@
 Parameters:
-  VPCID: 
-    - !If ImportedVPC
-    - !Ref ImportedVPCID
-    - !Ref VPC
-  PrivateSubnets:
-    - !If ImportedVPC
-    - !Join [ ',', [ !Ref ImportedPrivateSubnet1, !Ref ImportedPrivateSubnet2 ] ]
-    - !Join [ ',', [ !Ref PrivateSubnet1, !Ref PrivateSubnet2 ] ]
+  VPCID: !Ref VPC
+  PrivateSubnets: !Join [ ',', [ !Ref PrivateSubnet1, !Ref PrivateSubnet2 ] ]

--- a/internal/pkg/template/templates/addons/aurora/env/addons.parameters.yml
+++ b/internal/pkg/template/templates/addons/aurora/env/addons.parameters.yml
@@ -1,9 +1,9 @@
 Parameters:
   VPCID: 
-    - !If IsVPCImported
+    - !If ImportedVPC
     - !Ref ImportedVPCID
     - !Ref VPC
   PrivateSubnets:
-    - !If IsVPCImported
-    - !Ref ImportedPrivateSubnets
+    - !If ImportedVPC
+    - !Join [ ',', [ !Ref ImportedPrivateSubnet1, !Ref ImportedPrivateSubnet2 ] ]
     - !Join [ ',', [ !Ref PrivateSubnet1, !Ref PrivateSubnet2 ] ]

--- a/internal/pkg/template/templates/environment/cf.yml
+++ b/internal/pkg/template/templates/environment/cf.yml
@@ -38,12 +38,7 @@ Parameters:
     AllowedValues: [true, false]
   ServiceDiscoveryEndpoint:
     Type: String
-  ImportedVPCID:
-    Type: String
-  ImportedPrivateSubnets:
-    Type: String
 Conditions:
-  IsVPCImported: !Not [!Equals [!Ref ImportedVPCID, ""]]
   CreateALB:
     !Not [!Equals [ !Ref ALBWorkloads, "" ]]
   CreateInternalALB:


### PR DESCRIPTION
If people have some envs with imported VPC, we recommend them to use `Mappings`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
