### PR TITLE
refactor: Login to docker client only once for all images

### DIFF
--- a/internal/pkg/cli/deploy/mocks/mock_workload.go
+++ b/internal/pkg/cli/deploy/mocks/mock_workload.go
@@ -52,31 +52,31 @@ func (mr *MockActionRecommenderMockRecorder) RecommendedActions() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecommendedActions", reflect.TypeOf((*MockActionRecommender)(nil).RecommendedActions))
 }
 
-// MockRepositoryService is a mock of RepositoryService interface.
-type MockRepositoryService struct {
+// MockrepositoryService is a mock of repositoryService interface.
+type MockrepositoryService struct {
 	ctrl     *gomock.Controller
-	recorder *MockRepositoryServiceMockRecorder
+	recorder *MockrepositoryServiceMockRecorder
 }
 
-// MockRepositoryServiceMockRecorder is the mock recorder for MockRepositoryService.
-type MockRepositoryServiceMockRecorder struct {
-	mock *MockRepositoryService
+// MockrepositoryServiceMockRecorder is the mock recorder for MockrepositoryService.
+type MockrepositoryServiceMockRecorder struct {
+	mock *MockrepositoryService
 }
 
-// NewMockRepositoryService creates a new mock instance.
-func NewMockRepositoryService(ctrl *gomock.Controller) *MockRepositoryService {
-	mock := &MockRepositoryService{ctrl: ctrl}
-	mock.recorder = &MockRepositoryServiceMockRecorder{mock}
+// NewMockrepositoryService creates a new mock instance.
+func NewMockrepositoryService(ctrl *gomock.Controller) *MockrepositoryService {
+	mock := &MockrepositoryService{ctrl: ctrl}
+	mock.recorder = &MockrepositoryServiceMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockRepositoryService) EXPECT() *MockRepositoryServiceMockRecorder {
+func (m *MockrepositoryService) EXPECT() *MockrepositoryServiceMockRecorder {
 	return m.recorder
 }
 
 // BuildAndPush mocks base method.
-func (m *MockRepositoryService) BuildAndPush(docker repository.ContainerLoginBuildPusher, args *dockerengine.BuildArguments) (string, error) {
+func (m *MockrepositoryService) BuildAndPush(docker repository.ContainerLoginBuildPusher, args *dockerengine.BuildArguments) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BuildAndPush", docker, args)
 	ret0, _ := ret[0].(string)
@@ -85,13 +85,13 @@ func (m *MockRepositoryService) BuildAndPush(docker repository.ContainerLoginBui
 }
 
 // BuildAndPush indicates an expected call of BuildAndPush.
-func (mr *MockRepositoryServiceMockRecorder) BuildAndPush(docker, args interface{}) *gomock.Call {
+func (mr *MockrepositoryServiceMockRecorder) BuildAndPush(docker, args interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildAndPush", reflect.TypeOf((*MockRepositoryService)(nil).BuildAndPush), docker, args)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildAndPush", reflect.TypeOf((*MockrepositoryService)(nil).BuildAndPush), docker, args)
 }
 
 // Login mocks base method.
-func (m *MockRepositoryService) Login(docker repository.ContainerLoginBuildPusher) error {
+func (m *MockrepositoryService) Login(docker repository.ContainerLoginBuildPusher) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Login", docker)
 	ret0, _ := ret[0].(error)
@@ -99,24 +99,9 @@ func (m *MockRepositoryService) Login(docker repository.ContainerLoginBuildPushe
 }
 
 // Login indicates an expected call of Login.
-func (mr *MockRepositoryServiceMockRecorder) Login(docker interface{}) *gomock.Call {
+func (mr *MockrepositoryServiceMockRecorder) Login(docker interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Login", reflect.TypeOf((*MockRepositoryService)(nil).Login), docker)
-}
-
-// URI mocks base method.
-func (m *MockRepositoryService) URI() (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "URI")
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// URI indicates an expected call of URI.
-func (mr *MockRepositoryServiceMockRecorder) URI() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "URI", reflect.TypeOf((*MockRepositoryService)(nil).URI))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Login", reflect.TypeOf((*MockrepositoryService)(nil).Login), docker)
 }
 
 // Mocktemplater is a mock of templater interface.

--- a/internal/pkg/cli/deploy/mocks/mock_workload.go
+++ b/internal/pkg/cli/deploy/mocks/mock_workload.go
@@ -91,11 +91,12 @@ func (mr *MockrepositoryServiceMockRecorder) BuildAndPush(docker, args interface
 }
 
 // Login mocks base method.
-func (m *MockrepositoryService) Login(docker repository.ContainerLoginBuildPusher) error {
+func (m *MockrepositoryService) Login(docker repository.ContainerLoginBuildPusher) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Login", docker)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Login indicates an expected call of Login.

--- a/internal/pkg/cli/deploy/mocks/mock_workload.go
+++ b/internal/pkg/cli/deploy/mocks/mock_workload.go
@@ -52,31 +52,31 @@ func (mr *MockActionRecommenderMockRecorder) RecommendedActions() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecommendedActions", reflect.TypeOf((*MockActionRecommender)(nil).RecommendedActions))
 }
 
-// MockimageBuilderPusher is a mock of imageBuilderPusher interface.
-type MockimageBuilderPusher struct {
+// MockRepositoryService is a mock of RepositoryService interface.
+type MockRepositoryService struct {
 	ctrl     *gomock.Controller
-	recorder *MockimageBuilderPusherMockRecorder
+	recorder *MockRepositoryServiceMockRecorder
 }
 
-// MockimageBuilderPusherMockRecorder is the mock recorder for MockimageBuilderPusher.
-type MockimageBuilderPusherMockRecorder struct {
-	mock *MockimageBuilderPusher
+// MockRepositoryServiceMockRecorder is the mock recorder for MockRepositoryService.
+type MockRepositoryServiceMockRecorder struct {
+	mock *MockRepositoryService
 }
 
-// NewMockimageBuilderPusher creates a new mock instance.
-func NewMockimageBuilderPusher(ctrl *gomock.Controller) *MockimageBuilderPusher {
-	mock := &MockimageBuilderPusher{ctrl: ctrl}
-	mock.recorder = &MockimageBuilderPusherMockRecorder{mock}
+// NewMockRepositoryService creates a new mock instance.
+func NewMockRepositoryService(ctrl *gomock.Controller) *MockRepositoryService {
+	mock := &MockRepositoryService{ctrl: ctrl}
+	mock.recorder = &MockRepositoryServiceMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockimageBuilderPusher) EXPECT() *MockimageBuilderPusherMockRecorder {
+func (m *MockRepositoryService) EXPECT() *MockRepositoryServiceMockRecorder {
 	return m.recorder
 }
 
 // BuildAndPush mocks base method.
-func (m *MockimageBuilderPusher) BuildAndPush(docker repository.ContainerLoginBuildPusher, args *dockerengine.BuildArguments) (string, error) {
+func (m *MockRepositoryService) BuildAndPush(docker repository.ContainerLoginBuildPusher, args *dockerengine.BuildArguments) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BuildAndPush", docker, args)
 	ret0, _ := ret[0].(string)
@@ -85,9 +85,38 @@ func (m *MockimageBuilderPusher) BuildAndPush(docker repository.ContainerLoginBu
 }
 
 // BuildAndPush indicates an expected call of BuildAndPush.
-func (mr *MockimageBuilderPusherMockRecorder) BuildAndPush(docker, args interface{}) *gomock.Call {
+func (mr *MockRepositoryServiceMockRecorder) BuildAndPush(docker, args interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildAndPush", reflect.TypeOf((*MockimageBuilderPusher)(nil).BuildAndPush), docker, args)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildAndPush", reflect.TypeOf((*MockRepositoryService)(nil).BuildAndPush), docker, args)
+}
+
+// Login mocks base method.
+func (m *MockRepositoryService) Login(docker repository.ContainerLoginBuildPusher) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Login", docker)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Login indicates an expected call of Login.
+func (mr *MockRepositoryServiceMockRecorder) Login(docker interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Login", reflect.TypeOf((*MockRepositoryService)(nil).Login), docker)
+}
+
+// URI mocks base method.
+func (m *MockRepositoryService) URI() (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "URI")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// URI indicates an expected call of URI.
+func (mr *MockRepositoryServiceMockRecorder) URI() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "URI", reflect.TypeOf((*MockRepositoryService)(nil).URI))
 }
 
 // Mocktemplater is a mock of templater interface.

--- a/internal/pkg/cli/deploy/workload.go
+++ b/internal/pkg/cli/deploy/workload.go
@@ -68,8 +68,7 @@ func (noopActionRecommender) RecommendedActions() []string {
 	return nil
 }
 
-type RepositoryService interface {
-	URI() (string, error)
+type repositoryService interface {
 	Login(docker repository.ContainerLoginBuildPusher) error
 	BuildAndPush(docker repository.ContainerLoginBuildPusher, args *dockerengine.BuildArguments) (string, error)
 }
@@ -157,7 +156,7 @@ type workloadDeployer struct {
 	fs               fileReader
 	s3Client         uploader
 	addons           stackBuilder
-	repository       RepositoryService
+	repository       repositoryService
 	deployer         serviceDeployer
 	tmplGetter       deployedTemplateGetter
 	endpointGetter   endpointGetter
@@ -367,7 +366,7 @@ func (d *workloadDeployer) uploadContainerImages(out *UploadArtifactsOutput) err
 		return nil
 	}
 	out.ImageDigests = make(map[string]ContainerImageIdentifier, len(buildArgsPerContainer))
-	if err := LoginToDockerClient(d.repository); err != nil {
+	if err := loginToDockerClient(d.repository); err != nil {
 		return err
 	}
 	for name, buildArgs := range buildArgsPerContainer {
@@ -384,9 +383,9 @@ func (d *workloadDeployer) uploadContainerImages(out *UploadArtifactsOutput) err
 	return nil
 }
 
-// LoginToDockerClient logs in to the Docker client using the provided RepositoryService.
+// loginToDockerClient logs in to the Docker client using the provided RepositoryService.
 // Returns an error if any error occurs during the login process.
-func LoginToDockerClient(rs RepositoryService) error {
+func loginToDockerClient(rs repositoryService) error {
 	if err := rs.Login(dockerengine.New(exec.NewCmd())); err != nil {
 		return fmt.Errorf("login to docker: %w", err)
 	}

--- a/internal/pkg/cli/deploy/workload_test.go
+++ b/internal/pkg/cli/deploy/workload_test.go
@@ -36,7 +36,7 @@ import (
 )
 
 type deployMocks struct {
-	mockRepositoryService      *mocks.MockRepositoryService
+	mockRepositoryService      *mocks.MockrepositoryService
 	mockEndpointGetter         *mocks.MockendpointGetter
 	mockSpinner                *mocks.Mockspinner
 	mockPublicCIDRBlocksGetter *mocks.MockpublicCIDRBlocksGetter
@@ -592,7 +592,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 			m := &deployMocks{
 				mockUploader:          mocks.NewMockuploader(ctrl),
 				mockAddons:            mocks.NewMockstackBuilder(ctrl),
-				mockRepositoryService: mocks.NewMockRepositoryService(ctrl),
+				mockRepositoryService: mocks.NewMockrepositoryService(ctrl),
 				mockFileReader:        mocks.NewMockfileReader(ctrl),
 			}
 			tc.mock(t, m)

--- a/internal/pkg/cli/deploy/workload_test.go
+++ b/internal/pkg/cli/deploy/workload_test.go
@@ -201,7 +201,6 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 				},
 			},
 			mock: func(t *testing.T, m *deployMocks) {
-				m.mockRepositoryService.EXPECT().Login(gomock.Any()).Return(nil)
 				m.mockRepositoryService.EXPECT().BuildAndPush(gomock.Any(), &dockerengine.BuildArguments{
 					Dockerfile: "mockDockerfile",
 					Context:    "mockContext",
@@ -225,7 +224,6 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 				},
 			},
 			mock: func(t *testing.T, m *deployMocks) {
-				m.mockRepositoryService.EXPECT().Login(gomock.Any()).Return(nil)
 				m.mockRepositoryService.EXPECT().BuildAndPush(gomock.Any(), &dockerengine.BuildArguments{
 					Dockerfile: "mockDockerfile",
 					Context:    "mockContext",
@@ -256,7 +254,6 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 				},
 			},
 			mock: func(t *testing.T, m *deployMocks) {
-				m.mockRepositoryService.EXPECT().Login(gomock.Any()).Return(nil)
 				m.mockRepositoryService.EXPECT().BuildAndPush(gomock.Any(), &dockerengine.BuildArguments{
 					Dockerfile: "mockDockerfile",
 					Context:    "mockContext",
@@ -289,7 +286,6 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 			},
 			inMockGitTag: "gitTag",
 			mock: func(t *testing.T, m *deployMocks) {
-				m.mockRepositoryService.EXPECT().Login(gomock.Any()).Return(nil)
 				m.mockRepositoryService.EXPECT().BuildAndPush(gomock.Any(), &dockerengine.BuildArguments{
 					Dockerfile: "sidecarMockDockerfile",
 					Context:    "sidecarMockContext",

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -174,7 +174,7 @@ type repositoryURIGetter interface {
 }
 
 type dockerLogin interface {
-	Login(docker repository.ContainerLoginBuildPusher) error
+	Login(docker repository.ContainerLoginBuildPusher) (string, error)
 }
 
 type repositoryService interface {

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -20,12 +20,14 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation"
 	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation/stack"
 	"github.com/aws/copilot-cli/internal/pkg/describe"
+	"github.com/aws/copilot-cli/internal/pkg/docker/dockerengine"
 	"github.com/aws/copilot-cli/internal/pkg/docker/dockerfile"
 	"github.com/aws/copilot-cli/internal/pkg/ecs"
 	"github.com/aws/copilot-cli/internal/pkg/exec"
 	"github.com/aws/copilot-cli/internal/pkg/initialize"
 	"github.com/aws/copilot-cli/internal/pkg/logging"
 	"github.com/aws/copilot-cli/internal/pkg/manifest"
+	"github.com/aws/copilot-cli/internal/pkg/repository"
 	"github.com/aws/copilot-cli/internal/pkg/task"
 	"github.com/aws/copilot-cli/internal/pkg/template"
 	"github.com/aws/copilot-cli/internal/pkg/term/prompt"
@@ -161,6 +163,24 @@ type secretCreator interface {
 type secretDeleter interface {
 	DescribeSecret(secretName string) (*secretsmanager.DescribeSecretOutput, error)
 	DeleteSecret(secretName string) error
+}
+
+type imageBuilderPusher interface {
+	BuildAndPush(docker repository.ContainerLoginBuildPusher, args *dockerengine.BuildArguments) (string, error)
+}
+
+type repositoryURIGetter interface {
+	URI() (string, error)
+}
+
+type dockerLogin interface {
+	Login(docker repository.ContainerLoginBuildPusher) error
+}
+
+type repositoryService interface {
+	repositoryURIGetter
+	dockerLogin
+	imageBuilderPusher
 }
 
 type logEventsWriter interface {

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -20,14 +20,12 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation"
 	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation/stack"
 	"github.com/aws/copilot-cli/internal/pkg/describe"
-	"github.com/aws/copilot-cli/internal/pkg/docker/dockerengine"
 	"github.com/aws/copilot-cli/internal/pkg/docker/dockerfile"
 	"github.com/aws/copilot-cli/internal/pkg/ecs"
 	"github.com/aws/copilot-cli/internal/pkg/exec"
 	"github.com/aws/copilot-cli/internal/pkg/initialize"
 	"github.com/aws/copilot-cli/internal/pkg/logging"
 	"github.com/aws/copilot-cli/internal/pkg/manifest"
-	"github.com/aws/copilot-cli/internal/pkg/repository"
 	"github.com/aws/copilot-cli/internal/pkg/task"
 	"github.com/aws/copilot-cli/internal/pkg/template"
 	"github.com/aws/copilot-cli/internal/pkg/term/prompt"
@@ -163,19 +161,6 @@ type secretCreator interface {
 type secretDeleter interface {
 	DescribeSecret(secretName string) (*secretsmanager.DescribeSecretOutput, error)
 	DeleteSecret(secretName string) error
-}
-
-type imageBuilderPusher interface {
-	BuildAndPush(docker repository.ContainerLoginBuildPusher, args *dockerengine.BuildArguments) (string, error)
-}
-
-type repositoryURIGetter interface {
-	URI() (string, error)
-}
-
-type repositoryService interface {
-	repositoryURIGetter
-	imageBuilderPusher
 }
 
 type logEventsWriter interface {

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -22,12 +22,14 @@ import (
 	cloudformation0 "github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation"
 	stack "github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation/stack"
 	describe "github.com/aws/copilot-cli/internal/pkg/describe"
+	dockerengine "github.com/aws/copilot-cli/internal/pkg/docker/dockerengine"
 	dockerfile "github.com/aws/copilot-cli/internal/pkg/docker/dockerfile"
 	ecs0 "github.com/aws/copilot-cli/internal/pkg/ecs"
 	exec "github.com/aws/copilot-cli/internal/pkg/exec"
 	initialize "github.com/aws/copilot-cli/internal/pkg/initialize"
 	logging "github.com/aws/copilot-cli/internal/pkg/logging"
 	manifest "github.com/aws/copilot-cli/internal/pkg/manifest"
+	repository "github.com/aws/copilot-cli/internal/pkg/repository"
 	task "github.com/aws/copilot-cli/internal/pkg/task"
 	template "github.com/aws/copilot-cli/internal/pkg/template"
 	prompt "github.com/aws/copilot-cli/internal/pkg/term/prompt"
@@ -1535,6 +1537,186 @@ func (m *MocksecretDeleter) DescribeSecret(secretName string) (*secretsmanager.D
 func (mr *MocksecretDeleterMockRecorder) DescribeSecret(secretName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSecret", reflect.TypeOf((*MocksecretDeleter)(nil).DescribeSecret), secretName)
+}
+
+// MockimageBuilderPusher is a mock of imageBuilderPusher interface.
+type MockimageBuilderPusher struct {
+	ctrl     *gomock.Controller
+	recorder *MockimageBuilderPusherMockRecorder
+}
+
+// MockimageBuilderPusherMockRecorder is the mock recorder for MockimageBuilderPusher.
+type MockimageBuilderPusherMockRecorder struct {
+	mock *MockimageBuilderPusher
+}
+
+// NewMockimageBuilderPusher creates a new mock instance.
+func NewMockimageBuilderPusher(ctrl *gomock.Controller) *MockimageBuilderPusher {
+	mock := &MockimageBuilderPusher{ctrl: ctrl}
+	mock.recorder = &MockimageBuilderPusherMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockimageBuilderPusher) EXPECT() *MockimageBuilderPusherMockRecorder {
+	return m.recorder
+}
+
+// BuildAndPush mocks base method.
+func (m *MockimageBuilderPusher) BuildAndPush(docker repository.ContainerLoginBuildPusher, args *dockerengine.BuildArguments) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BuildAndPush", docker, args)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// BuildAndPush indicates an expected call of BuildAndPush.
+func (mr *MockimageBuilderPusherMockRecorder) BuildAndPush(docker, args interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildAndPush", reflect.TypeOf((*MockimageBuilderPusher)(nil).BuildAndPush), docker, args)
+}
+
+// MockrepositoryURIGetter is a mock of repositoryURIGetter interface.
+type MockrepositoryURIGetter struct {
+	ctrl     *gomock.Controller
+	recorder *MockrepositoryURIGetterMockRecorder
+}
+
+// MockrepositoryURIGetterMockRecorder is the mock recorder for MockrepositoryURIGetter.
+type MockrepositoryURIGetterMockRecorder struct {
+	mock *MockrepositoryURIGetter
+}
+
+// NewMockrepositoryURIGetter creates a new mock instance.
+func NewMockrepositoryURIGetter(ctrl *gomock.Controller) *MockrepositoryURIGetter {
+	mock := &MockrepositoryURIGetter{ctrl: ctrl}
+	mock.recorder = &MockrepositoryURIGetterMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockrepositoryURIGetter) EXPECT() *MockrepositoryURIGetterMockRecorder {
+	return m.recorder
+}
+
+// URI mocks base method.
+func (m *MockrepositoryURIGetter) URI() (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "URI")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// URI indicates an expected call of URI.
+func (mr *MockrepositoryURIGetterMockRecorder) URI() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "URI", reflect.TypeOf((*MockrepositoryURIGetter)(nil).URI))
+}
+
+// MockdockerLogin is a mock of dockerLogin interface.
+type MockdockerLogin struct {
+	ctrl     *gomock.Controller
+	recorder *MockdockerLoginMockRecorder
+}
+
+// MockdockerLoginMockRecorder is the mock recorder for MockdockerLogin.
+type MockdockerLoginMockRecorder struct {
+	mock *MockdockerLogin
+}
+
+// NewMockdockerLogin creates a new mock instance.
+func NewMockdockerLogin(ctrl *gomock.Controller) *MockdockerLogin {
+	mock := &MockdockerLogin{ctrl: ctrl}
+	mock.recorder = &MockdockerLoginMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockdockerLogin) EXPECT() *MockdockerLoginMockRecorder {
+	return m.recorder
+}
+
+// Login mocks base method.
+func (m *MockdockerLogin) Login(docker repository.ContainerLoginBuildPusher) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Login", docker)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Login indicates an expected call of Login.
+func (mr *MockdockerLoginMockRecorder) Login(docker interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Login", reflect.TypeOf((*MockdockerLogin)(nil).Login), docker)
+}
+
+// MockrepositoryService is a mock of repositoryService interface.
+type MockrepositoryService struct {
+	ctrl     *gomock.Controller
+	recorder *MockrepositoryServiceMockRecorder
+}
+
+// MockrepositoryServiceMockRecorder is the mock recorder for MockrepositoryService.
+type MockrepositoryServiceMockRecorder struct {
+	mock *MockrepositoryService
+}
+
+// NewMockrepositoryService creates a new mock instance.
+func NewMockrepositoryService(ctrl *gomock.Controller) *MockrepositoryService {
+	mock := &MockrepositoryService{ctrl: ctrl}
+	mock.recorder = &MockrepositoryServiceMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockrepositoryService) EXPECT() *MockrepositoryServiceMockRecorder {
+	return m.recorder
+}
+
+// BuildAndPush mocks base method.
+func (m *MockrepositoryService) BuildAndPush(docker repository.ContainerLoginBuildPusher, args *dockerengine.BuildArguments) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BuildAndPush", docker, args)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// BuildAndPush indicates an expected call of BuildAndPush.
+func (mr *MockrepositoryServiceMockRecorder) BuildAndPush(docker, args interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildAndPush", reflect.TypeOf((*MockrepositoryService)(nil).BuildAndPush), docker, args)
+}
+
+// Login mocks base method.
+func (m *MockrepositoryService) Login(docker repository.ContainerLoginBuildPusher) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Login", docker)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Login indicates an expected call of Login.
+func (mr *MockrepositoryServiceMockRecorder) Login(docker interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Login", reflect.TypeOf((*MockrepositoryService)(nil).Login), docker)
+}
+
+// URI mocks base method.
+func (m *MockrepositoryService) URI() (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "URI")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// URI indicates an expected call of URI.
+func (mr *MockrepositoryServiceMockRecorder) URI() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "URI", reflect.TypeOf((*MockrepositoryService)(nil).URI))
 }
 
 // MocklogEventsWriter is a mock of logEventsWriter interface.

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -22,14 +22,12 @@ import (
 	cloudformation0 "github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation"
 	stack "github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation/stack"
 	describe "github.com/aws/copilot-cli/internal/pkg/describe"
-	dockerengine "github.com/aws/copilot-cli/internal/pkg/docker/dockerengine"
 	dockerfile "github.com/aws/copilot-cli/internal/pkg/docker/dockerfile"
 	ecs0 "github.com/aws/copilot-cli/internal/pkg/ecs"
 	exec "github.com/aws/copilot-cli/internal/pkg/exec"
 	initialize "github.com/aws/copilot-cli/internal/pkg/initialize"
 	logging "github.com/aws/copilot-cli/internal/pkg/logging"
 	manifest "github.com/aws/copilot-cli/internal/pkg/manifest"
-	repository "github.com/aws/copilot-cli/internal/pkg/repository"
 	task "github.com/aws/copilot-cli/internal/pkg/task"
 	template "github.com/aws/copilot-cli/internal/pkg/template"
 	prompt "github.com/aws/copilot-cli/internal/pkg/term/prompt"
@@ -1537,135 +1535,6 @@ func (m *MocksecretDeleter) DescribeSecret(secretName string) (*secretsmanager.D
 func (mr *MocksecretDeleterMockRecorder) DescribeSecret(secretName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSecret", reflect.TypeOf((*MocksecretDeleter)(nil).DescribeSecret), secretName)
-}
-
-// MockimageBuilderPusher is a mock of imageBuilderPusher interface.
-type MockimageBuilderPusher struct {
-	ctrl     *gomock.Controller
-	recorder *MockimageBuilderPusherMockRecorder
-}
-
-// MockimageBuilderPusherMockRecorder is the mock recorder for MockimageBuilderPusher.
-type MockimageBuilderPusherMockRecorder struct {
-	mock *MockimageBuilderPusher
-}
-
-// NewMockimageBuilderPusher creates a new mock instance.
-func NewMockimageBuilderPusher(ctrl *gomock.Controller) *MockimageBuilderPusher {
-	mock := &MockimageBuilderPusher{ctrl: ctrl}
-	mock.recorder = &MockimageBuilderPusherMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockimageBuilderPusher) EXPECT() *MockimageBuilderPusherMockRecorder {
-	return m.recorder
-}
-
-// BuildAndPush mocks base method.
-func (m *MockimageBuilderPusher) BuildAndPush(docker repository.ContainerLoginBuildPusher, args *dockerengine.BuildArguments) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BuildAndPush", docker, args)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// BuildAndPush indicates an expected call of BuildAndPush.
-func (mr *MockimageBuilderPusherMockRecorder) BuildAndPush(docker, args interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildAndPush", reflect.TypeOf((*MockimageBuilderPusher)(nil).BuildAndPush), docker, args)
-}
-
-// MockrepositoryURIGetter is a mock of repositoryURIGetter interface.
-type MockrepositoryURIGetter struct {
-	ctrl     *gomock.Controller
-	recorder *MockrepositoryURIGetterMockRecorder
-}
-
-// MockrepositoryURIGetterMockRecorder is the mock recorder for MockrepositoryURIGetter.
-type MockrepositoryURIGetterMockRecorder struct {
-	mock *MockrepositoryURIGetter
-}
-
-// NewMockrepositoryURIGetter creates a new mock instance.
-func NewMockrepositoryURIGetter(ctrl *gomock.Controller) *MockrepositoryURIGetter {
-	mock := &MockrepositoryURIGetter{ctrl: ctrl}
-	mock.recorder = &MockrepositoryURIGetterMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockrepositoryURIGetter) EXPECT() *MockrepositoryURIGetterMockRecorder {
-	return m.recorder
-}
-
-// URI mocks base method.
-func (m *MockrepositoryURIGetter) URI() (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "URI")
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// URI indicates an expected call of URI.
-func (mr *MockrepositoryURIGetterMockRecorder) URI() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "URI", reflect.TypeOf((*MockrepositoryURIGetter)(nil).URI))
-}
-
-// MockrepositoryService is a mock of repositoryService interface.
-type MockrepositoryService struct {
-	ctrl     *gomock.Controller
-	recorder *MockrepositoryServiceMockRecorder
-}
-
-// MockrepositoryServiceMockRecorder is the mock recorder for MockrepositoryService.
-type MockrepositoryServiceMockRecorder struct {
-	mock *MockrepositoryService
-}
-
-// NewMockrepositoryService creates a new mock instance.
-func NewMockrepositoryService(ctrl *gomock.Controller) *MockrepositoryService {
-	mock := &MockrepositoryService{ctrl: ctrl}
-	mock.recorder = &MockrepositoryServiceMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockrepositoryService) EXPECT() *MockrepositoryServiceMockRecorder {
-	return m.recorder
-}
-
-// BuildAndPush mocks base method.
-func (m *MockrepositoryService) BuildAndPush(docker repository.ContainerLoginBuildPusher, args *dockerengine.BuildArguments) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BuildAndPush", docker, args)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// BuildAndPush indicates an expected call of BuildAndPush.
-func (mr *MockrepositoryServiceMockRecorder) BuildAndPush(docker, args interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildAndPush", reflect.TypeOf((*MockrepositoryService)(nil).BuildAndPush), docker, args)
-}
-
-// URI mocks base method.
-func (m *MockrepositoryService) URI() (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "URI")
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// URI indicates an expected call of URI.
-func (mr *MockrepositoryServiceMockRecorder) URI() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "URI", reflect.TypeOf((*MockrepositoryService)(nil).URI))
 }
 
 // MocklogEventsWriter is a mock of logEventsWriter interface.

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -1639,11 +1639,12 @@ func (m *MockdockerLogin) EXPECT() *MockdockerLoginMockRecorder {
 }
 
 // Login mocks base method.
-func (m *MockdockerLogin) Login(docker repository.ContainerLoginBuildPusher) error {
+func (m *MockdockerLogin) Login(docker repository.ContainerLoginBuildPusher) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Login", docker)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Login indicates an expected call of Login.
@@ -1691,11 +1692,12 @@ func (mr *MockrepositoryServiceMockRecorder) BuildAndPush(docker, args interface
 }
 
 // Login mocks base method.
-func (m *MockrepositoryService) Login(docker repository.ContainerLoginBuildPusher) error {
+func (m *MockrepositoryService) Login(docker repository.ContainerLoginBuildPusher) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Login", docker)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Login indicates an expected call of Login.

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -960,10 +960,11 @@ func (o *runTaskOpts) buildAndPushImage() error {
 	if o.dockerfileContextPath != "" {
 		ctx = o.dockerfileContextPath
 	}
-	if err := o.repository.Login(dockerengine.New(exec.NewCmd())); err != nil {
+	dockerCmdClient := dockerengine.New(exec.NewCmd())
+	if err := o.repository.Login(dockerCmdClient); err != nil {
 		return err
 	}
-	if _, err := o.repository.BuildAndPush(dockerengine.New(exec.NewCmd()), &dockerengine.BuildArguments{
+	if _, err := o.repository.BuildAndPush(dockerCmdClient, &dockerengine.BuildArguments{
 		Dockerfile: o.dockerfilePath,
 		Context:    ctx,
 		Tags:       append([]string{imageTagLatest}, additionalTags...),

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -40,7 +40,6 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/aws/ec2"
 	awsecs "github.com/aws/copilot-cli/internal/pkg/aws/ecs"
 	"github.com/aws/copilot-cli/internal/pkg/aws/sessions"
-	clideploy "github.com/aws/copilot-cli/internal/pkg/cli/deploy"
 	"github.com/aws/copilot-cli/internal/pkg/config"
 	"github.com/aws/copilot-cli/internal/pkg/deploy"
 	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation"
@@ -155,7 +154,7 @@ type runTaskOpts struct {
 
 	// Fields below are configured at runtime.
 	deployer             taskDeployer
-	repository           clideploy.RepositoryService
+	repository           repositoryService
 	runner               taskRunner
 	eventsWriter         eventsWriter
 	defaultClusterGetter defaultClusterGetter
@@ -961,7 +960,7 @@ func (o *runTaskOpts) buildAndPushImage() error {
 	if o.dockerfileContextPath != "" {
 		ctx = o.dockerfileContextPath
 	}
-	if err := clideploy.LoginToDockerClient(o.repository); err != nil {
+	if err := o.repository.Login(dockerengine.New(exec.NewCmd())); err != nil {
 		return err
 	}
 	if _, err := o.repository.BuildAndPush(dockerengine.New(exec.NewCmd()), &dockerengine.BuildArguments{

--- a/internal/pkg/cli/task_run_test.go
+++ b/internal/pkg/cli/task_run_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 
-	clideploy "github.com/aws/copilot-cli/internal/pkg/cli/deploy/mocks"
 	"github.com/aws/copilot-cli/internal/pkg/deploy"
 	"github.com/aws/copilot-cli/internal/pkg/docker/dockerengine"
 	"github.com/aws/copilot-cli/internal/pkg/ecs"
@@ -746,7 +745,7 @@ func TestTaskRunOpts_Ask(t *testing.T) {
 
 type runTaskMocks struct {
 	deployer             *mocks.MocktaskDeployer
-	repository           *clideploy.MockRepositoryService
+	repository           *mocks.MockrepositoryService
 	runner               *mocks.MocktaskRunner
 	store                *mocks.Mockstore
 	eventsWriter         *mocks.MockeventsWriter
@@ -1160,7 +1159,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 
 			mocks := runTaskMocks{
 				deployer:             mocks.NewMocktaskDeployer(ctrl),
-				repository:           clideploy.NewMockRepositoryService(ctrl),
+				repository:           mocks.NewMockrepositoryService(ctrl),
 				runner:               mocks.NewMocktaskRunner(ctrl),
 				store:                mocks.NewMockstore(ctrl),
 				eventsWriter:         mocks.NewMockeventsWriter(ctrl),

--- a/internal/pkg/cli/task_run_test.go
+++ b/internal/pkg/cli/task_run_test.go
@@ -11,14 +11,16 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+
 	"github.com/aws/aws-sdk-go/aws/session"
 
-	"github.com/aws/copilot-cli/internal/pkg/deploy"
 	"github.com/aws/copilot-cli/internal/pkg/docker/dockerengine"
+
 	"github.com/aws/copilot-cli/internal/pkg/ecs"
 	ecsMocks "github.com/aws/copilot-cli/internal/pkg/ecs/mocks"
 
 	"github.com/aws/copilot-cli/internal/pkg/cli/mocks"
+	"github.com/aws/copilot-cli/internal/pkg/deploy"
 	"github.com/aws/copilot-cli/internal/pkg/task"
 
 	"github.com/aws/copilot-cli/internal/pkg/config"
@@ -760,7 +762,6 @@ func mockHasDefaultCluster(m runTaskMocks) {
 }
 
 func mockRepositoryAnytime(m runTaskMocks) {
-	m.repository.EXPECT().Login(gomock.Any())
 	m.repository.EXPECT().BuildAndPush(gomock.Any(), gomock.Any()).AnyTimes()
 	m.repository.EXPECT().URI().AnyTimes()
 }
@@ -843,8 +844,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 					Command:    []string{},
 					EntryPoint: []string{},
 				}).Return(nil)
-				m.repository.EXPECT().Login(gomock.Any())
-				m.repository.EXPECT().BuildAndPush(gomock.Any(), gomock.Any())
+				m.repository.EXPECT().BuildAndPush(gomock.Any(), gomock.Eq(&defaultBuildArguments))
 				m.repository.EXPECT().URI().Return(mockRepoURI, errors.New("some error"))
 				mockHasDefaultCluster(m)
 			},
@@ -860,9 +860,8 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 					Command:    []string{},
 					EntryPoint: []string{},
 				}).Return(nil)
-				m.repository.EXPECT().URI().Return(mockRepoURI, nil)
-				m.repository.EXPECT().Login(gomock.Any())
 				m.repository.EXPECT().BuildAndPush(gomock.Any(), gomock.Eq(&defaultBuildArguments))
+				m.repository.EXPECT().URI().Return(mockRepoURI, nil)
 				m.deployer.EXPECT().DeployTask(&deploy.CreateTaskResourcesInput{
 					Name:       inGroupName,
 					Image:      "uri/repo:latest",
@@ -914,8 +913,6 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 				m.provider.EXPECT().Default().Return(&session.Session{}, nil)
 				m.store.EXPECT().GetEnvironment(gomock.Any(), gomock.Any()).AnyTimes()
 				m.deployer.EXPECT().DeployTask(gomock.Any()).AnyTimes()
-				m.repository.EXPECT().URI().Return(mockRepoURI, nil)
-				m.repository.EXPECT().Login(gomock.Any())
 				m.repository.EXPECT().BuildAndPush(gomock.Any(), gomock.Eq(
 					&dockerengine.BuildArguments{
 						Context: filepath.Dir(defaultDockerfilePath),
@@ -933,8 +930,6 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 				m.provider.EXPECT().Default().Return(&session.Session{}, nil)
 				m.store.EXPECT().GetEnvironment(gomock.Any(), gomock.Any()).AnyTimes()
 				m.deployer.EXPECT().DeployTask(gomock.Any()).AnyTimes()
-				m.repository.EXPECT().URI().Return(mockRepoURI, nil)
-				m.repository.EXPECT().Login(gomock.Any())
 				m.repository.EXPECT().BuildAndPush(gomock.Any(), gomock.Eq(
 					&dockerengine.BuildArguments{
 						Context: "../../other",
@@ -958,9 +953,8 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 					Command:    []string{"/bin/sh", "-c", "curl $ECS_CONTAINER_METADATA_URI_V4"},
 					EntryPoint: []string{"exec", "some command"},
 				}).Times(1).Return(nil)
-				m.repository.EXPECT().URI().Return(mockRepoURI, nil)
-				m.repository.EXPECT().Login(gomock.Any())
 				m.repository.EXPECT().BuildAndPush(gomock.Any(), gomock.Eq(&defaultBuildArguments))
+				m.repository.EXPECT().URI().Return(mockRepoURI, nil)
 				m.deployer.EXPECT().DeployTask(&deploy.CreateTaskResourcesInput{
 					Name:       inGroupName,
 					Image:      "uri/repo:latest",
@@ -1038,6 +1032,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 				m.provider.EXPECT().FromRole(gomock.Any(), gomock.Any())
 				m.store.EXPECT().GetApplication("my-app").Return(nil, errors.New("some error"))
 				m.deployer.EXPECT().DeployTask(gomock.Any(), gomock.Len(1)).AnyTimes() // NOTE: matching length because gomock is unable to match function arguments.
+				mockRepositoryAnytime(m)
 				m.runner.EXPECT().Run().AnyTimes()
 				m.defaultClusterGetter.EXPECT().HasDefaultCluster().Times(0)
 			},
@@ -1069,6 +1064,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 				m.uploader.EXPECT().Upload("arn:aws:s3:::bigbucket", key,
 					bytes.NewReader([]byte("SOMETHING=VALUE"))).Return(arn, nil)
 				m.deployer.EXPECT().DeployTask(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+				mockRepositoryAnytime(m)
 				m.runner.EXPECT().Run().AnyTimes()
 			},
 		},

--- a/internal/pkg/repository/repository.go
+++ b/internal/pkg/repository/repository.go
@@ -80,7 +80,7 @@ func (r *Repository) URI() (string, error) {
 	return uri, nil
 }
 
-// Login authenticates with a Docker registry by performing a Docker login,
+// Login authenticates with a ECR registry by performing a Docker login,
 // but only if the `credStore` attribute value is not set to `ecr-login`.
 // If the `credStore` value is `ecr-login`, no login is performed.
 // Returns an error if any error occurs during the login process.

--- a/internal/pkg/repository/repository.go
+++ b/internal/pkg/repository/repository.go
@@ -83,21 +83,21 @@ func (r *Repository) URI() (string, error) {
 // Login authenticates with a ECR registry by performing a Docker login,
 // but only if the `credStore` attribute value is not set to `ecr-login`.
 // If the `credStore` value is `ecr-login`, no login is performed.
-// Returns an error if any error occurs during the login process.
-func (r *Repository) Login(docker ContainerLoginBuildPusher) error {
+// Returns an uri and if any error occurs during the login process.
+func (r *Repository) Login(docker ContainerLoginBuildPusher) (string, error) {
 	uri, err := r.URI()
 	if err != nil {
-		return fmt.Errorf("retrieve URI for repository: %w", err)
+		return "", fmt.Errorf("retrieve URI for repository: %w", err)
 	}
 	if !docker.IsEcrCredentialHelperEnabled(uri) {
 		username, password, err := r.registry.Auth()
 		if err != nil {
-			return fmt.Errorf("get auth: %w", err)
+			return "", fmt.Errorf("get auth: %w", err)
 		}
 
 		if err := docker.Login(uri, username, password); err != nil {
-			return fmt.Errorf("login to repo %s: %w", uri, err)
+			return "", fmt.Errorf("login to repo %s: %w", uri, err)
 		}
 	}
-	return nil
+	return uri, nil
 }

--- a/internal/pkg/repository/repository.go
+++ b/internal/pkg/repository/repository.go
@@ -83,7 +83,7 @@ func (r *Repository) URI() (string, error) {
 // Login authenticates with a ECR registry by performing a Docker login,
 // but only if the `credStore` attribute value is not set to `ecr-login`.
 // If the `credStore` value is `ecr-login`, no login is performed.
-// Returns an uri and if any error occurs during the login process.
+// Returns a URI or an error, if any occurs during the login process.
 func (r *Repository) Login(docker ContainerLoginBuildPusher) (string, error) {
 	uri, err := r.URI()
 	if err != nil {

--- a/internal/pkg/repository/repository_test.go
+++ b/internal/pkg/repository/repository_test.go
@@ -123,13 +123,11 @@ func TestRepository_BuildAndPush(t *testing.T) {
 func Test_Login(t *testing.T) {
 	const mockRepoURI = "mockRepoURI"
 	testCases := map[string]struct {
-		inURI        string
 		inMockDocker func(m *mocks.MockContainerLoginBuildPusher)
 		mockRegistry func(m *mocks.MockRegistry)
 		wantedError  error
 	}{
 		"failed to get auth": {
-			inURI: "mockRepoURI",
 			mockRegistry: func(m *mocks.MockRegistry) {
 				m.EXPECT().Auth().Return("", "", errors.New("error getting auth"))
 			},
@@ -140,7 +138,6 @@ func Test_Login(t *testing.T) {
 			wantedError: errors.New("get auth: error getting auth"),
 		},
 		"failed to login": {
-			inURI: "mockRepoURI",
 			mockRegistry: func(m *mocks.MockRegistry) {
 				m.EXPECT().Auth().Return("my-name", "my-pwd", nil)
 			},
@@ -151,7 +148,6 @@ func Test_Login(t *testing.T) {
 			wantedError: fmt.Errorf("login to repo %s: error logging in", mockRepoURI),
 		},
 		"no error when performing login": {
-			inURI: "mockRepoURI",
 			mockRegistry: func(m *mocks.MockRegistry) {
 				m.EXPECT().Auth().Return("my-name", "my-pwd", nil)
 			},

--- a/internal/pkg/repository/repository_test.go
+++ b/internal/pkg/repository/repository_test.go
@@ -46,19 +46,6 @@ func TestRepository_BuildAndPush(t *testing.T) {
 			inMockDocker: func(m *mocks.MockContainerLoginBuildPusher) {},
 			wantedError:  errors.New("get repository URI: some error"),
 		},
-		// "failed to get auth": {
-		// 	inURI: defaultDockerArguments.URI,
-		// 	mockRegistry: func(m *mocks.MockRegistry) {
-		// 		m.EXPECT().Auth().Return("", "", errors.New("error getting auth"))
-		// 	},
-		// 	inMockDocker: func(m *mocks.MockContainerLoginBuildPusher) {
-		// 		m.EXPECT().Build(gomock.Any()).AnyTimes()
-		// 		m.EXPECT().IsEcrCredentialHelperEnabled(defaultDockerArguments.URI).Return(false)
-		// 		m.EXPECT().Login(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
-		// 		m.EXPECT().Push(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
-		// 	},
-		// 	wantedError: errors.New("get auth: error getting auth"),
-		// },
 		"failed to build image": {
 			inURI: defaultDockerArguments.URI,
 			mockRegistry: func(m *mocks.MockRegistry) {
@@ -71,19 +58,6 @@ func TestRepository_BuildAndPush(t *testing.T) {
 			},
 			wantedError: fmt.Errorf("build Dockerfile at %s: error building image", inDockerfilePath),
 		},
-		// "failed to login": {
-		// 	inURI: defaultDockerArguments.URI,
-		// 	mockRegistry: func(m *mocks.MockRegistry) {
-		// 		m.EXPECT().Auth().Return("my-name", "my-pwd", nil)
-		// 	},
-		// 	inMockDocker: func(m *mocks.MockContainerLoginBuildPusher) {
-		// 		m.EXPECT().Build(gomock.Any()).AnyTimes()
-		// 		m.EXPECT().IsEcrCredentialHelperEnabled(defaultDockerArguments.URI).Return(false)
-		// 		m.EXPECT().Login(mockRepoURI, "my-name", "my-pwd").Return(errors.New("error logging in"))
-		// 		m.EXPECT().Push(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
-		// 	},
-		// 	wantedError: fmt.Errorf("login to repo %s: error logging in", inRepoName),
-		// },
 		"failed to push": {
 			inURI: defaultDockerArguments.URI,
 			// mockRegistry: func(m *mocks.MockRegistry) {
@@ -101,7 +75,6 @@ func TestRepository_BuildAndPush(t *testing.T) {
 			inURI: defaultDockerArguments.URI,
 			inMockDocker: func(m *mocks.MockContainerLoginBuildPusher) {
 				m.EXPECT().Build(&defaultDockerArguments).Return(nil).Times(1)
-				// m.EXPECT().IsEcrCredentialHelperEnabled(defaultDockerArguments.URI).Return(true)
 				m.EXPECT().Push(mockRepoURI, mockTag1, mockTag2, mockTag3).Return("sha256:f1d4ae3f7261a72e98c6ebefe9985cf10a0ea5bd762585a43e0700ed99863807", nil)
 			},
 			wantedDigest: "sha256:f1d4ae3f7261a72e98c6ebefe9985cf10a0ea5bd762585a43e0700ed99863807",
@@ -109,12 +82,9 @@ func TestRepository_BuildAndPush(t *testing.T) {
 		"success": {
 			mockRegistry: func(m *mocks.MockRegistry) {
 				m.EXPECT().RepositoryURI(inRepoName).Return(defaultDockerArguments.URI, nil)
-				// m.EXPECT().Auth().Return("my-name", "my-pwd", nil).Times(1)
 			},
 			inMockDocker: func(m *mocks.MockContainerLoginBuildPusher) {
 				m.EXPECT().Build(&defaultDockerArguments).Return(nil).Times(1)
-				// m.EXPECT().IsEcrCredentialHelperEnabled(defaultDockerArguments.URI).Return(false)
-				// m.EXPECT().Login(mockRepoURI, "my-name", "my-pwd").Return(nil).Times(1)
 				m.EXPECT().Push(mockRepoURI, mockTag1, mockTag2, mockTag3).Return("sha256:f1d4ae3f7261a72e98c6ebefe9985cf10a0ea5bd762585a43e0700ed99863807", nil)
 			},
 			wantedDigest: "sha256:f1d4ae3f7261a72e98c6ebefe9985cf10a0ea5bd762585a43e0700ed99863807",

--- a/internal/pkg/repository/repository_test.go
+++ b/internal/pkg/repository/repository_test.go
@@ -125,6 +125,7 @@ func Test_Login(t *testing.T) {
 	testCases := map[string]struct {
 		inMockDocker func(m *mocks.MockContainerLoginBuildPusher)
 		mockRegistry func(m *mocks.MockRegistry)
+		wantedURI    string
 		wantedError  error
 	}{
 		"failed to get auth": {
@@ -155,6 +156,7 @@ func Test_Login(t *testing.T) {
 				m.EXPECT().IsEcrCredentialHelperEnabled("mockRepoURI").Return(false)
 				m.EXPECT().Login("mockRepoURI", "my-name", "my-pwd").Return(nil)
 			},
+			wantedURI: mockRepoURI,
 		},
 	}
 	for name, tc := range testCases {
@@ -176,11 +178,12 @@ func Test_Login(t *testing.T) {
 				uri:      mockRepoURI,
 			}
 
-			got := repo.Login(mockDocker)
+			got, gotErr := repo.Login(mockDocker)
 			if tc.wantedError != nil {
-				require.EqualError(t, tc.wantedError, got.Error())
+				require.EqualError(t, tc.wantedError, gotErr.Error())
 			} else {
 				require.NoError(t, tc.wantedError, got)
+				require.Equal(t, tc.wantedURI, got)
 			}
 		})
 	}

--- a/internal/pkg/repository/repository_test.go
+++ b/internal/pkg/repository/repository_test.go
@@ -46,19 +46,19 @@ func TestRepository_BuildAndPush(t *testing.T) {
 			inMockDocker: func(m *mocks.MockContainerLoginBuildPusher) {},
 			wantedError:  errors.New("get repository URI: some error"),
 		},
-		"failed to get auth": {
-			inURI: defaultDockerArguments.URI,
-			mockRegistry: func(m *mocks.MockRegistry) {
-				m.EXPECT().Auth().Return("", "", errors.New("error getting auth"))
-			},
-			inMockDocker: func(m *mocks.MockContainerLoginBuildPusher) {
-				m.EXPECT().Build(gomock.Any()).AnyTimes()
-				m.EXPECT().IsEcrCredentialHelperEnabled(defaultDockerArguments.URI).Return(false)
-				m.EXPECT().Login(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
-				m.EXPECT().Push(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
-			},
-			wantedError: errors.New("get auth: error getting auth"),
-		},
+		// "failed to get auth": {
+		// 	inURI: defaultDockerArguments.URI,
+		// 	mockRegistry: func(m *mocks.MockRegistry) {
+		// 		m.EXPECT().Auth().Return("", "", errors.New("error getting auth"))
+		// 	},
+		// 	inMockDocker: func(m *mocks.MockContainerLoginBuildPusher) {
+		// 		m.EXPECT().Build(gomock.Any()).AnyTimes()
+		// 		m.EXPECT().IsEcrCredentialHelperEnabled(defaultDockerArguments.URI).Return(false)
+		// 		m.EXPECT().Login(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+		// 		m.EXPECT().Push(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+		// 	},
+		// 	wantedError: errors.New("get auth: error getting auth"),
+		// },
 		"failed to build image": {
 			inURI: defaultDockerArguments.URI,
 			mockRegistry: func(m *mocks.MockRegistry) {
@@ -66,33 +66,33 @@ func TestRepository_BuildAndPush(t *testing.T) {
 			},
 			inMockDocker: func(m *mocks.MockContainerLoginBuildPusher) {
 				m.EXPECT().Build(&defaultDockerArguments).Return(errors.New("error building image"))
-				m.EXPECT().Login(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+				// m.EXPECT().Login(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 				m.EXPECT().Push(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 			},
 			wantedError: fmt.Errorf("build Dockerfile at %s: error building image", inDockerfilePath),
 		},
-		"failed to login": {
-			inURI: defaultDockerArguments.URI,
-			mockRegistry: func(m *mocks.MockRegistry) {
-				m.EXPECT().Auth().Return("my-name", "my-pwd", nil)
-			},
-			inMockDocker: func(m *mocks.MockContainerLoginBuildPusher) {
-				m.EXPECT().Build(gomock.Any()).AnyTimes()
-				m.EXPECT().IsEcrCredentialHelperEnabled(defaultDockerArguments.URI).Return(false)
-				m.EXPECT().Login(mockRepoURI, "my-name", "my-pwd").Return(errors.New("error logging in"))
-				m.EXPECT().Push(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
-			},
-			wantedError: fmt.Errorf("login to repo %s: error logging in", inRepoName),
-		},
+		// "failed to login": {
+		// 	inURI: defaultDockerArguments.URI,
+		// 	mockRegistry: func(m *mocks.MockRegistry) {
+		// 		m.EXPECT().Auth().Return("my-name", "my-pwd", nil)
+		// 	},
+		// 	inMockDocker: func(m *mocks.MockContainerLoginBuildPusher) {
+		// 		m.EXPECT().Build(gomock.Any()).AnyTimes()
+		// 		m.EXPECT().IsEcrCredentialHelperEnabled(defaultDockerArguments.URI).Return(false)
+		// 		m.EXPECT().Login(mockRepoURI, "my-name", "my-pwd").Return(errors.New("error logging in"))
+		// 		m.EXPECT().Push(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+		// 	},
+		// 	wantedError: fmt.Errorf("login to repo %s: error logging in", inRepoName),
+		// },
 		"failed to push": {
 			inURI: defaultDockerArguments.URI,
-			mockRegistry: func(m *mocks.MockRegistry) {
-				m.EXPECT().Auth().Times(1)
-			},
+			// mockRegistry: func(m *mocks.MockRegistry) {
+			// 	m.EXPECT().Auth().Times(1)
+			// },
 			inMockDocker: func(m *mocks.MockContainerLoginBuildPusher) {
 				m.EXPECT().Build(&defaultDockerArguments).Times(1)
-				m.EXPECT().IsEcrCredentialHelperEnabled(defaultDockerArguments.URI).Return(false)
-				m.EXPECT().Login(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+				// m.EXPECT().IsEcrCredentialHelperEnabled(defaultDockerArguments.URI).Return(false)
+				// m.EXPECT().Login(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 				m.EXPECT().Push(mockRepoURI, mockTag1, mockTag2, mockTag3).Return("", errors.New("error pushing image"))
 			},
 			wantedError: errors.New("push to repo my-repo: error pushing image"),
@@ -101,7 +101,7 @@ func TestRepository_BuildAndPush(t *testing.T) {
 			inURI: defaultDockerArguments.URI,
 			inMockDocker: func(m *mocks.MockContainerLoginBuildPusher) {
 				m.EXPECT().Build(&defaultDockerArguments).Return(nil).Times(1)
-				m.EXPECT().IsEcrCredentialHelperEnabled(defaultDockerArguments.URI).Return(true)
+				// m.EXPECT().IsEcrCredentialHelperEnabled(defaultDockerArguments.URI).Return(true)
 				m.EXPECT().Push(mockRepoURI, mockTag1, mockTag2, mockTag3).Return("sha256:f1d4ae3f7261a72e98c6ebefe9985cf10a0ea5bd762585a43e0700ed99863807", nil)
 			},
 			wantedDigest: "sha256:f1d4ae3f7261a72e98c6ebefe9985cf10a0ea5bd762585a43e0700ed99863807",
@@ -109,12 +109,12 @@ func TestRepository_BuildAndPush(t *testing.T) {
 		"success": {
 			mockRegistry: func(m *mocks.MockRegistry) {
 				m.EXPECT().RepositoryURI(inRepoName).Return(defaultDockerArguments.URI, nil)
-				m.EXPECT().Auth().Return("my-name", "my-pwd", nil).Times(1)
+				// m.EXPECT().Auth().Return("my-name", "my-pwd", nil).Times(1)
 			},
 			inMockDocker: func(m *mocks.MockContainerLoginBuildPusher) {
 				m.EXPECT().Build(&defaultDockerArguments).Return(nil).Times(1)
-				m.EXPECT().IsEcrCredentialHelperEnabled(defaultDockerArguments.URI).Return(false)
-				m.EXPECT().Login(mockRepoURI, "my-name", "my-pwd").Return(nil).Times(1)
+				// m.EXPECT().IsEcrCredentialHelperEnabled(defaultDockerArguments.URI).Return(false)
+				// m.EXPECT().Login(mockRepoURI, "my-name", "my-pwd").Return(nil).Times(1)
 				m.EXPECT().Push(mockRepoURI, mockTag1, mockTag2, mockTag3).Return("sha256:f1d4ae3f7261a72e98c6ebefe9985cf10a0ea5bd762585a43e0700ed99863807", nil)
 			},
 			wantedDigest: "sha256:f1d4ae3f7261a72e98c6ebefe9985cf10a0ea5bd762585a43e0700ed99863807",
@@ -151,6 +151,76 @@ func TestRepository_BuildAndPush(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tc.wantedDigest, digest)
+			}
+		})
+	}
+}
+
+func Test_Login(t *testing.T) {
+	const mockRepoURI = "mockRepoURI"
+	testCases := map[string]struct {
+		inURI        string
+		inMockDocker func(m *mocks.MockContainerLoginBuildPusher)
+		mockRegistry func(m *mocks.MockRegistry)
+		wantedError  error
+	}{
+		"failed to get auth": {
+			inURI: "mockRepoURI",
+			mockRegistry: func(m *mocks.MockRegistry) {
+				m.EXPECT().Auth().Return("", "", errors.New("error getting auth"))
+			},
+			inMockDocker: func(m *mocks.MockContainerLoginBuildPusher) {
+				m.EXPECT().IsEcrCredentialHelperEnabled("mockRepoURI").Return(false)
+				m.EXPECT().Login(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+			},
+			wantedError: errors.New("get auth: error getting auth"),
+		},
+		"failed to login": {
+			inURI: "mockRepoURI",
+			mockRegistry: func(m *mocks.MockRegistry) {
+				m.EXPECT().Auth().Return("my-name", "my-pwd", nil)
+			},
+			inMockDocker: func(m *mocks.MockContainerLoginBuildPusher) {
+				m.EXPECT().IsEcrCredentialHelperEnabled("mockRepoURI").Return(false)
+				m.EXPECT().Login("mockRepoURI", "my-name", "my-pwd").Return(errors.New("error logging in"))
+			},
+			wantedError: fmt.Errorf("login to repo %s: error logging in", mockRepoURI),
+		},
+		"no error when performing login": {
+			inURI: "mockRepoURI",
+			mockRegistry: func(m *mocks.MockRegistry) {
+				m.EXPECT().Auth().Return("my-name", "my-pwd", nil)
+			},
+			inMockDocker: func(m *mocks.MockContainerLoginBuildPusher) {
+				m.EXPECT().IsEcrCredentialHelperEnabled("mockRepoURI").Return(false)
+				m.EXPECT().Login("mockRepoURI", "my-name", "my-pwd").Return(nil)
+			},
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			mockRepoGetter := mocks.NewMockRegistry(ctrl)
+			mockDocker := mocks.NewMockContainerLoginBuildPusher(ctrl)
+
+			if tc.mockRegistry != nil {
+				tc.mockRegistry(mockRepoGetter)
+			}
+			if tc.inMockDocker != nil {
+				tc.inMockDocker(mockDocker)
+			}
+
+			repo := &Repository{
+				registry: mockRepoGetter,
+				uri:      mockRepoURI,
+			}
+
+			got := repo.Login(mockDocker)
+			if tc.wantedError != nil {
+				require.EqualError(t, tc.wantedError, got.Error())
+			} else {
+				require.NoError(t, tc.wantedError, got)
 			}
 		})
 	}

--- a/internal/pkg/repository/repository_test.go
+++ b/internal/pkg/repository/repository_test.go
@@ -53,20 +53,14 @@ func TestRepository_BuildAndPush(t *testing.T) {
 			},
 			inMockDocker: func(m *mocks.MockContainerLoginBuildPusher) {
 				m.EXPECT().Build(&defaultDockerArguments).Return(errors.New("error building image"))
-				// m.EXPECT().Login(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 				m.EXPECT().Push(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 			},
 			wantedError: fmt.Errorf("build Dockerfile at %s: error building image", inDockerfilePath),
 		},
 		"failed to push": {
 			inURI: defaultDockerArguments.URI,
-			// mockRegistry: func(m *mocks.MockRegistry) {
-			// 	m.EXPECT().Auth().Times(1)
-			// },
 			inMockDocker: func(m *mocks.MockContainerLoginBuildPusher) {
 				m.EXPECT().Build(&defaultDockerArguments).Times(1)
-				// m.EXPECT().IsEcrCredentialHelperEnabled(defaultDockerArguments.URI).Return(false)
-				// m.EXPECT().Login(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 				m.EXPECT().Push(mockRepoURI, mockTag1, mockTag2, mockTag3).Return("", errors.New("error pushing image"))
 			},
 			wantedError: errors.New("push to repo my-repo: error pushing image"),


### PR DESCRIPTION
<!-- Provide summary of changes -->
This PR provides logic to perform docker login if ECR credentials not enabled. After login is succeeded we build and push all the container images.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
