### PR TITLE
test(e2e): upgrade all e2e test suites to use go1.20

### DIFF
--- a/e2e/isolated/backend/Dockerfile
+++ b/e2e/isolated/backend/Dockerfile
@@ -1,6 +1,6 @@
 # We specify the base image we need for our
 # go application
-FROM golang:1.15 AS builder
+FROM public.ecr.aws/docker/library/golang:1.20 as builder
 # We create an /app directory within our
 # image that will hold our application source
 # files

--- a/e2e/isolated/backend/go.mod
+++ b/e2e/isolated/backend/go.mod
@@ -1,5 +1,5 @@
 module github.com/aws/copilot-cli/e2e/isolated/back-end
 
-go 1.15
+go 1.20
 
 require github.com/julienschmidt/httprouter v1.3.0

--- a/e2e/multi-svc-app/back-end/Dockerfile
+++ b/e2e/multi-svc-app/back-end/Dockerfile
@@ -1,6 +1,6 @@
 # We specify the base image we need for our
 # go application
-FROM golang:1.15 AS builder
+FROM public.ecr.aws/docker/library/golang:1.20 as builder
 # We create an /app directory within our
 # image that will hold our application source
 # files

--- a/e2e/multi-svc-app/back-end/go.mod
+++ b/e2e/multi-svc-app/back-end/go.mod
@@ -1,5 +1,5 @@
 module github.com/aws/copilot-cli/e2e/multi-app-project/back-end
 
-go 1.15
+go 1.20
 
 require github.com/julienschmidt/httprouter v1.3.0 // indirect

--- a/e2e/multi-svc-app/front-end/Dockerfile
+++ b/e2e/multi-svc-app/front-end/Dockerfile
@@ -1,6 +1,6 @@
 # We specify the base image we need for our
 # go application
-FROM golang:1.15 AS builder
+FROM public.ecr.aws/docker/library/golang:1.20 as builder
 # We create an /app directory within our
 # image that will hold our application source
 # files

--- a/e2e/multi-svc-app/front-end/go.mod
+++ b/e2e/multi-svc-app/front-end/go.mod
@@ -1,5 +1,5 @@
 module github.com/aws/copilot-cli/e2e/multi-app-project/front-end
 
-go 1.15
+go 1.20
 
 require github.com/julienschmidt/httprouter v1.3.0

--- a/e2e/multi-svc-app/www/Dockerfile
+++ b/e2e/multi-svc-app/www/Dockerfile
@@ -1,6 +1,6 @@
 # We specify the base image we need for our
 # go application
-FROM golang:1.15 AS builder
+FROM public.ecr.aws/docker/library/golang:1.20 as builder
 # We create an /app directory within our
 # image that will hold our application source
 # files

--- a/e2e/multi-svc-app/www/go.mod
+++ b/e2e/multi-svc-app/www/go.mod
@@ -1,5 +1,5 @@
 module github.com/aws/copilot-cli/e2e/multi-app-project/www
 
-go 1.15
+go 1.20
 
 require github.com/julienschmidt/httprouter v1.3.0


### PR DESCRIPTION
and 🤞🏼 should be all

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
