### PR TITLE
refactor(deploy): use test double in tests instead of init a stack

### DIFF
--- a/internal/pkg/cli/deploy/backend.go
+++ b/internal/pkg/cli/deploy/backend.go
@@ -20,8 +20,11 @@ import (
 
 type backendSvcDeployer struct {
 	*svcDeployer
-	backendMft         *manifest.BackendService
+	backendMft *manifest.BackendService
+
+	// Overriden in tests.
 	aliasCertValidator aliasCertValidator
+	newStack           func() cloudformation.StackConfiguration
 }
 
 // NewBackendDeployer is the constructor for backendSvcDeployer.
@@ -90,18 +93,26 @@ func (d *backendSvcDeployer) stackConfiguration(in *StackRuntimeConfiguration) (
 	if err := d.validateALBRuntime(); err != nil {
 		return nil, err
 	}
-	conf, err := stack.NewBackendService(stack.BackendServiceConfig{
-		App:                d.app,
-		EnvManifest:        d.envConfig,
-		Manifest:           d.backendMft,
-		RawManifest:        d.rawMft,
-		ArtifactBucketName: d.resources.S3Bucket,
-		RuntimeConfig:      *rc,
-		Addons:             d.addons,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("create stack configuration: %w", err)
+
+	var conf cloudformation.StackConfiguration
+	switch {
+	case d.newStack != nil:
+		conf = d.newStack()
+	default:
+		conf, err = stack.NewBackendService(stack.BackendServiceConfig{
+			App:                d.app,
+			EnvManifest:        d.envConfig,
+			Manifest:           d.backendMft,
+			RawManifest:        d.rawMft,
+			ArtifactBucketName: d.resources.S3Bucket,
+			RuntimeConfig:      *rc,
+			Addons:             d.addons,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("create stack configuration: %w", err)
+		}
 	}
+
 	return &svcStackConfigurationOutput{
 		conf: cloudformation.WrapWithTemplateOverrider(conf, d.overrider),
 		svcUpdater: d.newSvcUpdater(func(s *session.Session) serviceForceUpdater {

--- a/internal/pkg/cli/deploy/backend_test.go
+++ b/internal/pkg/cli/deploy/backend_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation"
+
 	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation/stack"
 
 	"github.com/aws/copilot-cli/internal/pkg/override"
@@ -249,6 +251,9 @@ func TestBackendSvcDeployer_stackConfiguration(t *testing.T) {
 				},
 				backendMft:         tc.Manifest,
 				aliasCertValidator: m.mockValidator,
+				newStack: func() cloudformation.StackConfiguration {
+					return new(stubCloudFormationStack)
+				},
 			}
 
 			_, err := deployer.stackConfiguration(&StackRuntimeConfiguration{})
@@ -305,6 +310,9 @@ func mockBackendServiceDeployer(opts ...func(*backendSvcDeployer)) *backendSvcDe
 					},
 				},
 			},
+		},
+		newStack: func() cloudformation.StackConfiguration {
+			return new(stubCloudFormationStack)
 		},
 	}
 	for _, opt := range opts {

--- a/internal/pkg/cli/deploy/job.go
+++ b/internal/pkg/cli/deploy/job.go
@@ -19,6 +19,9 @@ import (
 type jobDeployer struct {
 	*workloadDeployer
 	jobMft *manifest.ScheduledJob
+
+	// Overriden in tests.
+	newStack func() cloudformation.StackConfiguration
 }
 
 // IsServiceAvailableInRegion checks if service type exist in the given region.
@@ -93,18 +96,26 @@ func (d *jobDeployer) stackConfiguration(in *StackRuntimeConfiguration) (*jobSta
 	if err != nil {
 		return nil, err
 	}
-	conf, err := stack.NewScheduledJob(stack.ScheduledJobConfig{
-		App:                d.app,
-		Env:                d.env.Name,
-		Manifest:           d.jobMft,
-		RawManifest:        d.rawMft,
-		ArtifactBucketName: d.resources.S3Bucket,
-		RuntimeConfig:      *rc,
-		Addons:             d.addons,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("create stack configuration: %w", err)
+
+	var conf cloudformation.StackConfiguration
+	switch {
+	case d.newStack != nil:
+		conf = d.newStack()
+	default:
+		conf, err = stack.NewScheduledJob(stack.ScheduledJobConfig{
+			App:                d.app,
+			Env:                d.env.Name,
+			Manifest:           d.jobMft,
+			RawManifest:        d.rawMft,
+			ArtifactBucketName: d.resources.S3Bucket,
+			RuntimeConfig:      *rc,
+			Addons:             d.addons,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("create stack configuration: %w", err)
+		}
 	}
+	
 	return &jobStackConfigurationOutput{
 		conf: cloudformation.WrapWithTemplateOverrider(conf, d.overrider),
 	}, nil

--- a/internal/pkg/cli/deploy/job_test.go
+++ b/internal/pkg/cli/deploy/job_test.go
@@ -6,6 +6,8 @@ package deploy
 import (
 	"testing"
 
+	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation"
+
 	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation/stack"
 
 	"github.com/stretchr/testify/require"
@@ -83,6 +85,9 @@ func mockJobDeployer(opts ...func(*jobDeployer)) *jobDeployer {
 					},
 				},
 			},
+		},
+		newStack: func() cloudformation.StackConfiguration {
+			return new(stubCloudFormationStack)
 		},
 	}
 	for _, opt := range opts {

--- a/internal/pkg/cli/deploy/lbws.go
+++ b/internal/pkg/cli/deploy/lbws.go
@@ -50,7 +50,10 @@ type lbWebSvcDeployer struct {
 	appVersionGetter       versionGetter
 	publicCIDRBlocksGetter publicCIDRBlocksGetter
 	lbMft                  *manifest.LoadBalancedWebService
-	newAliasCertValidator  func(optionalRegion *string) aliasCertValidator
+
+	// Overriden in tests.
+	newAliasCertValidator func(optionalRegion *string) aliasCertValidator
+	newStack              func() cloudformation.StackConfiguration
 }
 
 // NewLBWSDeployer is the constructor for lbWebSvcDeployer.
@@ -154,19 +157,27 @@ func (d *lbWebSvcDeployer) stackConfiguration(in *StackRuntimeConfiguration) (*s
 		}
 		opts = append(opts, stack.WithNLB(cidrBlocks))
 	}
-	conf, err := stack.NewLoadBalancedWebService(stack.LoadBalancedWebServiceConfig{
-		App:                d.app,
-		EnvManifest:        d.envConfig,
-		Manifest:           d.lbMft,
-		RawManifest:        d.rawMft,
-		ArtifactBucketName: d.resources.S3Bucket,
-		RuntimeConfig:      *rc,
-		RootUserARN:        in.RootUserARN,
-		Addons:             d.addons,
-	}, opts...)
-	if err != nil {
-		return nil, fmt.Errorf("create stack configuration: %w", err)
+
+	var conf cloudformation.StackConfiguration
+	switch {
+	case d.newStack != nil:
+		conf = d.newStack()
+	default:
+		conf, err = stack.NewLoadBalancedWebService(stack.LoadBalancedWebServiceConfig{
+			App:                d.app,
+			EnvManifest:        d.envConfig,
+			Manifest:           d.lbMft,
+			RawManifest:        d.rawMft,
+			ArtifactBucketName: d.resources.S3Bucket,
+			RuntimeConfig:      *rc,
+			RootUserARN:        in.RootUserARN,
+			Addons:             d.addons,
+		}, opts...)
+		if err != nil {
+			return nil, fmt.Errorf("create stack configuration: %w", err)
+		}
 	}
+
 	return &svcStackConfigurationOutput{
 		conf: cloudformation.WrapWithTemplateOverrider(conf, d.overrider),
 		svcUpdater: d.newSvcUpdater(func(s *session.Session) serviceForceUpdater {

--- a/internal/pkg/cli/deploy/lbws_test.go
+++ b/internal/pkg/cli/deploy/lbws_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation"
+
 	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation/stack"
 
 	"github.com/aws/copilot-cli/internal/pkg/template"
@@ -108,6 +110,9 @@ func mockLoadBalancedWebServiceDeployer(opts ...func(deployer *lbWebSvcDeployer)
 					},
 				},
 			},
+		},
+		newStack: func() cloudformation.StackConfiguration {
+			return new(stubCloudFormationStack)
 		},
 	}
 	for _, opt := range opts {

--- a/internal/pkg/cli/deploy/rdws.go
+++ b/internal/pkg/cli/deploy/rdws.go
@@ -32,9 +32,12 @@ var rdwsAliasUsedWithoutDomainFriendlyText = fmt.Sprintf("To use %s, your applic
 
 type rdwsDeployer struct {
 	*svcDeployer
+	rdwsMft *manifest.RequestDrivenWebService
+
+	// Overriden in tests.
 	customResourceS3Client uploader
 	appVersionGetter       versionGetter
-	rdwsMft                *manifest.RequestDrivenWebService
+	newStack               func() cloudformation.StackConfiguration
 }
 
 // NewRDWSDeployer is the constructor for RDWSDeployer.
@@ -131,23 +134,30 @@ func (d *rdwsDeployer) stackConfiguration(in *StackRuntimeConfiguration) (*rdwsS
 		return nil, errors.New("alias specified when application is not associated with a domain")
 	}
 
-	conf, err := stack.NewRequestDrivenWebService(stack.RequestDrivenWebServiceConfig{
-		App: deploy.AppInformation{
-			Name:                d.app.Name,
-			Domain:              d.app.Domain,
-			PermissionsBoundary: d.app.PermissionsBoundary,
-			AccountPrincipalARN: in.RootUserARN,
-		},
-		Env:                d.env.Name,
-		Manifest:           d.rdwsMft,
-		RawManifest:        d.rawMft,
-		ArtifactBucketName: d.resources.S3Bucket,
-		RuntimeConfig:      *rc,
-		Addons:             d.addons,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("create stack configuration: %w", err)
+	var conf cloudformation.StackConfiguration
+	switch {
+	case d.newStack != nil:
+		conf = d.newStack()
+	default:
+		conf, err = stack.NewRequestDrivenWebService(stack.RequestDrivenWebServiceConfig{
+			App: deploy.AppInformation{
+				Name:                d.app.Name,
+				Domain:              d.app.Domain,
+				PermissionsBoundary: d.app.PermissionsBoundary,
+				AccountPrincipalARN: in.RootUserARN,
+			},
+			Env:                d.env.Name,
+			Manifest:           d.rdwsMft,
+			RawManifest:        d.rawMft,
+			ArtifactBucketName: d.resources.S3Bucket,
+			RuntimeConfig:      *rc,
+			Addons:             d.addons,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("create stack configuration: %w", err)
+		}
 	}
+
 	if d.rdwsMft.Alias == nil {
 		return &rdwsStackConfigurationOutput{
 			svcStackConfigurationOutput: svcStackConfigurationOutput{

--- a/internal/pkg/cli/deploy/rdws_test.go
+++ b/internal/pkg/cli/deploy/rdws_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation"
+
 	"github.com/aws/copilot-cli/internal/pkg/override"
 	"gopkg.in/yaml.v3"
 
@@ -229,6 +231,9 @@ func TestSvcDeployOpts_rdWebServiceStackConfiguration(t *testing.T) {
 						},
 					},
 				},
+				newStack: func() cloudformation.StackConfiguration {
+					return new(stubCloudFormationStack)
+				},
 			}
 
 			got, gotErr := deployer.stackConfiguration(&StackRuntimeConfiguration{
@@ -286,6 +291,9 @@ func mockRDWSDeployer(opts ...func(*rdwsDeployer)) *rdwsDeployer {
 					Memory: aws.Int(2048),
 				},
 			},
+		},
+		newStack: func() cloudformation.StackConfiguration {
+			return new(stubCloudFormationStack)
 		},
 	}
 	for _, opt := range opts {

--- a/internal/pkg/cli/deploy/worker.go
+++ b/internal/pkg/cli/deploy/worker.go
@@ -35,8 +35,11 @@ type snsTopicsLister interface {
 
 type workerSvcDeployer struct {
 	*svcDeployer
+	wsMft *manifest.WorkerService
+
+	// Overriden in tests.
 	topicLister snsTopicsLister
-	wsMft       *manifest.WorkerService
+	newStack    func() cloudformation.StackConfiguration
 }
 
 // IsServiceAvailableInRegion checks if service type exist in the given region.
@@ -169,18 +172,26 @@ func (d *workerSvcDeployer) stackConfiguration(in *StackRuntimeConfiguration) (*
 	if err = validateTopicsExist(subs, topicARNs, d.app.Name, d.env.Name); err != nil {
 		return nil, err
 	}
-	conf, err := stack.NewWorkerService(stack.WorkerServiceConfig{
-		App:                d.app,
-		Env:                d.env.Name,
-		Manifest:           d.wsMft,
-		RawManifest:        d.rawMft,
-		ArtifactBucketName: d.resources.S3Bucket,
-		RuntimeConfig:      *rc,
-		Addons:             d.addons,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("create stack configuration: %w", err)
+
+	var conf cloudformation.StackConfiguration
+	switch {
+	case d.newStack != nil:
+		conf = d.newStack()
+	default:
+		conf, err = stack.NewWorkerService(stack.WorkerServiceConfig{
+			App:                d.app,
+			Env:                d.env.Name,
+			Manifest:           d.wsMft,
+			RawManifest:        d.rawMft,
+			ArtifactBucketName: d.resources.S3Bucket,
+			RuntimeConfig:      *rc,
+			Addons:             d.addons,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("create stack configuration: %w", err)
+		}
 	}
+	
 	return &workerSvcStackConfigurationOutput{
 		svcStackConfigurationOutput: svcStackConfigurationOutput{
 			conf: cloudformation.WrapWithTemplateOverrider(conf, d.overrider),

--- a/internal/pkg/cli/deploy/worker_test.go
+++ b/internal/pkg/cli/deploy/worker_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation"
+
 	"github.com/aws/copilot-cli/internal/pkg/override"
 	"gopkg.in/yaml.v3"
 
@@ -163,6 +165,9 @@ func TestSvcDeployOpts_stackConfiguration_worker(t *testing.T) {
 						},
 					},
 				},
+				newStack: func() cloudformation.StackConfiguration {
+					return new(stubCloudFormationStack)
+				},
 			}
 
 			got, gotErr := deployer.stackConfiguration(&StackRuntimeConfiguration{})
@@ -275,6 +280,9 @@ func mockWorkerServiceDeployer(opts ...func(*workerSvcDeployer)) *workerSvcDeplo
 					},
 				},
 			},
+		},
+		newStack: func() cloudformation.StackConfiguration {
+			return new(stubCloudFormationStack)
 		},
 	}
 	for _, opt := range opts {

--- a/internal/pkg/cli/deploy/workload_test.go
+++ b/internal/pkg/cli/deploy/workload_test.go
@@ -13,10 +13,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/copilot-cli/internal/pkg/override"
+	cloudformation0 "github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
+	sdkcfn "github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/copilot-cli/internal/pkg/aws/cloudformation"
 	"github.com/aws/copilot-cli/internal/pkg/aws/ecs"
 	"github.com/aws/copilot-cli/internal/pkg/cli/deploy/mocks"
@@ -26,6 +27,7 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/deploy/upload/customresource"
 	"github.com/aws/copilot-cli/internal/pkg/docker/dockerengine"
 	"github.com/aws/copilot-cli/internal/pkg/manifest"
+	"github.com/aws/copilot-cli/internal/pkg/override"
 	"github.com/aws/copilot-cli/internal/pkg/template"
 	"github.com/aws/copilot-cli/internal/pkg/term/color"
 	"github.com/aws/copilot-cli/internal/pkg/term/log"
@@ -120,6 +122,28 @@ func (m *mockWorkloadMft) BuildArgs(rootDirectory string) *manifest.DockerBuildA
 
 func (m *mockWorkloadMft) ContainerPlatform() string {
 	return "mockContainerPlatform"
+}
+
+// stubCloudFormationStack implements the cloudformation.StackConfiguration interface.
+type stubCloudFormationStack struct{}
+
+func (s *stubCloudFormationStack) StackName() string {
+	return "demo"
+}
+func (s *stubCloudFormationStack) Template() (string, error) {
+	return `
+Resources:
+  Queue:
+    Type: AWS::SQS::Queue`, nil
+}
+func (s *stubCloudFormationStack) Parameters() ([]*sdkcfn.Parameter, error) {
+	return []*sdkcfn.Parameter{}, nil
+}
+func (s *stubCloudFormationStack) Tags() []*sdkcfn.Tag {
+	return []*sdkcfn.Tag{}
+}
+func (s *stubCloudFormationStack) SerializedParameters() (string, error) {
+	return "", nil
 }
 
 func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
@@ -1196,6 +1220,9 @@ func TestWorkloadDeployer_DeployWorkload(t *testing.T) {
 						},
 						NLBConfig: tc.inNLB,
 					},
+				},
+				newStack: func() cloudformation0.StackConfiguration {
+					return new(stubCloudFormationStack)
 				},
 			}
 


### PR DESCRIPTION
Today, we're creating a real `stack` object in our `cli/deploy` unit tests. When modifying the constructors in the `stack` pkg that results in all the tests in `cli/deploy` to fail because some dependency goes missing.

This change allows the unit tests in `cli/deploy` to pass in a stub CFN stack instead of initializing a real one.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
