### PR TITLE
refactor: convert ECR image of RuntimeConfig into `map` in stack package

### DIFF
--- a/internal/pkg/cli/deploy/workload.go
+++ b/internal/pkg/cli/deploy/workload.go
@@ -93,10 +93,7 @@ type fileReader interface {
 
 // StackRuntimeConfiguration contains runtime configuration for a workload CloudFormation stack.
 type StackRuntimeConfiguration struct {
-	// Use *string for three states (see https://github.com/aws/copilot-cli/pull/3268#discussion_r806060230)
-	// This is mainly to keep the `workload package` behavior backward-compatible, otherwise our old pipeline buildspec would break,
-	// since previously we parsed the env region from a mock ECR URL that we generated from `workload package``.
-	ImageDigest        *string
+	ImageDigests       map[string]ContainerImageIdentifier
 	EnvFileARN         string
 	AddonsURL          string
 	RootUserARN        string
@@ -336,7 +333,7 @@ func (img ContainerImageIdentifier) customOrGitTag() string {
 	return img.GitShortCommitTag
 }
 
-func (d *workloadDeployer) uploadContainerImage(imgBuilderPusher imageBuilderPusher) (*string, error) {
+func (d *workloadDeployer) uploadContainerImage(imgBuilderPusher imageBuilderPusher) (map[string]ContainerImageIdentifier, error) {
 	required, err := manifest.DockerfileBuildRequired(d.mft)
 	if err != nil {
 		return nil, err
@@ -362,8 +359,7 @@ func (d *workloadDeployer) uploadContainerImage(imgBuilderPusher imageBuilderPus
 			uuidTag:           d.image.uuidTag,
 		}
 	}
-	image := images[d.name]
-	return &image.Digest, nil
+	return images, nil
 }
 
 func buildArgsPerContainer(name, workspacePath string, img ContainerImageIdentifier, unmarshaledManifest interface{}) (map[string]*dockerengine.BuildArguments, error) {
@@ -425,14 +421,14 @@ type customResourcesFunc func(fs template.Reader) ([]*customresource.CustomResou
 
 // UploadArtifactsOutput is the output of UploadArtifacts.
 type UploadArtifactsOutput struct {
-	ImageDigest        *string
+	ImageDigests       map[string]ContainerImageIdentifier
 	EnvFileARN         string
 	AddonsURL          string
 	CustomResourceURLs map[string]string
 }
 
 func (d *workloadDeployer) uploadArtifacts() (*UploadArtifactsOutput, error) {
-	imageDigest, err := d.uploadContainerImage(d.imageBuilderPusher)
+	imageDigests, err := d.uploadContainerImage(d.imageBuilderPusher)
 	if err != nil {
 		return nil, err
 	}
@@ -445,9 +441,9 @@ func (d *workloadDeployer) uploadArtifacts() (*UploadArtifactsOutput, error) {
 	}
 
 	out := &UploadArtifactsOutput{
-		ImageDigest: imageDigest,
-		EnvFileARN:  s3Artifacts.envFileARN,
-		AddonsURL:   s3Artifacts.addonsURL,
+		ImageDigests: imageDigests,
+		EnvFileARN:   s3Artifacts.envFileARN,
+		AddonsURL:    s3Artifacts.addonsURL,
 	}
 	crs, err := d.customResources(d.templateFS)
 	if err != nil {
@@ -545,7 +541,7 @@ func (d *workloadDeployer) runtimeConfig(in *StackRuntimeConfiguration) (*stack.
 	if err != nil {
 		return nil, fmt.Errorf("get version of environment %q: %w", d.env.Name, err)
 	}
-	if len(aws.StringValue(in.ImageDigest)) == 0 {
+	if len(in.ImageDigests) == 0 {
 		return &stack.RuntimeConfig{
 			AddonsTemplateURL:        in.AddonsURL,
 			EnvFileARN:               in.EnvFileARN,
@@ -557,15 +553,19 @@ func (d *workloadDeployer) runtimeConfig(in *StackRuntimeConfiguration) (*stack.
 			EnvVersion:               envVersion,
 		}, nil
 	}
-	return &stack.RuntimeConfig{
-		AddonsTemplateURL: in.AddonsURL,
-		EnvFileARN:        in.EnvFileARN,
-		AdditionalTags:    in.Tags,
-		Image: &stack.ECRImage{
+	images := make(map[string]stack.ECRImage)
+	for container, img := range in.ImageDigests {
+		images[container] = stack.ECRImage{
 			RepoURL:  d.resources.RepositoryURLs[d.name],
-			ImageTag: d.image.customOrGitTag(),
-			Digest:   aws.StringValue(in.ImageDigest),
-		},
+			ImageTag: img.customOrGitTag(),
+			Digest:   img.Digest,
+		}
+	}
+	return &stack.RuntimeConfig{
+		AddonsTemplateURL:        in.AddonsURL,
+		EnvFileARN:               in.EnvFileARN,
+		AdditionalTags:           in.Tags,
+		Images:                   images,
 		ServiceDiscoveryEndpoint: endpoint,
 		AccountID:                d.env.AccountID,
 		Region:                   d.env.Region,

--- a/internal/pkg/cli/deploy/workload_test.go
+++ b/internal/pkg/cli/deploy/workload_test.go
@@ -186,7 +186,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 
 		wantAddonsURL     string
 		wantEnvFileARN    string
-		wantImageDigest   *string
+		wantImages        map[string]ContainerImageIdentifier
 		wantBuildRequired bool
 		wantErr           error
 	}{
@@ -216,7 +216,14 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 				}).Return("mockDigest", nil)
 				m.mockAddons = nil
 			},
-			wantImageDigest: aws.String("mockDigest"),
+			wantImages: map[string]ContainerImageIdentifier{
+				mockName: {
+					Digest:            "mockDigest",
+					CustomTag:         "v1.0",
+					GitShortCommitTag: "gitTag",
+					uuidTag:           mockUUID,
+				},
+			},
 		},
 
 		"build and push image with gitshortcommit successfully": {
@@ -231,7 +238,13 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 				}).Return("mockDigest", nil)
 				m.mockAddons = nil
 			},
-			wantImageDigest: aws.String("mockDigest"),
+			wantImages: map[string]ContainerImageIdentifier{
+				mockName: {
+					Digest:            "mockDigest",
+					GitShortCommitTag: "gitTag",
+					uuidTag:           mockUUID,
+				},
+			},
 		},
 		"build and push image with uuid successfully": {
 			inBuildRequired: true,
@@ -244,7 +257,14 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 				}).Return("mockDigest", nil)
 				m.mockAddons = nil
 			},
-			wantImageDigest: aws.String("mockDigest"),
+			wantImages: map[string]ContainerImageIdentifier{
+				mockName: {
+					Digest:            "mockDigest",
+					CustomTag:         "",
+					GitShortCommitTag: "",
+					uuidTag:           mockUUID,
+				},
+			},
 		},
 		"should retrieve Load Balanced Web Service custom resource URLs": {
 			mock: func(t *testing.T, m *deployMocks) {
@@ -539,7 +559,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 				require.NoError(t, gotErr)
 				require.Equal(t, tc.wantAddonsURL, got.AddonsURL)
 				require.Equal(t, tc.wantEnvFileARN, got.EnvFileARN)
-				require.Equal(t, tc.wantImageDigest, got.ImageDigest)
+				require.Equal(t, tc.wantImages, got.ImageDigests)
 			}
 		})
 	}

