### PR TITLE
chore(alarms): quick fix-- avoid calling `AlarmStatuses` with empty opts

### DIFF
--- a/internal/pkg/aws/cloudwatch/cloudwatch.go
+++ b/internal/pkg/aws/cloudwatch/cloudwatch.go
@@ -73,6 +73,9 @@ func (cw *CloudWatch) AlarmsWithTags(tags map[string]string) ([]AlarmStatus, err
 		}
 		alarmNames = append(alarmNames, name)
 	}
+	if len(alarmNames) == 0 {
+		return nil, nil
+	}
 	return cw.AlarmStatuses(WithNames(alarmNames))
 }
 
@@ -94,6 +97,8 @@ func WithPrefix(prefix string) DescribeAlarmOpts {
 }
 
 // AlarmStatuses returns the statuses of alarms optionally filtered (by name, prefix, etc.).
+// If the optional parameter is passed in but is nil, the statuses of ALL alarms in the
+// account will be returned!
 func (cw *CloudWatch) AlarmStatuses(opts ...DescribeAlarmOpts) ([]AlarmStatus, error) {
 	var alarmStatuses []AlarmStatus
 	in := &cloudwatch.DescribeAlarmsInput{}

--- a/internal/pkg/aws/cloudwatch/cloudwatch_test.go
+++ b/internal/pkg/aws/cloudwatch/cloudwatch_test.go
@@ -79,7 +79,7 @@ func TestCloudWatch_AlarmsWithTags(t *testing.T) {
 
 			wantAlarmStatus: nil,
 		},
-		"success": {
+		"should invoke DescribeAlarms on alarms that have matching tags": {
 			setupMocks: func(m cloudWatchMocks) {
 				gomock.InOrder(
 					m.rg.EXPECT().GetResourcesByTags(cloudwatchResourceType, gomock.Eq(testTags)).Return([]*rg.Resource{{ARN: mockAlarmArn}}, nil),

--- a/internal/pkg/aws/cloudwatch/cloudwatch_test.go
+++ b/internal/pkg/aws/cloudwatch/cloudwatch_test.go
@@ -28,6 +28,7 @@ func TestCloudWatch_AlarmsWithTags(t *testing.T) {
 		mockAlarmArn = "arn:aws:cloudwatch:us-west-2:1234567890:alarm:mockAlarmName"
 	)
 	mockError := errors.New("some error")
+	mockTime, _ := time.Parse(time.RFC3339, "2006-01-02T15:04:05+00:00")
 	testTags := map[string]string{
 		"copilot-application": appName,
 	}
@@ -74,12 +75,45 @@ func TestCloudWatch_AlarmsWithTags(t *testing.T) {
 		"return if no alarms found": {
 			setupMocks: func(m cloudWatchMocks) {
 				m.rg.EXPECT().GetResourcesByTags(cloudwatchResourceType, gomock.Eq(testTags)).Return([]*rg.Resource{}, nil)
-				m.cw.EXPECT().DescribeAlarms(gomock.Any()).Return(nil, nil)
 			},
 
 			wantAlarmStatus: nil,
 		},
-	}
+		"success": {
+			setupMocks: func(m cloudWatchMocks) {
+				gomock.InOrder(
+					m.rg.EXPECT().GetResourcesByTags(cloudwatchResourceType, gomock.Eq(testTags)).Return([]*rg.Resource{{ARN: mockAlarmArn}}, nil),
+					m.cw.EXPECT().DescribeAlarms(&cloudwatch.DescribeAlarmsInput{
+						AlarmNames: aws.StringSlice([]string{"mockAlarmName"}),
+					}).Return(&cloudwatch.DescribeAlarmsOutput{
+						MetricAlarms: []*cloudwatch.MetricAlarm{
+							{
+								AlarmArn:           aws.String(mockAlarmArn),
+								AlarmName:          aws.String("mockAlarmName"),
+								ComparisonOperator: aws.String(cloudwatch.ComparisonOperatorGreaterThanOrEqualToThreshold),
+								EvaluationPeriods:  aws.Int64(int64(300)),
+								Period:             aws.Int64(int64(5)),
+								Threshold:          aws.Float64(float64(70)),
+								MetricName:         aws.String("mockMetricName"),
+								StateValue:         aws.String("mockState"),
+								StateUpdatedTimestamp: &mockTime,
+
+							},
+						},
+						CompositeAlarms: nil,
+					}, nil))
+			},
+			wantAlarmStatus: []AlarmStatus{
+				{
+					Arn:       mockAlarmArn,
+					Name:      "mockAlarmName",
+					Type:      "Metric",
+					Condition: "mockMetricName ≥ 70.00 for 300 datapoints within 25 minutes",
+					Status:    "mockState",
+					UpdatedTimes: mockTime,
+
+				}},
+		}}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {

--- a/internal/pkg/describe/status_describe.go
+++ b/internal/pkg/describe/status_describe.go
@@ -216,6 +216,9 @@ func (s *ecsStatusDescriber) ecsServiceAutoscalingAlarms(cluster, service string
 	if err != nil {
 		return nil, fmt.Errorf("retrieve auto scaling alarm names for ECS service %s/%s: %w", cluster, service, err)
 	}
+	if alarmNames == nil {
+		return nil, nil
+	}
 	alarms, err := s.cwSvcGetter.AlarmStatuses(cloudwatch.WithNames(alarmNames))
 	if err != nil {
 		return nil, fmt.Errorf("get auto scaling CloudWatch alarms: %w", err)

--- a/internal/pkg/describe/status_describe.go
+++ b/internal/pkg/describe/status_describe.go
@@ -216,7 +216,7 @@ func (s *ecsStatusDescriber) ecsServiceAutoscalingAlarms(cluster, service string
 	if err != nil {
 		return nil, fmt.Errorf("retrieve auto scaling alarm names for ECS service %s/%s: %w", cluster, service, err)
 	}
-	if alarmNames == nil {
+	if len(alarmNames) == 0 {
 		return nil, nil
 	}
 	alarms, err := s.cwSvcGetter.AlarmStatuses(cloudwatch.WithNames(alarmNames))

--- a/internal/pkg/describe/status_describe_test.go
+++ b/internal/pkg/describe/status_describe_test.go
@@ -263,7 +263,6 @@ func TestServiceStatus_Describe(t *testing.T) {
 					m.alarmStatusGetter.EXPECT().AlarmsWithTags(gomock.Any()).Return([]cloudwatch.AlarmStatus{}, nil),
 					m.aas.EXPECT().ECSServiceAlarmNames(gomock.Any(), gomock.Any()).Return([]string{}, nil),
 					m.alarmStatusGetter.EXPECT().AlarmStatuses(gomock.Any()).Return(nil, nil),
-					m.alarmStatusGetter.EXPECT().AlarmStatuses(gomock.Any()).Return(nil, nil),
 					m.targetHealthGetter.EXPECT().TargetsHealth("group-1").Return(nil, errors.New("some error")),
 				)
 			},
@@ -285,7 +284,6 @@ func TestServiceStatus_Describe(t *testing.T) {
 				},
 				StoppedTasks:             nil,
 				TargetHealthDescriptions: nil,
-				//rendererConfigurer:       &barRendererConfigurer{},
 			},
 		},
 		"retrieve all target health information in service": {
@@ -350,7 +348,6 @@ func TestServiceStatus_Describe(t *testing.T) {
 						"copilot-service":     "mockSvc",
 					}).Return([]cloudwatch.AlarmStatus{}, nil),
 					m.aas.EXPECT().ECSServiceAlarmNames(mockCluster, mockService).Return([]string{}, nil),
-					m.alarmStatusGetter.EXPECT().AlarmStatuses(gomock.Any()).Return([]cloudwatch.AlarmStatus{}, nil),
 					m.alarmStatusGetter.EXPECT().AlarmStatuses(gomock.Any()).Return(nil, nil),
 					m.targetHealthGetter.EXPECT().TargetsHealth("group-1").Return([]*elbv2.TargetHealth{
 						{

--- a/internal/pkg/describe/status_describe_test.go
+++ b/internal/pkg/describe/status_describe_test.go
@@ -167,6 +167,83 @@ func TestServiceStatus_Describe(t *testing.T) {
 			},
 			wantedError: fmt.Errorf("get Copilot-created CloudWatch alarms: some error"),
 		},
+		"do not get status of extraneous alarms": {
+			setupMocks: func(m serviceStatusDescriberMocks) {
+				gomock.InOrder(
+					m.serviceDescriber.EXPECT().DescribeService("mockApp", "mockEnv", "mockSvc").Return(&ecs.ServiceDesc{
+						ClusterName: mockCluster,
+						Name:        mockService,
+						Tasks: []*awsecs.Task{
+							{
+								TaskArn:      aws.String("arn:aws:ecs:us-west-2:123456789012:task/mockCluster/1234567890123456789"),
+								StartedAt:    &startTime,
+								HealthStatus: aws.String("HEALTHY"),
+								LastStatus:   aws.String("RUNNING"),
+								Containers: []*ecsapi.Container{
+									{
+										Image:       aws.String("mockImageID1"),
+										ImageDigest: aws.String("69671a968e8ec3648e2697417750e"),
+									},
+								},
+								StoppedAt:     &stopTime,
+								StoppedReason: aws.String("some reason"),
+							},
+						},
+					}, nil),
+					m.ecsServiceGetter.EXPECT().Service(mockCluster, mockService).Return(&awsecs.Service{
+						Status:       aws.String("ACTIVE"),
+						DesiredCount: aws.Int64(1),
+						RunningCount: aws.Int64(1),
+						Deployments: []*ecsapi.Deployment{
+							{
+								UpdatedAt:      &startTime,
+								TaskDefinition: aws.String("mockTaskDefinition"),
+							},
+						},
+					}, nil),
+					m.alarmStatusGetter.EXPECT().AlarmsWithTags(map[string]string{
+						"copilot-application": "mockApp",
+						"copilot-environment": "mockEnv",
+						"copilot-service":     "mockSvc",
+					}).Return(nil, nil),
+					m.aas.EXPECT().ECSServiceAlarmNames(mockCluster, mockService).Return(nil, nil),
+					m.alarmStatusGetter.EXPECT().AlarmStatuses(gomock.Any()).Return(nil, nil),
+				)
+			},
+
+			wantedContent: &ecsServiceStatus{
+				Service: awsecs.ServiceStatus{
+					DesiredCount: 1,
+					RunningCount: 1,
+					Status:       "ACTIVE",
+					Deployments: []awsecs.Deployment{
+						{
+							UpdatedAt:      startTime,
+							TaskDefinition: "mockTaskDefinition",
+						},
+					},
+					LastDeploymentAt: startTime,
+					TaskDefinition:   "mockTaskDefinition",
+				},
+				Alarms: []cloudwatch.AlarmStatus{},
+				DesiredRunningTasks: []awsecs.TaskStatus{
+					{
+						Health:     "HEALTHY",
+						LastStatus: "RUNNING",
+						ID:         "1234567890123456789",
+						Images: []awsecs.Image{
+							{
+								Digest: "69671a968e8ec3648e2697417750e",
+								ID:     "mockImageID1",
+							},
+						},
+						StartedAt:     startTime,
+						StoppedAt:     stopTime,
+						StoppedReason: "some reason",
+					},
+				},
+			},
+		},
 		"do not error out if failed to get a service's target group health": {
 			setupMocks: func(m serviceStatusDescriberMocks) {
 				gomock.InOrder(
@@ -561,7 +638,6 @@ func TestServiceStatus_Describe(t *testing.T) {
 						StoppedReason: "some reason",
 					},
 				},
-				//rendererConfigurer: &barRendererConfigurer{},
 			},
 		},
 	}


### PR DESCRIPTION
The `AlarmStatuses` method (and `DescribeAlarms` API call) allow no arguments, in which case all alarms in the account are returned, without being filtered on name or whatever else. This prevents those calls where we don't have the filtering criteria we need.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
