### PR TITLE
chore: Implementation of Sidecar build and push in Parallel

### DIFF
--- a/internal/pkg/cli/deploy/workload.go
+++ b/internal/pkg/cli/deploy/workload.go
@@ -357,7 +357,6 @@ func (d *workloadDeployer) uploadContainerImage(imgBuilderPusher imageBuilderPus
 	if !required {
 		return nil, scDigests, nil
 	}
-	log.Infoln(scDigests)
 	return aws.String(digest), scDigests, nil
 }
 

--- a/internal/pkg/cli/deploy/workload.go
+++ b/internal/pkg/cli/deploy/workload.go
@@ -337,7 +337,7 @@ func (d *workloadDeployer) uploadContainerImage(imgBuilderPusher imageBuilderPus
 			return nil, nil, fmt.Errorf("build and push main container image: %w", err)
 		}
 	}
-	args := scbuildArgs(d.name, d.gitTag, UUIDTag, d.workspacePath, d.mft)
+	args := scBuildArgs(d.name, d.gitTag, UUIDTag, d.workspacePath, d.mft)
 	scdigests := make(map[string]string, len(args))
 	ctx, cancelWait := context.WithTimeout(context.Background(), waitForImageBuildAndPush)
 	defer cancelWait()
@@ -419,8 +419,8 @@ func userOrGitTag(userTag, gitTag string) string {
 	return gitTag
 }
 
