### PR TITLE
test(e2e): add exec suite manifest back

### DIFF
--- a/e2e/exec/copilot/hello/manifest.yml
+++ b/e2e/exec/copilot/hello/manifest.yml
@@ -1,0 +1,16 @@
+# We're creating the manifest ahead of time as we want to test the service with a count > 1.
+name: hello
+type: Load Balanced Web Service
+image:
+  build: 
+    dockerfile: hello/Dockerfile
+    context: hello
+  port: 80
+
+http:
+  path: '/'
+
+cpu: 256
+memory: 512
+count: 2
+exec: true


### PR DESCRIPTION
<!-- Provide summary of changes -->
As the comment says `# We're creating the manifest ahead of time as we want to test the service with a count > 1.`
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
