### PR TITLE
chore: inject S3 bucket name down to stack from deploy pkg

### DIFF
--- a/internal/pkg/cli/deploy/backend.go
+++ b/internal/pkg/cli/deploy/backend.go
@@ -91,12 +91,13 @@ func (d *backendSvcDeployer) stackConfiguration(in *StackRuntimeConfiguration) (
 		return nil, err
 	}
 	conf, err := stack.NewBackendService(stack.BackendServiceConfig{
-		App:           d.app,
-		EnvManifest:   d.envConfig,
-		Manifest:      d.backendMft,
-		RawManifest:   d.rawMft,
-		RuntimeConfig: *rc,
-		Addons:        d.addons,
+		App:                d.app,
+		EnvManifest:        d.envConfig,
+		Manifest:           d.backendMft,
+		RawManifest:        d.rawMft,
+		ArtifactBucketName: d.resources.S3Bucket,
+		RuntimeConfig:      *rc,
+		Addons:             d.addons,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create stack configuration: %w", err)

--- a/internal/pkg/cli/deploy/backend_test.go
+++ b/internal/pkg/cli/deploy/backend_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation/stack"
+
 	"github.com/aws/copilot-cli/internal/pkg/override"
 	"gopkg.in/yaml.v3"
 
@@ -237,6 +239,7 @@ func TestBackendSvcDeployer_stackConfiguration(t *testing.T) {
 						app:              tc.App,
 						env:              tc.Env,
 						endpointGetter:   m.mockEndpointGetter,
+						resources:        &stack.AppRegionalResources{},
 						envConfig:        tc.inEnvironmentConfig(),
 						envVersionGetter: m.mockEnvVersionGetter,
 					},
@@ -270,6 +273,7 @@ func mockBackendServiceDeployer(opts ...func(*backendSvcDeployer)) *backendSvcDe
 					App:  "demo",
 					Name: "test",
 				},
+				resources:        &stack.AppRegionalResources{},
 				envConfig:        new(manifest.Environment),
 				endpointGetter:   &mockEndpointGetter{endpoint: "demo.test.local"},
 				envVersionGetter: &mockEnvVersionGetter{version: "v1.0.0"},

--- a/internal/pkg/cli/deploy/job.go
+++ b/internal/pkg/cli/deploy/job.go
@@ -18,8 +18,7 @@ import (
 
 type jobDeployer struct {
 	*workloadDeployer
-	jobMft          *manifest.ScheduledJob
-	customResources customResourcesFunc
+	jobMft *manifest.ScheduledJob
 }
 
 // IsServiceAvailableInRegion checks if service type exist in the given region.
@@ -29,6 +28,7 @@ func (jobDeployer) IsServiceAvailableInRegion(region string) (bool, error) {
 
 // NewJobDeployer is the constructor for jobDeployer.
 func NewJobDeployer(in *WorkloadDeployerInput) (*jobDeployer, error) {
+	in.customResources = scheduledJobCustomResources
 	wkldDeployer, err := newWorkloadDeployer(in)
 	if err != nil {
 		return nil, err
@@ -40,19 +40,20 @@ func NewJobDeployer(in *WorkloadDeployerInput) (*jobDeployer, error) {
 	return &jobDeployer{
 		workloadDeployer: wkldDeployer,
 		jobMft:           jobMft,
-		customResources: func(fs template.Reader) ([]*customresource.CustomResource, error) {
-			crs, err := customresource.ScheduledJob(fs)
-			if err != nil {
-				return nil, fmt.Errorf("read custom resources for a %q: %w", manifest.ScheduledJobType, err)
-			}
-			return crs, nil
-		},
 	}, nil
+}
+
+func scheduledJobCustomResources(fs template.Reader) ([]*customresource.CustomResource, error) {
+	crs, err := customresource.ScheduledJob(fs)
+	if err != nil {
+		return nil, fmt.Errorf("read custom resources for a %q: %w", manifest.ScheduledJobType, err)
+	}
+	return crs, nil
 }
 
 // UploadArtifacts uploads the deployment artifacts such as the container image, custom resources, addons and env files.
 func (d *jobDeployer) UploadArtifacts() (*UploadArtifactsOutput, error) {
-	return d.uploadArtifacts(d.customResources)
+	return d.uploadArtifacts()
 }
 
 // GenerateCloudFormationTemplate generates a CloudFormation template and parameters for a workload.

--- a/internal/pkg/cli/deploy/job.go
+++ b/internal/pkg/cli/deploy/job.go
@@ -94,12 +94,13 @@ func (d *jobDeployer) stackConfiguration(in *StackRuntimeConfiguration) (*jobSta
 		return nil, err
 	}
 	conf, err := stack.NewScheduledJob(stack.ScheduledJobConfig{
-		App:           d.app,
-		Env:           d.env.Name,
-		Manifest:      d.jobMft,
-		RawManifest:   d.rawMft,
-		RuntimeConfig: *rc,
-		Addons:        d.addons,
+		App:                d.app,
+		Env:                d.env.Name,
+		Manifest:           d.jobMft,
+		RawManifest:        d.rawMft,
+		ArtifactBucketName: d.resources.S3Bucket,
+		RuntimeConfig:      *rc,
+		Addons:             d.addons,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create stack configuration: %w", err)

--- a/internal/pkg/cli/deploy/job_test.go
+++ b/internal/pkg/cli/deploy/job_test.go
@@ -6,6 +6,8 @@ package deploy
 import (
 	"testing"
 
+	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation/stack"
+
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 
@@ -56,6 +58,7 @@ func mockJobDeployer(opts ...func(*jobDeployer)) *jobDeployer {
 				App:  "demo",
 				Name: "test",
 			},
+			resources:        &stack.AppRegionalResources{},
 			envConfig:        new(manifest.Environment),
 			endpointGetter:   &mockEndpointGetter{endpoint: "demo.test.local"},
 			envVersionGetter: &mockEnvVersionGetter{version: "v1.0.0"},

--- a/internal/pkg/cli/deploy/lbws.go
+++ b/internal/pkg/cli/deploy/lbws.go
@@ -155,13 +155,14 @@ func (d *lbWebSvcDeployer) stackConfiguration(in *StackRuntimeConfiguration) (*s
 		opts = append(opts, stack.WithNLB(cidrBlocks))
 	}
 	conf, err := stack.NewLoadBalancedWebService(stack.LoadBalancedWebServiceConfig{
-		App:           d.app,
-		EnvManifest:   d.envConfig,
-		Manifest:      d.lbMft,
-		RawManifest:   d.rawMft,
-		RuntimeConfig: *rc,
-		RootUserARN:   in.RootUserARN,
-		Addons:        d.addons,
+		App:                d.app,
+		EnvManifest:        d.envConfig,
+		Manifest:           d.lbMft,
+		RawManifest:        d.rawMft,
+		ArtifactBucketName: d.resources.S3Bucket,
+		RuntimeConfig:      *rc,
+		RootUserARN:        in.RootUserARN,
+		Addons:             d.addons,
 	}, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("create stack configuration: %w", err)

--- a/internal/pkg/cli/deploy/lbws_test.go
+++ b/internal/pkg/cli/deploy/lbws_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation/stack"
+
 	"github.com/aws/copilot-cli/internal/pkg/template"
 
 	"gopkg.in/yaml.v3"
@@ -67,6 +69,7 @@ func mockLoadBalancedWebServiceDeployer(opts ...func(deployer *lbWebSvcDeployer)
 					App:  "demo",
 					Name: "test",
 				},
+				resources:        &stack.AppRegionalResources{},
 				envConfig:        new(manifest.Environment),
 				endpointGetter:   &mockEndpointGetter{endpoint: "demo.test.local"},
 				envVersionGetter: &mockEnvVersionGetter{version: "v1.0.0"},

--- a/internal/pkg/cli/deploy/lbws_test.go
+++ b/internal/pkg/cli/deploy/lbws_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/copilot-cli/internal/pkg/template"
+
 	"gopkg.in/yaml.v3"
 
 	"github.com/stretchr/testify/require"
@@ -69,6 +71,8 @@ func mockLoadBalancedWebServiceDeployer(opts ...func(deployer *lbWebSvcDeployer)
 				endpointGetter:   &mockEndpointGetter{endpoint: "demo.test.local"},
 				envVersionGetter: &mockEnvVersionGetter{version: "v1.0.0"},
 				overrider:        new(override.Noop),
+				templateFS:       template.New(),
+				customResources:  lbwsCustomResources,
 			},
 			newSvcUpdater: func(f func(*session.Session) serviceForceUpdater) serviceForceUpdater {
 				return nil

--- a/internal/pkg/cli/deploy/rdws.go
+++ b/internal/pkg/cli/deploy/rdws.go
@@ -138,11 +138,12 @@ func (d *rdwsDeployer) stackConfiguration(in *StackRuntimeConfiguration) (*rdwsS
 			PermissionsBoundary: d.app.PermissionsBoundary,
 			AccountPrincipalARN: in.RootUserARN,
 		},
-		Env:           d.env.Name,
-		Manifest:      d.rdwsMft,
-		RawManifest:   d.rawMft,
-		RuntimeConfig: *rc,
-		Addons:        d.addons,
+		Env:                d.env.Name,
+		Manifest:           d.rdwsMft,
+		RawManifest:        d.rawMft,
+		ArtifactBucketName: d.resources.S3Bucket,
+		RuntimeConfig:      *rc,
+		Addons:             d.addons,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create stack configuration: %w", err)

--- a/internal/pkg/cli/deploy/rdws_test.go
+++ b/internal/pkg/cli/deploy/rdws_test.go
@@ -257,6 +257,7 @@ func mockRDWSDeployer(opts ...func(*rdwsDeployer)) *rdwsDeployer {
 					App:  "demo",
 					Name: "test",
 				},
+				resources:        &stack.AppRegionalResources{},
 				envConfig:        new(manifest.Environment),
 				endpointGetter:   &mockEndpointGetter{endpoint: "demo.test.local"},
 				envVersionGetter: &mockEnvVersionGetter{version: "v1.0.0"},

--- a/internal/pkg/cli/deploy/worker.go
+++ b/internal/pkg/cli/deploy/worker.go
@@ -170,12 +170,13 @@ func (d *workerSvcDeployer) stackConfiguration(in *StackRuntimeConfiguration) (*
 		return nil, err
 	}
 	conf, err := stack.NewWorkerService(stack.WorkerServiceConfig{
-		App:           d.app,
-		Env:           d.env.Name,
-		Manifest:      d.wsMft,
-		RawManifest:   d.rawMft,
-		RuntimeConfig: *rc,
-		Addons:        d.addons,
+		App:                d.app,
+		Env:                d.env.Name,
+		Manifest:           d.wsMft,
+		RawManifest:        d.rawMft,
+		ArtifactBucketName: d.resources.S3Bucket,
+		RuntimeConfig:      *rc,
+		Addons:             d.addons,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create stack configuration: %w", err)

--- a/internal/pkg/cli/deploy/worker_test.go
+++ b/internal/pkg/cli/deploy/worker_test.go
@@ -245,6 +245,7 @@ func mockWorkerServiceDeployer(opts ...func(*workerSvcDeployer)) *workerSvcDeplo
 					App:  "demo",
 					Name: "test",
 				},
+				resources:        &stack.AppRegionalResources{},
 				envConfig:        new(manifest.Environment),
 				endpointGetter:   &mockEndpointGetter{endpoint: "demo.test.local"},
 				envVersionGetter: &mockEnvVersionGetter{version: "v1.0.0"},

--- a/internal/pkg/deploy/cloudformation/stack/backend_svc.go
+++ b/internal/pkg/deploy/cloudformation/stack/backend_svc.go
@@ -33,12 +33,13 @@ type BackendService struct {
 
 // BackendServiceConfig contains data required to initialize a backend service stack.
 type BackendServiceConfig struct {
-	App           *config.Application
-	EnvManifest   *manifest.Environment
-	Manifest      *manifest.BackendService
-	RawManifest   []byte // Content of the manifest file without any transformations.
-	RuntimeConfig RuntimeConfig
-	Addons        NestedStackConfigurer
+	App                *config.Application
+	EnvManifest        *manifest.Environment
+	Manifest           *manifest.BackendService
+	ArtifactBucketName string
+	RawManifest        []byte // Content of the manifest file without any transformations.
+	RuntimeConfig      RuntimeConfig
+	Addons             NestedStackConfigurer
 }
 
 // NewBackendService creates a new BackendService stack from a manifest file.
@@ -47,15 +48,16 @@ func NewBackendService(conf BackendServiceConfig) (*BackendService, error) {
 	b := &BackendService{
 		ecsWkld: &ecsWkld{
 			wkld: &wkld{
-				name:        aws.StringValue(conf.Manifest.Name),
-				env:         aws.StringValue(conf.EnvManifest.Name),
-				app:         conf.App.Name,
-				permBound:   conf.App.PermissionsBoundary,
-				rc:          conf.RuntimeConfig,
-				image:       conf.Manifest.ImageConfig.Image,
-				rawManifest: conf.RawManifest,
-				parser:      parser,
-				addons:      conf.Addons,
+				name:               aws.StringValue(conf.Manifest.Name),
+				env:                aws.StringValue(conf.EnvManifest.Name),
+				app:                conf.App.Name,
+				permBound:          conf.App.PermissionsBoundary,
+				artifactBucketName: conf.ArtifactBucketName,
+				rc:                 conf.RuntimeConfig,
+				image:              conf.Manifest.ImageConfig.Image,
+				rawManifest:        conf.RawManifest,
+				parser:             parser,
+				addons:             conf.Addons,
 			},
 			logRetention:        conf.Manifest.Logging.Retention,
 			tc:                  conf.Manifest.TaskConfig,

--- a/internal/pkg/deploy/cloudformation/stack/lb_web_svc.go
+++ b/internal/pkg/deploy/cloudformation/stack/lb_web_svc.go
@@ -53,13 +53,14 @@ func WithNLB(cidrBlocks []string) func(s *LoadBalancedWebService) {
 
 // LoadBalancedWebServiceConfig contains fields to configure LoadBalancedWebService.
 type LoadBalancedWebServiceConfig struct {
-	App           *config.Application
-	EnvManifest   *manifest.Environment
-	Manifest      *manifest.LoadBalancedWebService
-	RawManifest   []byte // Content of the manifest file without any transformations.
-	RuntimeConfig RuntimeConfig
-	RootUserARN   string
-	Addons        NestedStackConfigurer
+	App                *config.Application
+	EnvManifest        *manifest.Environment
+	Manifest           *manifest.LoadBalancedWebService
+	RawManifest        []byte // Content of the manifest file without any transformations.
+	RuntimeConfig      RuntimeConfig
+	RootUserARN        string
+	ArtifactBucketName string
+	Addons             NestedStackConfigurer
 }
 
 // NewLoadBalancedWebService creates a new CFN stack with an ECS service from a manifest file, given the options.
@@ -89,15 +90,16 @@ func NewLoadBalancedWebService(conf LoadBalancedWebServiceConfig,
 	s := &LoadBalancedWebService{
 		ecsWkld: &ecsWkld{
 			wkld: &wkld{
-				name:        aws.StringValue(conf.Manifest.Name),
-				env:         aws.StringValue(conf.EnvManifest.Name),
-				app:         conf.App.Name,
-				permBound:   conf.App.PermissionsBoundary,
-				rc:          conf.RuntimeConfig,
-				image:       conf.Manifest.ImageConfig.Image,
-				rawManifest: conf.RawManifest,
-				parser:      parser,
-				addons:      conf.Addons,
+				name:               aws.StringValue(conf.Manifest.Name),
+				env:                aws.StringValue(conf.EnvManifest.Name),
+				app:                conf.App.Name,
+				permBound:          conf.App.PermissionsBoundary,
+				artifactBucketName: conf.ArtifactBucketName,
+				rc:                 conf.RuntimeConfig,
+				image:              conf.Manifest.ImageConfig.Image,
+				rawManifest:        conf.RawManifest,
+				parser:             parser,
+				addons:             conf.Addons,
 			},
 			logRetention:        conf.Manifest.Logging.Retention,
 			tc:                  conf.Manifest.TaskConfig,

--- a/internal/pkg/deploy/cloudformation/stack/rd_web_svc.go
+++ b/internal/pkg/deploy/cloudformation/stack/rd_web_svc.go
@@ -54,13 +54,13 @@ type RequestDrivenWebService struct {
 
 // RequestDrivenWebServiceConfig contains data required to initialize a request-driven web service stack.
 type RequestDrivenWebServiceConfig struct {
-	App         deploy.AppInformation
-	Env         string
-	Manifest    *manifest.RequestDrivenWebService
-	RawManifest []byte
-
-	RuntimeConfig RuntimeConfig
-	Addons        NestedStackConfigurer
+	App                deploy.AppInformation
+	Env                string
+	Manifest           *manifest.RequestDrivenWebService
+	RawManifest        []byte
+	ArtifactBucketName string
+	RuntimeConfig      RuntimeConfig
+	Addons             NestedStackConfigurer
 }
 
 // NewRequestDrivenWebService creates a new RequestDrivenWebService stack from a manifest file.
@@ -69,15 +69,16 @@ func NewRequestDrivenWebService(cfg RequestDrivenWebServiceConfig) (*RequestDriv
 	return &RequestDrivenWebService{
 		appRunnerWkld: &appRunnerWkld{
 			wkld: &wkld{
-				name:        aws.StringValue(cfg.Manifest.Name),
-				env:         cfg.Env,
-				app:         cfg.App.Name,
-				permBound:   cfg.App.PermissionsBoundary,
-				rc:          cfg.RuntimeConfig,
-				image:       cfg.Manifest.ImageConfig.Image,
-				rawManifest: cfg.RawManifest,
-				addons:      cfg.Addons,
-				parser:      parser,
+				name:               aws.StringValue(cfg.Manifest.Name),
+				env:                cfg.Env,
+				app:                cfg.App.Name,
+				permBound:          cfg.App.PermissionsBoundary,
+				artifactBucketName: cfg.ArtifactBucketName,
+				rc:                 cfg.RuntimeConfig,
+				image:              cfg.Manifest.ImageConfig.Image,
+				rawManifest:        cfg.RawManifest,
+				addons:             cfg.Addons,
+				parser:             parser,
 			},
 			instanceConfig:    cfg.Manifest.InstanceConfig,
 			imageConfig:       cfg.Manifest.ImageConfig,

--- a/internal/pkg/deploy/cloudformation/stack/scheduled_job.go
+++ b/internal/pkg/deploy/cloudformation/stack/scheduled_job.go
@@ -92,12 +92,13 @@ func (e errDurationInvalid) Error() string {
 
 // ScheduledJobConfig contains data required to initialize a scheduled job stack.
 type ScheduledJobConfig struct {
-	App           *config.Application
-	Env           string
-	Manifest      *manifest.ScheduledJob
-	RawManifest   []byte
-	RuntimeConfig RuntimeConfig
-	Addons        NestedStackConfigurer
+	App                *config.Application
+	Env                string
+	Manifest           *manifest.ScheduledJob
+	ArtifactBucketName string
+	RawManifest        []byte
+	RuntimeConfig      RuntimeConfig
+	Addons             NestedStackConfigurer
 }
 
 // NewScheduledJob creates a new ScheduledJob stack from a manifest file.
@@ -106,15 +107,16 @@ func NewScheduledJob(cfg ScheduledJobConfig) (*ScheduledJob, error) {
 	return &ScheduledJob{
 		ecsWkld: &ecsWkld{
 			wkld: &wkld{
-				name:        aws.StringValue(cfg.Manifest.Name),
-				env:         cfg.Env,
-				app:         cfg.App.Name,
-				permBound:   cfg.App.PermissionsBoundary,
-				rc:          cfg.RuntimeConfig,
-				image:       cfg.Manifest.ImageConfig.Image,
-				rawManifest: cfg.RawManifest,
-				parser:      parser,
-				addons:      cfg.Addons,
+				name:               aws.StringValue(cfg.Manifest.Name),
+				env:                cfg.Env,
+				app:                cfg.App.Name,
+				permBound:          cfg.App.PermissionsBoundary,
+				artifactBucketName: cfg.ArtifactBucketName,
+				rc:                 cfg.RuntimeConfig,
+				image:              cfg.Manifest.ImageConfig.Image,
+				rawManifest:        cfg.RawManifest,
+				parser:             parser,
+				addons:             cfg.Addons,
 			},
 			logRetention:        cfg.Manifest.Logging.Retention,
 			tc:                  cfg.Manifest.TaskConfig,
@@ -277,7 +279,8 @@ func (j *ScheduledJob) awsSchedule() (string, error) {
 
 // toRate converts a cron "@every" directive to a rate expression defined in minutes.
 // example input: @every 1h30m
-//        output: rate(90 minutes)
+//
+//	output: rate(90 minutes)
 func toRate(duration string) (string, error) {
 	d, err := time.ParseDuration(duration)
 	if err != nil {
@@ -302,9 +305,10 @@ func toRate(duration string) (string, error) {
 // toFixedSchedule converts cron predefined schedules into AWS-flavored cron expressions.
 // (https://godoc.org/github.com/robfig/cron#hdr-Predefined_schedules)
 // Example input: @daily
-//        output: cron(0 0 * * ? *)
-//         input: @annually
-//        output: cron(0 0 1 1 ? *)
+//
+//	output: cron(0 0 * * ? *)
+//	 input: @annually
+//	output: cron(0 0 1 1 ? *)
 func toFixedSchedule(schedule string) (string, error) {
 	switch {
 	case strings.HasPrefix(schedule, hourly):
@@ -337,7 +341,8 @@ func awsCronFieldSpecified(input string) bool {
 // BOTH DOM and DOW cannot be specified
 // DOW numbers run 1-7, not 0-6
 // Example input: 0 9 * * 1-5 (at 9 am, Monday-Friday)
-//              : cron(0 9 ? * 2-6 *) (adds required ? operator, increments DOW to 1-index, adds year)
+//
+//	: cron(0 9 ? * 2-6 *) (adds required ? operator, increments DOW to 1-index, adds year)
 func toAWSCron(schedule string) (string, error) {
 	const (
 		MIN = iota

--- a/internal/pkg/deploy/cloudformation/stack/worker_svc.go
+++ b/internal/pkg/deploy/cloudformation/stack/worker_svc.go
@@ -30,12 +30,13 @@ type WorkerService struct {
 
 // WorkerServiceConfig contains data required to initialize a scheduled job stack.
 type WorkerServiceConfig struct {
-	App           *config.Application
-	Env           string
-	Manifest      *manifest.WorkerService
-	RawManifest   []byte
-	RuntimeConfig RuntimeConfig
-	Addons        NestedStackConfigurer
+	App                *config.Application
+	Env                string
+	Manifest           *manifest.WorkerService
+	ArtifactBucketName string
+	RawManifest        []byte
+	RuntimeConfig      RuntimeConfig
+	Addons             NestedStackConfigurer
 }
 
 // NewWorkerService creates a new WorkerService stack from a manifest file.
@@ -44,15 +45,16 @@ func NewWorkerService(cfg WorkerServiceConfig) (*WorkerService, error) {
 	return &WorkerService{
 		ecsWkld: &ecsWkld{
 			wkld: &wkld{
-				name:        aws.StringValue(cfg.Manifest.Name),
-				env:         cfg.Env,
-				app:         cfg.App.Name,
-				permBound:   cfg.App.PermissionsBoundary,
-				rc:          cfg.RuntimeConfig,
-				image:       cfg.Manifest.ImageConfig.Image,
-				rawManifest: cfg.RawManifest,
-				parser:      parser,
-				addons:      cfg.Addons,
+				name:               aws.StringValue(cfg.Manifest.Name),
+				env:                cfg.Env,
+				app:                cfg.App.Name,
+				permBound:          cfg.App.PermissionsBoundary,
+				artifactBucketName: cfg.ArtifactBucketName,
+				rc:                 cfg.RuntimeConfig,
+				image:              cfg.Manifest.ImageConfig.Image,
+				rawManifest:        cfg.RawManifest,
+				parser:             parser,
+				addons:             cfg.Addons,
 			},
 			logRetention:        cfg.Manifest.Logging.Retention,
 			tc:                  cfg.Manifest.TaskConfig,

--- a/internal/pkg/deploy/cloudformation/stack/workload.go
+++ b/internal/pkg/deploy/cloudformation/stack/workload.go
@@ -114,13 +114,14 @@ type location interface {
 // wkld represents a generic containerized workload.
 // A workload can be a long-running service, an ephemeral task, or a periodic task.
 type wkld struct {
-	name        string
-	env         string
-	app         string
-	permBound   string
-	rc          RuntimeConfig
-	image       location
-	rawManifest []byte // Content of the manifest file without any transformations.
+	name               string
+	env                string
+	app                string
+	permBound          string
+	artifactBucketName string
+	rc                 RuntimeConfig
+	image              location
+	rawManifest        []byte // Content of the manifest file without any transformations.
 
 	parser template.Parser
 	addons NestedStackConfigurer

--- a/internal/pkg/deploy/upload/customresource/customresource.go
+++ b/internal/pkg/deploy/upload/customresource/customresource.go
@@ -68,7 +68,8 @@ func (cr *CustomResource) Name() string {
 	return cr.name
 }
 
-func (cr *CustomResource) artifactPath() string {
+// ArtifactPath returns the S3 object key where the custom resource should be stored.
+func (cr *CustomResource) ArtifactPath() string {
 	return artifactpath.CustomResource(strings.ToLower(cr.Name()), cr.zip.Bytes())
 }
 
@@ -165,7 +166,7 @@ type UploadFunc func(key string, contents io.Reader) (url string, err error)
 func Upload(upload UploadFunc, crs []*CustomResource) (map[string]string, error) {
 	urls := make(map[string]string)
 	for _, cr := range crs {
-		url, err := upload(cr.artifactPath(), cr.zipReader())
+		url, err := upload(cr.ArtifactPath(), cr.zipReader())
 		if err != nil {
 			return nil, fmt.Errorf("upload custom resource %q: %w", cr.Name(), err)
 		}

--- a/internal/pkg/deploy/upload/customresource/customresource_test.go
+++ b/internal/pkg/deploy/upload/customresource/customresource_test.go
@@ -76,7 +76,7 @@ func TestRDWS(t *testing.T) {
 
 	// ensure artifact paths match.
 	for _, cr := range crs {
-		require.Equal(t, wantedPaths[cr.Name()], cr.artifactPath())
+		require.Equal(t, wantedPaths[cr.Name()], cr.ArtifactPath())
 	}
 }
 
@@ -138,7 +138,7 @@ func TestLBWS(t *testing.T) {
 
 	// ensure artifact paths match.
 	for _, cr := range crs {
-		require.Equal(t, wantedPaths[cr.Name()], cr.artifactPath())
+		require.Equal(t, wantedPaths[cr.Name()], cr.ArtifactPath())
 	}
 }
 
@@ -192,7 +192,7 @@ func TestWorker(t *testing.T) {
 
 	// ensure artifact paths match.
 	for _, cr := range crs {
-		require.Equal(t, wantedPaths[cr.Name()], cr.artifactPath())
+		require.Equal(t, wantedPaths[cr.Name()], cr.ArtifactPath())
 	}
 }
 
@@ -246,7 +246,7 @@ func TestBackend(t *testing.T) {
 
 	// ensure artifact paths match.
 	for _, cr := range crs {
-		require.Equal(t, wantedPaths[cr.Name()], cr.artifactPath())
+		require.Equal(t, wantedPaths[cr.Name()], cr.ArtifactPath())
 	}
 }
 
@@ -292,7 +292,7 @@ func TestScheduledJob(t *testing.T) {
 
 	// ensure artifact paths match.
 	for _, cr := range crs {
-		require.Equal(t, wantedPaths[cr.Name()], cr.artifactPath())
+		require.Equal(t, wantedPaths[cr.Name()], cr.ArtifactPath())
 	}
 }
 
@@ -354,7 +354,7 @@ func TestEnv(t *testing.T) {
 
 	// ensure artifact paths match.
 	for _, cr := range crs {
-		require.Equal(t, wantedPaths[cr.Name()], cr.artifactPath())
+		require.Equal(t, wantedPaths[cr.Name()], cr.ArtifactPath())
 	}
 }
 


### PR DESCRIPTION
The first two commits are the same as #4453, I've only added https://github.com/aws/copilot-cli/commit/a665b6240e132c47d4bc44b716fa72cb29474ac9 to start injecting the artifact bucket name down to stack to address Wanxian's comment.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
