### PR TITLE
chore(manifest): Populate Sidecar docker build arguments using BuildConfig function

### DIFF
--- a/internal/pkg/manifest/workload.go
+++ b/internal/pkg/manifest/workload.go
@@ -166,7 +166,7 @@ func (i Image) GetLocation() string {
 func (i *Image) BuildConfig(rootDirectory string) *DockerBuildArgs {
 	df := i.dockerfile()
 	ctx := i.context()
-	dockerfile, context := getDockerfileAndContext(rootDirectory, df, ctx)
+	dockerfile, context := dockerfileAndContext(rootDirectory, df, ctx)
 	return &DockerBuildArgs{
 		Dockerfile: dockerfile,
 		Context:    context,
@@ -176,14 +176,14 @@ func (i *Image) BuildConfig(rootDirectory string) *DockerBuildArgs {
 	}
 }
 
-// getDockerfileAndContext returns the dockerfile path and the build context
+// dockerfileAndContext returns the dockerfile path and the build context
 // of both main container and sidecar container images.
 // Prefer the following hierarchy:
 // 1. Specific dockerfile, specific context
 // 2. Specific dockerfile, context = dockerfile dir
 // 3. "Dockerfile" located in context dir
 // 4. "Dockerfile" located in ws root.
-func getDockerfileAndContext(rootDirectory, df, ctx string) (dockerfile, context *string) {
+func dockerfileAndContext(rootDirectory, df, ctx string) (dockerfile, context *string) {
 	dockerfile = aws.String(filepath.Join(rootDirectory, defaultDockerfileName))
 	context = aws.String(rootDirectory)
 

--- a/internal/pkg/manifest/workload_ecs.go
+++ b/internal/pkg/manifest/workload_ecs.go
@@ -334,7 +334,7 @@ func (cfg *SidecarConfig) ImageURI() (string, bool) {
 func (cfg *SidecarImageConfig) BuildConfig(rootDirectory string) *DockerBuildArgs {
 	df := cfg.dockerfile()
 	ctx := cfg.context()
-	dockerfile, context := getDockerfileAndContext(rootDirectory, df, ctx)
+	dockerfile, context := dockerfileAndContext(rootDirectory, df, ctx)
 	return &DockerBuildArgs{
 		Dockerfile: dockerfile,
 		Context:    context,

--- a/internal/pkg/manifest/workload_ecs.go
+++ b/internal/pkg/manifest/workload_ecs.go
@@ -347,14 +347,15 @@ func (cfg *SidecarImageConfig) BuildConfig(rootDirectory string) *DockerBuildArg
 // dockerfile returns the path to the sidecar container's Dockerfile if one is set.
 // If no dockerfile is specified, returns "".
 func (cfg *SidecarImageConfig) dockerfile() string {
-	if cfg.Build.Advanced.Dockerfile != nil {
+	switch {
+	case cfg.Build.Advanced.Dockerfile != nil:
 		return aws.StringValue(cfg.Build.Advanced.Dockerfile)
+	case cfg.Build.Basic != nil:
+		return aws.StringValue(cfg.Build.Basic)
+	default:
+		return ""
 	}
-	var dfPath string
-	if cfg.Build.Basic != nil {
-		dfPath = aws.StringValue(cfg.Build.Basic)
-	}
-	return dfPath
+
 }
 
 // context returns the build context directory of sidecar container's if it exists, otherwise an empty string.


### PR DESCRIPTION
<!-- Provide summary of changes -->
Related to #4254 
This PR will populate the docker build arguments for the Sidecar container images using `BuildConfig` function

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
