### PR TITLE
ci: make authenticated API calls in bin size commenter workflow

### DIFF
--- a/.github/workflows/ci_size_computer.yml
+++ b/.github/workflows/ci_size_computer.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Get latest release with tag
         id: latestrelease
         run: |
-          echo "VERSION_TAG=$(curl -s https://api.github.com/repos/aws/copilot-cli/releases/latest | jq '.tag_name' | sed 's/\"//g')" >> $GITHUB_OUTPUT
+          echo "VERSION_TAG=$(curl -s https://api.github.com/repos/aws/copilot-cli/releases/latest --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' | jq '.tag_name' | sed 's/\"//g')" >> $GITHUB_OUTPUT
 
       - name: Check out latest release tag
         uses: actions/checkout@v3


### PR DESCRIPTION
Our bin-size commenter workflow occasionally fails, and succeeds after rerun. My theory is that we hit the GitHub API rate limit, and therefore fail to fetch the latest version tag at "Get latest release with tag". We then pass a `VERSION_TAG=null` to `$GITHUB_OUTPUT`, cascading the failure to the next step "Check out latest release tag".

The rate limit is significantly higher for authenticated requests ([doc](https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limiting)). This PR tries to fix the issue by authenticating the calls following instructions [here](https://docs.github.com/en/actions/security-guides/automatic-token-authentication).

Not tested though :333333

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
