### PR TITLE
build: upgrade to go1.20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20
+          go-version: '1.20'
 
       - name: Set up Node
         uses: actions/setup-node@v1
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20
+          go-version: '1.20'
 
       - name: Set up Node
         uses: actions/setup-node@v1
@@ -71,7 +71,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20
+          go-version: '1.20'
 
       - name: Check out code
         uses: actions/checkout@v2
@@ -88,7 +88,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20
+          go-version: '1.20'
 
       - name: Check out code
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.20
 
       - name: Set up Node
         uses: actions/setup-node@v1
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.20
 
       - name: Set up Node
         uses: actions/setup-node@v1
@@ -71,7 +71,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.20
 
       - name: Check out code
         uses: actions/checkout@v2
@@ -88,7 +88,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.20
 
       - name: Check out code
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         command: [compile-linux, compile-windows, compile-darwin]
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.20
 
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.20
 
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.20
 
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.20
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.46.2
+          version: v1.51.2
           args: --timeout 5m0s
 
   license:

--- a/.github/workflows/ci_size_computer.yml
+++ b/.github/workflows/ci_size_computer.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20
+          go-version: '1.20'
 
       - name: Set up Node
         uses: actions/setup-node@v1

--- a/.github/workflows/ci_size_computer.yml
+++ b/.github/workflows/ci_size_computer.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.20
 
       - name: Set up Node
         uses: actions/setup-node@v1

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.20
 
       - name: Set up Node
         uses: actions/setup-node@v1

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20
+          go-version: '1.20'
 
       - name: Set up Node
         uses: actions/setup-node@v1

--- a/.release/buildspec.yml
+++ b/.release/buildspec.yml
@@ -6,8 +6,8 @@ phases:
       nodejs: 16
     commands:
       - 'cd $HOME/.goenv && git pull --ff-only && cd -'
-      - 'goenv install 1.18.4' # Check if a version is available: https://github.com/syndbg/goenv/tree/master/plugins/go-build/share/go-build
-      - 'goenv global 1.18.4'
+      - 'goenv install 1.20.1' # Check if a version is available: https://github.com/syndbg/goenv/tree/master/plugins/go-build/share/go-build
+      - 'goenv global 1.20.1'
   pre_build:
     commands:
       - echo "cd into $CODEBUILD_SRC_DIR"

--- a/.release/buildspec_e2e.yml
+++ b/.release/buildspec_e2e.yml
@@ -166,8 +166,8 @@ phases:
       nodejs: 16
     commands:
       - "cd $HOME/.goenv && git pull --ff-only && cd -"
-      - "goenv install 1.18.4"
-      - "goenv global 1.18.4"
+      - "goenv install 1.20.1"
+      - "goenv global 1.20.1"
   pre_build:
     commands:
       - printenv DOCKERHUB_TOKEN | docker login --username ${DOCKERHUB_USERNAME} --password-stdin

--- a/.release/buildspec_integ.yml
+++ b/.release/buildspec_integ.yml
@@ -15,8 +15,8 @@ phases:
       nodejs: 16
     commands:
       - 'cd $HOME/.goenv && git pull --ff-only && cd -'
-      - 'goenv install 1.18.4'
-      - 'goenv global 1.18.4'
+      - 'goenv install 1.20.1'
+      - 'goenv global 1.20.1'
   build:
     commands:
       - echo `git rev-parse HEAD` # Do not delete; for pipeline logging purposes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Please read it over and let us know if it's not up-to-date (or, even better, sub
 
 ### Environment
 
-- Make sure you are using Go 1.18 (`go version`).
+- Make sure you are using Go 1.20 (`go version`).
 - Fork the repository.
 - Clone your forked repository locally.
 - We use Go Modules to manage dependencies, so you can develop outside of your $GOPATH.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18
+FROM golang:1.20
 # We need to have both nodejs and go to build the binaries.
 # We could use multi-stage builds but that would require significantly changing our Makefile.
 RUN apt-get update

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker:20.10.13-dind
 
