### PR TITLE
fix(template): disassociate abr when delete

### DIFF
--- a/internal/pkg/aws/cloudformation/testdata/parse/lb-web-svc.yaml
+++ b/internal/pkg/aws/cloudformation/testdata/parse/lb-web-svc.yaml
@@ -140,6 +140,10 @@ Resources:
       DeploymentConfiguration:
         MinimumHealthyPercent: 100
         MaximumPercent: 200
+        Alarms:
+          AlarmNames: []
+          Enable: false
+          Rollback: true
       # This may need to be adjusted if the container takes a while to start up
       HealthCheckGracePeriodSeconds: 60
       LoadBalancers:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/http-autoscaling-template.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/http-autoscaling-template.yml
@@ -407,6 +407,10 @@ Resources:
           Rollback: true
         MinimumHealthyPercent: 100
         MaximumPercent: 200
+        Alarms:
+          AlarmNames: []
+          Enable: false
+          Rollback: true
       PropagateTags: SERVICE
       EnableExecuteCommand: true
       LaunchType: FARGATE

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/http-full-config-template.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/http-full-config-template.yml
@@ -287,6 +287,10 @@ Resources:
           Rollback: true
         MinimumHealthyPercent: 100
         MaximumPercent: 200
+        Alarms:
+          AlarmNames: []
+          Enable: false
+          Rollback: true
       PropagateTags: SERVICE
       EnableExecuteCommand: true
       LaunchType: FARGATE

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/http-only-path-template.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/http-only-path-template.yml
@@ -285,6 +285,10 @@ Resources:
           Rollback: true
         MinimumHealthyPercent: 100
         MaximumPercent: 200
+        Alarms:
+          AlarmNames: []
+          Enable: false
+          Rollback: true
       PropagateTags: SERVICE
       EnableExecuteCommand: true
       LaunchType: FARGATE

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/https-path-alias-template.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/https-path-alias-template.yml
@@ -391,6 +391,10 @@ Resources:
           Rollback: true
         MinimumHealthyPercent: 100
         MaximumPercent: 200
+        Alarms:
+          AlarmNames: []
+          Enable: false
+          Rollback: true
       PropagateTags: SERVICE
       EnableExecuteCommand: true
       LaunchType: FARGATE

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/simple-template-without-port-config.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/simple-template-without-port-config.yml
@@ -272,6 +272,10 @@ Resources:
           Rollback: true
         MinimumHealthyPercent: 100
         MaximumPercent: 200
+        Alarms:
+          AlarmNames: []
+          Enable: false
+          Rollback: true
       PropagateTags: SERVICE
       EnableExecuteCommand: true
       LaunchType: FARGATE

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/simple-template.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/simple-template.yml
@@ -275,6 +275,10 @@ Resources:
           Rollback: true
         MinimumHealthyPercent: 100
         MaximumPercent: 200
+        Alarms:
+          AlarmNames: []
+          Enable: false
+          Rollback: true
       PropagateTags: SERVICE
       EnableExecuteCommand: true
       LaunchType: FARGATE

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-grpc-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-grpc-test.stack.yml
@@ -430,6 +430,10 @@ Resources: # If a bucket URL is specified, that means the template exists.
           Rollback: true
         MinimumHealthyPercent: 100
         MaximumPercent: 200
+        Alarms:
+          AlarmNames: []
+          Enable: false
+          Rollback: true
       PropagateTags: SERVICE
       LaunchType: FARGATE
       ServiceConnectConfiguration: !If

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-dev.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-dev.stack.yml
@@ -308,6 +308,10 @@ Resources: # If a bucket URL is specified, that means the template exists.
           Rollback: true
         MinimumHealthyPercent: 100
         MaximumPercent: 200
+        Alarms:
+          AlarmNames: []
+          Enable: false
+          Rollback: true
       PropagateTags: SERVICE
       ServiceConnectConfiguration: !If
         - IsGovCloud

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-prod.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-prod.stack.yml
@@ -315,6 +315,10 @@ Resources: # If a bucket URL is specified, that means the template exists.
           Rollback: true
         MinimumHealthyPercent: 100
         MaximumPercent: 200