-// scbuildArgs returns the map of dockerengine build arguments for the each sidecar that requires a native build from dockerfile.
-func scbuildArgs(name, gitTag, uuid, workspacePath string, unmarshaledManifest interface{}) map[string]*dockerengine.BuildArguments {
+// scBuildArgs returns the map of dockerengine build arguments for the each sidecar that requires a native build from dockerfile.
+func scBuildArgs(name, gitTag, uuid, workspacePath string, unmarshaledManifest interface{}) map[string]*dockerengine.BuildArguments {
 	mf, ok := unmarshaledManifest.(dfArgs)
 	var args map[string]*manifest.DockerBuildArgs
 	if ok {

--- a/internal/pkg/cli/deploy/workload.go
+++ b/internal/pkg/cli/deploy/workload.go
@@ -357,6 +357,7 @@ func (d *workloadDeployer) uploadContainerImage(imgBuilderPusher imageBuilderPus
 	if !required {
 		return nil, scDigests, nil
 	}
+	log.Infoln(scDigests)
 	return aws.String(digest), scDigests, nil
 }
 

--- a/internal/pkg/cli/deploy/workload.go
+++ b/internal/pkg/cli/deploy/workload.go
@@ -356,6 +356,7 @@ func (d *workloadDeployer) uploadContainerImage(imgBuilderPusher imageBuilderPus
 	if err := g.Wait(); err != nil {
 		return nil, nil, err
 	}
+	// The below if loop is for simple test cases.
 	if !required {
 		return nil, scdigests, nil
 	}

--- a/internal/pkg/cli/deploy/workload.go
+++ b/internal/pkg/cli/deploy/workload.go
@@ -338,9 +338,6 @@ func (d *workloadDeployer) uploadContainerImage(imgBuilderPusher imageBuilderPus
 		}
 	}
 	args := scbuildArgs(d.name, d.gitTag, UUIDTag, d.workspacePath, d.mft)
-	if args == nil {
-		return aws.String(digest), nil, nil
-	}
 	scdigests := make(map[string]string, len(args))
 	ctx, cancelWait := context.WithTimeout(context.Background(), waitForImageBuildAndPush)
 	defer cancelWait()
@@ -358,6 +355,9 @@ func (d *workloadDeployer) uploadContainerImage(imgBuilderPusher imageBuilderPus
 	}
 	if err := g.Wait(); err != nil {
 		return nil, nil, err
+	}
+	if !required {
+		return nil, scdigests, nil
 	}
 	return aws.String(digest), scdigests, nil
 }
@@ -526,7 +526,6 @@ func (d *workloadDeployer) uploadArtifacts() (*UploadArtifactsOutput, error) {
 	if err != nil {
 		return nil, fmt.Errorf("upload custom resources for %q: %w", d.name, err)
 	}
-	log.Infoln(urls)
 	out.CustomResourceURLs = urls
 	return out, nil
 }

--- a/internal/pkg/cli/deploy/workload_test.go
+++ b/internal/pkg/cli/deploy/workload_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	cloudformation0 "github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation"
+	"github.com/aws/copilot-cli/internal/pkg/docker/dockerengine"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -25,7 +26,6 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/deploy"
 	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation/stack"
 	"github.com/aws/copilot-cli/internal/pkg/deploy/upload/customresource"
-	"github.com/aws/copilot-cli/internal/pkg/docker/dockerengine"
 	"github.com/aws/copilot-cli/internal/pkg/manifest"
 	"github.com/aws/copilot-cli/internal/pkg/override"
 	"github.com/aws/copilot-cli/internal/pkg/template"
@@ -179,11 +179,12 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 		mockServiceDeployer func(deployer *workloadDeployer) artifactsUploader
 		customResourcesFunc customResourcesFunc
 
-		wantAddonsURL     string
-		wantEnvFileARN    string
-		wantImageDigest   *string
-		wantBuildRequired bool
-		wantErr           error
+		wantAddonsURL        string
+		wantEnvFileARN       string
+		wantImageDigest      *string
+		wantedscImageDigests map[string]string
+		wantBuildRequired    bool
+		wantErr              error
 	}{
 		"error if failed to build and push image": {
 			inBuildRequired: true,

--- a/internal/pkg/cli/deploy/workload_test.go
+++ b/internal/pkg/cli/deploy/workload_test.go
@@ -102,9 +102,8 @@ func (m *mockTopicLister) ListSNSTopics(_, _ string) ([]deploy.Topic, error) {
 }
 
 type mockWorkloadMft struct {
-	fileName        string
-	buildRequired   bool
-	dockerBuildArgs map[string]*manifest.DockerBuildArgs
+	fileName      string
+	buildRequired bool
 }
 
 func (m *mockWorkloadMft) EnvFile() string {

--- a/internal/pkg/cli/git.go
+++ b/internal/pkg/cli/git.go
@@ -30,7 +30,6 @@ func hasUncommitedGitChanges(r execRunner) (bool, error) {
 }
 
 // imageTagFromGit returns the image tag to apply in case the user is in a git repository.
-// If the user provided their own tag, then just use that.
 // If there is a clean git commit with no local changes, then return the git commit id.
 // Otherwise, returns the empty string.
 func imageTagFromGit(r execRunner) string {

--- a/internal/pkg/cli/git.go
+++ b/internal/pkg/cli/git.go
@@ -33,10 +33,7 @@ func hasUncommitedGitChanges(r execRunner) (bool, error) {
 // If the user provided their own tag, then just use that.
 // If there is a clean git commit with no local changes, then return the git commit id.
 // Otherwise, returns the empty string.
-func imageTagFromGit(r execRunner, userTag string) string {
-	if userTag != "" {
-		return userTag
-	}
+func imageTagFromGit(r execRunner) string {
 	commit, err := describeGitChanges(r)
 	if err != nil {
 		return ""

--- a/internal/pkg/cli/job_deploy.go
+++ b/internal/pkg/cli/job_deploy.go
@@ -42,6 +42,7 @@ type deployJobOpts struct {
 	newJobDeployer       func() (workloadDeployer, error)
 	envFeaturesDescriber versionCompatibilityChecker
 	sel                  wsSelector
+	gitTag               string
 
 	// cached variables
 	targetApp         *config.Application
@@ -98,6 +99,7 @@ func newJobDeployer(o *deployJobOpts) (workloadDeployer, error) {
 		App:              o.targetApp,
 		Env:              o.targetEnv,
 		ImageTag:         o.imageTag,
+		GitTag:           o.gitTag,
 		Mft:              content,
 		RawMft:           raw,
 		EnvVersionGetter: o.envFeaturesDescriber,
@@ -214,7 +216,7 @@ After fixing the deployment, you can:
 }
 
 func (o *deployJobOpts) configureClients() error {
-	o.imageTag = imageTagFromGit(o.cmd, o.imageTag) // Best effort assign git tag.
+	o.gitTag = imageTagFromGit(o.cmd) // Best effort assign git tag.
 	env, err := o.store.GetEnvironment(o.appName, o.envName)
 	if err != nil {
 		return err

--- a/internal/pkg/cli/job_deploy.go
+++ b/internal/pkg/cli/job_deploy.go
@@ -190,6 +190,7 @@ func (o *deployJobOpts) Execute() error {
 	if _, err = deployer.DeployWorkload(&deploy.DeployWorkloadInput{
 		StackRuntimeConfiguration: deploy.StackRuntimeConfiguration{
 			ImageDigest:        uploadOut.ImageDigest,
+			ScImageDigests:     uploadOut.ScImageDigests,
 			EnvFileARN:         uploadOut.EnvFileARN,
 			AddonsURL:          uploadOut.AddonsURL,
 			RootUserARN:        o.rootUserARN,

--- a/internal/pkg/cli/job_package.go
+++ b/internal/pkg/cli/job_package.go
@@ -74,12 +74,13 @@ func newPackageJobOpts(vars packageJobVars) (*packageJobOpts, error) {
 	}
 
 	opts.newPackageCmd = func(o *packageJobOpts) {
+		gitTag := imageTagFromGit(o.runner)
 		opts.packageCmd = &packageSvcOpts{
 			packageSvcVars: packageSvcVars{
 				name:         o.name,
 				envName:      o.envName,
 				appName:      o.appName,
-				tag:          imageTagFromGit(o.runner, o.tag),
+				tag:          o.tag,
 				outputDir:    o.outputDir,
 				uploadAssets: o.uploadAssets,
 			},
@@ -94,6 +95,7 @@ func newPackageJobOpts(vars packageJobVars) (*packageJobOpts, error) {
 			fs:                fs,
 			sessProvider:      sessProvider,
 			newStackGenerator: newWorkloadStackGenerator,
+			gitTag:            gitTag,
 		}
 	}
 	return opts, nil

--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -62,6 +62,7 @@ type deploySvcOpts struct {
 	spinner progress
 	sel     wsSelector
 	prompt  prompter
+	gitTag  string
 
 	// cached variables
 	targetApp         *config.Application
@@ -130,6 +131,7 @@ func newSvcDeployer(o *deploySvcOpts) (workloadDeployer, error) {
 		App:              targetApp,
 		Env:              o.targetEnv,
 		ImageTag:         o.imageTag,
+		GitTag:           o.gitTag,
 		Mft:              content,
 		RawMft:           raw,
 		EnvVersionGetter: o.envFeaturesDescriber,
@@ -323,7 +325,7 @@ func (o *deploySvcOpts) validateOrAskEnvName() error {
 }
 
 func (o *deploySvcOpts) configureClients() error {
-	o.imageTag = imageTagFromGit(o.cmd, o.imageTag) // Best effort assign git tag.
+	o.gitTag = imageTagFromGit(o.cmd) // Best effort assign git tag.
 	env, err := o.store.GetEnvironment(o.appName, o.envName)
 	if err != nil {
 		return fmt.Errorf("get environment %s configuration: %w", o.envName, err)

--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -232,6 +232,7 @@ func (o *deploySvcOpts) Execute() error {
 	deployRecs, err := deployer.DeployWorkload(&clideploy.DeployWorkloadInput{
 		StackRuntimeConfiguration: clideploy.StackRuntimeConfiguration{
 			ImageDigest:        uploadOut.ImageDigest,
+			ScImageDigests:     uploadOut.ScImageDigests,
 			EnvFileARN:         uploadOut.EnvFileARN,
 			AddonsURL:          uploadOut.AddonsURL,
 			RootUserARN:        o.rootUserARN,

--- a/internal/pkg/cli/svc_package.go
+++ b/internal/pkg/cli/svc_package.go
@@ -340,6 +340,7 @@ func (o *packageSvcOpts) getWorkloadStack(generator workloadStackGenerator) (*cf
 			RootUserARN:        o.rootUserARN,
 			Tags:               targetApp.Tags,
 			ImageDigest:        uploadOut.ImageDigest,
+			ScImageDigests:     uploadOut.ScImageDigests,
 			EnvFileARN:         uploadOut.EnvFileARN,
 			AddonsURL:          uploadOut.AddonsURL,
 			CustomResourceURLs: uploadOut.CustomResourceURLs,

--- a/internal/pkg/cli/svc_package.go
+++ b/internal/pkg/cli/svc_package.go
@@ -62,6 +62,7 @@ type packageSvcOpts struct {
 	newInterpolator      func(app, env string) interpolator
 	newStackGenerator    func(*packageSvcOpts) (workloadStackGenerator, error)
 	envFeaturesDescriber versionCompatibilityChecker
+	gitTag               string
 
 	// cached variables
 	targetApp         *config.Application
@@ -130,6 +131,7 @@ func newWorkloadStackGenerator(o *packageSvcOpts) (workloadStackGenerator, error
 		App:              targetApp,
 		Env:              targetEnv,
 		ImageTag:         o.tag,
+		GitTag:           o.gitTag,
 		Mft:              content,
 		RawMft:           raw,
 		EnvVersionGetter: o.envFeaturesDescriber,
@@ -260,7 +262,7 @@ func (o *packageSvcOpts) validateOrAskEnvName() error {
 }
 
 func (o *packageSvcOpts) configureClients() error {
-	o.tag = imageTagFromGit(o.runner, o.tag) // Best effort assign git tag.
+	o.gitTag = imageTagFromGit(o.runner) // Best effort assign git tag.
 	// client to retrieve an application's resources created with CloudFormation.
 	defaultSess, err := o.sessProvider.Default()
 	if err != nil {

--- a/internal/pkg/cli/svc_package_test.go
+++ b/internal/pkg/cli/svc_package_test.go
@@ -175,7 +175,11 @@ http:
   alias: 'hunter.com'
 cpu: 256
 memory: 512
-count: 1`
+count: 1
+sidecars:
+  nginx:
+    image:
+      build: "hello/Dockerfile"`
 	)
 	testCases := map[string]struct {
 		inVars packageSvcVars
@@ -201,11 +205,17 @@ count: 1`
 				m.ws.EXPECT().ReadWorkloadManifest("api").Return([]byte(lbwsMft), nil)
 				m.generator.EXPECT().UploadArtifacts().Return(&deploy.UploadArtifactsOutput{
 					ImageDigest: aws.String(mockDigest),
+					ScImageDigests: map[string]string{
+						"nginx": "mockSidecarDigest",
+					},
 				}, nil)
 				m.generator.EXPECT().GenerateCloudFormationTemplate(&deploy.GenerateCloudFormationTemplateInput{
 					StackRuntimeConfiguration: deploy.StackRuntimeConfiguration{
 						ImageDigest: aws.String(mockDigest),
 						RootUserARN: mockARN,
+						ScImageDigests: map[string]string{
+							"nginx": "mockSidecarDigest",
+						},
 					},
 				}).Return(&deploy.GenerateCloudFormationTemplateOutput{
 					Template:   "mystack",

--- a/internal/pkg/deploy/cloudformation/stack/backend_svc.go
+++ b/internal/pkg/deploy/cloudformation/stack/backend_svc.go
@@ -94,7 +94,7 @@ func (s *BackendService) Template() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("parse exposed ports in service manifest %s: %w", s.name, err)
 	}
-	sidecars, err := convertSidecars(s.manifest.Sidecars, exposedPorts.PortsForContainer)
+	sidecars, err := convertSidecars(s.manifest.Sidecars, exposedPorts.PortsForContainer, s.rc.ScECRImage)
 	if err != nil {
 		return "", fmt.Errorf("convert the sidecar configuration for service %s: %w", s.name, err)
 	}

--- a/internal/pkg/deploy/cloudformation/stack/lb_web_svc.go
+++ b/internal/pkg/deploy/cloudformation/stack/lb_web_svc.go
@@ -138,7 +138,7 @@ func (s *LoadBalancedWebService) Template() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("parse exposed ports in service manifest %s: %w", s.name, err)
 	}
-	sidecars, err := convertSidecars(s.manifest.Sidecars, exposedPorts.PortsForContainer)
+	sidecars, err := convertSidecars(s.manifest.Sidecars, exposedPorts.PortsForContainer, s.rc.ScECRImage)
 	if err != nil {
 		return "", fmt.Errorf("convert the sidecar configuration for service %s: %w", s.name, err)
 	}

--- a/internal/pkg/deploy/cloudformation/stack/scheduled_job.go
+++ b/internal/pkg/deploy/cloudformation/stack/scheduled_job.go
@@ -143,7 +143,7 @@ func (j *ScheduledJob) Template() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("parse exposed ports in service manifest %s: %w", j.name, err)
 	}
-	sidecars, err := convertSidecars(j.manifest.Sidecars, exposedPorts.PortsForContainer)
+	sidecars, err := convertSidecars(j.manifest.Sidecars, exposedPorts.PortsForContainer, j.rc.ScECRImage)
 	if err != nil {
 		return "", fmt.Errorf("convert the sidecar configuration for job %s: %w", j.name, err)
 	}

--- a/internal/pkg/deploy/cloudformation/stack/transformers.go
+++ b/internal/pkg/deploy/cloudformation/stack/transformers.go
@@ -79,7 +79,7 @@ func convertPortMappings(exposedPorts []manifest.ExposedPort) []*template.PortMa
 }
 
 // convertSidecars converts the manifest sidecar configuration into a format parsable by the templates pkg.
-func convertSidecars(s map[string]*manifest.SidecarConfig, exposedPorts map[string][]manifest.ExposedPort) ([]*template.SidecarOpts, error) {
+func convertSidecars(s map[string]*manifest.SidecarConfig, exposedPorts map[string][]manifest.ExposedPort, i SidecarECRImage) ([]*template.SidecarOpts, error) {
 	var sidecars []*template.SidecarOpts
 	if s == nil {
 		return nil, nil
@@ -93,7 +93,12 @@ func convertSidecars(s map[string]*manifest.SidecarConfig, exposedPorts map[stri
 	sort.Strings(keys)
 	for _, name := range keys {
 		config := s[name]
-		imageURI, _ := config.ImageURI()
+		var imageURI string
+		if uri, ok := config.ImageURI(); ok {
+			imageURI = uri
+		} else {
+			imageURI = i.getSidecarLocation(name)
+		}
 		entrypoint, err := convertEntryPoint(config.EntryPoint)
 		if err != nil {
 			return nil, err

--- a/internal/pkg/deploy/cloudformation/stack/worker_svc.go
+++ b/internal/pkg/deploy/cloudformation/stack/worker_svc.go
@@ -84,7 +84,7 @@ func (s *WorkerService) Template() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("parse exposed ports in service manifest %s: %w", s.name, err)
 	}
-	sidecars, err := convertSidecars(s.manifest.Sidecars, exposedPorts.PortsForContainer)
+	sidecars, err := convertSidecars(s.manifest.Sidecars, exposedPorts.PortsForContainer, s.rc.ScECRImage)
 	if err != nil {
 		return "", fmt.Errorf("convert the sidecar configuration for service %s: %w", s.name, err)
 	}

--- a/internal/pkg/deploy/cloudformation/stack/workload.go
+++ b/internal/pkg/deploy/cloudformation/stack/workload.go
@@ -82,9 +82,10 @@ type RuntimeConfig struct {
 // ECRImage represents configuration about the pushed ECR image that is needed to
 // create a CloudFormation stack.
 type ECRImage struct {
-	RepoURL  string // RepoURL is the ECR repository URL the container image should be pushed to.
-	ImageTag string // Tag is the container image's unique tag.
-	Digest   string // The image digest.
+	RepoURL        string            // RepoURL is the ECR repository URL the container image should be pushed to.
+	ImageTag       string            // Tag is the container image's unique tag.
+	Digest         string            // The image digest.
+	ScImageDigests map[string]string // ImageDigests of sidecar container Images.
 }
 
 // GetLocation returns the ECR image URI.

--- a/internal/pkg/deploy/cloudformation/stack/workload.go
+++ b/internal/pkg/deploy/cloudformation/stack/workload.go
@@ -77,15 +77,15 @@ type RuntimeConfig struct {
 	AccountID                string
 	Region                   string
 	EnvVersion               string
+	ScECRImage               SidecarECRImage
 }
 
 // ECRImage represents configuration about the pushed ECR image that is needed to
 // create a CloudFormation stack.
 type ECRImage struct {
-	RepoURL        string            // RepoURL is the ECR repository URL the container image should be pushed to.
-	ImageTag       string            // Tag is the container image's unique tag.
-	Digest         string            // The image digest.
-	ScImageDigests map[string]string // ImageDigests of sidecar container Images.
+	RepoURL  string // RepoURL is the ECR repository URL the container image should be pushed to.
+	ImageTag string // Tag is the container image's unique tag.
+	Digest   string // The image digest.
 }
 
 // GetLocation returns the ECR image URI.
@@ -100,6 +100,22 @@ func (i ECRImage) GetLocation() string {
 		return fmt.Sprintf("%s@%s", i.RepoURL, i.Digest)
 	}
 	return fmt.Sprintf("%s:%s", i.RepoURL, "latest")
+}
+
+type SidecarECRImage struct {
+	RepoURL             string
+	SidecarImageTag     string
+	SidecarImageDigests map[string]string
+}
+
+func (s SidecarECRImage) getSidecarLocation(scName string) string {
+	if digest, ok := s.SidecarImageDigests[scName]; ok {
+		return fmt.Sprintf("%s@%s", s.RepoURL, digest)
+	}
+	if s.SidecarImageTag != "" {
+		return fmt.Sprintf("%s:%s-%s", s.RepoURL, scName, s.SidecarImageTag)
+	}
+	return ""
 }
 
 // NestedStackConfigurer configures a nested stack that deploys addons.

--- a/internal/pkg/docker/dockerengine/dockerengine.go
+++ b/internal/pkg/docker/dockerengine/dockerengine.go
@@ -146,7 +146,7 @@ func (c CmdClient) Login(uri, username, password string) error {
 
 // Push pushes the images with the specified tags and ecr repository URI, and returns the image digest on success.
 func (c CmdClient) Push(uri string, tags ...string) (digest string, err error) {
-	images := []string{uri}
+	images := []string{}
 	for _, tag := range tags {
 		images = append(images, imageName(uri, tag))
 	}
@@ -225,9 +225,6 @@ func (c CmdClient) GetPlatform() (os, arch string, err error) {
 }
 
 func imageName(uri, tag string) string {
-	if tag == "" {
-		return uri // If no tag is specified build with latest.
-	}
 	return fmt.Sprintf("%s:%s", uri, tag)
 }
 

--- a/internal/pkg/manifest/backend_svc.go
+++ b/internal/pkg/manifest/backend_svc.go
@@ -124,6 +124,20 @@ func (s *BackendService) BuildArgs(wsRoot string) *DockerBuildArgs {
 	return s.ImageConfig.Image.BuildConfig(wsRoot)
 }
 
+// SidecarBuildArgs returns a map of docker build arguments for sidecar container images.
+func (s *BackendService) SidecarBuildArgs(wsRoot string) map[string]*DockerBuildArgs {
+	if len(s.Sidecars) == 0 {
+		return nil
+	}
+	buildArgs := make(map[string]*DockerBuildArgs, len(s.Sidecars))
+	for k, v := range s.Sidecars {
+		if _, ok := v.ImageURI(); !ok {
+			buildArgs[k] = v.Image.Advanced.BuildConfig(wsRoot)
+		}
+	}
+	return buildArgs
+}
+
 // EnvFile returns the location of the env file against the ws root directory.
 func (s *BackendService) EnvFile() string {
 	return aws.StringValue(s.TaskConfig.EnvFile)

--- a/internal/pkg/manifest/job.go
+++ b/internal/pkg/manifest/job.go
@@ -141,6 +141,20 @@ func (j *ScheduledJob) BuildArgs(wsRoot string) *DockerBuildArgs {
 	return j.ImageConfig.Image.BuildConfig(wsRoot)
 }
 
+// SidecarBuildArgs returns a map of docker build arguments for sidecar container images.
+func (j *ScheduledJob) SidecarBuildArgs(wsRoot string) map[string]*DockerBuildArgs {
+	if len(j.Sidecars) == 0 {
+		return nil
+	}
+	buildArgs := make(map[string]*DockerBuildArgs, len(j.Sidecars))
+	for k, v := range j.Sidecars {
+		if _, ok := v.ImageURI(); !ok {
+			buildArgs[k] = v.Image.Advanced.BuildConfig(wsRoot)
+		}
+	}
+	return buildArgs
+}
+
 // BuildRequired returns if the service requires building from the local Dockerfile.
 func (j *ScheduledJob) BuildRequired() (bool, error) {
 	return requiresBuild(j.ImageConfig.Image)

--- a/internal/pkg/manifest/lb_web_svc.go
+++ b/internal/pkg/manifest/lb_web_svc.go
@@ -191,6 +191,24 @@ func (s *LoadBalancedWebService) BuildArgs(wsRoot string) *DockerBuildArgs {
 	return s.ImageConfig.Image.BuildConfig(wsRoot)
 }
 
+// SidecarBuildRequired returns map of sidecar names that a build is required or not.
+func (s *LoadBalancedWebService) SidecarBuildRequired() map[string]bool {
+	isBuildRequired := make(map[string]bool, len(s.Sidecars))
+	for k, v := range s.Sidecars {
+		_, ok := v.ImageURI()
+		isBuildRequired[k] = !ok
+	}
+	return isBuildRequired
+}
+
+func (s *LoadBalancedWebService) SidecarBuildArgs(wsRoot string) map[string]*DockerBuildArgs {
+	buildArgs := make(map[string]*DockerBuildArgs, len(s.Sidecars))
+	for k, v := range s.Sidecars {
+		buildArgs[k] = v.Image.Advanced.BuildConfig(wsRoot)
+	}
+	return buildArgs
+}
+
 // EnvFile returns the location of the env file against the ws root directory.
 func (s *LoadBalancedWebService) EnvFile() string {
 	return aws.StringValue(s.TaskConfig.EnvFile)

--- a/internal/pkg/manifest/lb_web_svc.go
+++ b/internal/pkg/manifest/lb_web_svc.go
@@ -191,20 +191,16 @@ func (s *LoadBalancedWebService) BuildArgs(wsRoot string) *DockerBuildArgs {
 	return s.ImageConfig.Image.BuildConfig(wsRoot)
 }
 
-// SidecarBuildRequired returns map of sidecar names that a build is required or not.
-func (s *LoadBalancedWebService) SidecarBuildRequired() map[string]bool {
-	isBuildRequired := make(map[string]bool, len(s.Sidecars))
-	for k, v := range s.Sidecars {
-		_, ok := v.ImageURI()
-		isBuildRequired[k] = !ok
-	}
-	return isBuildRequired
-}
-
+// SidecarBuildArgs returns a map of docker build arguments for sidecar container images.
 func (s *LoadBalancedWebService) SidecarBuildArgs(wsRoot string) map[string]*DockerBuildArgs {
+	if len(s.Sidecars) == 0 {
+		return nil
+	}
 	buildArgs := make(map[string]*DockerBuildArgs, len(s.Sidecars))
 	for k, v := range s.Sidecars {
-		buildArgs[k] = v.Image.Advanced.BuildConfig(wsRoot)
+		if _, ok := v.ImageURI(); !ok {
+			buildArgs[k] = v.Image.Advanced.BuildConfig(wsRoot)
+		}
 	}
 	return buildArgs
 }

--- a/internal/pkg/manifest/worker_svc.go
+++ b/internal/pkg/manifest/worker_svc.go
@@ -281,6 +281,20 @@ func (s *WorkerService) BuildArgs(wsRoot string) *DockerBuildArgs {
 	return s.ImageConfig.Image.BuildConfig(wsRoot)
 }
 
+// SidecarBuildArgs returns a map of docker build arguments for sidecar container images.
+func (s *WorkerService) SidecarBuildArgs(wsRoot string) map[string]*DockerBuildArgs {
+	if len(s.Sidecars) == 0 {
+		return nil
+	}
+	buildArgs := make(map[string]*DockerBuildArgs, len(s.Sidecars))
+	for k, v := range s.Sidecars {
+		if _, ok := v.ImageURI(); !ok {
+			buildArgs[k] = v.Image.Advanced.BuildConfig(wsRoot)
+		}
+	}
+	return buildArgs
+}
+
 // EnvFile returns the location of the env file against the ws root directory.
 func (s *WorkerService) EnvFile() string {
 	return aws.StringValue(s.TaskConfig.EnvFile)


### PR DESCRIPTION
<!-- Provide summary of changes -->
This PR relates to #4254 
With this PR we build and push multiple sidecar images in parallel to AWS ECR.

But the UX of the Command line looks messy because of the go routines. Still working on it to make UX prettier.


<!-- Issue number, if ava
![Screen Shot 2023-02-14 at 11 51 01 AM](https://user-images.githubusercontent.com/71282729/218846524-00e75d20-3f5f-43a0-934e-e028199ca543.png)
ilable. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