-ARG GOLANG_VERSION=1.18
+ARG GOLANG_VERSION=1.20
 
 # Docker needs somewhere to put creds from docker login.
 RUN wget https://github.com/docker/docker-credential-helpers/releases/download/v0.6.0/docker-credential-pass-v0.6.0-amd64.tar.gz && tar -xf docker-credential-pass-v0.6.0-amd64.tar.gz && chmod +x docker-credential-pass &&  mv docker-credential-pass /bin

--- a/e2e/apprunner/back-end/Dockerfile
+++ b/e2e/apprunner/back-end/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/golang:1.19 as builder
+FROM public.ecr.aws/docker/library/golang:1.20 as builder
 
 ENV GOPROXY=direct
 WORKDIR /go/src/app

--- a/e2e/apprunner/back-end/go.mod
+++ b/e2e/apprunner/back-end/go.mod
@@ -1,3 +1,3 @@
 module github.com/aws/copilot-cli/e2e/appprunner/back-end
 
-go 1.19
+go 1.20

--- a/e2e/apprunner/front-end/Dockerfile
+++ b/e2e/apprunner/front-end/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/golang:1.19 as builder
+FROM public.ecr.aws/docker/library/golang:1.20 as builder
 
 ENV GOPROXY=direct
 WORKDIR /go/src/app

--- a/e2e/apprunner/front-end/go.mod
+++ b/e2e/apprunner/front-end/go.mod
@@ -1,3 +1,3 @@
 module github.com/aws/copilot-cli/e2e/apprunner/front-end
 
-go 1.19
+go 1.20

--- a/e2e/apprunner/front-end/main.go
+++ b/e2e/apprunner/front-end/main.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -53,7 +53,7 @@ func ProxyRequest(w http.ResponseWriter, r *http.Request) {
 	defer resp.Body.Close()
 	log.Println("Did request")
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		handleErr("read response: %s", err)
 		return

--- a/e2e/exec/exec_test.go
+++ b/e2e/exec/exec_test.go
@@ -5,7 +5,7 @@ package exec_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -169,7 +169,7 @@ var _ = Describe("exec flow", func() {
 			}, "60s", "1s").Should(Equal(200))
 			// Read the response - our deployed service should return a body with its
 			// name as the value.
-			bodyBytes, err := ioutil.ReadAll(resp.Body)
+			bodyBytes, err := io.ReadAll(resp.Body)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(bodyBytes)).To(Equal(svcName))
 		})
@@ -219,7 +219,7 @@ var _ = Describe("exec flow", func() {
 				}, "60s", "1s").Should(Equal(200))
 				// Our deployed service should return a body with the new content
 				// as the value.
-				bodyBytes, err := ioutil.ReadAll(resp.Body)
+				bodyBytes, err := io.ReadAll(resp.Body)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(strings.TrimSpace(string(bodyBytes))).To(Equal(newContent))
 				time.Sleep(3 * time.Second)

--- a/e2e/multi-svc-app/front-end/main.go
+++ b/e2e/multi-svc-app/front-end/main.go
@@ -6,7 +6,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -53,7 +53,7 @@ func ServiceGet(w http.ResponseWriter, req *http.Request, ps httprouter.Params) 
 	}
 	log.Println("Get on service discovery endpoint Succeeded")
 	defer resp.Body.Close()
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, _ := io.ReadAll(resp.Body)
 	w.WriteHeader(http.StatusOK)
 	w.Write(body)
 }

--- a/e2e/multi-svc-app/multi_svc_app_test.go
+++ b/e2e/multi-svc-app/multi_svc_app_test.go
@@ -5,7 +5,7 @@ package multi_svc_app_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -258,7 +258,7 @@ var _ = Describe("Multiple Service App", func() {
 
 				// Read the response - our deployed apps should return a body with their
 				// name as the value.
-				bodyBytes, err := ioutil.ReadAll(resp.Body)
+				bodyBytes, err := io.ReadAll(resp.Body)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(bodyBytes)).To(Equal(svcName))
 			}
@@ -333,7 +333,7 @@ var _ = Describe("Multiple Service App", func() {
 
 			// Read the response - our deployed apps should return a body with their
 			// name as the value.
-			bodyBytes, err := ioutil.ReadAll(resp.Body)
+			bodyBytes, err := io.ReadAll(resp.Body)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(bodyBytes)).To(Equal("back-end-service"))
 		})