--- a/internal/pkg/cli/job_deploy.go
+++ b/internal/pkg/cli/job_deploy.go
@@ -191,7 +191,7 @@ func (o *deployJobOpts) Execute() error {
 	}
 	if _, err = deployer.DeployWorkload(&deploy.DeployWorkloadInput{
 		StackRuntimeConfiguration: deploy.StackRuntimeConfiguration{
-			ImageDigest:        uploadOut.ImageDigest,
+			ImageDigests:       uploadOut.ImageDigests,
 			EnvFileARN:         uploadOut.EnvFileARN,
 			AddonsURL:          uploadOut.AddonsURL,
 			RootUserARN:        o.rootUserARN,

--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -235,7 +235,7 @@ func (o *deploySvcOpts) Execute() error {
 	}
 	deployRecs, err := deployer.DeployWorkload(&clideploy.DeployWorkloadInput{
 		StackRuntimeConfiguration: clideploy.StackRuntimeConfiguration{
-			ImageDigest:        uploadOut.ImageDigest,
+			ImageDigests:       uploadOut.ImageDigests,
 			EnvFileARN:         uploadOut.EnvFileARN,
 			AddonsURL:          uploadOut.AddonsURL,
 			RootUserARN:        o.rootUserARN,

--- a/internal/pkg/cli/svc_package.go
+++ b/internal/pkg/cli/svc_package.go
@@ -341,7 +341,7 @@ func (o *packageSvcOpts) getWorkloadStack(generator workloadStackGenerator) (*cf
 		StackRuntimeConfiguration: clideploy.StackRuntimeConfiguration{
 			RootUserARN:        o.rootUserARN,
 			Tags:               targetApp.Tags,
-			ImageDigest:        uploadOut.ImageDigest,
+			ImageDigests:       uploadOut.ImageDigests,
 			EnvFileARN:         uploadOut.EnvFileARN,
 			AddonsURL:          uploadOut.AddonsURL,
 			CustomResourceURLs: uploadOut.CustomResourceURLs,

--- a/internal/pkg/cli/svc_package_test.go
+++ b/internal/pkg/cli/svc_package_test.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 
@@ -200,11 +199,19 @@ count: 1`
 			setupMocks: func(m *svcPackageExecuteMock) {
 				m.ws.EXPECT().ReadWorkloadManifest("api").Return([]byte(lbwsMft), nil)
 				m.generator.EXPECT().UploadArtifacts().Return(&deploy.UploadArtifactsOutput{
-					ImageDigest: aws.String(mockDigest),
+					ImageDigests: map[string]deploy.ContainerImageIdentifier{
+						"api": {
+							Digest: mockDigest,
+						},
+					},
 				}, nil)
 				m.generator.EXPECT().GenerateCloudFormationTemplate(&deploy.GenerateCloudFormationTemplateInput{
 					StackRuntimeConfiguration: deploy.StackRuntimeConfiguration{
-						ImageDigest: aws.String(mockDigest),
+						ImageDigests: map[string]deploy.ContainerImageIdentifier{
+							"api": {
+								Digest: mockDigest,
+							},
+						},
 						RootUserARN: mockARN,
 					},
 				}).Return(&deploy.GenerateCloudFormationTemplateOutput{

--- a/internal/pkg/deploy/cloudformation/stack/backend_svc_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/backend_svc_test.go
@@ -273,9 +273,11 @@ Outputs:
 			},
 			Manifest: mft,
 			RuntimeConfig: RuntimeConfig{
-				Image: &ECRImage{
-					RepoURL:  testImageRepoURL,
-					ImageTag: testImageTag,
+				Images: map[string]ECRImage{
+					"test": {
+						RepoURL:  testImageRepoURL,
+						ImageTag: testImageTag,
+					},
 				},
 				CustomResourcesURL: map[string]string{
 					"EnvControllerFunction":       "https://my-bucket.s3.Region.amazonaws.com/sha1/envcontroller.zip",
@@ -440,9 +442,11 @@ Outputs:
 			},
 			Manifest: mft,
 			RuntimeConfig: RuntimeConfig{
-				Image: &ECRImage{
-					RepoURL:  testImageRepoURL,
-					ImageTag: testImageTag,
+				Images: map[string]ECRImage{
+					"test": {
+						RepoURL:  testImageRepoURL,
+						ImageTag: testImageTag,
+					},
 				},
 			},
 			Addons:             addons,

--- a/internal/pkg/deploy/cloudformation/stack/lb_web_svc_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/lb_web_svc_test.go
@@ -240,9 +240,11 @@ Outputs:
 			},
 			Manifest: mft,
 			RuntimeConfig: RuntimeConfig{
-				Image: &ECRImage{
-					RepoURL:  testImageRepoURL,
-					ImageTag: testImageTag,
+				Images: map[string]ECRImage{
+					"test": {
+						RepoURL:  testImageRepoURL,
+						ImageTag: testImageTag,
+					},
 				},
 				AccountID: "0123456789012",
 				Region:    "us-west-2",
@@ -924,9 +926,11 @@ func TestLoadBalancedWebService_Parameters(t *testing.T) {
 						env:  testEnvName,
 						app:  testAppName,
 						rc: RuntimeConfig{
-							Image: &ECRImage{
-								RepoURL:  testImageRepoURL,
-								ImageTag: testImageTag,
+							Images: map[string]ECRImage{
+								aws.StringValue(testManifest.Name): {
+									RepoURL:  testImageRepoURL,
+									ImageTag: testImageTag,
+								},
 							},
 						},
 					},
@@ -967,9 +971,11 @@ func TestLoadBalancedWebService_SerializedParameters(t *testing.T) {
 				env:  testEnvName,
 				app:  testAppName,
 				rc: RuntimeConfig{
-					Image: &ECRImage{
-						RepoURL:  testImageRepoURL,
-						ImageTag: testImageTag,
+					Images: map[string]ECRImage{
+						"frontend": {
+							RepoURL:  testImageRepoURL,
+							ImageTag: testImageTag,
+						},
 					},
 					AdditionalTags: map[string]string{
 						"owner": "boss",
@@ -1029,9 +1035,11 @@ func TestLoadBalancedWebService_Tags(t *testing.T) {
 				env:  testEnvName,
 				app:  testAppName,
 				rc: RuntimeConfig{
-					Image: &ECRImage{
-						RepoURL:  testImageRepoURL,
-						ImageTag: testImageTag,
+					Images: map[string]ECRImage{
+						"frontend": {
+							RepoURL:  testImageRepoURL,
+							ImageTag: testImageTag,
+						},
 					},
 					AdditionalTags: map[string]string{
 						"owner":              "boss",

--- a/internal/pkg/deploy/cloudformation/stack/rd_web_svc_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/rd_web_svc_test.go
@@ -335,9 +335,11 @@ Outputs:
 						env:  testEnvName,
 						app:  testAppName,
 						rc: RuntimeConfig{
-							Image: &ECRImage{
-								RepoURL:  testImageRepoURL,
-								ImageTag: testImageTag,
+							Images: map[string]ECRImage{
+								"testServiceName": {
+									RepoURL:  testImageRepoURL,
+									ImageTag: testImageTag,
+								},
 							},
 							ServiceDiscoveryEndpoint: mockSD,
 							AccountID:                "0123456789012",
@@ -493,9 +495,11 @@ func TestRequestDrivenWebService_SerializedParameters(t *testing.T) {
 				env:  testEnvName,
 				app:  testAppName,
 				rc: RuntimeConfig{
-					Image: &ECRImage{
-						RepoURL:  testImageRepoURL,
-						ImageTag: testImageTag,
+					Images: map[string]ECRImage{
+						aws.StringValue(testRDWebServiceManifest.Name): {
+							RepoURL:  testImageRepoURL,
+							ImageTag: testImageTag,
+						},
 					},
 				},
 			},

--- a/internal/pkg/deploy/cloudformation/stack/scheduled_job_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/scheduled_job_test.go
@@ -181,9 +181,11 @@ DiscoveryServiceArn: !GetAtt DiscoveryService.Arn`,
 						env:  testJobEnvName,
 						app:  testJobAppName,
 						rc: RuntimeConfig{
-							Image: &ECRImage{
-								ImageTag: testJobImageTag,
-								RepoURL:  testJobImageRepoURL,
+							Images: map[string]ECRImage{
+								"testServiceName": {
+									RepoURL:  testImageRepoURL,
+									ImageTag: testImageTag,
+								},
 							},
 							AccountID: "0123456789012",
 							Region:    "us-west-2",
@@ -523,9 +525,11 @@ func TestScheduledJob_Parameters(t *testing.T) {
 						env:  testEnvName,
 						app:  testAppName,
 						rc: RuntimeConfig{
-							Image: &ECRImage{
-								RepoURL:  testImageRepoURL,
-								ImageTag: testImageTag,
+							Images: map[string]ECRImage{
+								"frontend": {
+									RepoURL:  testImageRepoURL,
+									ImageTag: testImageTag,
+								},
 							},
 						},
 					},
@@ -565,9 +569,11 @@ func TestScheduledJob_SerializedParameters(t *testing.T) {
 				env:  testEnvName,
 				app:  testAppName,
 				rc: RuntimeConfig{
-					Image: &ECRImage{
-						RepoURL:  testImageRepoURL,
-						ImageTag: testImageTag,
+					Images: map[string]ECRImage{
+						aws.StringValue(testScheduledJobManifest.Name): {
+							RepoURL:  testImageRepoURL,
+							ImageTag: testImageTag,
+						},
 					},
 					AdditionalTags: map[string]string{
 						"owner": "boss",

--- a/internal/pkg/deploy/cloudformation/stack/stack_local_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/stack_local_integration_test.go
@@ -74,9 +74,11 @@ func Test_Stack_Local_Integration(t *testing.T) {
 		EnvManifest: envConfig,
 		Manifest:    v,
 		RuntimeConfig: stack.RuntimeConfig{
-			Image: &stack.ECRImage{
-				RepoURL:  imageURL,
-				ImageTag: imageTag,
+			Images: map[string]stack.ECRImage{
+				aws.StringValue(v.Name): {
+					RepoURL:  imageURL,
+					ImageTag: imageTag,
+				},
 			},
 			EnvVersion: "v1.42.0",
 		},

--- a/internal/pkg/deploy/cloudformation/stack/validate_template_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/validate_template_integration_test.go
@@ -56,9 +56,11 @@ func TestAutoscalingIntegration_Validate(t *testing.T) {
 		},
 		Manifest: v,
 		RuntimeConfig: stack.RuntimeConfig{
-			Image: &stack.ECRImage{
-				RepoURL:  imageURL,
-				ImageTag: imageTag,
+			Images: map[string]stack.ECRImage{
+				aws.StringValue(v.Name): {
+					RepoURL:  imageURL,
+					ImageTag: imageTag,
+				},
 			},
 			ServiceDiscoveryEndpoint: "test.app.local",
 			CustomResourcesURL: map[string]string{

--- a/internal/pkg/deploy/cloudformation/stack/worker_svc_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/worker_svc_test.go
@@ -210,9 +210,11 @@ Outputs:
 						env:  testEnvName,
 						app:  testAppName,
 						rc: RuntimeConfig{
-							Image: &ECRImage{
-								RepoURL:  testImageRepoURL,
-								ImageTag: testImageTag,
+							Images: map[string]ECRImage{
+								testServiceName: {
+									RepoURL:  testImageRepoURL,
+									ImageTag: testImageTag,
+								},
 							},
 							AccountID: "0123456789012",
 							Region:    "us-west-2",

--- a/internal/pkg/deploy/cloudformation/stack/workload.go
+++ b/internal/pkg/deploy/cloudformation/stack/workload.go
@@ -68,11 +68,11 @@ const (
 // RuntimeConfig represents configuration that's defined outside of the manifest file
 // that is needed to create a CloudFormation stack.
 type RuntimeConfig struct {
-	Image              *ECRImage         // Optional. Image location in an ECR repository.
-	AddonsTemplateURL  string            // Optional. S3 object URL for the addons template.
-	EnvFileARN         string            // Optional. S3 object ARN for the env file.
-	AdditionalTags     map[string]string // AdditionalTags are labels applied to resources in the workload stack.
-	CustomResourcesURL map[string]string // Mapping of Custom Resource Function Name to the S3 URL where the function zip file is stored.
+	Images             map[string]ECRImage // Optional. Image location in an ECR repository.
+	AddonsTemplateURL  string              // Optional. S3 object URL for the addons template.
+	EnvFileARN         string              // Optional. S3 object ARN for the env file.
+	AdditionalTags     map[string]string   // AdditionalTags are labels applied to resources in the workload stack.
+	CustomResourcesURL map[string]string   // Mapping of Custom Resource Function Name to the S3 URL where the function zip file is stored.
 
 	// The target environment metadata.
 	ServiceDiscoveryEndpoint string // Endpoint for the service discovery namespace in the environment.
@@ -156,8 +156,8 @@ func (w *wkld) Parameters() ([]*cloudformation.Parameter, error) {
 	if w.image != nil {
 		img = w.image.GetLocation()
 	}
-	if w.rc.Image != nil {
-		img = w.rc.Image.GetLocation()
+	if w.rc.Images != nil {
+		img = w.rc.Images[w.name].GetLocation()
 	}
 	return []*cloudformation.Parameter{
 		{
@@ -366,8 +366,8 @@ func (w *appRunnerWkld) Parameters() ([]*cloudformation.Parameter, error) {
 	if w.image != nil {
 		img = w.image.GetLocation()
 	}
-	if w.rc.Image != nil {
-		img = w.rc.Image.GetLocation()
+	if w.rc.Images != nil {
+		img = w.rc.Images[w.name].GetLocation()
 	}
 
 	imageRepositoryType, err := apprunner.DetermineImageRepositoryType(img)


### PR DESCRIPTION
<!-- Provide summary of changes -->
With This PR we convert the current stack package  
https://github.com/aws/copilot-cli/blob/mainline/internal/pkg/deploy/cloudformation/stack/workload.go#L69

into

```yaml
type RuntimeConfig struct {
   Images map[string]ECRImage // Optional. Image location in an ECR repository.
}
```
In this way we can use same struct `ECRImage` for both main and sidecar containers.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
