### PR TITLE
chore: add `--diff` flag in svc/job/env deploy

### DIFF
--- a/internal/pkg/cli/env_deploy.go
+++ b/internal/pkg/cli/env_deploy.go
@@ -27,6 +27,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const continueDeploymentPrompt = "Continue with the deployment?"
+
 type deployEnvVars struct {
 	appName         string
 	name            string
@@ -166,12 +168,12 @@ func (o *deployEnvOpts) Execute() error {
 			ForceNewUpdate:      o.forceNewUpdate,
 		})
 		if err != nil {
-			return fmt.Errorf("generate the template for environment %s: %w", o.name, err)
+			return fmt.Errorf("generate the template for environment %q: %w", o.name, err)
 		}
 		if err := diff(deployer, output.Template, os.Stdout); err != nil {
-			return err
+			return fmt.Errorf("generate diff for environment %q: %w", o.name, err)
 		}
-		contd, err := o.prompt.Confirm("Continue with the deployment?", "")
+		contd, err := o.prompt.Confirm(continueDeploymentPrompt, "")
 		if err != nil {
 			return fmt.Errorf("ask whether to continue with the deployment: %w", err)
 		}

--- a/internal/pkg/cli/flag.go
+++ b/internal/pkg/cli/flag.go
@@ -39,6 +39,7 @@ const (
 	stackOutputDirFlag    = "output-dir"
 	uploadAssetsFlag      = "upload-assets"
 	deployFlag            = "deploy"
+	diffFlag              = "diff"
 
 	// Flags for operational commands.
 	limitFlag                   = "limit"
@@ -249,6 +250,7 @@ const (
 	yesFlagDescription          = "Skips confirmation prompt."
 	resourceTagsFlagDescription = `Optional. Labels with a key and value separated by commas.
 Allows you to categorize resources.`
+	diffFlagDescription = "Show the diff of the to-be-deployed CFN template against the deployed one."
 
 	// Deployment.
 	deployTestFlagDescription = `Deploy your service or job to a "test" environment.`

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -655,8 +655,15 @@ type interpolator interface {
 
 type workloadDeployer interface {
 	UploadArtifacts() (*clideploy.UploadArtifactsOutput, error)
+	GenerateCloudFormationTemplate(in *clideploy.GenerateCloudFormationTemplateInput) (
+		*clideploy.GenerateCloudFormationTemplateOutput, error)
 	DeployWorkload(in *clideploy.DeployWorkloadInput) (clideploy.ActionRecommender, error)
 	IsServiceAvailableInRegion(region string) (bool, error)
+	templateDiffer
+}
+
+type templateDiffer interface {
+	DeployDiff(inTmpl string) (string, error)
 }
 
 type workloadStackGenerator interface {
@@ -664,6 +671,7 @@ type workloadStackGenerator interface {
 	GenerateCloudFormationTemplate(in *clideploy.GenerateCloudFormationTemplateInput) (
 		*clideploy.GenerateCloudFormationTemplateOutput, error)
 	AddonsTemplate() (string, error)
+	templateDiffer
 }
 
 type runner interface {

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -682,6 +682,9 @@ type envDeployer interface {
 	DeployEnvironment(in *clideploy.DeployEnvironmentInput) error
 	Validate(*manifest.Environment) error
 	UploadArtifacts() (*clideploy.UploadEnvArtifactsOutput, error)
+	GenerateCloudFormationTemplate(in *clideploy.DeployEnvironmentInput) (
+		*clideploy.GenerateCloudFormationTemplateOutput, error)
+	templateDiffer
 }
 
 type envPackager interface {

--- a/internal/pkg/cli/job_deploy.go
+++ b/internal/pkg/cli/job_deploy.go
@@ -212,7 +212,7 @@ func (o *deployJobOpts) Execute() error {
 		if err := diff(deployer, output.Template, o.diffWriter); err != nil {
 			return err
 		}
-		contd, err := o.prompt.Confirm("Continue with the deployment?", "")
+		contd, err := o.prompt.Confirm(continueDeploymentPrompt, "")
 		if err != nil {
 			return fmt.Errorf("ask whether to continue with the deployment: %w", err)
 		}

--- a/internal/pkg/cli/job_deploy.go
+++ b/internal/pkg/cli/job_deploy.go
@@ -337,6 +337,6 @@ func buildJobDeployCmd() *cobra.Command {
 	cmd.Flags().StringVar(&vars.imageTag, imageTagFlag, "", imageTagFlagDescription)
 	cmd.Flags().StringToStringVar(&vars.resourceTags, resourceTagsFlag, nil, resourceTagsFlagDescription)
 	cmd.Flags().BoolVar(&vars.disableRollback, noRollbackFlag, false, noRollbackFlagDescription)
-
+	cmd.Flags().BoolVar(&vars.showDiff, diffFlag, false, diffFlagDescription)
 	return cmd
 }

--- a/internal/pkg/cli/job_deploy_test.go
+++ b/internal/pkg/cli/job_deploy_test.go
@@ -293,7 +293,7 @@ func TestJobDeployOpts_Execute(t *testing.T) {
 				m.mockDeployer.EXPECT().GenerateCloudFormationTemplate(gomock.Any()).Return(&deploy.GenerateCloudFormationTemplateOutput{}, nil)
 				m.mockDeployer.EXPECT().DeployDiff(gomock.Any()).Return("", errors.New("some error"))
 			},
-			wantedError: errors.New("generate diff: some error"),
+			wantedError: errors.New("some error"),
 		},
 		"write 'no changes' if there is no diff": {
 			inShowDiff: true,

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -7113,6 +7113,21 @@ func (m *MockworkloadDeployer) EXPECT() *MockworkloadDeployerMockRecorder {
 	return m.recorder
 }
 
+// DeployDiff mocks base method.
+func (m *MockworkloadDeployer) DeployDiff(inTmpl string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeployDiff", inTmpl)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeployDiff indicates an expected call of DeployDiff.
+func (mr *MockworkloadDeployerMockRecorder) DeployDiff(inTmpl interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeployDiff", reflect.TypeOf((*MockworkloadDeployer)(nil).DeployDiff), inTmpl)
+}
+
 // DeployWorkload mocks base method.
 func (m *MockworkloadDeployer) DeployWorkload(in *deploy.DeployWorkloadInput) (deploy.ActionRecommender, error) {
 	m.ctrl.T.Helper()

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -7369,6 +7369,21 @@ func (m *MockenvDeployer) EXPECT() *MockenvDeployerMockRecorder {
 	return m.recorder
 }
 
+// DeployDiff mocks base method.
+func (m *MockenvDeployer) DeployDiff(inTmpl string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeployDiff", inTmpl)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeployDiff indicates an expected call of DeployDiff.
+func (mr *MockenvDeployerMockRecorder) DeployDiff(inTmpl interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeployDiff", reflect.TypeOf((*MockenvDeployer)(nil).DeployDiff), inTmpl)
+}
+
 // DeployEnvironment mocks base method.
 func (m *MockenvDeployer) DeployEnvironment(in *deploy.DeployEnvironmentInput) error {
 	m.ctrl.T.Helper()
@@ -7381,6 +7396,21 @@ func (m *MockenvDeployer) DeployEnvironment(in *deploy.DeployEnvironmentInput) e
 func (mr *MockenvDeployerMockRecorder) DeployEnvironment(in interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeployEnvironment", reflect.TypeOf((*MockenvDeployer)(nil).DeployEnvironment), in)
+}
+
+// GenerateCloudFormationTemplate mocks base method.
+func (m *MockenvDeployer) GenerateCloudFormationTemplate(in *deploy.DeployEnvironmentInput) (*deploy.GenerateCloudFormationTemplateOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GenerateCloudFormationTemplate", in)
+	ret0, _ := ret[0].(*deploy.GenerateCloudFormationTemplateOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GenerateCloudFormationTemplate indicates an expected call of GenerateCloudFormationTemplate.
+func (mr *MockenvDeployerMockRecorder) GenerateCloudFormationTemplate(in interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateCloudFormationTemplate", reflect.TypeOf((*MockenvDeployer)(nil).GenerateCloudFormationTemplate), in)
 }
 
 // UploadArtifacts mocks base method.

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -7128,6 +7128,21 @@ func (mr *MockworkloadDeployerMockRecorder) DeployWorkload(in interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeployWorkload", reflect.TypeOf((*MockworkloadDeployer)(nil).DeployWorkload), in)
 }
 
+// GenerateCloudFormationTemplate mocks base method.
+func (m *MockworkloadDeployer) GenerateCloudFormationTemplate(in *deploy.GenerateCloudFormationTemplateInput) (*deploy.GenerateCloudFormationTemplateOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GenerateCloudFormationTemplate", in)
+	ret0, _ := ret[0].(*deploy.GenerateCloudFormationTemplateOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GenerateCloudFormationTemplate indicates an expected call of GenerateCloudFormationTemplate.
+func (mr *MockworkloadDeployerMockRecorder) GenerateCloudFormationTemplate(in interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateCloudFormationTemplate", reflect.TypeOf((*MockworkloadDeployer)(nil).GenerateCloudFormationTemplate), in)
+}
+
 // IsServiceAvailableInRegion mocks base method.
 func (m *MockworkloadDeployer) IsServiceAvailableInRegion(region string) (bool, error) {
 	m.ctrl.T.Helper()
@@ -7156,6 +7171,44 @@ func (m *MockworkloadDeployer) UploadArtifacts() (*deploy.UploadArtifactsOutput,
 func (mr *MockworkloadDeployerMockRecorder) UploadArtifacts() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadArtifacts", reflect.TypeOf((*MockworkloadDeployer)(nil).UploadArtifacts))
+}
+
+// MocktemplateDiffer is a mock of templateDiffer interface.
+type MocktemplateDiffer struct {
+	ctrl     *gomock.Controller
+	recorder *MocktemplateDifferMockRecorder
+}
+
+// MocktemplateDifferMockRecorder is the mock recorder for MocktemplateDiffer.
+type MocktemplateDifferMockRecorder struct {
+	mock *MocktemplateDiffer
+}
+
+// NewMocktemplateDiffer creates a new mock instance.
+func NewMocktemplateDiffer(ctrl *gomock.Controller) *MocktemplateDiffer {
+	mock := &MocktemplateDiffer{ctrl: ctrl}
+	mock.recorder = &MocktemplateDifferMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MocktemplateDiffer) EXPECT() *MocktemplateDifferMockRecorder {
+	return m.recorder
+}
+
+// DeployDiff mocks base method.
+func (m *MocktemplateDiffer) DeployDiff(inTmpl string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeployDiff", inTmpl)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeployDiff indicates an expected call of DeployDiff.
+func (mr *MocktemplateDifferMockRecorder) DeployDiff(inTmpl interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeployDiff", reflect.TypeOf((*MocktemplateDiffer)(nil).DeployDiff), inTmpl)
 }
 
 // MockworkloadStackGenerator is a mock of workloadStackGenerator interface.
@@ -7194,6 +7247,21 @@ func (m *MockworkloadStackGenerator) AddonsTemplate() (string, error) {
 func (mr *MockworkloadStackGeneratorMockRecorder) AddonsTemplate() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddonsTemplate", reflect.TypeOf((*MockworkloadStackGenerator)(nil).AddonsTemplate))
+}
+
+// DeployDiff mocks base method.
+func (m *MockworkloadStackGenerator) DeployDiff(inTmpl string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeployDiff", inTmpl)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeployDiff indicates an expected call of DeployDiff.
+func (mr *MockworkloadStackGeneratorMockRecorder) DeployDiff(inTmpl interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeployDiff", reflect.TypeOf((*MockworkloadStackGenerator)(nil).DeployDiff), inTmpl)
 }
 
 // GenerateCloudFormationTemplate mocks base method.

--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -73,6 +73,7 @@ type deploySvcOpts struct {
 	appliedDynamicMft manifest.DynamicWorkload
 	rootUserARN       string
 	deployRecs        clideploy.ActionRecommender
+	noDeploy          bool
 }
 
 func newSvcDeployOpts(vars deployWkldVars) (*deploySvcOpts, error) {
@@ -256,6 +257,7 @@ func (o *deploySvcOpts) Execute() error {
 			return fmt.Errorf("ask whether to continue with the deployment: %w", err)
 		}
 		if !contd {
+			o.noDeploy = true
 			return nil
 		}
 	}
@@ -294,6 +296,9 @@ After fixing the deployment, you can:
 
 // RecommendActions returns follow-up actions the user can take after successfully executing the command.
 func (o *deploySvcOpts) RecommendActions() error {
+	if o.noDeploy {
+		return nil
+	}
 	var recommendations []string
 	uriRecs, err := o.uriRecommendedActions()
 	if err != nil {

--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -578,6 +578,18 @@ func (e *errFeatureIncompatibleWithEnvironment) RecommendActions() string {
 
 }
 
+func diff(differ templateDiffer, tmpl string, writer io.Writer) error {
+	out, err := differ.DeployDiff(tmpl)
+	if err != nil {
+		return err
+	}
+	if out == "" {
+		out = "No changes.\n"
+	}
+	_, err = writer.Write([]byte(out))
+	return err
+}
+
 // buildSvcDeployCmd builds the `svc deploy` subcommand.
 func buildSvcDeployCmd() *cobra.Command {
 	vars := deployWkldVars{}

--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -256,7 +256,7 @@ func (o *deploySvcOpts) Execute() error {
 		if err := diff(deployer, output.Template, o.diffWriter); err != nil {
 			return err
 		}
-		contd, err := o.prompt.Confirm("Continue with the deployment?", "")
+		contd, err := o.prompt.Confirm(continueDeploymentPrompt, "")
 		if err != nil {
 			return fmt.Errorf("ask whether to continue with the deployment: %w", err)
 		}

--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -248,7 +248,16 @@ func (o *deploySvcOpts) Execute() error {
 		if err != nil {
 			return fmt.Errorf("generate workload %s template against environment %s: %w", o.name, o.envName, err)
 		}
-		return diff(deployer, output.Template, os.Stdout)
+		if err := diff(deployer, output.Template, os.Stdout); err != nil {
+			return err
+		}
+		contd, err := o.prompt.Confirm("Continue with the deployment?", "")
+		if err != nil {
+			return fmt.Errorf("ask whether to continue with the deployment: %w", err)
+		}
+		if !contd {
+			return nil
+		}
 	}
 	deployRecs, err := deployer.DeployWorkload(&clideploy.DeployWorkloadInput{
 		StackRuntimeConfiguration: clideploy.StackRuntimeConfiguration{

--- a/internal/pkg/cli/svc_deploy_test.go
+++ b/internal/pkg/cli/svc_deploy_test.go
@@ -6,6 +6,7 @@ package cli
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -130,6 +131,8 @@ type deployMocks struct {
 	mockWsReader             *mocks.MockwsWlDirReader
 	mockEnvFeaturesDescriber *mocks.MockversionCompatibilityChecker
 	mockMft                  *mockWorkloadMft
+	mockDiffWriter           *strings.Builder
+	mockPrompter             *mocks.Mockprompter
 }
 
 func TestSvcDeployOpts_Execute(t *testing.T) {
@@ -140,7 +143,9 @@ func TestSvcDeployOpts_Execute(t *testing.T) {
 	)
 	mockError := errors.New("some error")
 	testCases := map[string]struct {
+		inShowDiff  bool
 		mock        func(m *deployMocks)
+		wantedDiff  string
 		wantedError error
 	}{
 		"error out if fail to read workload manifest": {
@@ -200,6 +205,148 @@ func TestSvcDeployOpts_Execute(t *testing.T) {
 
 			wantedError: fmt.Errorf("upload deploy resources for service frontend: some error"),
 		},
+		"error if failed to generate the template to show diff": {
+			inShowDiff: true,
+			mock: func(m *deployMocks) {
+				m.mockWsReader.EXPECT().ReadWorkloadManifest(mockSvcName).Return([]byte(""), nil)
+				m.mockInterpolator.EXPECT().Interpolate("").Return("", nil)
+				m.mockMft = &mockWorkloadMft{
+					mockRequiredEnvironmentFeatures: func() []string {
+						return []string{"mockFeature1"}
+					},
+				}
+				m.mockEnvFeaturesDescriber.EXPECT().Version().Return("v1.mock", nil)
+				m.mockEnvFeaturesDescriber.EXPECT().AvailableFeatures().Return([]string{"mockFeature1", "mockFeature2"}, nil)
+				m.mockDeployer.EXPECT().IsServiceAvailableInRegion("").Return(false, nil)
+				m.mockDeployer.EXPECT().UploadArtifacts().Return(&clideploy.UploadArtifactsOutput{}, nil)
+				m.mockDeployer.EXPECT().GenerateCloudFormationTemplate(gomock.Any()).Return(nil, errors.New("some error"))
+			},
+			wantedError: fmt.Errorf("generate the template for workload %q against environment %q: some error", mockSvcName, mockEnvName),
+		},
+		"error if failed to generate the diff": {
+			inShowDiff: true,
+			mock: func(m *deployMocks) {
+				m.mockWsReader.EXPECT().ReadWorkloadManifest(mockSvcName).Return([]byte(""), nil)
+				m.mockInterpolator.EXPECT().Interpolate("").Return("", nil)
+				m.mockMft = &mockWorkloadMft{
+					mockRequiredEnvironmentFeatures: func() []string {
+						return []string{"mockFeature1"}
+					},
+				}
+				m.mockEnvFeaturesDescriber.EXPECT().Version().Return("v1.mock", nil)
+				m.mockEnvFeaturesDescriber.EXPECT().AvailableFeatures().Return([]string{"mockFeature1", "mockFeature2"}, nil)
+				m.mockDeployer.EXPECT().IsServiceAvailableInRegion("").Return(false, nil)
+				m.mockDeployer.EXPECT().UploadArtifacts().Return(&clideploy.UploadArtifactsOutput{}, nil)
+				m.mockDeployer.EXPECT().GenerateCloudFormationTemplate(gomock.Any()).Return(&clideploy.GenerateCloudFormationTemplateOutput{}, nil)
+				m.mockDeployer.EXPECT().DeployDiff(gomock.Any()).Return("", errors.New("some error"))
+			},
+			wantedError: errors.New("generate diff: some error"),
+		},
+		"write 'no changes' if there is no diff": {
+			inShowDiff: true,
+			mock: func(m *deployMocks) {
+				m.mockWsReader.EXPECT().ReadWorkloadManifest(mockSvcName).Return([]byte(""), nil)
+				m.mockInterpolator.EXPECT().Interpolate("").Return("", nil)
+				m.mockMft = &mockWorkloadMft{
+					mockRequiredEnvironmentFeatures: func() []string {
+						return []string{"mockFeature1"}
+					},
+				}
+				m.mockEnvFeaturesDescriber.EXPECT().Version().Return("v1.mock", nil)
+				m.mockEnvFeaturesDescriber.EXPECT().AvailableFeatures().Return([]string{"mockFeature1", "mockFeature2"}, nil)
+				m.mockDeployer.EXPECT().IsServiceAvailableInRegion("").Return(false, nil)
+				m.mockDeployer.EXPECT().UploadArtifacts().Return(&clideploy.UploadArtifactsOutput{}, nil)
+				m.mockDeployer.EXPECT().GenerateCloudFormationTemplate(gomock.Any()).Return(&clideploy.GenerateCloudFormationTemplateOutput{}, nil)
+				m.mockDeployer.EXPECT().DeployDiff(gomock.Any()).Return("", nil)
+				m.mockDiffWriter = &strings.Builder{}
+				m.mockPrompter.EXPECT().Confirm(gomock.Eq("Continue with the deployment?"), gomock.Any(), gomock.Any()).Return(false, nil)
+			},
+			wantedDiff: "No changes.\n",
+		},
+		"write the correct diff": {
+			inShowDiff: true,
+			mock: func(m *deployMocks) {
+				m.mockWsReader.EXPECT().ReadWorkloadManifest(mockSvcName).Return([]byte(""), nil)
+				m.mockInterpolator.EXPECT().Interpolate("").Return("", nil)
+				m.mockMft = &mockWorkloadMft{
+					mockRequiredEnvironmentFeatures: func() []string {
+						return []string{"mockFeature1"}
+					},
+				}
+				m.mockEnvFeaturesDescriber.EXPECT().Version().Return("v1.mock", nil)
+				m.mockEnvFeaturesDescriber.EXPECT().AvailableFeatures().Return([]string{"mockFeature1", "mockFeature2"}, nil)
+				m.mockDeployer.EXPECT().IsServiceAvailableInRegion("").Return(false, nil)
+				m.mockDeployer.EXPECT().UploadArtifacts().Return(&clideploy.UploadArtifactsOutput{}, nil)
+				m.mockDeployer.EXPECT().GenerateCloudFormationTemplate(gomock.Any()).Return(&clideploy.GenerateCloudFormationTemplateOutput{}, nil)
+				m.mockDeployer.EXPECT().DeployDiff(gomock.Any()).Return("mock diff", nil)
+				m.mockDiffWriter = &strings.Builder{}
+				m.mockPrompter.EXPECT().Confirm(gomock.Eq("Continue with the deployment?"), gomock.Any(), gomock.Any()).Return(false, nil)
+			},
+			wantedDiff: "mock diff",
+		},
+		"error if fail to ask whether to continue the deployment": {
+			inShowDiff: true,
+			mock: func(m *deployMocks) {
+				m.mockWsReader.EXPECT().ReadWorkloadManifest(mockSvcName).Return([]byte(""), nil)
+				m.mockInterpolator.EXPECT().Interpolate("").Return("", nil)
+				m.mockMft = &mockWorkloadMft{
+					mockRequiredEnvironmentFeatures: func() []string {
+						return []string{"mockFeature1"}
+					},
+				}
+				m.mockEnvFeaturesDescriber.EXPECT().Version().Return("v1.mock", nil)
+				m.mockEnvFeaturesDescriber.EXPECT().AvailableFeatures().Return([]string{"mockFeature1", "mockFeature2"}, nil)
+				m.mockDeployer.EXPECT().IsServiceAvailableInRegion("").Return(false, nil)
+				m.mockDeployer.EXPECT().UploadArtifacts().Return(&clideploy.UploadArtifactsOutput{}, nil)
+				m.mockDeployer.EXPECT().GenerateCloudFormationTemplate(gomock.Any()).Return(&clideploy.GenerateCloudFormationTemplateOutput{}, nil)
+				m.mockDeployer.EXPECT().DeployDiff(gomock.Any()).Return("mock diff", nil)
+				m.mockDiffWriter = &strings.Builder{}
+				m.mockPrompter.EXPECT().Confirm(gomock.Eq("Continue with the deployment?"), gomock.Any(), gomock.Any()).Return(false, errors.New("some error"))
+			},
+			wantedError: errors.New("ask whether to continue with the deployment: some error"),
+		},
+		"do not deploy if asked to": {
+			inShowDiff: true,
+			mock: func(m *deployMocks) {
+				m.mockWsReader.EXPECT().ReadWorkloadManifest(mockSvcName).Return([]byte(""), nil)
+				m.mockInterpolator.EXPECT().Interpolate("").Return("", nil)
+				m.mockMft = &mockWorkloadMft{
+					mockRequiredEnvironmentFeatures: func() []string {
+						return []string{"mockFeature1"}
+					},
+				}
+				m.mockEnvFeaturesDescriber.EXPECT().Version().Return("v1.mock", nil)
+				m.mockEnvFeaturesDescriber.EXPECT().AvailableFeatures().Return([]string{"mockFeature1", "mockFeature2"}, nil)
+				m.mockDeployer.EXPECT().IsServiceAvailableInRegion("").Return(false, nil)
+				m.mockDeployer.EXPECT().UploadArtifacts().Return(&clideploy.UploadArtifactsOutput{}, nil)
+				m.mockDeployer.EXPECT().GenerateCloudFormationTemplate(gomock.Any()).Return(&clideploy.GenerateCloudFormationTemplateOutput{}, nil)
+				m.mockDeployer.EXPECT().DeployDiff(gomock.Any()).Return("mock diff", nil)
+				m.mockDiffWriter = &strings.Builder{}
+				m.mockPrompter.EXPECT().Confirm(gomock.Eq("Continue with the deployment?"), gomock.Any(), gomock.Any()).Return(false, nil)
+				m.mockDeployer.EXPECT().DeployWorkload(gomock.Any()).Times(0)
+			},
+		},
+		"deploy if asked to": {
+			inShowDiff: true,
+			mock: func(m *deployMocks) {
+				m.mockWsReader.EXPECT().ReadWorkloadManifest(mockSvcName).Return([]byte(""), nil)
+				m.mockInterpolator.EXPECT().Interpolate("").Return("", nil)
+				m.mockMft = &mockWorkloadMft{
+					mockRequiredEnvironmentFeatures: func() []string {
+						return []string{"mockFeature1"}
+					},
+				}
+				m.mockEnvFeaturesDescriber.EXPECT().Version().Return("v1.mock", nil)
+				m.mockEnvFeaturesDescriber.EXPECT().AvailableFeatures().Return([]string{"mockFeature1", "mockFeature2"}, nil)
+				m.mockDeployer.EXPECT().IsServiceAvailableInRegion("").Return(false, nil)
+				m.mockDeployer.EXPECT().UploadArtifacts().Return(&clideploy.UploadArtifactsOutput{}, nil)
+				m.mockDeployer.EXPECT().GenerateCloudFormationTemplate(gomock.Any()).Return(&clideploy.GenerateCloudFormationTemplateOutput{}, nil)
+				m.mockDeployer.EXPECT().DeployDiff(gomock.Any()).Return("mock diff", nil)
+				m.mockDiffWriter = &strings.Builder{}
+				m.mockPrompter.EXPECT().Confirm(gomock.Eq("Continue with the deployment?"), gomock.Any(), gomock.Any()).Return(true, nil)
+				m.mockDeployer.EXPECT().DeployWorkload(gomock.Any()).Times(1)
+			},
+		},
 		"error if failed to deploy service": {
 			mock: func(m *deployMocks) {
 				m.mockWsReader.EXPECT().ReadWorkloadManifest(mockSvcName).Return([]byte(""), nil)
@@ -247,14 +394,16 @@ func TestSvcDeployOpts_Execute(t *testing.T) {
 				mockInterpolator:         mocks.NewMockinterpolator(ctrl),
 				mockWsReader:             mocks.NewMockwsWlDirReader(ctrl),
 				mockEnvFeaturesDescriber: mocks.NewMockversionCompatibilityChecker(ctrl),
+				mockPrompter:             mocks.NewMockprompter(ctrl),
 			}
 			tc.mock(m)
 
 			opts := deploySvcOpts{
 				deployWkldVars: deployWkldVars{
-					appName: mockAppName,
-					name:    mockSvcName,
-					envName: mockEnvName,
+					appName:  mockAppName,
+					name:     mockSvcName,
+					envName:  mockEnvName,
+					showDiff: tc.inShowDiff,
 
 					clientConfigured: true,
 				},
@@ -269,8 +418,11 @@ func TestSvcDeployOpts_Execute(t *testing.T) {
 					return m.mockMft, nil
 				},
 				envFeaturesDescriber: m.mockEnvFeaturesDescriber,
-				targetApp:            &config.Application{},
-				targetEnv:            &config.Environment{},
+				prompt:               m.mockPrompter,
+				diffWriter:           m.mockDiffWriter,
+
+				targetApp: &config.Application{},
+				targetEnv: &config.Environment{},
 			}
 
 			// WHEN
@@ -281,6 +433,9 @@ func TestSvcDeployOpts_Execute(t *testing.T) {
 				require.NoError(t, err)
 			} else {
 				require.EqualError(t, err, tc.wantedError.Error())
+			}
+			if tc.wantedDiff != "" {
+				require.Equal(t, tc.wantedDiff, m.mockDiffWriter.String())
 			}
 		})
 	}

--- a/internal/pkg/cli/svc_deploy_test.go
+++ b/internal/pkg/cli/svc_deploy_test.go
@@ -240,7 +240,7 @@ func TestSvcDeployOpts_Execute(t *testing.T) {
 				m.mockDeployer.EXPECT().GenerateCloudFormationTemplate(gomock.Any()).Return(&clideploy.GenerateCloudFormationTemplateOutput{}, nil)
 				m.mockDeployer.EXPECT().DeployDiff(gomock.Any()).Return("", errors.New("some error"))
 			},
-			wantedError: errors.New("generate diff: some error"),
+			wantedError: errors.New("some error"),
 		},
 		"write 'no changes' if there is no diff": {
 			inShowDiff: true,

--- a/internal/pkg/cli/svc_package.go
+++ b/internal/pkg/cli/svc_package.go
@@ -441,18 +441,6 @@ func contains(s string, items []string) bool {
 	return false
 }
 
-func diff(differ templateDiffer, tmpl string, writer io.WriteCloser) error {
-	out, err := differ.DeployDiff(tmpl)
-	if err != nil {
-		return err
-	}
-	if out == "" {
-		out = "No changes.\n"
-	}
-	_, err = writer.Write([]byte(out))
-	return err
-}
-
 // buildSvcPackageCmd builds the command for printing a service's CloudFormation template.
 func buildSvcPackageCmd() *cobra.Command {
 	vars := packageSvcVars{}

--- a/internal/pkg/cli/svc_package.go
+++ b/internal/pkg/cli/svc_package.go
@@ -58,7 +58,6 @@ type packageSvcOpts struct {
 	runner               execRunner
 	sessProvider         *sessions.Provider
 	sel                  wsSelector
-	prompt               prompter
 	unmarshal            func([]byte) (manifest.DynamicWorkload, error)
 	newInterpolator      func(app, env string) interpolator
 	newStackGenerator    func(*packageSvcOpts) (workloadStackGenerator, error)
@@ -96,7 +95,6 @@ func newPackageSvcOpts(vars packageSvcVars) (*packageSvcOpts, error) {
 		unmarshal:         manifest.UnmarshalWorkload,
 		runner:            exec.NewCmd(),
 		sel:               selector.NewLocalWorkloadSelector(prompter, store, ws),
-		prompt:            prompter,
 		templateWriter:    os.Stdout,
 		paramsWriter:      discardFile{},
 		addonsWriter:      discardFile{},


### PR DESCRIPTION
Looks like a large PR but the logic is super similar across env/svc/job deploy. Most of the additions are because of unit tests! (and the unit tests are similar across env/svc/job deploy as well)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
