### PR TITLE
chore(cli): add and validate a lifecycle flag for `storage init`

### DIFF
--- a/internal/pkg/cli/flag.go
+++ b/internal/pkg/cli/flag.go
@@ -67,6 +67,7 @@ const (
 
 	// Flags for storage.
 	storageTypeFlag                    = "storage-type"
+	storageLifecycleFlag               = "lifecycle"
 	storagePartitionKeyFlag            = "partition-key"
 	storageSortKeyFlag                 = "sort-key"
 	storageNoSortFlag                  = "no-sort"
@@ -285,6 +286,7 @@ Uploaded asset locations are filled in the template configuration.`
 	// Storage.
 	storageFlagDescription             = "Name of the storage resource to create."
 	storageWorkloadFlagDescription     = "Name of the service or job to associate with storage."
+	storageLifecycleFlagDescription    = "Whether the storage should be created and deleted at the same time as a workload or as the environment"
 	storagePartitionKeyFlagDescription = `Partition key for the DDB table.
 Must be of the format '<keyName>:<dataType>'.`
 	storageSortKeyFlagDescription = `Optional. Sort key for the DDB table.

--- a/internal/pkg/cli/storage_init_test.go
+++ b/internal/pkg/cli/storage_init_test.go
@@ -24,6 +24,7 @@ func TestStorageInitOpts_Validate(t *testing.T) {
 		inStorageType       string
 		inSvcName           string
 		inStorageName       string
+		inLifecycle         string
 		inPartition         string
 		inSort              string
 		inLSISorts          []string
@@ -66,6 +67,13 @@ func TestStorageInitOpts_Validate(t *testing.T) {
 			inSvcName:     "frontend",
 			inStorageName: "my-bucket",
 			wantedErr:     errors.New("retrieve local workload names: wanted err"),
+		},
+		"bad lifecycle option": {
+			mockWs:      func(m *mocks.MockwsAddonManager) {},
+			mockStore:   func(m *mocks.Mockstore) {},
+			inAppName:   "bowie",
+			inLifecycle: "weird input",
+			wantedErr:   errors.New(`invalid lifecycle; must be one of "workload" or "environment"`),
 		},
 		"successfully validates valid s3 bucket name": {
 			mockWs:        func(m *mocks.MockwsAddonManager) {},
@@ -211,6 +219,7 @@ func TestStorageInitOpts_Validate(t *testing.T) {
 					storageType:             tc.inStorageType,
 					storageName:             tc.inStorageName,
 					workloadName:            tc.inSvcName,
+					lifecycle:               tc.inLifecycle,
 					partitionKey:            tc.inPartition,
 					sortKey:                 tc.inSort,
 					lsiSorts:                tc.inLSISorts,


### PR DESCRIPTION
Note that the flag is optional defaulting to "workload" so we don't prompt for it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
