### PR TITLE
refactor(storage): create single purpose constructors

### DIFF
--- a/internal/pkg/addon/storage.go
+++ b/internal/pkg/addon/storage.go
@@ -18,7 +18,7 @@ const (
 	rdsTemplatePath       = "addons/aurora/cf.yml"
 	rdsV2TemplatePath     = "addons/aurora/serverlessv2.yml"
 	rdsRDWSTemplatePath   = "addons/aurora/rdws/cf.yml"
-	rdsRDWSV2TemplatePath = "addons/aurora/rdws/serverlessv2.yml"
+	rdsV2RDWSTemplatePath = "addons/aurora/rdws/serverlessv2.yml"
 	rdsRDWSParamsPath     = "addons/aurora/rdws/addons.parameters.yml"
 
 	envS3TemplatePath                   = "addons/s3/env/cf.yml"
@@ -287,7 +287,7 @@ func RDWSServerlessV2Template(input RDSProps) *RDSTemplate {
 	return &RDSTemplate{
 		RDSProps: input,
 		parser:   template.New(),
-		tmplPath: rdsRDWSV2TemplatePath,
+		tmplPath: rdsV2RDWSTemplatePath,
 	}
 }
 

--- a/internal/pkg/addon/storage.go
+++ b/internal/pkg/addon/storage.go
@@ -226,7 +226,7 @@ type DDBLocalSecondaryIndex struct {
 	Name         *string
 }
 
-// AccessPolicyProps TODO
+// AccessPolicyProps holds properties to configure an access policy to an S3 or DDB storage.
 type AccessPolicyProps StorageProps
 
 // EnvS3AccessPolicyTemplate creates a new marshaler for the access policy attached to a workload
@@ -249,7 +249,8 @@ func EnvDDBAccessPolicyTemplate(input *AccessPolicyProps) *AccessPolicyTemplate 
 	}
 }
 
-// AccessPolicyTemplate TODO
+// AccessPolicyTemplate contains configuration options which describe an access policy to an S3 or DDB storage.
+// Implements the encoding.BinaryMarshaler interface.
 type AccessPolicyTemplate struct {
 	AccessPolicyProps
 	parser   template.Parser
@@ -329,7 +330,7 @@ func EnvServerlessForRDWSTemplate(input RDSProps) *RDSTemplate {
 	}
 }
 
-// RDSIngressProps TODO
+// RDSIngressProps holds properties to create a security group ingress to an RDS storage.
 type RDSIngressProps struct {
 	ClusterName string // The name of the cluster.
 	Engine      string // The engine type of the RDS Aurora Serverless cluster.
@@ -345,7 +346,8 @@ func EnvServerlessRDWSIngressTemplate(input RDSIngressProps) *RDSIngressTemplate
 	}
 }
 
