### PR TITLE
refactor(selector): expose Prompter interface

### DIFF
--- a/internal/pkg/term/selector/creds.go
+++ b/internal/pkg/term/selector/creds.go
@@ -33,7 +33,7 @@ type SessionProvider interface {
 
 // CredsSelect prompts users for credentials.
 type CredsSelect struct {
-	Prompt  prompter
+	Prompt  Prompter
 	Profile Names
 	Session SessionProvider
 }

--- a/internal/pkg/term/selector/ec2.go
+++ b/internal/pkg/term/selector/ec2.go
@@ -20,12 +20,12 @@ type VPCSubnetLister interface {
 
 // EC2Select is a selector for Ec2 resources.
 type EC2Select struct {
-	prompt prompter
+	prompt Prompter
 	ec2Svc VPCSubnetLister
 }
 
 // NewEC2Select returns a new selector that chooses Ec2 resources.
-func NewEC2Select(prompt prompter, ec2Client VPCSubnetLister) *EC2Select {
+func NewEC2Select(prompt Prompter, ec2Client VPCSubnetLister) *EC2Select {
 	return &EC2Select{
 		prompt: prompt,
 		ec2Svc: ec2Client,

--- a/internal/pkg/term/selector/local_selector.go
+++ b/internal/pkg/term/selector/local_selector.go
@@ -23,11 +23,11 @@ const (
 
 // staticSelector selects from a list of static options.
 type staticSelector struct {
-	prompt prompter
+	prompt Prompter
 }
 
 // NewStaticSelector constructs a staticSelector.
-func NewStaticSelector(prompt prompter) *staticSelector {
+func NewStaticSelector(prompt Prompter) *staticSelector {
 	return &staticSelector{
 		prompt: prompt,
 	}
@@ -127,13 +127,13 @@ func (s *staticSelector) askCron(scheduleValidator prompt.ValidatorFunc) (string
 
 // localFileSelector selects from a local file system where a workspace does not necessarily exist.
 type localFileSelector struct {
-	prompt        prompter
+	prompt        Prompter
 	fs            *afero.Afero
 	workingDirAbs string
 }
 
 // NewLocalFileSelector constructs a localFileSelector.
-func NewLocalFileSelector(prompt prompter, fs afero.Fs) (*localFileSelector, error) {
+func NewLocalFileSelector(prompt Prompter, fs afero.Fs) (*localFileSelector, error) {
 	workingDirAbs, err := os.Getwd()
 	if err != nil {
 		return nil, fmt.Errorf("get working directory: %w", err)

--- a/internal/pkg/term/selector/selector.go
+++ b/internal/pkg/term/selector/selector.go
@@ -91,8 +91,8 @@ var presetSchedules = []prompt.Option{
 	{Value: yearly, Hint: "At midnight, Jan 1st UTC"},
 }
 
-// prompter wraps the methods to ask for inputs from the terminal.
-type prompter interface {
+// Prompter wraps the methods to ask for inputs from the terminal.
+type Prompter interface {
 	Get(message, help string, validator prompt.ValidatorFunc, promptOpts ...prompt.PromptConfig) (string, error)
 	SelectOne(message, help string, options []string, promptOpts ...prompt.PromptConfig) (string, error)
 	SelectOption(message, help string, opts []prompt.Option, promptCfgs ...prompt.PromptConfig) (value string, err error)
@@ -165,7 +165,7 @@ type taskLister interface {
 
 // AppEnvSelector prompts users to select the name of an application or environment.
 type AppEnvSelector struct {
-	prompt       prompter
+	prompt       Prompter
 	appEnvLister appEnvLister
 }
 
@@ -189,19 +189,19 @@ type LocalEnvironmentSelector struct {
 
 // WorkspaceSelector selects from local workspace.
 type WorkspaceSelector struct {
-	prompt prompter
+	prompt Prompter
 	ws     workspaceRetriever
 }
 
 // WsPipelineSelector is a workspace pipeline selector.
 type WsPipelineSelector struct {
-	prompt prompter
+	prompt Prompter
 	ws     wsPipelinesLister
 }
 
 // CodePipelineSelector is a selector for deployed pipelines.
 type CodePipelineSelector struct {
-	prompt         prompter
+	prompt         Prompter
 	pipelineLister codePipelineLister
 }
 
@@ -230,7 +230,7 @@ type CFTaskSelector struct {
 }
 
 // NewCFTaskSelect constructs a CFTaskSelector.
-func NewCFTaskSelect(prompt prompter, store configLister, cf taskStackDescriber) *CFTaskSelector {
+func NewCFTaskSelect(prompt Prompter, store configLister, cf taskStackDescriber) *CFTaskSelector {
 	return &CFTaskSelector{
 		AppEnvSelector: NewAppEnvSelector(prompt, store),
 		cfStore:        cf,
@@ -257,7 +257,7 @@ func TaskWithDefaultCluster() GetDeployedTaskOpts {
 
 // TaskSelector is a Copilot running task selector.
 type TaskSelector struct {
-	prompt         prompter
+	prompt         Prompter
 	lister         taskLister
 	app            string
 	env            string
@@ -267,7 +267,7 @@ type TaskSelector struct {
 }
 
 // NewAppEnvSelector returns a selector that chooses applications or environments.
-func NewAppEnvSelector(prompt prompter, store appEnvLister) *AppEnvSelector {
+func NewAppEnvSelector(prompt Prompter, store appEnvLister) *AppEnvSelector {
 	return &AppEnvSelector{
 		prompt:       prompt,
 		appEnvLister: store,
@@ -275,7 +275,7 @@ func NewAppEnvSelector(prompt prompter, store appEnvLister) *AppEnvSelector {
 }
 
 // NewConfigSelector returns a new selector that chooses applications, environments, or services from the config store.
-func NewConfigSelector(prompt prompter, store configLister) *ConfigSelector {
+func NewConfigSelector(prompt Prompter, store configLister) *ConfigSelector {
 	return &ConfigSelector{
 		AppEnvSelector: NewAppEnvSelector(prompt, store),
 		workloadLister: store,
@@ -284,7 +284,7 @@ func NewConfigSelector(prompt prompter, store configLister) *ConfigSelector {
 
 // NewLocalWorkloadSelector returns a new selector that chooses applications and environments from the config store, but
 // services from the local workspace.
-func NewLocalWorkloadSelector(prompt prompter, store configLister, ws workspaceRetriever) *LocalWorkloadSelector {
+func NewLocalWorkloadSelector(prompt Prompter, store configLister, ws workspaceRetriever) *LocalWorkloadSelector {
 	return &LocalWorkloadSelector{
 		ConfigSelector: NewConfigSelector(prompt, store),
 		ws:             ws,
@@ -293,7 +293,7 @@ func NewLocalWorkloadSelector(prompt prompter, store configLister, ws workspaceR
 
 // NewLocalEnvironmentSelector returns a new selector that chooses applications from the config store, but an environment
 // from the local workspace.
-func NewLocalEnvironmentSelector(prompt prompter, store configLister, ws workspaceRetriever) *LocalEnvironmentSelector {
+func NewLocalEnvironmentSelector(prompt Prompter, store configLister, ws workspaceRetriever) *LocalEnvironmentSelector {
 	return &LocalEnvironmentSelector{
 		AppEnvSelector: NewAppEnvSelector(prompt, store),
 		ws:             ws,
@@ -301,7 +301,7 @@ func NewLocalEnvironmentSelector(prompt prompter, store configLister, ws workspa
 }
 
 // NewWorkspaceSelector returns a new selector that prompts for local information.
-func NewWorkspaceSelector(prompt prompter, ws workspaceRetriever) *WorkspaceSelector {
+func NewWorkspaceSelector(prompt Prompter, ws workspaceRetriever) *WorkspaceSelector {
 	return &WorkspaceSelector{
 		prompt: prompt,
 		ws:     ws,
@@ -309,7 +309,7 @@ func NewWorkspaceSelector(prompt prompter, ws workspaceRetriever) *WorkspaceSele
 }
 
 // NewWsPipelineSelector returns a new selector with pipelines from the local workspace.
-func NewWsPipelineSelector(prompt prompter, ws wsPipelinesLister) *WsPipelineSelector {
+func NewWsPipelineSelector(prompt Prompter, ws wsPipelinesLister) *WsPipelineSelector {
 	return &WsPipelineSelector{
 		prompt: prompt,
 		ws:     ws,
@@ -317,7 +317,7 @@ func NewWsPipelineSelector(prompt prompter, ws wsPipelinesLister) *WsPipelineSel
 }
 
 // NewAppPipelineSelector returns new selectors with deployed pipelines and apps.
-func NewAppPipelineSelector(prompt prompter, store configLister, lister codePipelineLister) *AppPipelineSelector {
+func NewAppPipelineSelector(prompt Prompter, store configLister, lister codePipelineLister) *AppPipelineSelector {
 	return &AppPipelineSelector{
 		AppEnvSelector: NewAppEnvSelector(prompt, store),
 		CodePipelineSelector: &CodePipelineSelector{
@@ -328,7 +328,7 @@ func NewAppPipelineSelector(prompt prompter, store configLister, lister codePipe
 }
 
 // NewDeploySelect returns a new selector that chooses services and environments from the deploy store.
-func NewDeploySelect(prompt prompter, configStore configLister, deployStore deployedWorkloadsRetriever) *DeploySelector {
+func NewDeploySelect(prompt Prompter, configStore configLister, deployStore deployedWorkloadsRetriever) *DeploySelector {
 	return &DeploySelector{
 		ConfigSelector: NewConfigSelector(prompt, configStore),
 		deployStoreSvc: deployStore,
@@ -336,7 +336,7 @@ func NewDeploySelect(prompt prompter, configStore configLister, deployStore depl
 }
 
 // NewTaskSelector returns a new selector that chooses a running task.
-func NewTaskSelector(prompt prompter, lister taskLister) *TaskSelector {
+func NewTaskSelector(prompt Prompter, lister taskLister) *TaskSelector {
 	return &TaskSelector{
 		prompt: prompt,
 		lister: lister,


### PR DESCRIPTION
The interface is an input in our constructors, making it public.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
