### PR TITLE
chore: keep `http.path: '/'` for LBWS in apps with domain

### DIFF
--- a/internal/pkg/initialize/workload_test.go
+++ b/internal/pkg/initialize/workload_test.go
@@ -246,6 +246,7 @@ func TestAppInitOpts_createLoadBalancedAppManifest(t *testing.T) {
 		inSvcName        string
 		inDockerfilePath string
 		inAppName        string
+		inAppDomain      string
 		mockstore        func(m *mocks.MockStore)
 
 		wantedErr  error
@@ -280,7 +281,7 @@ func TestAppInitOpts_createLoadBalancedAppManifest(t *testing.T) {
 
 			wantedPath: "/",
 		},
-		"creates manifest with / as the path when it's the only LBWebApp": {
+		"creates manifest with / as the path when it's the only LBWebService": {
 			inAppName:        "app",
 			inSvcName:        "frontend",
 			inSvcPort:        80,
@@ -297,7 +298,7 @@ func TestAppInitOpts_createLoadBalancedAppManifest(t *testing.T) {
 
 			wantedPath: "/",
 		},
-		"creates manifest with {app name} as the path if there's another LBWebApp": {
+		"creates manifest with {service name} as the path if there's another LBWebService": {
 			inAppName:        "app",
 			inSvcName:        "frontend",
 			inSvcPort:        80,
@@ -306,13 +307,31 @@ func TestAppInitOpts_createLoadBalancedAppManifest(t *testing.T) {
 			mockstore: func(m *mocks.MockStore) {
 				m.EXPECT().ListServices("app").Return([]*config.Workload{
 					{
-						Name: "another-app",
+						Name: "admin",
 						Type: manifestinfo.LoadBalancedWebServiceType,
 					},
 				}, nil)
 			},
 
 			wantedPath: "frontend",
+		},
+		"creates manifest with root path if the application is initialized with a domain": {
+			inAppName:        "app",
+			inSvcName:        "frontend",
+			inSvcPort:        80,
+			inDockerfilePath: "/Dockerfile",
+			inAppDomain:      "example.com",
+
+			mockstore: func(m *mocks.MockStore) {
+				m.EXPECT().ListServices("app").Return([]*config.Workload{
+					{
+						Name: "admin",
+						Type: manifestinfo.LoadBalancedWebServiceType,
+					},
+				}, nil)
+			},
+
+			wantedPath: "/",
 		},
 	}
 
@@ -333,7 +352,8 @@ func TestAppInitOpts_createLoadBalancedAppManifest(t *testing.T) {
 					App:            tc.inAppName,
 					DockerfilePath: tc.inDockerfilePath,
 				},
-				Port: tc.inSvcPort,
+				Port:      tc.inSvcPort,
+				appDomain: &tc.inAppDomain,
 			}
 
 			initter := &WorkloadInitializer{


### PR DESCRIPTION
Address UX feedback from https://app.gitter.im/#/room/#aws_copilot-cli:gitter.im/$BrcLblwPZotiiRhfC6TOSgtLApSNnZBto3Puky4BSzk to stop writing the service name in LBWS manifest if the application is initialized with a domain

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