-// RDSIngressTemplate TODO
+// RDSIngressTemplate contains configuration options which describe an ingress to an RDS cluster.
+// Implements the encoding.BinaryMarshaler interface.
 type RDSIngressTemplate struct {
 	RDSIngressProps
 	parser   template.Parser
@@ -361,7 +363,7 @@ func (t *RDSIngressTemplate) MarshalBinary() ([]byte, error) {
 	return content.Bytes(), nil
 }
 
-// RDSTemplate contains configuration options which fully describe a RDS Aurora Serverless cluster.
+// RDSTemplate contains configuration options which fully describe aa RDS Aurora Serverless cluster.
 // Implements the encoding.BinaryMarshaler interface.
 type RDSTemplate struct {
 	RDSProps

--- a/internal/pkg/addon/storage.go
+++ b/internal/pkg/addon/storage.go
@@ -9,8 +9,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/aws/copilot-cli/internal/pkg/manifest"
-
 	"github.com/aws/copilot-cli/internal/pkg/template"
 )
 
@@ -250,7 +248,6 @@ type DDBLocalSecondaryIndex struct {
 
 // RDSProps holds RDS-specific properties.
 type RDSProps struct {
-	WorkloadType   string   // The type of the workload associated with the RDS addon.
 	ClusterName    string   // The name of the cluster.
 	Engine         string   // The engine type of the RDS Aurora Serverless cluster.
 	InitialDBName  string   // The name of the initial database created inside the cluster.
@@ -260,40 +257,56 @@ type RDSProps struct {
 
 // WorkloadServerlessV1Template creates a marshaler for a workload-level Aurora Serverless v1 addon.
 func WorkloadServerlessV1Template(input RDSProps) *RDSTemplate {
-	tmplPath := rdsTemplatePath
-	if input.WorkloadType == manifest.RequestDrivenWebServiceType {
-		tmplPath = rdsRDWSTemplatePath
-	}
 	return &RDSTemplate{
 		RDSProps: input,
 		parser:   template.New(),
-		tmplPath: tmplPath,
+		tmplPath: rdsTemplatePath,
+	}
+}
+
+// RDWSServerlessV1Template creates a marshaler for an Aurora Serverless v1 addon attached on an RDWS.
+func RDWSServerlessV1Template(input RDSProps) *RDSTemplate {
+	return &RDSTemplate{
+		RDSProps: input,
+		parser:   template.New(),
+		tmplPath: rdsRDWSTemplatePath,
 	}
 }
 
 // WorkloadServerlessV2Template creates a marshaler for a workload-level Aurora Serverless v2 addon.
 func WorkloadServerlessV2Template(input RDSProps) *RDSTemplate {
-	tmplPath := rdsV2TemplatePath
-	if input.WorkloadType == manifest.RequestDrivenWebServiceType {
-		tmplPath = rdsRDWSV2TemplatePath
-	}
 	return &RDSTemplate{
 		RDSProps: input,
 		parser:   template.New(),
-		tmplPath: tmplPath,
+		tmplPath: rdsV2TemplatePath,
+	}
+}
+
+// RDWSServerlessV2Template creates a marshaler for an Aurora Serverless v2 addon attached on an RDWS.
+func RDWSServerlessV2Template(input RDSProps) *RDSTemplate {
+	return &RDSTemplate{
+		RDSProps: input,
+		parser:   template.New(),
+		tmplPath: rdsRDWSV2TemplatePath,
 	}
 }
 
 // EnvServerlessTemplate creates a marshaler for an environment-level Aurora Serverless v2 addon.
 func EnvServerlessTemplate(input RDSProps) *RDSTemplate {
-	tmplPath := envRDSTemplatePath
-	if input.WorkloadType == manifest.RequestDrivenWebServiceType {
-		tmplPath = envRDSForRDWSTemplatePath
-	}
 	return &RDSTemplate{
 		RDSProps: input,
 		parser:   template.New(),
-		tmplPath: tmplPath,
+		tmplPath: envRDSTemplatePath,
+	}
+}
+
+// EnvServerlessForRDWSTemplate creates a marshaler for an environment-level Aurora Serverless v2 addon
+// whose ingress is an RDWS.
+func EnvServerlessForRDWSTemplate(input RDSProps) *RDSTemplate {
+	return &RDSTemplate{
+		RDSProps: input,
+		parser:   template.New(),
+		tmplPath: envRDSForRDWSTemplatePath,
 	}
 }
 

--- a/internal/pkg/addon/storage_test.go
+++ b/internal/pkg/addon/storage_test.go
@@ -529,7 +529,7 @@ func TestConstructors(t *testing.T) {
 	})
 
 	t.Run("marshaler for the access policy of an env-level S3", func(t *testing.T) {
-		out := EnvS3AccessPolicyTemplate(&S3Props{})
+		out := EnvS3AccessPolicyTemplate(&AccessPolicyProps{})
 		require.Equal(t, envS3AccessPolicyTemplatePath, out.tmplPath)
 	})
 
@@ -544,7 +544,7 @@ func TestConstructors(t *testing.T) {
 	})
 
 	t.Run("marshaler for the access policy of an env-level ddb", func(t *testing.T) {
-		out := EnvDDBAccessPolicyTemplate(&DynamoDBProps{})
+		out := EnvDDBAccessPolicyTemplate(&AccessPolicyProps{})
 		require.Equal(t, envDynamoDBAccessPolicyTemplatePath, out.tmplPath)
 	})
 
@@ -594,7 +594,7 @@ func TestConstructors(t *testing.T) {
 	})
 
 	t.Run("marshaler for the ingress attached to an RDWS for an env-level aurora", func(t *testing.T) {
-		out := EnvServerlessRDWSIngressTemplate(RDSProps{})
+		out := EnvServerlessRDWSIngressTemplate(RDSIngressProps{})
 		require.Equal(t, envRDSIngressForRDWSTemplatePath, out.tmplPath)
 	})
 }

