### PR TITLE
refactor: reorder storage init test cases

### DIFF
--- a/internal/pkg/cli/storage_init_test.go
+++ b/internal/pkg/cli/storage_init_test.go
@@ -229,27 +229,15 @@ type mockStorageInitAsk struct {
 
 func TestStorageInitOpts_Ask(t *testing.T) {
 	const (
-		wantedAppName      = "ddos"
-		wantedSvcName      = "frontend"
-		wantedBucketName   = "coolBucket"
-		wantedTableName    = "coolTable"
-		wantedPartitionKey = "DogName:String"
-		wantedSortKey      = "PhotoId:Number"
+		wantedAppName    = "ddos"
+		wantedSvcName    = "frontend"
+		wantedBucketName = "coolBucket"
 	)
 	testCases := map[string]struct {
 		inAppName     string
 		inStorageType string
 		inSvcName     string
 		inStorageName string
-		inPartition   string
-		inSort        string
-		inLSISorts    []string
-		inNoLSI       bool
-		inNoSort      bool
-
-		inServerlessVersion string
-		inDBEngine          string
-		inInitialDBName     string
 
 		mock func(m *mockStorageInitAsk)
 
@@ -331,11 +319,8 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 		"no error or asks when fully specified": {
 			inAppName:     wantedAppName,
 			inSvcName:     wantedSvcName,
-			inStorageType: dynamoDBStorageType,
-			inStorageName: wantedTableName,
-			inPartition:   wantedPartitionKey,
-			inSort:        wantedSortKey,
-			inLSISorts:    []string{"email:String"},
+			inStorageType: s3StorageType,
+			inStorageName: wantedBucketName,
 			mock:          func(m *mockStorageInitAsk) {},
 		},
 	}
@@ -355,15 +340,6 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 					storageType:  tc.inStorageType,
 					storageName:  tc.inStorageName,
 					workloadName: tc.inSvcName,
-					partitionKey: tc.inPartition,
-					sortKey:      tc.inSort,
-					lsiSorts:     tc.inLSISorts,
-					noLSI:        tc.inNoLSI,
-					noSort:       tc.inNoSort,
-
-					auroraServerlessVersion: tc.inServerlessVersion,
-					rdsEngine:               tc.inDBEngine,
-					rdsInitialDBName:        tc.inInitialDBName,
 				},
 				appName: tc.inAppName,
 				sel:     m.sel,
@@ -679,6 +655,12 @@ func TestStorageInitOpts_AskDDB(t *testing.T) {
 
 			},
 			wantedErr: fmt.Errorf("get DDB alternate sort key type: some error"),
+		},
+		"do not ask for ddb config when fully specified": {
+			inPartition: wantedPartitionKey,
+			inSort:      wantedSortKey,
+			inLSISorts:  []string{"email:String"},
+			mock:        func(m *mockStorageInitAsk) {},
 		},
 	}
 	for name, tc := range testCases {

--- a/internal/pkg/cli/storage_init_test.go
+++ b/internal/pkg/cli/storage_init_test.go
@@ -18,6 +18,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type mockStorageInitValidate struct {
+	ws    *mocks.MockwsAddonManager
+	store *mocks.Mockstore
+}
+
 func TestStorageInitOpts_Validate(t *testing.T) {
 	testCases := map[string]struct {
 		inAppName           string
@@ -33,23 +38,20 @@ func TestStorageInitOpts_Validate(t *testing.T) {
 		inServerlessVersion string
 		inEngine            string
 
+		mock      func(m *mockStorageInitValidate)
 		mockWs    func(m *mocks.MockwsAddonManager)
 		mockStore func(m *mocks.Mockstore)
 
 		wantedErr error
 	}{
 		"no app in workspace": {
-			mockWs:    func(m *mocks.MockwsAddonManager) {},
-			mockStore: func(m *mocks.Mockstore) {},
-
+			mock:      func(m *mockStorageInitValidate) {},
 			wantedErr: errNoAppInWorkspace,
 		},
 		"svc not in workspace": {
-			mockWs: func(m *mocks.MockwsAddonManager) {
-				m.EXPECT().WorkloadExists(gomock.Eq("frontend")).Return(false, nil)
+			mock: func(m *mockStorageInitValidate) {
+				m.ws.EXPECT().WorkloadExists(gomock.Eq("frontend")).Return(false, nil)
 			},
-			mockStore: func(m *mocks.Mockstore) {},
-
 			inAppName:     "bowie",
 			inStorageType: s3StorageType,
 			inSvcName:     "frontend",
@@ -57,11 +59,9 @@ func TestStorageInitOpts_Validate(t *testing.T) {
 			wantedErr:     errors.New("workload frontend not found in the workspace"),
 		},
 		"workspace error": {
-			mockWs: func(m *mocks.MockwsAddonManager) {
-				m.EXPECT().WorkloadExists(gomock.Eq("frontend")).Return(false, errors.New("wanted err"))
+			mock: func(m *mockStorageInitValidate) {
+				m.ws.EXPECT().WorkloadExists(gomock.Eq("frontend")).Return(false, errors.New("wanted err"))
 			},
-			mockStore: func(m *mocks.Mockstore) {},
-
 			inAppName:     "bowie",
 			inStorageType: s3StorageType,
 			inSvcName:     "frontend",
@@ -69,139 +69,113 @@ func TestStorageInitOpts_Validate(t *testing.T) {
 			wantedErr:     errors.New("check if frontend exists in the workspace: wanted err"),
 		},
 		"bad lifecycle option": {
-			mockWs:      func(m *mocks.MockwsAddonManager) {},
-			mockStore:   func(m *mocks.Mockstore) {},
 			inAppName:   "bowie",
 			inLifecycle: "weird input",
+			mock:        func(m *mockStorageInitValidate) {},
 			wantedErr:   errors.New(`invalid lifecycle; must be one of "workload" or "environment"`),
 		},
 		"successfully validates valid s3 bucket name": {
-			mockWs:        func(m *mocks.MockwsAddonManager) {},
-			mockStore:     func(m *mocks.Mockstore) {},
 			inAppName:     "bowie",
 			inStorageType: s3StorageType,
 			inStorageName: "my-bucket.4",
-			wantedErr:     nil,
+			mock:          func(m *mockStorageInitValidate) {},
 		},
 		"successfully validates valid DDB table name": {
-			mockWs:        func(m *mocks.MockwsAddonManager) {},
-			mockStore:     func(m *mocks.Mockstore) {},
 			inAppName:     "bowie",
 			inStorageType: dynamoDBStorageType,
 			inStorageName: "my-cool_table.3",
-			wantedErr:     nil,
+			mock:          func(m *mockStorageInitValidate) {},
 		},
 		"default to ddb name validation when storage type unspecified": {
-			mockWs:        func(m *mocks.MockwsAddonManager) {},
-			mockStore:     func(m *mocks.Mockstore) {},
 			inAppName:     "bowie",
 			inStorageType: "",
 			inStorageName: "my-cool_table.3",
-			wantedErr:     nil,
+			mock:          func(m *mockStorageInitValidate) {},
 		},
 		"s3 bad character": {
-			mockWs:        func(m *mocks.MockwsAddonManager) {},
-			mockStore:     func(m *mocks.Mockstore) {},
 			inAppName:     "bowie",
 			inStorageType: s3StorageType,
 			inStorageName: "mybadbucket???",
+			mock:          func(m *mockStorageInitValidate) {},
 			wantedErr:     errValueBadFormatWithPeriod,
 		},
 		"ddb bad character": {
-			mockWs:        func(m *mocks.MockwsAddonManager) {},
-			mockStore:     func(m *mocks.Mockstore) {},
 			inAppName:     "bowie",
 			inStorageType: dynamoDBStorageType,
 			inStorageName: "badTable!!!",
+			mock:          func(m *mockStorageInitValidate) {},
 			wantedErr:     errValueBadFormatWithPeriodUnderscore,
 		},
 		"successfully validates partition key flag": {
-			mockWs:        func(m *mocks.MockwsAddonManager) {},
-			mockStore:     func(m *mocks.Mockstore) {},
 			inAppName:     "bowie",
 			inStorageType: dynamoDBStorageType,
 			inPartition:   "points:String",
-			wantedErr:     nil,
+			mock:          func(m *mockStorageInitValidate) {},
 		},
 		"successfully validates sort key flag": {
-			mockWs:        func(m *mocks.MockwsAddonManager) {},
-			mockStore:     func(m *mocks.Mockstore) {},
 			inAppName:     "bowie",
 			inStorageType: dynamoDBStorageType,
 			inSort:        "userID:Number",
-			wantedErr:     nil,
+			mock:          func(m *mockStorageInitValidate) {},
 		},
 		"successfully validates LSI": {
-			mockWs:        func(m *mocks.MockwsAddonManager) {},
-			mockStore:     func(m *mocks.Mockstore) {},
 			inAppName:     "bowie",
 			inStorageType: dynamoDBStorageType,
 			inLSISorts:    []string{"userID:Number", "data:Binary"},
-			wantedErr:     nil,
+			mock:          func(m *mockStorageInitValidate) {},
 		},
 		"success on providing --no-sort": {
-			mockWs:        func(m *mocks.MockwsAddonManager) {},
-			mockStore:     func(m *mocks.Mockstore) {},
 			inAppName:     "bowie",
 			inStorageType: dynamoDBStorageType,
 			inNoSort:      true,
-			wantedErr:     nil,
+			mock:          func(m *mockStorageInitValidate) {},
 		},
 		"success on providing --no-lsi": {
-			mockWs:        func(m *mocks.MockwsAddonManager) {},
-			mockStore:     func(m *mocks.Mockstore) {},
 			inAppName:     "bowie",
 			inStorageType: dynamoDBStorageType,
 			inNoLSI:       true,
-			wantedErr:     nil,
+			mock:          func(m *mockStorageInitValidate) {},
 		},
 		"fails when --no-lsi and --lsi are both provided": {
-			mockWs:        func(m *mocks.MockwsAddonManager) {},
-			mockStore:     func(m *mocks.Mockstore) {},
 			inAppName:     "bowie",
 			inStorageType: dynamoDBStorageType,
 			inLSISorts:    []string{"userID:Number"},
 			inNoLSI:       true,
+			mock:          func(m *mockStorageInitValidate) {},
 			wantedErr:     fmt.Errorf("validate LSI configuration: cannot specify --no-lsi and --lsi options at once"),
 		},
 		"fails when --no-sort and --lsi are both provided": {
-			mockWs:        func(m *mocks.MockwsAddonManager) {},
-			mockStore:     func(m *mocks.Mockstore) {},
 			inAppName:     "bowie",
 			inStorageType: dynamoDBStorageType,
 			inLSISorts:    []string{"userID:Number"},
 			inNoSort:      true,
+			mock:          func(m *mockStorageInitValidate) {},
 			wantedErr:     fmt.Errorf("validate LSI configuration: cannot specify --no-sort and --lsi options at once"),
 		},
 		"invalid database engine type": {
 			inAppName: "meow",
 			inEngine:  "mysql",
 
-			mockWs:    func(m *mocks.MockwsAddonManager) {},
-			mockStore: func(m *mocks.Mockstore) {},
-
+			mock:      func(m *mockStorageInitValidate) {},
 			wantedErr: errors.New("invalid engine type mysql: must be one of \"MySQL\", \"PostgreSQL\""),
 		},
 		"successfully validates aurora serverless version v1": {
-			mockWs:              func(m *mocks.MockwsAddonManager) {},
-			mockStore:           func(m *mocks.Mockstore) {},
 			inAppName:           "bowie",
 			inStorageType:       rdsStorageType,
 			inServerlessVersion: auroraServerlessVersionV1,
+			mock:                func(m *mockStorageInitValidate) {},
 		},
 		"successfully validates aurora serverless version v2": {
-			mockWs:              func(m *mocks.MockwsAddonManager) {},
-			mockStore:           func(m *mocks.Mockstore) {},
 			inAppName:           "bowie",
 			inStorageType:       rdsStorageType,
 			inServerlessVersion: auroraServerlessVersionV2,
+			mock:                func(m *mockStorageInitValidate) {},
 		},
 		"invalid aurora serverless version": {
-			mockWs:              func(m *mocks.MockwsAddonManager) {},
-			mockStore:           func(m *mocks.Mockstore) {},
 			inAppName:           "bowie",
 			inStorageType:       rdsStorageType,
 			inServerlessVersion: "weird-serverless-version",
+			mock:                func(m *mockStorageInitValidate) {},
 			wantedErr:           errors.New("invalid Aurora Serverless version weird-serverless-version: must be one of \"v1\", \"v2\""),
 		},
 	}
@@ -210,10 +184,11 @@ func TestStorageInitOpts_Validate(t *testing.T) {
 			// GIVEN
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
-			mockWs := mocks.NewMockwsAddonManager(ctrl)
-			mockStore := mocks.NewMockstore(ctrl)
-			tc.mockWs(mockWs)
-			tc.mockStore(mockStore)
+			m := mockStorageInitValidate{
+				ws:    mocks.NewMockwsAddonManager(ctrl),
+				store: mocks.NewMockstore(ctrl),
+			}
+			tc.mock(&m)
 			opts := initStorageOpts{
 				initStorageVars: initStorageVars{
 					storageType:             tc.inStorageType,
@@ -229,8 +204,8 @@ func TestStorageInitOpts_Validate(t *testing.T) {
 					rdsEngine:               tc.inEngine,
 				},
 				appName: tc.inAppName,
-				ws:      mockWs,
-				store:   mockStore,
+				ws:      m.ws,
+				store:   m.store,
 			}
 
 			// WHEN
@@ -280,16 +255,12 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 		inDBEngine          string
 		inInitialDBName     string
 
-		mock       func(m *mockStorageInitAsk)
-		mockPrompt func(m *mocks.Mockprompter)
-		mockCfg    func(m *mocks.MockwsSelector)
-		mockWS     func(m *mocks.MockwsAddonManager)
+		mock func(m *mockStorageInitAsk)
 
-		wantedErr error
-
+		wantedErr  error
 		wantedVars *initStorageVars
 	}{
-		"Asks for storage type": {
+		"asks for storage type": {
 			inAppName:     wantedAppName,
 			inSvcName:     wantedSvcName,
 			inStorageName: wantedBucketName,
@@ -317,35 +288,27 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 			inSvcName:     wantedSvcName,
 			inStorageName: wantedBucketName,
 
-			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().SelectOption(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", errors.New("some error"))
+			mock: func(m *mockStorageInitAsk) {
+				m.prompt.EXPECT().SelectOption(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", errors.New("some error"))
 			},
-			mockCfg: func(m *mocks.MockwsSelector) {},
-
 			wantedErr: fmt.Errorf("select storage type: some error"),
 		},
 		"asks for storage workload": {
 			inAppName:     wantedAppName,
 			inStorageName: wantedBucketName,
 			inStorageType: s3StorageType,
-
-			mockPrompt: func(m *mocks.Mockprompter) {},
-			mockCfg: func(m *mocks.MockwsSelector) {
-				m.EXPECT().Workload(gomock.Eq(storageInitSvcPrompt), gomock.Any()).Return(wantedSvcName, nil)
+			mock: func(m *mockStorageInitAsk) {
+				m.sel.EXPECT().Workload(gomock.Eq(storageInitSvcPrompt), gomock.Any()).Return(wantedSvcName, nil)
 			},
-
-			wantedErr: nil,
 		},
 		"error if svc not returned": {
 			inAppName:     wantedAppName,
 			inStorageName: wantedBucketName,
 			inStorageType: s3StorageType,
+			mock: func(m *mockStorageInitAsk) {
+				m.sel.EXPECT().Workload(gomock.Any(), gomock.Any()).Return("", errors.New("some error"))
 
-			mockPrompt: func(m *mocks.Mockprompter) {},
-			mockCfg: func(m *mocks.MockwsSelector) {
-				m.EXPECT().Workload(gomock.Any(), gomock.Any()).Return("", errors.New("some error"))
 			},
-
 			wantedErr: fmt.Errorf("retrieve local workload names: some error"),
 		},
 		"asks for storage name": {
@@ -353,22 +316,13 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 			inSvcName:     wantedSvcName,
 			inStorageType: s3StorageType,
 
-			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().Get(gomock.Eq(
-					fmt.Sprintf(fmtStorageInitNamePrompt,
-						color.HighlightUserInput(s3BucketFriendlyText),
-					),
-				),
-					gomock.Any(),
-					gomock.Any(),
-					gomock.Any(),
-				).Return(wantedBucketName, nil)
+			mock: func(m *mockStorageInitAsk) {
+				m.prompt.EXPECT().Get(gomock.Eq(fmt.Sprintf(fmtStorageInitNamePrompt, color.HighlightUserInput(s3BucketFriendlyText))),
+					gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(wantedBucketName, nil)
 			},
-			mockCfg: func(m *mocks.MockwsSelector) {},
-
-			wantedErr: nil,
 		},
-		"Asks for cluster name for RDS storage": {
+		"asks for cluster name for RDS storage": {
 			inAppName:           wantedAppName,
 			inSvcName:           wantedSvcName,
 			inStorageType:       rdsStorageType,
@@ -376,20 +330,15 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 			inDBEngine:          wantedDBEngine,
 			inInitialDBName:     wantedInitialDBName,
 
-			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().Get(
+			mock: func(m *mockStorageInitAsk) {
+				m.prompt.EXPECT().Get(
 					gomock.Eq("What would you like to name this Database Cluster?"),
 					gomock.Any(),
 					gomock.Any(),
 					gomock.Any(),
 				).Return(wantedBucketName, nil)
+				m.ws.EXPECT().ReadWorkloadManifest(wantedSvcName).Return(workspace.WorkloadManifest("type: Load Balanced Web Service"), nil)
 			},
-			mockCfg: func(m *mocks.MockwsSelector) {},
-			mockWS: func(m *mocks.MockwsAddonManager) {
-				m.EXPECT().ReadWorkloadManifest(wantedSvcName).Return(workspace.WorkloadManifest("type: Load Balanced Web Service"), nil)
-			},
-
-			wantedErr: nil,
 			wantedVars: &initStorageVars{
 				storageType:             rdsStorageType,
 				storageName:             wantedBucketName,
@@ -404,11 +353,9 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 			inSvcName:     wantedSvcName,
 			inStorageType: s3StorageType,
 
-			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", errors.New("some error"))
+			mock: func(m *mockStorageInitAsk) {
+				m.prompt.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", errors.New("some error"))
 			},
-			mockCfg: func(m *mocks.MockwsSelector) {},
-
 			wantedErr: fmt.Errorf("input storage name: some error"),
 		},
 		"asks for partition key if not specified": {
@@ -419,26 +366,23 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 			inSort:        wantedSortKey,
 			inNoLSI:       true,
 
-			mockPrompt: func(m *mocks.Mockprompter) {
+			mock: func(m *mockStorageInitAsk) {
 				keyPrompt := fmt.Sprintf(fmtStorageInitDDBKeyPrompt,
 					color.HighlightUserInput("partition key"),
 					color.HighlightUserInput(dynamoDBStorageType),
 				)
 				keyTypePrompt := fmt.Sprintf(fmtStorageInitDDBKeyTypePrompt, ddbKeyString)
-				m.EXPECT().Get(gomock.Eq(keyPrompt),
+				m.prompt.EXPECT().Get(gomock.Eq(keyPrompt),
 					gomock.Any(),
 					gomock.Any(),
 					gomock.Any(),
 				).Return(wantedPartitionKey, nil)
-				m.EXPECT().SelectOne(gomock.Eq(keyTypePrompt),
+				m.prompt.EXPECT().SelectOne(gomock.Eq(keyTypePrompt),
 					gomock.Any(),
 					attributeTypes,
 					gomock.Any(),
 				).Return(ddbStringType, nil)
 			},
-			mockCfg: func(m *mocks.MockwsSelector) {},
-
-			wantedErr: nil,
 		},
 		"error if fail to return partition key": {
 			inAppName:     wantedAppName,
@@ -446,14 +390,13 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 			inStorageType: dynamoDBStorageType,
 			inStorageName: wantedTableName,
 
-			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().Get(gomock.Any(),
+			mock: func(m *mockStorageInitAsk) {
+				m.prompt.EXPECT().Get(gomock.Any(),
 					gomock.Any(),
 					gomock.Any(),
 					gomock.Any(),
 				).Return("", errors.New("some error"))
 			},
-			mockCfg:   func(m *mocks.MockwsSelector) {},
 			wantedErr: fmt.Errorf("get DDB partition key: some error"),
 		},
 		"error if fail to return partition key type": {
@@ -462,21 +405,18 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 			inStorageType: dynamoDBStorageType,
 			inStorageName: wantedTableName,
 			inSort:        wantedSortKey,
-
-			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().Get(gomock.Any(),
+			mock: func(m *mockStorageInitAsk) {
+				m.prompt.EXPECT().Get(gomock.Any(),
 					gomock.Any(),
 					gomock.Any(),
 					gomock.Any(),
 				).Return(wantedPartitionKey, nil)
-				m.EXPECT().SelectOne(gomock.Any(),
+				m.prompt.EXPECT().SelectOne(gomock.Any(),
 					gomock.Any(),
 					gomock.Any(),
 					gomock.Any(),
 				).Return("", errors.New("some error"))
 			},
-			mockCfg: func(m *mocks.MockwsSelector) {},
-
 			wantedErr: fmt.Errorf("get DDB partition key datatype: some error"),
 		},
 		"ask for sort key if not specified": {
@@ -487,8 +427,8 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 			inPartition:   wantedPartitionKey,
 			inNoLSI:       true,
 
-			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().Confirm(
+			mock: func(m *mockStorageInitAsk) {
+				m.prompt.EXPECT().Confirm(
 					gomock.Eq(storageInitDDBSortKeyConfirm),
 					gomock.Any(),
 					gomock.Any(),
@@ -498,20 +438,17 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 					color.HighlightUserInput(dynamoDBStorageType),
 				)
 				keyTypePrompt := fmt.Sprintf(fmtStorageInitDDBKeyTypePrompt, ddbKeyString)
-				m.EXPECT().Get(gomock.Eq(keyPrompt),
+				m.prompt.EXPECT().Get(gomock.Eq(keyPrompt),
 					gomock.Any(),
 					gomock.Any(),
 					gomock.Any(),
 				).Return(wantedPartitionKey, nil)
-				m.EXPECT().SelectOne(gomock.Eq(keyTypePrompt),
+				m.prompt.EXPECT().SelectOne(gomock.Eq(keyTypePrompt),
 					gomock.Any(),
 					attributeTypes,
 					gomock.Any(),
 				).Return(ddbStringType, nil)
 			},
-			mockCfg: func(m *mocks.MockwsSelector) {},
-
-			wantedErr: nil,
 		},
 		"error if fail to confirm add sort key": {
 			inAppName:     wantedAppName,
@@ -520,14 +457,13 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 			inStorageName: wantedTableName,
 			inPartition:   wantedPartitionKey,
 
-			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().Confirm(
+			mock: func(m *mockStorageInitAsk) {
+				m.prompt.EXPECT().Confirm(
 					gomock.Eq(storageInitDDBSortKeyConfirm),
 					gomock.Any(),
 					gomock.Any(),
 				).Return(false, errors.New("some error"))
 			},
-			mockCfg:   func(m *mocks.MockwsSelector) {},
 			wantedErr: fmt.Errorf("confirm DDB sort key: some error"),
 		},
 		"error if fail to return sort key": {
@@ -536,21 +472,18 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 			inStorageType: dynamoDBStorageType,
 			inStorageName: wantedTableName,
 			inPartition:   wantedPartitionKey,
-
-			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().Confirm(
+			mock: func(m *mockStorageInitAsk) {
+				m.prompt.EXPECT().Confirm(
 					gomock.Eq(storageInitDDBSortKeyConfirm),
 					gomock.Any(),
 					gomock.Any(),
 				).Return(true, nil)
-				m.EXPECT().Get(gomock.Any(),
+				m.prompt.EXPECT().Get(gomock.Any(),
 					gomock.Any(),
 					gomock.Any(),
 					gomock.Any(),
 				).Return("", errors.New("some error"))
 			},
-			mockCfg: func(m *mocks.MockwsSelector) {},
-
 			wantedErr: fmt.Errorf("get DDB sort key: some error"),
 		},
 		"error if fail to return sort key type": {
@@ -560,25 +493,23 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 			inStorageName: wantedTableName,
 			inPartition:   wantedPartitionKey,
 
-			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().Confirm(
+			mock: func(m *mockStorageInitAsk) {
+				m.prompt.EXPECT().Confirm(
 					gomock.Eq(storageInitDDBSortKeyConfirm),
 					gomock.Any(),
 					gomock.Any(),
 				).Return(true, nil)
-				m.EXPECT().Get(gomock.Any(),
+				m.prompt.EXPECT().Get(gomock.Any(),
 					gomock.Any(),
 					gomock.Any(),
 					gomock.Any(),
 				).Return(wantedPartitionKey, nil)
-				m.EXPECT().SelectOne(gomock.Any(),
+				m.prompt.EXPECT().SelectOne(gomock.Any(),
 					gomock.Any(),
 					gomock.Any(),
 					gomock.Any(),
 				).Return("", errors.New("some error"))
 			},
-			mockCfg: func(m *mocks.MockwsSelector) {},
-
 			wantedErr: fmt.Errorf("get DDB sort key datatype: some error"),
 		},
 		"don't ask for sort key if no-sort specified": {
@@ -589,11 +520,7 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 			inPartition:   wantedPartitionKey,
 			inNoSort:      true,
 			inNoLSI:       true,
-
-			mockPrompt: func(m *mocks.Mockprompter) {},
-			mockCfg:    func(m *mocks.MockwsSelector) {},
-
-			wantedErr: nil,
+			mock:          func(m *mockStorageInitAsk) {},
 		},
 		"ok if --no-lsi and --sort-key are both specified": {
 			inAppName:     wantedAppName,
@@ -603,10 +530,7 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 			inPartition:   wantedPartitionKey,
 			inSort:        wantedSortKey,
 			inNoLSI:       true,
-
-			mockPrompt: func(m *mocks.Mockprompter) {},
-			mockCfg:    func(m *mocks.MockwsSelector) {},
-			wantedErr:  nil,
+			mock:          func(m *mockStorageInitAsk) {},
 		},
 		"don't ask about LSI if no-sort is specified": {
 			inAppName:     wantedAppName,
@@ -615,11 +539,7 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 			inStorageName: wantedTableName,
 			inPartition:   wantedPartitionKey,
 			inNoSort:      true,
-
-			mockPrompt: func(m *mocks.Mockprompter) {},
-			mockCfg:    func(m *mocks.MockwsSelector) {},
-
-			wantedErr: nil,
+			mock:          func(m *mockStorageInitAsk) {},
 		},
 		"ask for LSI if not specified": {
 			inAppName:     wantedAppName,
@@ -629,33 +549,32 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 			inPartition:   wantedPartitionKey,
 			inSort:        wantedSortKey,
 
-			mockPrompt: func(m *mocks.Mockprompter) {
+			mock: func(m *mockStorageInitAsk) {
 				lsiTypePrompt := fmt.Sprintf(fmtStorageInitDDBKeyTypePrompt, color.Emphasize("alternate sort key"))
 				lsiTypeHelp := fmt.Sprintf(fmtStorageInitDDBKeyTypeHelp, "alternate sort key")
-				m.EXPECT().Confirm(
+				m.prompt.EXPECT().Confirm(
 					gomock.Eq(storageInitDDBLSIPrompt),
 					gomock.Eq(storageInitDDBLSIHelp),
 					gomock.Any(),
 				).Return(true, nil)
-				m.EXPECT().Get(
+				m.prompt.EXPECT().Get(
 					gomock.Eq(storageInitDDBLSINamePrompt),
 					gomock.Eq(storageInitDDBLSINameHelp),
 					gomock.Any(),
 					gomock.Any(),
 				).Return("Email", nil)
-				m.EXPECT().SelectOne(
+				m.prompt.EXPECT().SelectOne(
 					gomock.Eq(lsiTypePrompt),
 					gomock.Eq(lsiTypeHelp),
 					gomock.Eq(attributeTypes),
 					gomock.Any(),
 				).Return(ddbStringType, nil)
-				m.EXPECT().Confirm(
+				m.prompt.EXPECT().Confirm(
 					gomock.Eq(storageInitDDBMoreLSIPrompt),
 					gomock.Eq(storageInitDDBLSIHelp),
 					gomock.Any(),
 				).Return(false, nil)
 			},
-			mockCfg: func(m *mocks.MockwsSelector) {},
 			wantedVars: &initStorageVars{
 				storageName:  wantedTableName,
 				workloadName: wantedSvcName,
@@ -675,14 +594,13 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 			inPartition:   wantedPartitionKey,
 			inSort:        wantedSortKey,
 
-			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().Confirm(
+			mock: func(m *mockStorageInitAsk) {
+				m.prompt.EXPECT().Confirm(
 					gomock.Eq(storageInitDDBLSIPrompt),
 					gomock.Eq(storageInitDDBLSIHelp),
 					gomock.Any(),
 				).Return(false, nil)
 			},
-			mockCfg: func(m *mocks.MockwsSelector) {},
 			wantedVars: &initStorageVars{
 				storageName:  wantedTableName,
 				workloadName: wantedSvcName,
@@ -700,15 +618,13 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 			inStorageName: wantedTableName,
 			inPartition:   wantedPartitionKey,
 
-			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().Confirm(
+			mock: func(m *mockStorageInitAsk) {
+				m.prompt.EXPECT().Confirm(
 					gomock.Eq(storageInitDDBSortKeyConfirm),
 					gomock.Eq(storageInitDDBSortKeyHelp),
 					gomock.Any(),
 				).Return(false, nil)
 			},
-			mockCfg: func(m *mocks.MockwsSelector) {},
-
 			wantedVars: &initStorageVars{
 				storageName:  wantedTableName,
 				workloadName: wantedSvcName,
@@ -726,21 +642,18 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 			inStorageName: wantedTableName,
 			inPartition:   wantedPartitionKey,
 			inSort:        wantedSortKey,
-
-			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().Confirm(
+			mock: func(m *mockStorageInitAsk) {
+				m.prompt.EXPECT().Confirm(
 					gomock.Eq(storageInitDDBLSIPrompt),
 					gomock.Any(),
 					gomock.Any(),
 				).Return(true, nil)
-				m.EXPECT().Get(gomock.Any(),
+				m.prompt.EXPECT().Get(gomock.Any(),
 					gomock.Any(),
 					gomock.Any(),
 					gomock.Any(),
 				).Return("", errors.New("some error"))
 			},
-			mockCfg: func(m *mocks.MockwsSelector) {},
-
 			wantedErr: fmt.Errorf("get DDB alternate sort key name: some error"),
 		},
 		"errors if fail to confirm lsi": {
@@ -750,16 +663,13 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 			inStorageName: wantedTableName,
 			inPartition:   wantedPartitionKey,
 			inSort:        wantedSortKey,
-
-			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().Confirm(
+			mock: func(m *mockStorageInitAsk) {
+				m.prompt.EXPECT().Confirm(
 					gomock.Any(),
 					gomock.Any(),
 					gomock.Any(),
 				).Return(false, errors.New("some error"))
 			},
-			mockCfg: func(m *mocks.MockwsSelector) {},
-
 			wantedErr: fmt.Errorf("confirm add alternate sort key: some error"),
 		},
 		"error if lsi type misspecified": {
@@ -769,27 +679,24 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 			inStorageName: wantedTableName,
 			inPartition:   wantedPartitionKey,
 			inSort:        wantedSortKey,
-
-			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().Confirm(
+			mock: func(m *mockStorageInitAsk) {
+				m.prompt.EXPECT().Confirm(
 					gomock.Any(),
 					gomock.Any(),
 					gomock.Any(),
 				).Return(true, nil)
-				m.EXPECT().Get(gomock.Any(),
+				m.prompt.EXPECT().Get(gomock.Any(),
 					gomock.Any(),
 					gomock.Any(),
 					gomock.Any(),
 				).Return("cool", nil)
-				m.EXPECT().SelectOne(gomock.Any(),
+				m.prompt.EXPECT().SelectOne(gomock.Any(),
 					gomock.Any(),
 					gomock.Any(),
 					gomock.Any(),
 				).Return("", errors.New("some error"))
 
 			},
-			mockCfg: func(m *mocks.MockwsSelector) {},
-
 			wantedErr: fmt.Errorf("get DDB alternate sort key type: some error"),
 		},
 		"no error or asks when fully specified": {
@@ -800,10 +707,7 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 			inPartition:   wantedPartitionKey,
 			inSort:        wantedSortKey,
 			inLSISorts:    []string{"email:String"},
-
-			mockPrompt: func(m *mocks.Mockprompter) {},
-			mockCfg:    func(m *mocks.MockwsSelector) {},
-			wantedErr:  nil,
+			mock:          func(m *mockStorageInitAsk) {},
 		},
 		"asks for engine if not specified": {
 			inAppName:     wantedAppName,
@@ -814,15 +718,12 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 			inServerlessVersion: wantedServerlessVersion,
 			inInitialDBName:     wantedInitialDBName,
 
-			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().SelectOne(gomock.Eq(storageInitRDSDBEnginePrompt), gomock.Any(), gomock.Any(), gomock.Any()).
+			mock: func(m *mockStorageInitAsk) {
+				m.prompt.EXPECT().SelectOne(gomock.Eq(storageInitRDSDBEnginePrompt), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(wantedDBEngine, nil)
-			},
-			mockCfg: func(m *mocks.MockwsSelector) {},
-			mockWS: func(m *mocks.MockwsAddonManager) {
-				m.EXPECT().ReadWorkloadManifest(wantedSvcName).Return(workspace.WorkloadManifest("type: Load Balanced Web Service"), nil)
-			},
+				m.ws.EXPECT().ReadWorkloadManifest(wantedSvcName).Return(workspace.WorkloadManifest("type: Load Balanced Web Service"), nil)
 
+			},
 			wantedVars: &initStorageVars{
 				storageType:             rdsStorageType,
 				storageName:             wantedBucketName,
@@ -841,13 +742,11 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 			inServerlessVersion: wantedServerlessVersion,
 			inInitialDBName:     wantedInitialDBName,
 
-			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().SelectOne(storageInitRDSDBEnginePrompt, gomock.Any(), gomock.Any(), gomock.Any()).
+			mock: func(m *mockStorageInitAsk) {
+				m.prompt.EXPECT().SelectOne(storageInitRDSDBEnginePrompt, gomock.Any(), gomock.Any(), gomock.Any()).
 					Return("", errors.New("some error"))
-			},
-			mockCfg: func(m *mocks.MockwsSelector) {},
-			mockWS: func(m *mocks.MockwsAddonManager) {
-				m.EXPECT().ReadWorkloadManifest(wantedSvcName).Return(workspace.WorkloadManifest("type: Load Balanced Web Service"), nil)
+				m.ws.EXPECT().ReadWorkloadManifest(wantedSvcName).Return(workspace.WorkloadManifest("type: Load Balanced Web Service"), nil)
+
 			},
 			wantedErr: errors.New("select database engine: some error"),
 		},
@@ -860,15 +759,11 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 			inServerlessVersion: wantedServerlessVersion,
 			inDBEngine:          wantedDBEngine,
 
-			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().Get(gomock.Eq(storageInitRDSInitialDBNamePrompt), gomock.Any(), gomock.Any(), gomock.Any()).
+			mock: func(m *mockStorageInitAsk) {
+				m.prompt.EXPECT().Get(gomock.Eq(storageInitRDSInitialDBNamePrompt), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(wantedInitialDBName, nil)
+				m.ws.EXPECT().ReadWorkloadManifest(wantedSvcName).Return(workspace.WorkloadManifest("type: Load Balanced Web Service"), nil)
 			},
-			mockCfg: func(m *mocks.MockwsSelector) {},
-			mockWS: func(m *mocks.MockwsAddonManager) {
-				m.EXPECT().ReadWorkloadManifest(wantedSvcName).Return(workspace.WorkloadManifest("type: Load Balanced Web Service"), nil)
-			},
-
 			wantedVars: &initStorageVars{
 				storageType:             rdsStorageType,
 				storageName:             wantedBucketName,
@@ -887,15 +782,12 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 			inServerlessVersion: wantedServerlessVersion,
 			inDBEngine:          wantedDBEngine,
 
-			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().Get(storageInitRDSInitialDBNamePrompt, gomock.Any(), gomock.Any(), gomock.Any()).
+			mock: func(m *mockStorageInitAsk) {
+				m.prompt.EXPECT().Get(storageInitRDSInitialDBNamePrompt, gomock.Any(), gomock.Any(), gomock.Any()).
 					Return("", errors.New("some error"))
-			},
-			mockCfg: func(m *mocks.MockwsSelector) {},
-			mockWS: func(m *mocks.MockwsAddonManager) {
-				m.EXPECT().ReadWorkloadManifest(wantedSvcName).Return(workspace.WorkloadManifest("type: Load Balanced Web Service"), nil)
-			},
+				m.ws.EXPECT().ReadWorkloadManifest(wantedSvcName).Return(workspace.WorkloadManifest("type: Load Balanced Web Service"), nil)
 
+			},
 			wantedErr: fmt.Errorf("input initial database name: some error"),
 		},
 	}

--- a/internal/pkg/cli/storage_init_test.go
+++ b/internal/pkg/cli/storage_init_test.go
@@ -358,347 +358,6 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 			},
 			wantedErr: fmt.Errorf("input storage name: some error"),
 		},
-		"asks for partition key if not specified": {
-			inAppName:     wantedAppName,
-			inSvcName:     wantedSvcName,
-			inStorageType: dynamoDBStorageType,
-			inStorageName: wantedTableName,
-			inSort:        wantedSortKey,
-			inNoLSI:       true,
-
-			mock: func(m *mockStorageInitAsk) {
-				keyPrompt := fmt.Sprintf(fmtStorageInitDDBKeyPrompt,
-					color.HighlightUserInput("partition key"),
-					color.HighlightUserInput(dynamoDBStorageType),
-				)
-				keyTypePrompt := fmt.Sprintf(fmtStorageInitDDBKeyTypePrompt, ddbKeyString)
-				m.prompt.EXPECT().Get(gomock.Eq(keyPrompt),
-					gomock.Any(),
-					gomock.Any(),
-					gomock.Any(),
-				).Return(wantedPartitionKey, nil)
-				m.prompt.EXPECT().SelectOne(gomock.Eq(keyTypePrompt),
-					gomock.Any(),
-					attributeTypes,
-					gomock.Any(),
-				).Return(ddbStringType, nil)
-			},
-		},
-		"error if fail to return partition key": {
-			inAppName:     wantedAppName,
-			inSvcName:     wantedSvcName,
-			inStorageType: dynamoDBStorageType,
-			inStorageName: wantedTableName,
-
-			mock: func(m *mockStorageInitAsk) {
-				m.prompt.EXPECT().Get(gomock.Any(),
-					gomock.Any(),
-					gomock.Any(),
-					gomock.Any(),
-				).Return("", errors.New("some error"))
-			},
-			wantedErr: fmt.Errorf("get DDB partition key: some error"),
-		},
-		"error if fail to return partition key type": {
-			inAppName:     wantedAppName,
-			inSvcName:     wantedSvcName,
-			inStorageType: dynamoDBStorageType,
-			inStorageName: wantedTableName,
-			inSort:        wantedSortKey,
-			mock: func(m *mockStorageInitAsk) {
-				m.prompt.EXPECT().Get(gomock.Any(),
-					gomock.Any(),
-					gomock.Any(),
-					gomock.Any(),
-				).Return(wantedPartitionKey, nil)
-				m.prompt.EXPECT().SelectOne(gomock.Any(),
-					gomock.Any(),
-					gomock.Any(),
-					gomock.Any(),
-				).Return("", errors.New("some error"))
-			},
-			wantedErr: fmt.Errorf("get DDB partition key datatype: some error"),
-		},
-		"ask for sort key if not specified": {
-			inAppName:     wantedAppName,
-			inSvcName:     wantedSvcName,
-			inStorageType: dynamoDBStorageType,
-			inStorageName: wantedTableName,
-			inPartition:   wantedPartitionKey,
-			inNoLSI:       true,
-
-			mock: func(m *mockStorageInitAsk) {
-				m.prompt.EXPECT().Confirm(
-					gomock.Eq(storageInitDDBSortKeyConfirm),
-					gomock.Any(),
-					gomock.Any(),
-				).Return(true, nil)
-				keyPrompt := fmt.Sprintf(fmtStorageInitDDBKeyPrompt,
-					color.HighlightUserInput("sort key"),
-					color.HighlightUserInput(dynamoDBStorageType),
-				)
-				keyTypePrompt := fmt.Sprintf(fmtStorageInitDDBKeyTypePrompt, ddbKeyString)
-				m.prompt.EXPECT().Get(gomock.Eq(keyPrompt),
-					gomock.Any(),
-					gomock.Any(),
-					gomock.Any(),
-				).Return(wantedPartitionKey, nil)
-				m.prompt.EXPECT().SelectOne(gomock.Eq(keyTypePrompt),
-					gomock.Any(),
-					attributeTypes,
-					gomock.Any(),
-				).Return(ddbStringType, nil)
-			},
-		},
-		"error if fail to confirm add sort key": {
-			inAppName:     wantedAppName,
-			inSvcName:     wantedSvcName,
-			inStorageType: dynamoDBStorageType,
-			inStorageName: wantedTableName,
-			inPartition:   wantedPartitionKey,
-
-			mock: func(m *mockStorageInitAsk) {
-				m.prompt.EXPECT().Confirm(
-					gomock.Eq(storageInitDDBSortKeyConfirm),
-					gomock.Any(),
-					gomock.Any(),
-				).Return(false, errors.New("some error"))
-			},
-			wantedErr: fmt.Errorf("confirm DDB sort key: some error"),
-		},
-		"error if fail to return sort key": {
-			inAppName:     wantedAppName,
-			inSvcName:     wantedSvcName,
-			inStorageType: dynamoDBStorageType,
-			inStorageName: wantedTableName,
-			inPartition:   wantedPartitionKey,
-			mock: func(m *mockStorageInitAsk) {
-				m.prompt.EXPECT().Confirm(
-					gomock.Eq(storageInitDDBSortKeyConfirm),
-					gomock.Any(),
-					gomock.Any(),
-				).Return(true, nil)
-				m.prompt.EXPECT().Get(gomock.Any(),
-					gomock.Any(),
-					gomock.Any(),
-					gomock.Any(),
-				).Return("", errors.New("some error"))
-			},
-			wantedErr: fmt.Errorf("get DDB sort key: some error"),
-		},
-		"error if fail to return sort key type": {
-			inAppName:     wantedAppName,
-			inSvcName:     wantedSvcName,
-			inStorageType: dynamoDBStorageType,
-			inStorageName: wantedTableName,
-			inPartition:   wantedPartitionKey,
-
-			mock: func(m *mockStorageInitAsk) {
-				m.prompt.EXPECT().Confirm(
-					gomock.Eq(storageInitDDBSortKeyConfirm),
-					gomock.Any(),
-					gomock.Any(),
-				).Return(true, nil)
-				m.prompt.EXPECT().Get(gomock.Any(),
-					gomock.Any(),
-					gomock.Any(),
-					gomock.Any(),
-				).Return(wantedPartitionKey, nil)
-				m.prompt.EXPECT().SelectOne(gomock.Any(),
-					gomock.Any(),
-					gomock.Any(),
-					gomock.Any(),
-				).Return("", errors.New("some error"))
-			},
-			wantedErr: fmt.Errorf("get DDB sort key datatype: some error"),
-		},
-		"don't ask for sort key if no-sort specified": {
-			inAppName:     wantedAppName,
-			inSvcName:     wantedSvcName,
-			inStorageType: dynamoDBStorageType,
-			inStorageName: wantedTableName,
-			inPartition:   wantedPartitionKey,
-			inNoSort:      true,
-			inNoLSI:       true,
-			mock:          func(m *mockStorageInitAsk) {},
-		},
-		"ok if --no-lsi and --sort-key are both specified": {
-			inAppName:     wantedAppName,
-			inSvcName:     wantedSvcName,
-			inStorageType: dynamoDBStorageType,
-			inStorageName: wantedTableName,
-			inPartition:   wantedPartitionKey,
-			inSort:        wantedSortKey,
-			inNoLSI:       true,
-			mock:          func(m *mockStorageInitAsk) {},
-		},
-		"don't ask about LSI if no-sort is specified": {
-			inAppName:     wantedAppName,
-			inSvcName:     wantedSvcName,
-			inStorageType: dynamoDBStorageType,
-			inStorageName: wantedTableName,
-			inPartition:   wantedPartitionKey,
-			inNoSort:      true,
-			mock:          func(m *mockStorageInitAsk) {},
-		},
-		"ask for LSI if not specified": {
-			inAppName:     wantedAppName,
-			inSvcName:     wantedSvcName,
-			inStorageType: dynamoDBStorageType,
-			inStorageName: wantedTableName,
-			inPartition:   wantedPartitionKey,
-			inSort:        wantedSortKey,
-
-			mock: func(m *mockStorageInitAsk) {
-				lsiTypePrompt := fmt.Sprintf(fmtStorageInitDDBKeyTypePrompt, color.Emphasize("alternate sort key"))
-				lsiTypeHelp := fmt.Sprintf(fmtStorageInitDDBKeyTypeHelp, "alternate sort key")
-				m.prompt.EXPECT().Confirm(
-					gomock.Eq(storageInitDDBLSIPrompt),
-					gomock.Eq(storageInitDDBLSIHelp),
-					gomock.Any(),
-				).Return(true, nil)
-				m.prompt.EXPECT().Get(
-					gomock.Eq(storageInitDDBLSINamePrompt),
-					gomock.Eq(storageInitDDBLSINameHelp),
-					gomock.Any(),
-					gomock.Any(),
-				).Return("Email", nil)
-				m.prompt.EXPECT().SelectOne(
-					gomock.Eq(lsiTypePrompt),
-					gomock.Eq(lsiTypeHelp),
-					gomock.Eq(attributeTypes),
-					gomock.Any(),
-				).Return(ddbStringType, nil)
-				m.prompt.EXPECT().Confirm(
-					gomock.Eq(storageInitDDBMoreLSIPrompt),
-					gomock.Eq(storageInitDDBLSIHelp),
-					gomock.Any(),
-				).Return(false, nil)
-			},
-			wantedVars: &initStorageVars{
-				storageName:  wantedTableName,
-				workloadName: wantedSvcName,
-				storageType:  dynamoDBStorageType,
-
-				partitionKey: wantedPartitionKey,
-				sortKey:      wantedSortKey,
-				noLSI:        false,
-				lsiSorts:     []string{"Email:String"},
-			},
-		},
-		"noLSI is set correctly if no lsis specified": {
-			inAppName:     wantedAppName,
-			inSvcName:     wantedSvcName,
-			inStorageType: dynamoDBStorageType,
-			inStorageName: wantedTableName,
-			inPartition:   wantedPartitionKey,
-			inSort:        wantedSortKey,
-
-			mock: func(m *mockStorageInitAsk) {
-				m.prompt.EXPECT().Confirm(
-					gomock.Eq(storageInitDDBLSIPrompt),
-					gomock.Eq(storageInitDDBLSIHelp),
-					gomock.Any(),
-				).Return(false, nil)
-			},
-			wantedVars: &initStorageVars{
-				storageName:  wantedTableName,
-				workloadName: wantedSvcName,
-				storageType:  dynamoDBStorageType,
-
-				partitionKey: wantedPartitionKey,
-				sortKey:      wantedSortKey,
-				noLSI:        true,
-			},
-		},
-		"noLSI is set correctly if no sort key": {
-			inAppName:     wantedAppName,
-			inSvcName:     wantedSvcName,
-			inStorageType: dynamoDBStorageType,
-			inStorageName: wantedTableName,
-			inPartition:   wantedPartitionKey,
-
-			mock: func(m *mockStorageInitAsk) {
-				m.prompt.EXPECT().Confirm(
-					gomock.Eq(storageInitDDBSortKeyConfirm),
-					gomock.Eq(storageInitDDBSortKeyHelp),
-					gomock.Any(),
-				).Return(false, nil)
-			},
-			wantedVars: &initStorageVars{
-				storageName:  wantedTableName,
-				workloadName: wantedSvcName,
-				storageType:  dynamoDBStorageType,
-
-				partitionKey: wantedPartitionKey,
-				noLSI:        true,
-				noSort:       true,
-			},
-		},
-		"error if lsi name misspecified": {
-			inAppName:     wantedAppName,
-			inSvcName:     wantedSvcName,
-			inStorageType: dynamoDBStorageType,
-			inStorageName: wantedTableName,
-			inPartition:   wantedPartitionKey,
-			inSort:        wantedSortKey,
-			mock: func(m *mockStorageInitAsk) {
-				m.prompt.EXPECT().Confirm(
-					gomock.Eq(storageInitDDBLSIPrompt),
-					gomock.Any(),
-					gomock.Any(),
-				).Return(true, nil)
-				m.prompt.EXPECT().Get(gomock.Any(),
-					gomock.Any(),
-					gomock.Any(),
-					gomock.Any(),
-				).Return("", errors.New("some error"))
-			},
-			wantedErr: fmt.Errorf("get DDB alternate sort key name: some error"),
-		},
-		"errors if fail to confirm lsi": {
-			inAppName:     wantedAppName,
-			inSvcName:     wantedSvcName,
-			inStorageType: dynamoDBStorageType,
-			inStorageName: wantedTableName,
-			inPartition:   wantedPartitionKey,
-			inSort:        wantedSortKey,
-			mock: func(m *mockStorageInitAsk) {
-				m.prompt.EXPECT().Confirm(
-					gomock.Any(),
-					gomock.Any(),
-					gomock.Any(),
-				).Return(false, errors.New("some error"))
-			},
-			wantedErr: fmt.Errorf("confirm add alternate sort key: some error"),
-		},
-		"error if lsi type misspecified": {
-			inAppName:     wantedAppName,
-			inSvcName:     wantedSvcName,
-			inStorageType: dynamoDBStorageType,
-			inStorageName: wantedTableName,
-			inPartition:   wantedPartitionKey,
-			inSort:        wantedSortKey,
-			mock: func(m *mockStorageInitAsk) {
-				m.prompt.EXPECT().Confirm(
-					gomock.Any(),
-					gomock.Any(),
-					gomock.Any(),
-				).Return(true, nil)
-				m.prompt.EXPECT().Get(gomock.Any(),
-					gomock.Any(),
-					gomock.Any(),
-					gomock.Any(),
-				).Return("cool", nil)
-				m.prompt.EXPECT().SelectOne(gomock.Any(),
-					gomock.Any(),
-					gomock.Any(),
-					gomock.Any(),
-				).Return("", errors.New("some error"))
-
-			},
-			wantedErr: fmt.Errorf("get DDB alternate sort key type: some error"),
-		},
 		"no error or asks when fully specified": {
 			inAppName:     wantedAppName,
 			inSvcName:     wantedSvcName,
@@ -823,6 +482,340 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 				ws:      m.ws,
 			}
 			tc.mock(&m)
+			// WHEN
+			err := opts.Ask()
+
+			// THEN
+			if tc.wantedErr != nil {
+				require.EqualError(t, err, tc.wantedErr.Error())
+			} else {
+				require.NoError(t, err)
+			}
+			if tc.wantedVars != nil {
+				require.Equal(t, *tc.wantedVars, opts.initStorageVars)
+			}
+		})
+	}
+}
+
+func TestStorageInitOpts_AskDDB(t *testing.T) {
+	const (
+		wantedSvcName      = "frontend"
+		wantedTableName    = "coolTable"
+		wantedPartitionKey = "DogName:String"
+		wantedSortKey      = "PhotoId:Number"
+	)
+	testCases := map[string]struct {
+		inPartition string
+		inSort      string
+		inLSISorts  []string
+		inNoLSI     bool
+		inNoSort    bool
+
+		inServerlessVersion string
+		inDBEngine          string
+		inInitialDBName     string
+
+		mock func(m *mockStorageInitAsk)
+
+		wantedErr  error
+		wantedVars *initStorageVars
+	}{
+		"asks for partition key if not specified": {
+			inSort:  wantedSortKey,
+			inNoLSI: true,
+
+			mock: func(m *mockStorageInitAsk) {
+				keyPrompt := fmt.Sprintf(fmtStorageInitDDBKeyPrompt,
+					color.HighlightUserInput("partition key"),
+					color.HighlightUserInput(dynamoDBStorageType),
+				)
+				keyTypePrompt := fmt.Sprintf(fmtStorageInitDDBKeyTypePrompt, ddbKeyString)
+				m.prompt.EXPECT().Get(gomock.Eq(keyPrompt),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+				).Return(wantedPartitionKey, nil)
+				m.prompt.EXPECT().SelectOne(gomock.Eq(keyTypePrompt),
+					gomock.Any(),
+					attributeTypes,
+					gomock.Any(),
+				).Return(ddbStringType, nil)
+			},
+		},
+		"error if fail to return partition key": {
+			mock: func(m *mockStorageInitAsk) {
+				m.prompt.EXPECT().Get(gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+				).Return("", errors.New("some error"))
+			},
+			wantedErr: fmt.Errorf("get DDB partition key: some error"),
+		},
+		"error if fail to return partition key type": {
+			inSort: wantedSortKey,
+			mock: func(m *mockStorageInitAsk) {
+				m.prompt.EXPECT().Get(gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+				).Return(wantedPartitionKey, nil)
+				m.prompt.EXPECT().SelectOne(gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+				).Return("", errors.New("some error"))
+			},
+			wantedErr: fmt.Errorf("get DDB partition key datatype: some error"),
+		},
+		"ask for sort key if not specified": {
+			inPartition: wantedPartitionKey,
+			inNoLSI:     true,
+			mock: func(m *mockStorageInitAsk) {
+				m.prompt.EXPECT().Confirm(
+					gomock.Eq(storageInitDDBSortKeyConfirm),
+					gomock.Any(),
+					gomock.Any(),
+				).Return(true, nil)
+				keyPrompt := fmt.Sprintf(fmtStorageInitDDBKeyPrompt,
+					color.HighlightUserInput("sort key"),
+					color.HighlightUserInput(dynamoDBStorageType),
+				)
+				keyTypePrompt := fmt.Sprintf(fmtStorageInitDDBKeyTypePrompt, ddbKeyString)
+				m.prompt.EXPECT().Get(gomock.Eq(keyPrompt),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+				).Return(wantedPartitionKey, nil)
+				m.prompt.EXPECT().SelectOne(gomock.Eq(keyTypePrompt),
+					gomock.Any(),
+					attributeTypes,
+					gomock.Any(),
+				).Return(ddbStringType, nil)
+			},
+		},
+		"error if fail to confirm add sort key": {
+			inPartition: wantedPartitionKey,
+			mock: func(m *mockStorageInitAsk) {
+				m.prompt.EXPECT().Confirm(
+					gomock.Eq(storageInitDDBSortKeyConfirm),
+					gomock.Any(),
+					gomock.Any(),
+				).Return(false, errors.New("some error"))
+			},
+			wantedErr: fmt.Errorf("confirm DDB sort key: some error"),
+		},
+		"error if fail to return sort key": {
+			inPartition: wantedPartitionKey,
+			mock: func(m *mockStorageInitAsk) {
+				m.prompt.EXPECT().Confirm(
+					gomock.Eq(storageInitDDBSortKeyConfirm),
+					gomock.Any(),
+					gomock.Any(),
+				).Return(true, nil)
+				m.prompt.EXPECT().Get(gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+				).Return("", errors.New("some error"))
+			},
+			wantedErr: fmt.Errorf("get DDB sort key: some error"),
+		},
+		"error if fail to return sort key type": {
+			inPartition: wantedPartitionKey,
+			mock: func(m *mockStorageInitAsk) {
+				m.prompt.EXPECT().Confirm(
+					gomock.Eq(storageInitDDBSortKeyConfirm),
+					gomock.Any(),
+					gomock.Any(),
+				).Return(true, nil)
+				m.prompt.EXPECT().Get(gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+				).Return(wantedPartitionKey, nil)
+				m.prompt.EXPECT().SelectOne(gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+				).Return("", errors.New("some error"))
+			},
+			wantedErr: fmt.Errorf("get DDB sort key datatype: some error"),
+		},
+		"don't ask for sort key if no-sort specified": {
+			inPartition: wantedPartitionKey,
+			inNoSort:    true,
+			inNoLSI:     true,
+			mock:        func(m *mockStorageInitAsk) {},
+		},
+		"ok if --no-lsi and --sort-key are both specified": {
+			inPartition: wantedPartitionKey,
+			inSort:      wantedSortKey,
+			inNoLSI:     true,
+			mock:        func(m *mockStorageInitAsk) {},
+		},
+		"don't ask about LSI if no-sort is specified": {
+			inPartition: wantedPartitionKey,
+			inNoSort:    true,
+			mock:        func(m *mockStorageInitAsk) {},
+		},
+		"ask for LSI if not specified": {
+			inPartition: wantedPartitionKey,
+			inSort:      wantedSortKey,
+			mock: func(m *mockStorageInitAsk) {
+				lsiTypePrompt := fmt.Sprintf(fmtStorageInitDDBKeyTypePrompt, color.Emphasize("alternate sort key"))
+				lsiTypeHelp := fmt.Sprintf(fmtStorageInitDDBKeyTypeHelp, "alternate sort key")
+				m.prompt.EXPECT().Confirm(
+					gomock.Eq(storageInitDDBLSIPrompt),
+					gomock.Eq(storageInitDDBLSIHelp),
+					gomock.Any(),
+				).Return(true, nil)
+				m.prompt.EXPECT().Get(
+					gomock.Eq(storageInitDDBLSINamePrompt),
+					gomock.Eq(storageInitDDBLSINameHelp),
+					gomock.Any(),
+					gomock.Any(),
+				).Return("Email", nil)
+				m.prompt.EXPECT().SelectOne(
+					gomock.Eq(lsiTypePrompt),
+					gomock.Eq(lsiTypeHelp),
+					gomock.Eq(attributeTypes),
+					gomock.Any(),
+				).Return(ddbStringType, nil)
+				m.prompt.EXPECT().Confirm(
+					gomock.Eq(storageInitDDBMoreLSIPrompt),
+					gomock.Eq(storageInitDDBLSIHelp),
+					gomock.Any(),
+				).Return(false, nil)
+			},
+			wantedVars: &initStorageVars{
+				storageName:  wantedTableName,
+				workloadName: wantedSvcName,
+				storageType:  dynamoDBStorageType,
+
+				partitionKey: wantedPartitionKey,
+				sortKey:      wantedSortKey,
+				noLSI:        false,
+				lsiSorts:     []string{"Email:String"},
+			},
+		},
+		"noLSI is set correctly if no lsis specified": {
+			inPartition: wantedPartitionKey,
+			inSort:      wantedSortKey,
+			mock: func(m *mockStorageInitAsk) {
+				m.prompt.EXPECT().Confirm(
+					gomock.Eq(storageInitDDBLSIPrompt),
+					gomock.Eq(storageInitDDBLSIHelp),
+					gomock.Any(),
+				).Return(false, nil)
+			},
+			wantedVars: &initStorageVars{
+				storageName:  wantedTableName,
+				workloadName: wantedSvcName,
+				storageType:  dynamoDBStorageType,
+
+				partitionKey: wantedPartitionKey,
+				sortKey:      wantedSortKey,
+				noLSI:        true,
+			},
+		},
+		"noLSI is set correctly if no sort key": {
+			inPartition: wantedPartitionKey,
+			mock: func(m *mockStorageInitAsk) {
+				m.prompt.EXPECT().Confirm(
+					gomock.Eq(storageInitDDBSortKeyConfirm),
+					gomock.Eq(storageInitDDBSortKeyHelp),
+					gomock.Any(),
+				).Return(false, nil)
+			},
+			wantedVars: &initStorageVars{
+				storageName:  wantedTableName,
+				workloadName: wantedSvcName,
+				storageType:  dynamoDBStorageType,
+
+				partitionKey: wantedPartitionKey,
+				noLSI:        true,
+				noSort:       true,
+			},
+		},
+		"error if lsi name misspecified": {
+			inPartition: wantedPartitionKey,
+			inSort:      wantedSortKey,
+			mock: func(m *mockStorageInitAsk) {
+				m.prompt.EXPECT().Confirm(
+					gomock.Eq(storageInitDDBLSIPrompt),
+					gomock.Any(),
+					gomock.Any(),
+				).Return(true, nil)
+				m.prompt.EXPECT().Get(gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+				).Return("", errors.New("some error"))
+			},
+			wantedErr: fmt.Errorf("get DDB alternate sort key name: some error"),
+		},
+		"errors if fail to confirm lsi": {
+			inPartition: wantedPartitionKey,
+			inSort:      wantedSortKey,
+			mock: func(m *mockStorageInitAsk) {
+				m.prompt.EXPECT().Confirm(
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+				).Return(false, errors.New("some error"))
+			},
+			wantedErr: fmt.Errorf("confirm add alternate sort key: some error"),
+		},
+		"error if lsi type misspecified": {
+			inPartition: wantedPartitionKey,
+			inSort:      wantedSortKey,
+			mock: func(m *mockStorageInitAsk) {
+				m.prompt.EXPECT().Confirm(
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+				).Return(true, nil)
+				m.prompt.EXPECT().Get(gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+				).Return("cool", nil)
+				m.prompt.EXPECT().SelectOne(gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+				).Return("", errors.New("some error"))
+
+			},
+			wantedErr: fmt.Errorf("get DDB alternate sort key type: some error"),
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// GIVEN
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			m := mockStorageInitAsk{
+				prompt: mocks.NewMockprompter(ctrl),
+			}
+			tc.mock(&m)
+			opts := initStorageOpts{
+				initStorageVars: initStorageVars{
+					storageType:  dynamoDBStorageType,
+					storageName:  wantedTableName,
+					workloadName: wantedSvcName,
+					partitionKey: tc.inPartition,
+					sortKey:      tc.inSort,
+					lsiSorts:     tc.inLSISorts,
+					noLSI:        tc.inNoLSI,
+					noSort:       tc.inNoSort,
+				},
+				appName: "ddos",
+				prompt:  m.prompt,
+			}
 			// WHEN
 			err := opts.Ask()
 

--- a/internal/pkg/cli/storage_init_test.go
+++ b/internal/pkg/cli/storage_init_test.go
@@ -39,9 +39,6 @@ func TestStorageInitOpts_Validate(t *testing.T) {
 		inEngine            string
 
 		mock      func(m *mockStorageInitValidate)
-		mockWs    func(m *mocks.MockwsAddonManager)
-		mockStore func(m *mocks.Mockstore)
-
 		wantedErr error
 	}{
 		"no app in workspace": {


### PR DESCRIPTION
1. move individual `mockWS` and `mockPrompt` into a struct `mockStorageInitAsk` and `mockStorageInitAsk`
2. `Ask` test suite has become too big and has a lot of distracting input parameters. I have separated `Ask` test suites into three: `AskDDB` that test the ddb-related prompts, `AskRDS` that test the rds-related prompts, `Ask` which handles only the prompts that's tangential to storage type
3. Add just one more unit test case to test fully config DDB

Previously, there were 28 test cases; after this PR (because of 3), there will be 29.

<strike> Will rebase on https://github.com/aws/copilot-cli/pull/4437 after it's merged to save me from resolving conflicts 😹 <img src=https://slackmojis.com/emojis/7875-coolsob/download width=20px/> </strike> done
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
