### PR TITLE
chore: fix deduping imports in "stack.ts" for cdk overrides

### DIFF
--- a/internal/pkg/template/templates/overrides/cdk/stack.ts
+++ b/internal/pkg/template/templates/overrides/cdk/stack.ts
@@ -1,7 +1,7 @@
 import * as cdk from 'aws-cdk-lib';
 import * as path from 'path';
-{{- range $resourceType := .Resources.UniqueTypes }}
-import { {{$resourceType.ImportName}} as {{$resourceType.ImportShortRename}} } from 'aws-cdk-lib';
+{{- range $import := .Resources.Imports }}
+import { {{$import.ImportName}} as {{$import.ImportShortRename}} } from 'aws-cdk-lib';
 {{- end }}
 
 interface TransformedStackProps extends cdk.StackProps {


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
