### PR TITLE
feat: add `--add-ingress-from` flag to `storage init`

### DIFF
--- a/internal/pkg/cli/cli.go
+++ b/internal/pkg/cli/cli.go
@@ -128,14 +128,12 @@ func indentListItem(multiline string) string {
 	return strings.Join(prefixedLines, "\n")
 }
 
-type stringMutator func(string) string
-
-func mutateStringSlice(in []string, mutate stringMutator) []string {
-	mutant := make([]string, len(in))
-	for idx, str := range in {
-		mutant[idx] = mutate(str)
+func applyAll[T any](in []T, fn func(item T) T) []T {
+	out := make([]T, len(in))
+	for i, v := range in {
+		out[i] = fn(v)
 	}
-	return mutant
+	return out
 }
 
 // displayPath takes any path and returns it in a form ready to be displayed to

--- a/internal/pkg/cli/cli.go
+++ b/internal/pkg/cli/cli.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"github.com/dustin/go-humanize/english"
@@ -129,12 +128,14 @@ func indentListItem(multiline string) string {
 	return strings.Join(prefixedLines, "\n")
 }
 
-func quoteStringSlice(in []string) []string {
-	quoted := make([]string, len(in))
+type stringMutator func(string) string
+
+func mutateStringSlice(in []string, mutate stringMutator) []string {
+	mutant := make([]string, len(in))
 	for idx, str := range in {
-		quoted[idx] = strconv.Quote(str)
+		mutant[idx] = mutate(str)
 	}
-	return quoted
+	return mutant
 }
 
 // displayPath takes any path and returns it in a form ready to be displayed to

--- a/internal/pkg/cli/flag.go
+++ b/internal/pkg/cli/flag.go
@@ -166,7 +166,7 @@ const (
 // Descriptions for flags.
 var (
 	svcTypeFlagDescription = fmt.Sprintf(`Type of service to create. Must be one of:
-%s.`, strings.Join(mutateStringSlice(manifest.ServiceTypes(), strconv.Quote), ", "))
+%s.`, strings.Join(applyAll(manifest.ServiceTypes(), strconv.Quote), ", "))
 	imageFlagDescription = fmt.Sprintf(`The location of an existing Docker image.
 Cannot be specified with --%s or --%s.`, dockerFileFlag, dockerFileContextFlag)
 	dockerFileFlagDescription = fmt.Sprintf(`Path to the Dockerfile.
@@ -174,11 +174,11 @@ Cannot be specified with --%s.`, imageFlag)
 	dockerFileContextFlagDescription = fmt.Sprintf(`Path to the Docker build context.
 Cannot be specified with --%s.`, imageFlag)
 	storageTypeFlagDescription = fmt.Sprintf(`Type of storage to add. Must be one of:
-%s.`, strings.Join(mutateStringSlice(storageTypes, strconv.Quote), ", "))
+%s.`, strings.Join(applyAll(storageTypes, strconv.Quote), ", "))
 	jobTypeFlagDescription = fmt.Sprintf(`Type of job to create. Must be one of:
-%s.`, strings.Join(mutateStringSlice(manifest.JobTypes(), strconv.Quote), ", "))
+%s.`, strings.Join(applyAll(manifest.JobTypes(), strconv.Quote), ", "))
 	wkldTypeFlagDescription = fmt.Sprintf(`Type of job or svc to create. Must be one of:
-%s.`, strings.Join(mutateStringSlice(manifest.WorkloadTypes(), strconv.Quote), ", "))
+%s.`, strings.Join(applyAll(manifest.WorkloadTypes(), strconv.Quote), ", "))
 
 	clusterFlagDescription = fmt.Sprintf(`Optional. The short name or full ARN of the cluster to run the task in. 
 Cannot be specified with --%s, --%s or --%s.`, appFlag, envFlag, taskDefaultFlag)

--- a/internal/pkg/cli/flag.go
+++ b/internal/pkg/cli/flag.go
@@ -12,11 +12,6 @@ import (
 	"github.com/dustin/go-humanize/english"
 )
 
-var (
-	storageInitDDBFlags    = []string{storagePartitionKeyFlag, storageSortKeyFlag, storageNoSortFlag, storageLSIConfigFlag, storageNoLSIFlag}
-	storageInitAuroraFlags = []string{storageAuroraServerlessVersionFlag, storageRDSEngineFlag, storageRDSInitialDBFlag, storageRDSParameterGroupFlag}
-)
-
 // Long flag names.
 const (
 	// Common flags.

--- a/internal/pkg/cli/flag.go
+++ b/internal/pkg/cli/flag.go
@@ -5,6 +5,7 @@ package cli
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/aws/copilot-cli/internal/pkg/manifest"
@@ -165,7 +166,7 @@ const (
 // Descriptions for flags.
 var (
 	svcTypeFlagDescription = fmt.Sprintf(`Type of service to create. Must be one of:
-%s.`, strings.Join(quoteStringSlice(manifest.ServiceTypes()), ", "))
+%s.`, strings.Join(mutateStringSlice(manifest.ServiceTypes(), strconv.Quote), ", "))
 	imageFlagDescription = fmt.Sprintf(`The location of an existing Docker image.
 Cannot be specified with --%s or --%s.`, dockerFileFlag, dockerFileContextFlag)
 	dockerFileFlagDescription = fmt.Sprintf(`Path to the Dockerfile.
@@ -173,11 +174,11 @@ Cannot be specified with --%s.`, imageFlag)
 	dockerFileContextFlagDescription = fmt.Sprintf(`Path to the Docker build context.
 Cannot be specified with --%s.`, imageFlag)
 	storageTypeFlagDescription = fmt.Sprintf(`Type of storage to add. Must be one of:
-%s.`, strings.Join(quoteStringSlice(storageTypes), ", "))
+%s.`, strings.Join(mutateStringSlice(storageTypes, strconv.Quote), ", "))
 	jobTypeFlagDescription = fmt.Sprintf(`Type of job to create. Must be one of:
-%s.`, strings.Join(quoteStringSlice(manifest.JobTypes()), ", "))
+%s.`, strings.Join(mutateStringSlice(manifest.JobTypes(), strconv.Quote), ", "))
 	wkldTypeFlagDescription = fmt.Sprintf(`Type of job or svc to create. Must be one of:
-%s.`, strings.Join(quoteStringSlice(manifest.WorkloadTypes()), ", "))
+%s.`, strings.Join(mutateStringSlice(manifest.WorkloadTypes(), strconv.Quote), ", "))
 
 	clusterFlagDescription = fmt.Sprintf(`Optional. The short name or full ARN of the cluster to run the task in. 
 Cannot be specified with --%s, --%s or --%s.`, appFlag, envFlag, taskDefaultFlag)

--- a/internal/pkg/cli/flag.go
+++ b/internal/pkg/cli/flag.go
@@ -290,7 +290,8 @@ Uploaded asset locations are filled in the template configuration.`
 	storageWorkloadFlagDescription       = "Name of the service or job to associate with storage."
 	storageLifecycleFlagDescription      = "Whether the storage should be created and deleted at the same time as a workload or as the environment"
 	storageAddIngressFromFlagDescription = `The workload that needs access to an environment-level addon.
-Must be specified with --name and --storage-type.`
+Must be specified with --name and --storage-type.
+Can be specified with --engine.`
 	storagePartitionKeyFlagDescription = `Partition key for the DDB table.
 Must be of the format '<keyName>:<dataType>'.`
 	storageSortKeyFlagDescription = `Optional. Sort key for the DDB table.

--- a/internal/pkg/cli/flag.go
+++ b/internal/pkg/cli/flag.go
@@ -68,6 +68,7 @@ const (
 	// Flags for storage.
 	storageTypeFlag                    = "storage-type"
 	storageLifecycleFlag               = "lifecycle"
+	storageAddIngressFromFlag          = "add-ingress-from"
 	storagePartitionKeyFlag            = "partition-key"
 	storageSortKeyFlag                 = "sort-key"
 	storageNoSortFlag                  = "no-sort"
@@ -284,9 +285,11 @@ Uploaded asset locations are filled in the template configuration.`
 	pipelineTypeFlagDescription      = `The type of pipeline. Must be either "Workloads" or "Environments".`
 
 	// Storage.
-	storageFlagDescription             = "Name of the storage resource to create."
-	storageWorkloadFlagDescription     = "Name of the service or job to associate with storage."
-	storageLifecycleFlagDescription    = "Whether the storage should be created and deleted at the same time as a workload or as the environment"
+	storageFlagDescription               = "Name of the storage resource to create."
+	storageWorkloadFlagDescription       = "Name of the service or job to associate with storage."
+	storageLifecycleFlagDescription      = "Whether the storage should be created and deleted at the same time as a workload or as the environment"
+	storageAddIngressFromFlagDescription = `The workload that needs access to an environment-level storage.
+Must be specified with --name and --storage-type.`
 	storagePartitionKeyFlagDescription = `Partition key for the DDB table.
 Must be of the format '<keyName>:<dataType>'.`
 	storageSortKeyFlagDescription = `Optional. Sort key for the DDB table.

--- a/internal/pkg/cli/flag.go
+++ b/internal/pkg/cli/flag.go
@@ -12,6 +12,11 @@ import (
 	"github.com/dustin/go-humanize/english"
 )
 
+var (
+	storageInitDDBFlags    = []string{storagePartitionKeyFlag, storageSortKeyFlag, storageNoSortFlag, storageLSIConfigFlag, storageNoLSIFlag}
+	storageInitAuroraFlags = []string{storageAuroraServerlessVersionFlag, storageRDSEngineFlag, storageRDSInitialDBFlag, storageRDSParameterGroupFlag}
+)
+
 // Long flag names.
 const (
 	// Common flags.

--- a/internal/pkg/cli/flag.go
+++ b/internal/pkg/cli/flag.go
@@ -289,7 +289,7 @@ Uploaded asset locations are filled in the template configuration.`
 	storageFlagDescription               = "Name of the storage resource to create."
 	storageWorkloadFlagDescription       = "Name of the service or job to associate with storage."
 	storageLifecycleFlagDescription      = "Whether the storage should be created and deleted at the same time as a workload or as the environment"
-	storageAddIngressFromFlagDescription = `The workload that needs access to an environment-level storage.
+	storageAddIngressFromFlagDescription = `The workload that needs access to an environment-level addon.
 Must be specified with --name and --storage-type.`
 	storagePartitionKeyFlagDescription = `Partition key for the DDB table.
 Must be of the format '<keyName>:<dataType>'.`

--- a/internal/pkg/cli/pipeline_init.go
+++ b/internal/pkg/cli/pipeline_init.go
@@ -11,6 +11,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation/stack"
@@ -409,7 +410,7 @@ func (o *initPipelineOpts) askOrValidatePipelineType() error {
 				return nil
 			}
 		}
-		return fmt.Errorf("invalid pipeline type %q; must be one of %s", o.pipelineType, english.WordSeries(quoteStringSlice(pipelineTypes), "or"))
+		return fmt.Errorf("invalid pipeline type %q; must be one of %s", o.pipelineType, english.WordSeries(mutateStringSlice(pipelineTypes, strconv.Quote), "or"))
 	}
 
 	typ, err := o.prompt.SelectOption("What type of continuous delivery pipeline is this?",

--- a/internal/pkg/cli/pipeline_init.go
+++ b/internal/pkg/cli/pipeline_init.go
@@ -410,7 +410,7 @@ func (o *initPipelineOpts) askOrValidatePipelineType() error {
 				return nil
 			}
 		}
-		return fmt.Errorf("invalid pipeline type %q; must be one of %s", o.pipelineType, english.WordSeries(mutateStringSlice(pipelineTypes, strconv.Quote), "or"))
+		return fmt.Errorf("invalid pipeline type %q; must be one of %s", o.pipelineType, english.WordSeries(applyAll(pipelineTypes, strconv.Quote), "or"))
 	}
 
 	typ, err := o.prompt.SelectOption("What type of continuous delivery pipeline is this?",

--- a/internal/pkg/cli/storage_init.go
+++ b/internal/pkg/cli/storage_init.go
@@ -7,6 +7,7 @@ import (
 	"encoding"
 	"errors"
 	"fmt"
+	"strconv"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ssm"
@@ -235,7 +236,7 @@ func (o *initStorageOpts) validateStorageLifecycle() error {
 			return nil
 		}
 	}
-	return fmt.Errorf("invalid lifecycle; must be one of %s", english.OxfordWordSeries(quoteStringSlice(validLifecycleOptions), "or"))
+	return fmt.Errorf("invalid lifecycle; must be one of %s", english.OxfordWordSeries(mutateStringSlice(validLifecycleOptions, strconv.Quote), "or"))
 }
 
 func (o *initStorageOpts) validateServerlessVersion() error {

--- a/internal/pkg/cli/storage_init.go
+++ b/internal/pkg/cli/storage_init.go
@@ -268,6 +268,14 @@ func (o *initStorageOpts) validateAddIngressFrom() error {
 	if o.storageType == "" {
 		return fmt.Errorf("--%s is required when --%s is used", storageTypeFlag, storageAddIngressFromFlag)
 	}
+	exist, err := o.ws.WorkloadExists(o.addIngressFrom)
+	if err != nil {
+		return fmt.Errorf("check if %s exists in the workspace: %w", o.addIngressFrom, err)
+	}
+	if !exist {
+		return fmt.Errorf("workload %s not found in the workspace", o.addIngressFrom)
+	}
+	o.workloadExists = true
 	return nil
 
 }

--- a/internal/pkg/cli/storage_init.go
+++ b/internal/pkg/cli/storage_init.go
@@ -254,11 +254,11 @@ func (o *initStorageOpts) validateAddIngressFrom() error {
 		log.Errorf("Most configuration flags are incompatible with --%s: %s %s; %s %s.\n",
 			storageAddIngressFromFlag,
 			color.Faint.Sprintf("(DynamoDB flags)"),
-			english.WordSeries(mutateStringSlice(ddbFlagExclusiveWithAddIngress, func(in string) string {
+			english.WordSeries(applyAll(ddbFlagExclusiveWithAddIngress, func(in string) string {
 				return fmt.Sprintf("--%s", in)
 			}), "and"),
 			color.Faint.Sprintf("(Aurora serverless flags)"),
-			english.WordSeries(mutateStringSlice(rdsFlagExclusiveWithAddIngress, func(in string) string {
+			english.WordSeries(applyAll(rdsFlagExclusiveWithAddIngress, func(in string) string {
 				return fmt.Sprintf("--%s", in)
 			}), "and"))
 		return fmt.Errorf(`specified --%s with --%s`, o.configFlagExclusiveWithAddIngress, storageAddIngressFromFlag)
@@ -290,7 +290,7 @@ func (o *initStorageOpts) validateStorageLifecycle() error {
 			return nil
 		}
 	}
-	return fmt.Errorf("invalid lifecycle; must be one of %s", english.OxfordWordSeries(mutateStringSlice(validLifecycleOptions, strconv.Quote), "or"))
+	return fmt.Errorf("invalid lifecycle; must be one of %s", english.OxfordWordSeries(applyAll(validLifecycleOptions, strconv.Quote), "or"))
 }
 
 func (o *initStorageOpts) validateServerlessVersion() error {

--- a/internal/pkg/cli/storage_init.go
+++ b/internal/pkg/cli/storage_init.go
@@ -971,17 +971,13 @@ Resource names are injected into your containers as environment variables for ea
 	requiredFlags.AddFlag(cmd.Flags().Lookup(workloadFlag))
 
 	ddbFlags := pflag.NewFlagSet("DynamoDB", pflag.ContinueOnError)
-	ddbFlags.AddFlag(cmd.Flags().Lookup(storagePartitionKeyFlag))
-	ddbFlags.AddFlag(cmd.Flags().Lookup(storageSortKeyFlag))
-	ddbFlags.AddFlag(cmd.Flags().Lookup(storageNoSortFlag))
-	ddbFlags.AddFlag(cmd.Flags().Lookup(storageLSIConfigFlag))
-	ddbFlags.AddFlag(cmd.Flags().Lookup(storageNoLSIFlag))
-
+	for _, f := range storageInitDDBFlags {
+		ddbFlags.AddFlag(cmd.Flags().Lookup(f))
+	}
 	auroraFlags := pflag.NewFlagSet("Aurora Serverless", pflag.ContinueOnError)
-	auroraFlags.AddFlag(cmd.Flags().Lookup(storageAuroraServerlessVersionFlag))
-	auroraFlags.AddFlag(cmd.Flags().Lookup(storageRDSEngineFlag))
-	auroraFlags.AddFlag(cmd.Flags().Lookup(storageRDSInitialDBFlag))
-	auroraFlags.AddFlag(cmd.Flags().Lookup(storageRDSParameterGroupFlag))
+	for _, f := range storageInitAuroraFlags {
+		auroraFlags.AddFlag(cmd.Flags().Lookup(f))
+	}
 
 	cmd.Annotations = map[string]string{
 		// The order of the sections we want to display.

--- a/internal/pkg/cli/storage_init.go
+++ b/internal/pkg/cli/storage_init.go
@@ -301,6 +301,9 @@ func (o *initStorageOpts) validateServerlessVersion() error {
 
 // Ask asks for fields that are required but not passed in.
 func (o *initStorageOpts) Ask() error {
+	if o.addIngressFrom != "" {
+		return nil
+	}
 	if err := o.validateOrAskStorageWl(); err != nil {
 		return err
 	}

--- a/internal/pkg/cli/storage_init.go
+++ b/internal/pkg/cli/storage_init.go
@@ -214,6 +214,11 @@ func (o *initStorageOpts) Validate() error {
 			return err
 		}
 	}
+	if o.addIngressFrom != "" {
+		if err := o.validateAddIngressFrom(); err != nil {
+			return err
+		}
+	}
 	// --no-lsi and --lsi are mutually exclusive.
 	if o.noLSI && len(o.lsiSorts) != 0 {
 		return fmt.Errorf("validate LSI configuration: cannot specify --no-lsi and --lsi options at once")
@@ -228,6 +233,17 @@ func (o *initStorageOpts) Validate() error {
 		}
 	}
 	return nil
+}
+
+func (o *initStorageOpts) validateAddIngressFrom() error {
+	if o.storageName == "" {
+		return fmt.Errorf("--%s is required when --%s is used", nameFlag, storageAddIngressFromFlag)
+	}
+	if o.storageType == "" {
+		return fmt.Errorf("--%s is required when --%s is used", storageTypeFlag, storageAddIngressFromFlag)
+	}
+	return nil
+
 }
 
 func (o *initStorageOpts) validateStorageLifecycle() error {

--- a/internal/pkg/cli/storage_init.go
+++ b/internal/pkg/cli/storage_init.go
@@ -180,9 +180,6 @@ type initStorageOpts struct {
 	configSel configSelector
 	prompt    prompter
 
-	// Flag status.
-	configFlagExclusiveWithAddIngress string
-
 	// Cached data.
 	workloadType   string
 	workloadExists bool

--- a/internal/pkg/cli/storage_init.go
+++ b/internal/pkg/cli/storage_init.go
@@ -140,10 +140,11 @@ var engineTypes = []string{
 }
 
 type initStorageVars struct {
-	storageType  string
-	storageName  string
-	workloadName string
-	lifecycle    string
+	storageType    string
+	storageName    string
+	workloadName   string
+	lifecycle      string
+	addIngressFrom string
 
 	// Dynamo DB specific values collected via flags or prompts
 	partitionKey string
@@ -950,6 +951,7 @@ Resource names are injected into your containers as environment variables for ea
 	cmd.Flags().StringVarP(&vars.storageType, storageTypeFlag, typeFlagShort, "", storageTypeFlagDescription)
 	cmd.Flags().StringVarP(&vars.workloadName, workloadFlag, workloadFlagShort, "", storageWorkloadFlagDescription)
 	cmd.Flags().StringVarP(&vars.lifecycle, storageLifecycleFlag, "", lifecycleWorkloadLevel, storageLifecycleFlagDescription)
+	cmd.Flags().StringVarP(&vars.addIngressFrom, storageAddIngressFromFlag, "", "", storageAddIngressFromFlagDescription)
 
 	cmd.Flags().StringVar(&vars.partitionKey, storagePartitionKeyFlag, "", storagePartitionKeyFlagDescription)
 	cmd.Flags().StringVar(&vars.sortKey, storageSortKeyFlag, "", storageSortKeyFlagDescription)

--- a/internal/pkg/cli/storage_init_test.go
+++ b/internal/pkg/cli/storage_init_test.go
@@ -58,22 +58,6 @@ func TestStorageInitOpts_Validate(t *testing.T) {
 			mock:             func(m *mockStorageInitValidate) {},
 			wantedErr:        errors.New("--workload cannot be specified with --add-ingress-from"),
 		},
-		"fails when --add-ingress-from is accompanied by ddb flags": {
-			inAppName:        "bowie",
-			inAddIngressFrom: "api",
-			mock: func(m *mockStorageInitValidate) {
-				m.flagExclusiveWithAddIngress = storageNoLSIFlag
-			},
-			wantedErr: errors.New("specified --no-lsi with --add-ingress-from"),
-		},
-		"fails when --add-ingress-from is accompanied by aurora flags": {
-			inAppName:        "bowie",
-			inAddIngressFrom: "api",
-			mock: func(m *mockStorageInitValidate) {
-				m.flagExclusiveWithAddIngress = storageRDSInitialDBFlag
-			},
-			wantedErr: errors.New("specified --initial-db with --add-ingress-from"),
-		},
 		"fails when --add-ingress-from is accompanied by workload-level lifecycle": {
 			inAppName:        "bowie",
 			inAddIngressFrom: "api",

--- a/internal/pkg/cli/storage_init_test.go
+++ b/internal/pkg/cli/storage_init_test.go
@@ -17,9 +17,8 @@ import (
 )
 
 type mockStorageInitValidate struct {
-	ws                          *mocks.MockwsReadWriter
-	store                       *mocks.Mockstore
-	flagExclusiveWithAddIngress string
+	ws    *mocks.MockwsReadWriter
+	store *mocks.Mockstore
 }
 
 func TestStorageInitOpts_Validate(t *testing.T) {
@@ -156,8 +155,6 @@ func TestStorageInitOpts_Validate(t *testing.T) {
 				appName: tc.inAppName,
 				ws:      m.ws,
 				store:   m.store,
-
-				configFlagExclusiveWithAddIngress: m.flagExclusiveWithAddIngress,
 			}
 
 			// WHEN

--- a/internal/pkg/cli/storage_init_test.go
+++ b/internal/pkg/cli/storage_init_test.go
@@ -95,6 +95,26 @@ func TestStorageInitOpts_Validate(t *testing.T) {
 			mock:             func(m *mockStorageInitValidate) {},
 			wantedErr:        errors.New("--storage-type is required when --add-ingress-from is used"),
 		},
+		"fails to check if --add-ingress-from workload is in the workspace": {
+			inAppName:        "bowie",
+			inAddIngressFrom: "api",
+			inStorageName:    "coolbucket",
+			inStorageType:    s3StorageType,
+			mock: func(m *mockStorageInitValidate) {
+				m.ws.EXPECT().WorkloadExists("api").Return(false, errors.New("some error"))
+			},
+			wantedErr: errors.New("check if api exists in the workspace: some error"),
+		},
+		"fails when --add-ingress-from workload is not in the workspace": {
+			inAppName:        "bowie",
+			inAddIngressFrom: "api",
+			inStorageName:    "coolbucket",
+			inStorageType:    s3StorageType,
+			mock: func(m *mockStorageInitValidate) {
+				m.ws.EXPECT().WorkloadExists("api").Return(false, nil)
+			},
+			wantedErr: errors.New("workload api not found in the workspace"),
+		},
 		"fails when --no-lsi and --lsi are both provided": {
 			inAppName:     "bowie",
 			inStorageType: dynamoDBStorageType,

--- a/internal/pkg/cli/storage_init_test.go
+++ b/internal/pkg/cli/storage_init_test.go
@@ -28,6 +28,7 @@ func TestStorageInitOpts_Validate(t *testing.T) {
 		inSvcName           string
 		inStorageName       string
 		inLifecycle         string
+		inAddIngressFrom    string
 		inPartition         string
 		inSort              string
 		inLSISorts          []string
@@ -48,6 +49,19 @@ func TestStorageInitOpts_Validate(t *testing.T) {
 			inLifecycle: "weird input",
 			mock:        func(m *mockStorageInitValidate) {},
 			wantedErr:   errors.New(`invalid lifecycle; must be one of "workload" or "environment"`),
+		},
+		"fails when --add-ingress-from is not accompanied by storage name": {
+			inAppName:        "bowie",
+			inAddIngressFrom: "api",
+			mock:             func(m *mockStorageInitValidate) {},
+			wantedErr:        errors.New("--name is required when --add-ingress-from is used"),
+		},
+		"fails when --add-ingress-from is not accompanied by storage type": {
+			inAppName:        "bowie",
+			inAddIngressFrom: "api",
+			inStorageName:    "coolbucket",
+			mock:             func(m *mockStorageInitValidate) {},
+			wantedErr:        errors.New("--storage-type is required when --add-ingress-from is used"),
 		},
 		"fails when --no-lsi and --lsi are both provided": {
 			inAppName:     "bowie",
@@ -101,6 +115,7 @@ func TestStorageInitOpts_Validate(t *testing.T) {
 					storageName:             tc.inStorageName,
 					workloadName:            tc.inSvcName,
 					lifecycle:               tc.inLifecycle,
+					addIngressFrom:          tc.inAddIngressFrom,
 					partitionKey:            tc.inPartition,
 					sortKey:                 tc.inSort,
 					lsiSorts:                tc.inLSISorts,

--- a/internal/pkg/cli/storage_init_test.go
+++ b/internal/pkg/cli/storage_init_test.go
@@ -210,15 +210,20 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 		wantedBucketName = "cool-bucket"
 	)
 	testCases := map[string]struct {
-		inStorageType string
-		inSvcName     string
-		inStorageName string
+		inStorageType    string
+		inSvcName        string
+		inStorageName    string
+		inAddIngressFrom string
 
 		mock func(m *mockStorageInitAsk)
 
 		wantedErr  error
 		wantedVars *initStorageVars
 	}{
+		"prompt for nothing if --add-ingress-from is used": {
+			inAddIngressFrom: "api",
+			mock:             func(m *mockStorageInitAsk) {},
+		},
 		"invalid storage type": {
 			inStorageType: "box",
 			inSvcName:     "frontend",
@@ -353,9 +358,10 @@ func TestStorageInitOpts_Ask(t *testing.T) {
 			}
 			opts := initStorageOpts{
 				initStorageVars: initStorageVars{
-					storageType:  tc.inStorageType,
-					storageName:  tc.inStorageName,
-					workloadName: tc.inSvcName,
+					storageType:    tc.inStorageType,
+					storageName:    tc.inStorageName,
+					workloadName:   tc.inSvcName,
+					addIngressFrom: tc.inAddIngressFrom,
 				},
 				appName: wantedAppName,
 				sel:     m.sel,

--- a/internal/pkg/cli/storage_init_test.go
+++ b/internal/pkg/cli/storage_init_test.go
@@ -17,10 +17,9 @@ import (
 )
 
 type mockStorageInitValidate struct {
-	ws                 *mocks.MockwsReadWriter
-	store              *mocks.Mockstore
-	isDDBConfigured    bool
-	isAuroraConfigured bool
+	ws                          *mocks.MockwsReadWriter
+	store                       *mocks.Mockstore
+	flagExclusiveWithAddIngress string
 }
 
 func TestStorageInitOpts_Validate(t *testing.T) {
@@ -63,17 +62,17 @@ func TestStorageInitOpts_Validate(t *testing.T) {
 			inAppName:        "bowie",
 			inAddIngressFrom: "api",
 			mock: func(m *mockStorageInitValidate) {
-				m.isDDBConfigured = true
+				m.flagExclusiveWithAddIngress = storageNoLSIFlag
 			},
-			wantedErr: errors.New("dynamoDB flags cannot be specified with --add-ingress-from: --partition-key, --sort-key, --no-sort, --lsi and --no-lsi"),
+			wantedErr: errors.New("specified --no-lsi with --add-ingress-from"),
 		},
 		"fails when --add-ingress-from is accompanied by aurora flags": {
 			inAppName:        "bowie",
 			inAddIngressFrom: "api",
 			mock: func(m *mockStorageInitValidate) {
-				m.isAuroraConfigured = true
+				m.flagExclusiveWithAddIngress = storageRDSInitialDBFlag
 			},
-			wantedErr: errors.New("aurora serverless flags cannot be specified with --add-ingress-from: --serverless-version, --engine, --initial-db and --parameter-group"),
+			wantedErr: errors.New("specified --initial-db with --add-ingress-from"),
 		},
 		"fails when --add-ingress-from is accompanied by workload-level lifecycle": {
 			inAppName:        "bowie",
@@ -180,8 +179,7 @@ func TestStorageInitOpts_Validate(t *testing.T) {
 				ws:      m.ws,
 				store:   m.store,
 
-				isDDBConfigured:    m.isDDBConfigured,
-				isAuroraConfigured: m.isAuroraConfigured,
+				configFlagExclusiveWithAddIngress: m.flagExclusiveWithAddIngress,
 			}
 
 			// WHEN

--- a/internal/pkg/cli/validate.go
+++ b/internal/pkg/cli/validate.go
@@ -789,7 +789,7 @@ func validatePubSubName(name string) error {
 }
 
 func prettify(inputStrings []string) string {
-	prettyTypes := mutateStringSlice(inputStrings, strconv.Quote)
+	prettyTypes := applyAll(inputStrings, strconv.Quote)
 	return strings.Join(prettyTypes, ", ")
 }
 

--- a/internal/pkg/cli/validate.go
+++ b/internal/pkg/cli/validate.go
@@ -789,7 +789,7 @@ func validatePubSubName(name string) error {
 }
 
 func prettify(inputStrings []string) string {
-	prettyTypes := quoteStringSlice(inputStrings)
+	prettyTypes := mutateStringSlice(inputStrings, strconv.Quote)
 	return strings.Join(prettyTypes, ", ")
 }
 


### PR DESCRIPTION
The flag will produce the `AccessPolicy` or  `SecurityGroupIngress` as a workload-level addon for the workload to access an env-level storage.

This PR includes the `Validate` and `Ask` part of the flag.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