+        Alarms:
+          AlarmNames: []
+          Enable: false
+          Rollback: true
       PropagateTags: SERVICE
       LaunchType: FARGATE
       ServiceConnectConfiguration: !If

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-test.stack.yml
@@ -295,6 +295,10 @@ Resources: # If a bucket URL is specified, that means the template exists.
           Rollback: true
         MinimumHealthyPercent: 100
         MaximumPercent: 200
+        Alarms:
+          AlarmNames: []
+          Enable: false
+          Rollback: true
       PropagateTags: SERVICE
       LaunchType: FARGATE
       ServiceConnectConfiguration:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-prod.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-prod.stack.yml
@@ -551,6 +551,10 @@ Resources: # If a bucket URL is specified, that means the template exists.
           Rollback: true
         MinimumHealthyPercent: 100
         MaximumPercent: 200
+        Alarms:
+          AlarmNames: []
+          Enable: false
+          Rollback: true
       PropagateTags: SERVICE
       CapacityProviderStrategy:
         - CapacityProvider: FARGATE_SPOT

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-staging.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-staging.stack.yml
@@ -320,6 +320,10 @@ Resources: # If a bucket URL is specified, that means the template exists.
           Rollback: true
         MinimumHealthyPercent: 100
         MaximumPercent: 200
+        Alarms:
+          AlarmNames: []
+          Enable: false
+          Rollback: true
       PropagateTags: SERVICE
       ServiceConnectConfiguration: !If
         - IsGovCloud

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-test.stack.yml
@@ -431,6 +431,10 @@ Resources: # If a bucket URL is specified, that means the template exists.
           Rollback: true
         MinimumHealthyPercent: 100
         MaximumPercent: 200
+        Alarms:
+          AlarmNames: []
+          Enable: false
+          Rollback: true
       PropagateTags: SERVICE
       LaunchType: FARGATE
       ServiceConnectConfiguration: !If

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/windows-svc-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/windows-svc-test.stack.yml
@@ -300,6 +300,10 @@ Resources: # If a bucket URL is specified, that means the template exists.
           Rollback: true
         MinimumHealthyPercent: 100
         MaximumPercent: 200
+        Alarms:
+          AlarmNames: []
+          Enable: false
+          Rollback: true
       PropagateTags: SERVICE
       ServiceConnectConfiguration: !If
         - IsGovCloud

--- a/internal/pkg/template/templates/workloads/partials/cf/service-base-properties.yml
+++ b/internal/pkg/template/templates/workloads/partials/cf/service-base-properties.yml
@@ -16,8 +16,8 @@ DeploymentConfiguration:
     Rollback: true
   MinimumHealthyPercent: {{ .DeploymentConfiguration.MinHealthyPercent }}
   MaximumPercent: {{ .DeploymentConfiguration.MaxPercent }}
-  {{- if .DeploymentConfiguration.Rollback.HasRollbackAlarms }}
   Alarms:
+  {{- if .DeploymentConfiguration.Rollback.HasRollbackAlarms }}
     {{- if .DeploymentConfiguration.Rollback.AlarmNames }}
     AlarmNames: {{ fmtSlice (quoteSlice .DeploymentConfiguration.Rollback.AlarmNames) }}
     {{- else if .DeploymentConfiguration.Rollback.HasCustomAlarms }}
@@ -33,8 +33,11 @@ DeploymentConfiguration:
       {{- end }}
     {{- end }}
     Enable: true
+  {{- else }}
+    AlarmNames: []
+    Enable: false
+  {{- end}}
     Rollback: true
-  {{- end }}
 PropagateTags: SERVICE
 {{- if .ExecuteCommand }}
 EnableExecuteCommand: true


### PR DESCRIPTION
<!-- Provide summary of changes -->
This PR fixes a bug that when users remove ABR from their manifests and run `svc deploy`, the alarms will not be disassociated from the services. Also, `svc deploy` to remove ABR will fail if the alarm is currently in `ALARM` state.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