--- a/internal/pkg/addon/storage_test.go
+++ b/internal/pkg/addon/storage_test.go
@@ -570,7 +570,7 @@ func TestConstructors(t *testing.T) {
 
 	t.Run("marshaler for RDWS workload-level aurora serverless v2", func(t *testing.T) {
 		out := RDWSServerlessV2Template(RDSProps{})
-		require.Equal(t, rdsRDWSV2TemplatePath, out.tmplPath)
+		require.Equal(t, rdsV2RDWSTemplatePath, out.tmplPath)
 	})
 
 	t.Run("parameter marshaler for env-level aurora accessible by a workload", func(t *testing.T) {

--- a/internal/pkg/addon/storage_test.go
+++ b/internal/pkg/addon/storage_test.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/copilot-cli/internal/pkg/manifest"
 	"github.com/aws/copilot-cli/internal/pkg/template"
 	"github.com/aws/copilot-cli/internal/pkg/template/mocks"
 	"github.com/golang/mock/gomock"
@@ -115,9 +114,9 @@ func TestS3Template_MarshalBinary(t *testing.T) {
 
 func TestRDSTemplate_MarshalBinary(t *testing.T) {
 	testCases := map[string]struct {
-		workloadType     string
-		version          string
-		engine           string
+		version string
+		engine  string
+
 		mockDependencies func(ctrl *gomock.Controller, r *RDSTemplate)
 
 		wantedBinary []byte
@@ -157,18 +156,6 @@ func TestRDSTemplate_MarshalBinary(t *testing.T) {
 			},
 			wantedBinary: []byte("mysql"),
 		},
-		"renders rdws rds v1 template": {
-			workloadType: "Request-Driven Web Service",
-			version:      auroraServerlessVersionV1,
-			engine:       RDSEngineTypeMySQL,
-			mockDependencies: func(ctrl *gomock.Controller, r *RDSTemplate) {
-				m := mocks.NewMockParser(ctrl)
-				r.parser = m
-				m.EXPECT().Parse(gomock.Eq("mockPath"), *r, gomock.Any()).
-					Return(&template.Content{Buffer: bytes.NewBufferString("mysql")}, nil)
-			},
-			wantedBinary: []byte("mysql"),
-		},
 		"renders postgresql v2 content": {
 			version: auroraServerlessVersionV2,
 			engine:  RDSEngineTypePostgreSQL,
@@ -193,18 +180,6 @@ func TestRDSTemplate_MarshalBinary(t *testing.T) {
 			},
 			wantedBinary: []byte("mysql"),
 		},
-		"renders rdws rds v2 template": {
-			workloadType: "Request-Driven Web Service",
-			version:      auroraServerlessVersionV2,
-			engine:       RDSEngineTypeMySQL,
-			mockDependencies: func(ctrl *gomock.Controller, r *RDSTemplate) {
-				m := mocks.NewMockParser(ctrl)
-				r.parser = m
-				m.EXPECT().Parse(gomock.Eq("mockPath"), *r, gomock.Any()).
-					Return(&template.Content{Buffer: bytes.NewBufferString("mysql")}, nil)
-			},
-			wantedBinary: []byte("mysql"),
-		},
 	}
 
 	for name, tc := range testCases {
@@ -214,8 +189,7 @@ func TestRDSTemplate_MarshalBinary(t *testing.T) {
 			defer ctrl.Finish()
 			addon := &RDSTemplate{
 				RDSProps: RDSProps{
-					WorkloadType: tc.workloadType,
-					Engine:       tc.engine,
+					Engine: tc.engine,
 				},
 				tmplPath: "mockPath",
 			}
@@ -575,16 +549,12 @@ func TestConstructors(t *testing.T) {
 	})
 
 	t.Run("marshaler for non-RDWS workload-level aurora serverless v1", func(t *testing.T) {
-		out := WorkloadServerlessV1Template(RDSProps{
-			WorkloadType: manifest.LoadBalancedWebServiceType,
-		})
+		out := WorkloadServerlessV1Template(RDSProps{})
 		require.Equal(t, rdsTemplatePath, out.tmplPath)
 	})
 
 	t.Run("marshaler for non-RDWS workload-level aurora serverless v2", func(t *testing.T) {
-		out := WorkloadServerlessV2Template(RDSProps{
-			WorkloadType: manifest.LoadBalancedWebServiceType,
-		})
+		out := WorkloadServerlessV2Template(RDSProps{})
 		require.Equal(t, rdsV2TemplatePath, out.tmplPath)
 	})
 
@@ -594,16 +564,12 @@ func TestConstructors(t *testing.T) {
 	})
 
 	t.Run("marshaler for RDWS workload-level aurora serverless v1", func(t *testing.T) {
-		out := WorkloadServerlessV1Template(RDSProps{
-			WorkloadType: manifest.RequestDrivenWebServiceType,
-		})
+		out := RDWSServerlessV1Template(RDSProps{})
 		require.Equal(t, rdsRDWSTemplatePath, out.tmplPath)
 	})
 
 	t.Run("marshaler for RDWS workload-level aurora serverless v2", func(t *testing.T) {
-		out := WorkloadServerlessV2Template(RDSProps{
-			WorkloadType: manifest.RequestDrivenWebServiceType,
-		})
+		out := RDWSServerlessV2Template(RDSProps{})
 		require.Equal(t, rdsRDWSV2TemplatePath, out.tmplPath)
 	})
 
@@ -613,16 +579,12 @@ func TestConstructors(t *testing.T) {
 	})
 
 	t.Run("marshaler for env-level aurora accessible by a non-RDWS", func(t *testing.T) {
-		out := EnvServerlessTemplate(RDSProps{
-			WorkloadType: manifest.LoadBalancedWebServiceType,
-		})
+		out := EnvServerlessTemplate(RDSProps{})
 		require.Equal(t, envRDSTemplatePath, out.tmplPath)
 	})
 
 	t.Run("marshaler for env-level aurora accessible by an RDWS", func(t *testing.T) {
-		out := EnvServerlessTemplate(RDSProps{
-			WorkloadType: manifest.RequestDrivenWebServiceType,
-		})
+		out := EnvServerlessForRDWSTemplate(RDSProps{})
 		require.Equal(t, envRDSForRDWSTemplatePath, out.tmplPath)
 	})
 
@@ -632,9 +594,7 @@ func TestConstructors(t *testing.T) {
 	})
 
 	t.Run("marshaler for the ingress attached to an RDWS for an env-level aurora", func(t *testing.T) {
-		out := EnvServerlessRDWSIngressTemplate(RDSProps{
-			WorkloadType: manifest.RequestDrivenWebServiceType,
-		})
+		out := EnvServerlessRDWSIngressTemplate(RDSProps{})
 		require.Equal(t, envRDSIngressForRDWSTemplatePath, out.tmplPath)
 	})
 }

--- a/internal/pkg/cli/storage_init.go
+++ b/internal/pkg/cli/storage_init.go
@@ -814,11 +814,15 @@ func (o *initStorageOpts) envRDSAddonBlobs() ([]addonBlob, error) {
 	if err != nil {
 		return nil, err
 	}
+	envTmplBlob := addon.EnvServerlessTemplate(props)
+	if o.workloadType == manifest.RequestDrivenWebServiceType {
+		envTmplBlob = addon.EnvServerlessForRDWSTemplate(props)
+	}
 	blobs := []addonBlob{
 		{
 			path:        o.ws.EnvAddonFilePath(fmt.Sprintf("%s.yml", o.storageName)),
 			description: "template",
-			blob:        addon.EnvServerlessTemplate(props),
+			blob:        envTmplBlob,
 		},
 		{
 			path:        o.ws.EnvAddonFilePath("addons.parameters.yml"),

--- a/internal/pkg/cli/storage_init.go
+++ b/internal/pkg/cli/storage_init.go
@@ -125,8 +125,8 @@ const (
 
 	fmtRDSStorageNameDefault = "%s-cluster"
 
-	engineTypeMySQL      = "MySQL"
-	engineTypePostgreSQL = "PostgreSQL"
+	engineTypeMySQL      = addon.RDSEngineTypeMySQL
+	engineTypePostgreSQL = addon.RDSEngineTypePostgreSQL
 )
 
 var auroraServerlessVersions = []string{
@@ -848,23 +848,13 @@ func (o *initStorageOpts) envRDSAddonBlobs() ([]addonBlob, error) {
 }
 
 func (o *initStorageOpts) rdsProps() (addon.RDSProps, error) {
-	var engine string
-	switch o.rdsEngine {
-	case engineTypeMySQL:
-		engine = addon.RDSEngineTypeMySQL
-	case engineTypePostgreSQL:
-		engine = addon.RDSEngineTypePostgreSQL
-	default:
-		return addon.RDSProps{}, errors.New("unknown engine type")
-	}
-
 	envs, err := o.environmentNames()
 	if err != nil {
 		return addon.RDSProps{}, err
 	}
 	return addon.RDSProps{
 		ClusterName:    o.storageName,
-		Engine:         engine,
+		Engine:         o.rdsEngine,
 		InitialDBName:  o.rdsInitialDBName,
 		ParameterGroup: o.rdsParameterGroup,
 		Envs:           envs,

--- a/internal/pkg/cli/storage_init.go
+++ b/internal/pkg/cli/storage_init.go
@@ -709,7 +709,9 @@ func (o *initStorageOpts) envDDBAddonBlobs() ([]addonBlob, error) {
 	return append(blobs, addonBlob{
 		path:        o.ws.WorkloadAddonFilePath(o.workloadName, fmt.Sprintf("%s-access-policy.yml", o.storageName)),
 		description: "template",
-		blob:        addon.EnvDDBAccessPolicyTemplate(props),
+		blob: addon.EnvDDBAccessPolicyTemplate(&addon.AccessPolicyProps{
+			Name: o.storageName,
+		}),
 	}), nil
 }
 
@@ -764,7 +766,9 @@ func (o *initStorageOpts) envS3AddonBlobs() ([]addonBlob, error) {
 	return append(blobs, addonBlob{
 		path:        o.ws.WorkloadAddonFilePath(o.workloadName, fmt.Sprintf("%s-access-policy.yml", o.storageName)),
 		description: "template",
-		blob:        addon.EnvS3AccessPolicyTemplate(props),
+		blob: addon.EnvS3AccessPolicyTemplate(&addon.AccessPolicyProps{
+			Name: o.storageName,
+		}),
 	}), nil
 }
 
@@ -837,7 +841,10 @@ func (o *initStorageOpts) envRDSAddonBlobs() ([]addonBlob, error) {
 		addonBlob{
 			path:        o.ws.WorkloadAddonFilePath(o.workloadName, fmt.Sprintf("%s-ingress.yml", o.storageName)),
 			description: "template",
-			blob:        addon.EnvServerlessRDWSIngressTemplate(props),
+			blob: addon.EnvServerlessRDWSIngressTemplate(addon.RDSIngressProps{
+				ClusterName: o.storageName,
+				Engine:      o.rdsEngine,
+			}),
 		},
 		addonBlob{
 			path:        o.ws.WorkloadAddonFilePath(o.workloadName, "addons.parameters.yml"),


### PR DESCRIPTION
Two major changes:
1. Previously, `WorkloadType`  are passed in as props to RDS constructors. Depending on whether `WorkloadType` is RDWS or not, the constructor decides what the template path is. This PR removes `WorkloadType` and instead create different constructors designed for RDWS vs. non-RDWS. 
2. Previously, AccessPolicy and Ingress uses the same `Template` struct as 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