@@ -376,7 +376,7 @@ var _ = Describe("Multiple Service App", func() {
 				if fetchErr != nil {
 					return "", fetchErr
 				}
-				bodyBytes, err := ioutil.ReadAll(resp.Body)
+				bodyBytes, err := io.ReadAll(resp.Body)
 				if err != nil {
 					return "", err
 				}
@@ -407,7 +407,7 @@ var _ = Describe("Multiple Service App", func() {
 
 			// Read the response - successfully overridden build arg will result
 			// in a response of "open sesame"
-			bodyBytes, err := ioutil.ReadAll(resp.Body)
+			bodyBytes, err := io.ReadAll(resp.Body)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(bodyBytes)).To(Equal("open sesame"))
 		})

--- a/e2e/sidecars/sidecars_test.go
+++ b/e2e/sidecars/sidecars_test.go
@@ -6,7 +6,6 @@ package sidecars_test
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"os"
@@ -192,14 +191,14 @@ var _ = Describe("sidecars flow", func() {
 		It("overwrite existing manifest", func() {
 			logGroupName := fmt.Sprintf("%s-test-%s", appName, svcName)
 			newManifest = fmt.Sprintf(manifest, sidecarImageURI, nginxPort, logGroupName)
-			err := ioutil.WriteFile("./copilot/hello/manifest.yml", []byte(newManifest), 0644)
+			err := os.WriteFile("./copilot/hello/manifest.yml", []byte(newManifest), 0644)
 			Expect(err).NotTo(HaveOccurred(), "overwrite manifest")
 		})
 		It("add addons folder for Firelens permissions", func() {
 			err := os.MkdirAll("./copilot/hello/addons", 0777)
 			Expect(err).NotTo(HaveOccurred(), "create addons dir")
 
-			fds, err := ioutil.ReadDir("./hello/addons")
+			fds, err := os.ReadDir("./hello/addons")
 			Expect(err).NotTo(HaveOccurred(), "read addons dir")
 
 			for _, fd := range fds {
@@ -256,7 +255,7 @@ var _ = Describe("sidecars flow", func() {
 
 			// Read the response - our deployed apps should return a body with their
 			// name as the value.
-			bodyBytes, err := ioutil.ReadAll(resp.Body)
+			bodyBytes, err := io.ReadAll(resp.Body)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(bodyBytes)).To(Equal("Ready"))
 		})

--- a/e2e/worker/worker_test.go
+++ b/e2e/worker/worker_test.go
@@ -6,7 +6,7 @@ package worker_test
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strconv"
@@ -222,7 +222,7 @@ publish:
 					return fmt.Errorf("response status is %d and not %d", resp.StatusCode, http.StatusOK)
 				}
 
-				body, err := ioutil.ReadAll(resp.Body)
+				body, err := io.ReadAll(resp.Body)
 				if err != nil {
 					return err
 				}
@@ -254,7 +254,7 @@ publish:
 					return fmt.Errorf("response status is %d and not %d", resp.StatusCode, http.StatusOK)
 				}
 
-				body, err := ioutil.ReadAll(resp.Body)
+				body, err := io.ReadAll(resp.Body)
 				if err != nil {
 					return err
 				}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/copilot-cli
 
-go 1.18
+go 1.20
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.2

--- a/internal/pkg/cli/svc_exec.go
+++ b/internal/pkg/cli/svc_exec.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"math/rand"
 	"strings"
-	"time"
 
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/aws/copilot-cli/internal/pkg/aws/identity"
@@ -82,7 +81,6 @@ func newSvcExecOpts(vars execVars) (*svcExecOpts, error) {
 			return awsecs.New(s)
 		},
 		randInt: func(x int) int {
-			rand.Seed(time.Now().Unix())
 			return rand.Intn(x)
 		},
 		ssmPluginManager: exec.NewSSMPluginCommand(nil),

--- a/internal/pkg/deploy/cloudformation/stack/backend_svc_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/backend_svc_integration_test.go
@@ -8,7 +8,7 @@ package stack_test
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -74,11 +74,11 @@ func TestBackendService_TemplateAndParamsGeneration(t *testing.T) {
 			defer ctrl.Finish()
 
 			// parse files
-			manifestBytes, err := ioutil.ReadFile(tc.ManifestPath)
+			manifestBytes, err := os.ReadFile(tc.ManifestPath)
 			require.NoError(t, err)
-			tmplBytes, err := ioutil.ReadFile(tc.TemplatePath)
+			tmplBytes, err := os.ReadFile(tc.TemplatePath)
 			require.NoError(t, err)
-			paramsBytes, err := ioutil.ReadFile(tc.ParamsPath)
+			paramsBytes, err := os.ReadFile(tc.ParamsPath)
 			require.NoError(t, err)
 
 			dynamicMft, err := manifest.UnmarshalWorkload([]byte(manifestBytes))

--- a/internal/pkg/exec/ssm_plugin_install_latest_binary_linux.go
+++ b/internal/pkg/exec/ssm_plugin_install_latest_binary_linux.go
@@ -6,7 +6,6 @@ package exec
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,7 +14,7 @@ import (
 // InstallLatestBinary installs the latest ssm plugin.
 func (s SSMPluginCommand) InstallLatestBinary() error {
 	if s.tempDir == "" {
-		dir, err := ioutil.TempDir("", "ssmplugin")
+		dir, err := os.MkdirTemp("", "ssmplugin")
 		if err != nil {
 			return fmt.Errorf("create a temporary directory: %w", err)
 		}

--- a/internal/pkg/exec/ssm_plugin_install_latest_binary_linux_test.go
+++ b/internal/pkg/exec/ssm_plugin_install_latest_binary_linux_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -77,7 +76,7 @@ func TestSSMPluginCommand_InstallLatestBinary_linux(t *testing.T) {
 		},
 	}
 	for name, tc := range tests {
-		mockDir, _ = ioutil.TempDir("", "temp")
+		mockDir, _ = os.MkdirTemp("", "temp")
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			tc.setupMocks(ctrl)

--- a/regression/multi-svc-app/multi_svc_app_test.go
+++ b/regression/multi-svc-app/multi_svc_app_test.go
@@ -5,9 +5,9 @@ package multi_svc_app_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
+	"io"
 	"path/filepath"
 
 	"github.com/aws/copilot-cli/regression/client"
@@ -63,7 +63,7 @@ var _ = Describe("regression", func() {
 				}, "60s", "1s").Should(Equal(200))
 
 				By("Having their names as the value in response body")
-				bodyBytes, err := ioutil.ReadAll(resp.Body)
+				bodyBytes, err := io.ReadAll(resp.Body)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(bodyBytes)).To(Equal(expectedWorkloadResponse[svcName]))
 			}
@@ -86,7 +86,7 @@ var _ = Describe("regression", func() {
 			Expect(resp.StatusCode).To(Equal(200))
 
 			By("Getting the expected response body")
-			bodyBytes, err := ioutil.ReadAll(resp.Body)
+			bodyBytes, err := io.ReadAll(resp.Body)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(bodyBytes)).To(Equal(expectedWorkloadResponse["back-end-service-discovery"]))
 
@@ -101,7 +101,7 @@ var _ = Describe("regression", func() {
 				if fetchErr != nil {
 					return "", fetchErr
 				}
-				bodyBytes, err := ioutil.ReadAll(resp.Body)
+				bodyBytes, err := io.ReadAll(resp.Body)
 				if err != nil {
 					return "", err
 				}


### PR DESCRIPTION
Release note for go v1.20: https://tip.golang.org/doc/go1.20

This PR does a bunch of things:
1. Upgrade go v1.20
2. Bump the GitHub action `setup-go` from `@v2` to `@v3`
3. This also requires us to bump the `golangci-lint` version in the GitHub action from `1.46` to `1.52`
4. `rand.Seed` is deprecated in v1.20 so this is fixed.
5. The lint at `1.52` treats linter issue that is *not* in the build tag as fatal.  Therefore the linter issue in the e2e tests need to be fixed now. So they are fixed. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
