### PR TITLE
chore: add `--diff` flag in svc/job/env package 

### DIFF
--- a/internal/pkg/cli/env_package.go
+++ b/internal/pkg/cli/env_package.go
@@ -66,6 +66,7 @@ type packageEnvOpts struct {
 	tplWriter    io.WriteCloser
 	paramsWriter io.WriteCloser
 	addonsWriter io.WriteCloser
+	diffWriter   io.Writer
 
 	newInterpolator func(appName, envName string) interpolator
 	newEnvPackager  func() (envPackager, error)
@@ -100,6 +101,7 @@ func newPackageEnvOpts(vars packageEnvVars) (*packageEnvOpts, error) {
 		tplWriter:    os.Stdout,
 		paramsWriter: discardFile{},
 		addonsWriter: discardFile{},
+		diffWriter:   os.Stdout,
 
 		newInterpolator: func(appName, envName string) interpolator {
 			return manifest.NewInterpolator(appName, envName)
@@ -196,6 +198,9 @@ func (o *packageEnvOpts) Execute() error {
 	})
 	if err != nil {
 		return fmt.Errorf("generate CloudFormation template from environment %q manifest: %v", o.envName, err)
+	}
+	if o.showDiff {
+		return diff(packager, res.Template, o.diffWriter)
 	}
 	addonsTemplate, err := packager.AddonsTemplate()
 	if err != nil {

--- a/internal/pkg/cli/env_package.go
+++ b/internal/pkg/cli/env_package.go
@@ -134,14 +134,6 @@ func newPackageEnvOpts(vars packageEnvVars) (*packageEnvOpts, error) {
 
 // Validate returns an error for any invalid optional flags.
 func (o *packageEnvOpts) Validate() error {
-	if o.showDiff {
-		if o.outputDir != "" {
-			return fmt.Errorf("`--%s` cannot be specified together with `--%s`", diffFlag, stackOutputDirFlag)
-		}
-		if o.uploadAssets {
-			return fmt.Errorf("`--%s` cannot be specified together with `--%s`", diffFlag, uploadAssetsFlag)
-		}
-	}
 	return nil
 }
 
@@ -341,5 +333,8 @@ func buildEnvPkgCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&vars.uploadAssets, uploadAssetsFlag, false, uploadAssetsFlagDescription)
 	cmd.Flags().BoolVar(&vars.forceNewUpdate, forceFlag, false, forceEnvDeployFlagDescription)
 	cmd.Flags().BoolVar(&vars.showDiff, diffFlag, false, diffFlagDescription)
+
+	cmd.MarkFlagsMutuallyExclusive(diffFlag, stackOutputDirFlag)
+	cmd.MarkFlagsMutuallyExclusive(diffFlag, uploadAssetsFlag)
 	return cmd
 }

--- a/internal/pkg/cli/env_package.go
+++ b/internal/pkg/cli/env_package.go
@@ -41,6 +41,7 @@ type packageEnvVars struct {
 	outputDir      string
 	uploadAssets   bool
 	forceNewUpdate bool
+	showDiff       bool
 }
 
 type discardFile struct{}
@@ -131,6 +132,14 @@ func newPackageEnvOpts(vars packageEnvVars) (*packageEnvOpts, error) {
 
 // Validate returns an error for any invalid optional flags.
 func (o *packageEnvOpts) Validate() error {
+	if o.showDiff {
+		if o.outputDir != "" {
+			return fmt.Errorf("`--%s` cannot be specified together with `--%s`", diffFlag, stackOutputDirFlag)
+		}
+		if o.uploadAssets {
+			return fmt.Errorf("`--%s` cannot be specified together with `--%s`", diffFlag, uploadAssetsFlag)
+		}
+	}
 	return nil
 }
 
@@ -326,5 +335,6 @@ func buildEnvPkgCmd() *cobra.Command {
 	cmd.Flags().StringVar(&vars.outputDir, stackOutputDirFlag, "", stackOutputDirFlagDescription)
 	cmd.Flags().BoolVar(&vars.uploadAssets, uploadAssetsFlag, false, uploadAssetsFlagDescription)
 	cmd.Flags().BoolVar(&vars.forceNewUpdate, forceFlag, false, forceEnvDeployFlagDescription)
+	cmd.Flags().BoolVar(&vars.showDiff, diffFlag, false, diffFlagDescription)
 	return cmd
 }

--- a/internal/pkg/cli/env_package_test.go
+++ b/internal/pkg/cli/env_package_test.go
@@ -27,48 +27,6 @@ import (
 	"github.com/golang/mock/gomock"
 )
 
-func TestPackageEnvOpts_Validate(t *testing.T) {
-	testCases := map[string]struct {
-		inShowDiff     bool
-		inOutputDir    string
-		inUploadAssets bool
-		wantedErr      error
-	}{
-		"error if diff is specified with output-dir": {
-			inShowDiff:  true,
-			inOutputDir: "what/a/dir",
-			wantedErr:   errors.New("`--diff` cannot be specified together with `--output-dir`"),
-		},
-		"error if diff is specified with upload-assets": {
-			inShowDiff:     true,
-			inUploadAssets: true,
-			wantedErr:      errors.New("`--diff` cannot be specified together with `--upload-assets`"),
-		},
-		"no diff": {},
-		"diff": {
-			inShowDiff: true,
-		},
-	}
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			opts := &packageEnvOpts{
-				packageEnvVars: packageEnvVars{
-					showDiff:     tc.inShowDiff,
-					outputDir:    tc.inOutputDir,
-					uploadAssets: tc.inUploadAssets,
-				},
-			}
-			// WHEN
-			err := opts.Validate()
-			if tc.wantedErr != nil {
-				require.EqualError(t, err, tc.wantedErr.Error())
-			} else {
-				require.NoError(t, err)
-			}
-		})
-	}
-}
-
 func TestPackageEnvOpts_Ask(t *testing.T) {
 	testCases := map[string]struct {
 		in        packageEnvVars

--- a/internal/pkg/cli/env_package_test.go
+++ b/internal/pkg/cli/env_package_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -175,8 +176,9 @@ func TestPackageEnvOpts_Execute(t *testing.T) {
 	testCases := map[string]struct {
 		mockedCmd func(controller *gomock.Controller) *packageEnvOpts
 
-		wantedFS  func(t *testing.T, fs afero.Fs)
-		wantedErr error
+		wantedDiff string
+		wantedFS   func(t *testing.T, fs afero.Fs)
+		wantedErr  error
 	}{
 		"should return a wrapped error when reading env manifest fails": {
 			mockedCmd: func(ctrl *gomock.Controller) *packageEnvOpts {
@@ -326,6 +328,38 @@ func TestPackageEnvOpts_Execute(t *testing.T) {
 			},
 			wantedErr: errors.New(`generate CloudFormation template from environment "test" manifest: some error`),
 		},
+		"should return an error if fail to get the diff": {
+			mockedCmd: func(ctrl *gomock.Controller) *packageEnvOpts {
+				ws := mocks.NewMockwsEnvironmentReader(ctrl)
+				ws.EXPECT().ReadEnvironmentManifest(gomock.Any()).Return([]byte("name: test\ntype: Environment\n"), nil)
+				interop := mocks.NewMockinterpolator(ctrl)
+				interop.EXPECT().Interpolate(gomock.Any()).Return("name: test\ntype: Environment\n", nil)
+				caller := mocks.NewMockidentityService(ctrl)
+				caller.EXPECT().Get().Return(identity.Caller{}, nil)
+				deployer := mocks.NewMockenvPackager(ctrl)
+				deployer.EXPECT().Validate(gomock.Any()).Return(nil)
+				deployer.EXPECT().GenerateCloudFormationTemplate(gomock.Any()).Return(&deploy.GenerateCloudFormationTemplateOutput{}, nil)
+				deployer.EXPECT().DeployDiff(gomock.Any()).Return("", errors.New("some error"))
+				return &packageEnvOpts{
+					packageEnvVars: packageEnvVars{
+						envName:  "test",
+						showDiff: true,
+					},
+					ws:     ws,
+					caller: caller,
+					newInterpolator: func(_, _ string) interpolator {
+						return interop
+					},
+					newEnvPackager: func() (envPackager, error) {
+						return deployer, nil
+					},
+					envCfg:     &config.Environment{Name: "test"},
+					appCfg:     &config.Application{},
+					diffWriter: &strings.Builder{},
+				}
+			},
+			wantedErr: errors.New("some error"),
+		},
 		"should return a wrapped error when retrieving addons CloudFormation template fails": {
 			mockedCmd: func(ctrl *gomock.Controller) *packageEnvOpts {
 				ws := mocks.NewMockwsEnvironmentReader(ctrl)
@@ -411,6 +445,38 @@ func TestPackageEnvOpts_Execute(t *testing.T) {
 				}
 			},
 			wantedFS: func(_ *testing.T, _ afero.Fs) {},
+		},
+		"should write the diff": {
+			mockedCmd: func(ctrl *gomock.Controller) *packageEnvOpts {
+				ws := mocks.NewMockwsEnvironmentReader(ctrl)
+				ws.EXPECT().ReadEnvironmentManifest(gomock.Any()).Return([]byte("name: test\ntype: Environment\n"), nil)
+				interop := mocks.NewMockinterpolator(ctrl)
+				interop.EXPECT().Interpolate(gomock.Any()).Return("name: test\ntype: Environment\n", nil)
+				caller := mocks.NewMockidentityService(ctrl)
+				caller.EXPECT().Get().Return(identity.Caller{}, nil)
+				deployer := mocks.NewMockenvPackager(ctrl)
+				deployer.EXPECT().Validate(gomock.Any()).Return(nil)
+				deployer.EXPECT().GenerateCloudFormationTemplate(gomock.Any()).Return(&deploy.GenerateCloudFormationTemplateOutput{}, nil)
+				deployer.EXPECT().DeployDiff(gomock.Any()).Return("mock diff", nil)
+				return &packageEnvOpts{
+					packageEnvVars: packageEnvVars{
+						envName:  "test",
+						showDiff: true,
+					},
+					ws:     ws,
+					caller: caller,
+					newInterpolator: func(_, _ string) interpolator {
+						return interop
+					},
+					newEnvPackager: func() (envPackager, error) {
+						return deployer, nil
+					},
+					envCfg:     &config.Environment{Name: "test"},
+					appCfg:     &config.Application{},
+					diffWriter: &strings.Builder{},
+				}
+			},
+			wantedDiff: "mock diff",
 		},
 		"should write files to output directories without addons": {
 			mockedCmd: func(ctrl *gomock.Controller) *packageEnvOpts {
@@ -564,9 +630,16 @@ func TestPackageEnvOpts_Execute(t *testing.T) {
 			// THEN
 			if tc.wantedErr == nil {
 				require.NoError(t, actual)
-				tc.wantedFS(t, cmd.fs)
 			} else {
 				require.EqualError(t, actual, tc.wantedErr.Error())
+			}
+
+			if tc.wantedFS != nil {
+				tc.wantedFS(t, cmd.fs)
+			}
+
+			if tc.wantedDiff != "" {
+				require.Equal(t, tc.wantedDiff, cmd.diffWriter.(*strings.Builder).String())
 			}
 		})
 	}

--- a/internal/pkg/cli/env_package_test.go
+++ b/internal/pkg/cli/env_package_test.go
@@ -26,6 +26,48 @@ import (
 	"github.com/golang/mock/gomock"
 )
 
+func TestPackageEnvOpts_Validate(t *testing.T) {
+	testCases := map[string]struct {
+		inShowDiff     bool
+		inOutputDir    string
+		inUploadAssets bool
+		wantedErr      error
+	}{
+		"error if diff is specified with output-dir": {
+			inShowDiff:  true,
+			inOutputDir: "what/a/dir",
+			wantedErr:   errors.New("`--diff` cannot be specified together with `--output-dir`"),
+		},
+		"error if diff is specified with upload-assets": {
+			inShowDiff:     true,
+			inUploadAssets: true,
+			wantedErr:      errors.New("`--diff` cannot be specified together with `--upload-assets`"),
+		},
+		"no diff": {},
+		"diff": {
+			inShowDiff: true,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			opts := &packageEnvOpts{
+				packageEnvVars: packageEnvVars{
+					showDiff:     tc.inShowDiff,
+					outputDir:    tc.inOutputDir,
+					uploadAssets: tc.inUploadAssets,
+				},
+			}
+			// WHEN
+			err := opts.Validate()
+			if tc.wantedErr != nil {
+				require.EqualError(t, err, tc.wantedErr.Error())
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestPackageEnvOpts_Ask(t *testing.T) {
 	testCases := map[string]struct {
 		in        packageEnvVars

--- a/internal/pkg/cli/flag.go
+++ b/internal/pkg/cli/flag.go
@@ -250,7 +250,7 @@ const (
 	yesFlagDescription          = "Skips confirmation prompt."
 	resourceTagsFlagDescription = `Optional. Labels with a key and value separated by commas.
 Allows you to categorize resources.`
-	diffFlagDescription = "Show the diff of the to-be-deployed CFN template against the deployed one."
+	diffFlagDescription = "Compares the generated CloudFormation template to the deployed stack."
 
 	// Deployment.
 	deployTestFlagDescription = `Deploy your service or job to a "test" environment.`

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -692,4 +692,5 @@ type envPackager interface {
 	Validate(*manifest.Environment) error
 	UploadArtifacts() (*clideploy.UploadEnvArtifactsOutput, error)
 	AddonsTemplate() (string, error)
+	templateDiffer
 }

--- a/internal/pkg/cli/job_package.go
+++ b/internal/pkg/cli/job_package.go
@@ -34,6 +34,7 @@ type packageJobVars struct {
 	tag          string
 	outputDir    string
 	uploadAssets bool
+	showDiff     bool
 }
 
 type packageJobOpts struct {
@@ -119,6 +120,14 @@ func (o *packageJobOpts) Validate() error {
 			return err
 		}
 	}
+	if o.showDiff {
+		if o.outputDir != "" {
+			return fmt.Errorf("`--%s` cannot be specified together with `--%s`", diffFlag, stackOutputDirFlag)
+		}
+		if o.uploadAssets {
+			return fmt.Errorf("`--%s` cannot be specified together with `--%s`", diffFlag, uploadAssetsFlag)
+		}
+	}
 	return nil
 }
 
@@ -201,5 +210,6 @@ func buildJobPackageCmd() *cobra.Command {
 	cmd.Flags().StringVar(&vars.tag, imageTagFlag, "", imageTagFlagDescription)
 	cmd.Flags().StringVar(&vars.outputDir, stackOutputDirFlag, "", stackOutputDirFlagDescription)
 	cmd.Flags().BoolVar(&vars.uploadAssets, uploadAssetsFlag, false, uploadAssetsFlagDescription)
+	cmd.Flags().BoolVar(&vars.showDiff, diffFlag, false, diffFlagDescription)
 	return cmd
 }

--- a/internal/pkg/cli/job_package.go
+++ b/internal/pkg/cli/job_package.go
@@ -120,14 +120,6 @@ func (o *packageJobOpts) Validate() error {
 			return err
 		}
 	}
-	if o.showDiff {
-		if o.outputDir != "" {
-			return fmt.Errorf("`--%s` cannot be specified together with `--%s`", diffFlag, stackOutputDirFlag)
-		}
-		if o.uploadAssets {
-			return fmt.Errorf("`--%s` cannot be specified together with `--%s`", diffFlag, uploadAssetsFlag)
-		}
-	}
 	return nil
 }
 
@@ -211,5 +203,8 @@ func buildJobPackageCmd() *cobra.Command {
 	cmd.Flags().StringVar(&vars.outputDir, stackOutputDirFlag, "", stackOutputDirFlagDescription)
 	cmd.Flags().BoolVar(&vars.uploadAssets, uploadAssetsFlag, false, uploadAssetsFlagDescription)
 	cmd.Flags().BoolVar(&vars.showDiff, diffFlag, false, diffFlagDescription)
+
+	cmd.MarkFlagsMutuallyExclusive(diffFlag, stackOutputDirFlag)
+	cmd.MarkFlagsMutuallyExclusive(diffFlag, uploadAssetsFlag)
 	return cmd
 }

--- a/internal/pkg/cli/job_package_test.go
+++ b/internal/pkg/cli/job_package_test.go
@@ -76,29 +76,6 @@ func TestPackageJobOpts_Validate(t *testing.T) {
 				EnvironmentName: "test",
 			}).Error(),
 		},
-		"error if diff is specified with output-dir": {
-			inAppName:    "phonetool",
-			inShowDiff:   true,
-			inOutputDir:  "what/a/dir",
-			setupMocks:   func() {},
-			wantedErrorS: "`--diff` cannot be specified together with `--output-dir`",
-		},
-		"error if diff is specified with upload-assets": {
-			inAppName:      "phonetool",
-			inShowDiff:     true,
-			inUploadAssets: true,
-			setupMocks:     func() {},
-			wantedErrorS:   "`--diff` cannot be specified together with `--upload-assets`",
-		},
-		"no diff": {
-			inAppName:  "phonetool",
-			setupMocks: func() {},
-		},
-		"diff": {
-			inAppName:  "phonetool",
-			inShowDiff: true,
-			setupMocks: func() {},
-		},
 	}
 
 	for name, tc := range testCases {

--- a/internal/pkg/cli/job_package_test.go
+++ b/internal/pkg/cli/job_package_test.go
@@ -24,6 +24,10 @@ func TestPackageJobOpts_Validate(t *testing.T) {
 		inEnvName string
 		inJobName string
 
+		inShowDiff     bool
+		inOutputDir    string
+		inUploadAssets bool
+
 		setupMocks func()
 
 		wantedErrorS string
@@ -72,6 +76,29 @@ func TestPackageJobOpts_Validate(t *testing.T) {
 				EnvironmentName: "test",
 			}).Error(),
 		},
+		"error if diff is specified with output-dir": {
+			inAppName:    "phonetool",
+			inShowDiff:   true,
+			inOutputDir:  "what/a/dir",
+			setupMocks:   func() {},
+			wantedErrorS: "`--diff` cannot be specified together with `--output-dir`",
+		},
+		"error if diff is specified with upload-assets": {
+			inAppName:      "phonetool",
+			inShowDiff:     true,
+			inUploadAssets: true,
+			setupMocks:     func() {},
+			wantedErrorS:   "`--diff` cannot be specified together with `--upload-assets`",
+		},
+		"no diff": {
+			inAppName:  "phonetool",
+			setupMocks: func() {},
+		},
+		"diff": {
+			inAppName:  "phonetool",
+			inShowDiff: true,
+			setupMocks: func() {},
+		},
 	}
 
 	for name, tc := range testCases {
@@ -90,6 +117,10 @@ func TestPackageJobOpts_Validate(t *testing.T) {
 					name:    tc.inJobName,
 					envName: tc.inEnvName,
 					appName: tc.inAppName,
+
+					showDiff:     tc.inShowDiff,
+					outputDir:    tc.inOutputDir,
+					uploadAssets: tc.inUploadAssets,
 				},
 				ws:    mockWorkspace,
 				store: mockStore,

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -7518,6 +7518,21 @@ func (mr *MockenvPackagerMockRecorder) AddonsTemplate() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddonsTemplate", reflect.TypeOf((*MockenvPackager)(nil).AddonsTemplate))
 }
 
+// DeployDiff mocks base method.
+func (m *MockenvPackager) DeployDiff(inTmpl string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeployDiff", inTmpl)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeployDiff indicates an expected call of DeployDiff.
+func (mr *MockenvPackagerMockRecorder) DeployDiff(inTmpl interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeployDiff", reflect.TypeOf((*MockenvPackager)(nil).DeployDiff), inTmpl)
+}
+
 // GenerateCloudFormationTemplate mocks base method.
 func (m *MockenvPackager) GenerateCloudFormationTemplate(in *deploy.DeployEnvironmentInput) (*deploy.GenerateCloudFormationTemplateOutput, error) {
 	m.ctrl.T.Helper()

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -7309,6 +7309,44 @@ func (mr *MockworkloadStackGeneratorMockRecorder) UploadArtifacts() *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadArtifacts", reflect.TypeOf((*MockworkloadStackGenerator)(nil).UploadArtifacts))
 }
 
+// MocktemplateDiffer is a mock of templateDiffer interface.
+type MocktemplateDiffer struct {
+	ctrl     *gomock.Controller
+	recorder *MocktemplateDifferMockRecorder
+}
+
+// MocktemplateDifferMockRecorder is the mock recorder for MocktemplateDiffer.
+type MocktemplateDifferMockRecorder struct {
+	mock *MocktemplateDiffer
+}
+
+// NewMocktemplateDiffer creates a new mock instance.
+func NewMocktemplateDiffer(ctrl *gomock.Controller) *MocktemplateDiffer {
+	mock := &MocktemplateDiffer{ctrl: ctrl}
+	mock.recorder = &MocktemplateDifferMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MocktemplateDiffer) EXPECT() *MocktemplateDifferMockRecorder {
+	return m.recorder
+}
+
+// DeployDiff mocks base method.
+func (m *MocktemplateDiffer) DeployDiff(inTmpl string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeployDiff", inTmpl)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeployDiff indicates an expected call of DeployDiff.
+func (mr *MocktemplateDifferMockRecorder) DeployDiff(inTmpl interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeployDiff", reflect.TypeOf((*MocktemplateDiffer)(nil).DeployDiff), inTmpl)
+}
+
 // Mockrunner is a mock of runner interface.
 type Mockrunner struct {
 	ctrl     *gomock.Controller

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -7309,44 +7309,6 @@ func (mr *MockworkloadStackGeneratorMockRecorder) UploadArtifacts() *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadArtifacts", reflect.TypeOf((*MockworkloadStackGenerator)(nil).UploadArtifacts))
 }
 
-// MocktemplateDiffer is a mock of templateDiffer interface.
-type MocktemplateDiffer struct {
-	ctrl     *gomock.Controller
-	recorder *MocktemplateDifferMockRecorder
-}
-
-// MocktemplateDifferMockRecorder is the mock recorder for MocktemplateDiffer.
-type MocktemplateDifferMockRecorder struct {
-	mock *MocktemplateDiffer
-}
-
-// NewMocktemplateDiffer creates a new mock instance.
-func NewMocktemplateDiffer(ctrl *gomock.Controller) *MocktemplateDiffer {
-	mock := &MocktemplateDiffer{ctrl: ctrl}
-	mock.recorder = &MocktemplateDifferMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MocktemplateDiffer) EXPECT() *MocktemplateDifferMockRecorder {
-	return m.recorder
-}
-
-// DeployDiff mocks base method.
-func (m *MocktemplateDiffer) DeployDiff(inTmpl string) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeployDiff", inTmpl)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DeployDiff indicates an expected call of DeployDiff.
-func (mr *MocktemplateDifferMockRecorder) DeployDiff(inTmpl interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeployDiff", reflect.TypeOf((*MocktemplateDiffer)(nil).DeployDiff), inTmpl)
-}
-
 // Mockrunner is a mock of runner interface.
 type Mockrunner struct {
 	ctrl     *gomock.Controller

--- a/internal/pkg/cli/svc_package.go
+++ b/internal/pkg/cli/svc_package.go
@@ -56,6 +56,7 @@ type packageSvcOpts struct {
 	templateWriter       io.WriteCloser
 	paramsWriter         io.WriteCloser
 	addonsWriter         io.WriteCloser
+	diffWriter           io.Writer
 	runner               execRunner
 	sessProvider         *sessions.Provider
 	sel                  wsSelector
@@ -99,6 +100,7 @@ func newPackageSvcOpts(vars packageSvcVars) (*packageSvcOpts, error) {
 		templateWriter:    os.Stdout,
 		paramsWriter:      discardFile{},
 		addonsWriter:      discardFile{},
+		diffWriter:        os.Stdout,
 		newInterpolator:   newManifestInterpolator,
 		sessProvider:      sessProvider,
 		newStackGenerator: newWorkloadStackGenerator,
@@ -217,6 +219,9 @@ func (o *packageSvcOpts) Execute() error {
 	stack, err := o.getWorkloadStack(gen)
 	if err != nil {
 		return err
+	}
+	if o.showDiff {
+		return diff(gen, stack.template, o.diffWriter)
 	}
 	if err := o.writeAndClose(o.templateWriter, stack.template); err != nil {
 		return err

--- a/internal/pkg/cli/svc_package.go
+++ b/internal/pkg/cli/svc_package.go
@@ -166,14 +166,6 @@ func newWorkloadStackGenerator(o *packageSvcOpts) (workloadStackGenerator, error
 
 // Validate returns an error for any invalid optional flags.
 func (o *packageSvcOpts) Validate() error {
-	if o.showDiff {
-		if o.outputDir != "" {
-			return fmt.Errorf("`--%s` cannot be specified together with `--%s`", diffFlag, stackOutputDirFlag)
-		}
-		if o.uploadAssets {
-			return fmt.Errorf("`--%s` cannot be specified together with `--%s`", diffFlag, uploadAssetsFlag)
-		}
-	}
 	return nil
 }
 
@@ -485,5 +477,8 @@ func buildSvcPackageCmd() *cobra.Command {
 	cmd.Flags().StringVar(&vars.outputDir, stackOutputDirFlag, "", stackOutputDirFlagDescription)
 	cmd.Flags().BoolVar(&vars.uploadAssets, uploadAssetsFlag, false, uploadAssetsFlagDescription)
 	cmd.Flags().BoolVar(&vars.showDiff, diffFlag, false, diffFlagDescription)
+
+	cmd.MarkFlagsMutuallyExclusive(diffFlag, stackOutputDirFlag)
+	cmd.MarkFlagsMutuallyExclusive(diffFlag, uploadAssetsFlag)
 	return cmd
 }

--- a/internal/pkg/cli/svc_package.go
+++ b/internal/pkg/cli/svc_package.go
@@ -40,6 +40,7 @@ type packageSvcVars struct {
 	tag          string
 	outputDir    string
 	uploadAssets bool
+	showDiff     bool
 
 	// To facilitate unit tests.
 	clientConfigured bool
@@ -163,6 +164,14 @@ func newWorkloadStackGenerator(o *packageSvcOpts) (workloadStackGenerator, error
 
 // Validate returns an error for any invalid optional flags.
 func (o *packageSvcOpts) Validate() error {
+	if o.showDiff {
+		if o.outputDir != "" {
+			return fmt.Errorf("`--%s` cannot be specified together with `--%s`", diffFlag, stackOutputDirFlag)
+		}
+		if o.uploadAssets {
+			return fmt.Errorf("`--%s` cannot be specified together with `--%s`", diffFlag, uploadAssetsFlag)
+		}
+	}
 	return nil
 }
 
@@ -470,5 +479,6 @@ func buildSvcPackageCmd() *cobra.Command {
 	cmd.Flags().StringVar(&vars.tag, imageTagFlag, "", imageTagFlagDescription)
 	cmd.Flags().StringVar(&vars.outputDir, stackOutputDirFlag, "", stackOutputDirFlagDescription)
 	cmd.Flags().BoolVar(&vars.uploadAssets, uploadAssetsFlag, false, uploadAssetsFlagDescription)
+	cmd.Flags().BoolVar(&vars.showDiff, diffFlag, false, diffFlagDescription)
 	return cmd
 }

--- a/internal/pkg/cli/svc_package_test.go
+++ b/internal/pkg/cli/svc_package_test.go
@@ -18,48 +18,6 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/manifest"
 )
 
-func TestPackageSvcOpts_Validate(t *testing.T) {
-	testCases := map[string]struct {
-		inShowDiff     bool
-		inOutputDir    string
-		inUploadAssets bool
-		wantedErr      error
-	}{
-		"error if diff is specified with output-dir": {
-			inShowDiff:  true,
-			inOutputDir: "what/a/dir",
-			wantedErr:   errors.New("`--diff` cannot be specified together with `--output-dir`"),
-		},
-		"error if diff is specified with upload-assets": {
-			inShowDiff:     true,
-			inUploadAssets: true,
-			wantedErr:      errors.New("`--diff` cannot be specified together with `--upload-assets`"),
-		},
-		"no diff": {},
-		"diff": {
-			inShowDiff: true,
-		},
-	}
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			opts := &packageSvcOpts{
-				packageSvcVars: packageSvcVars{
-					showDiff:     tc.inShowDiff,
-					outputDir:    tc.inOutputDir,
-					uploadAssets: tc.inUploadAssets,
-				},
-			}
-			// WHEN
-			err := opts.Validate()
-			if tc.wantedErr != nil {
-				require.EqualError(t, err, tc.wantedErr.Error())
-			} else {
-				require.NoError(t, err)
-			}
-		})
-	}
-}
-
 type svcPackageAskMock struct {
 	store *mocks.Mockstore
 	sel   *mocks.MockwsSelector

--- a/internal/pkg/cli/svc_package_test.go
+++ b/internal/pkg/cli/svc_package_test.go
@@ -224,8 +224,57 @@ count: 1`
 		wantedStack  string
 		wantedParams string
 		wantedAddons string
+		wantedDiff   string
 		wantedErr    error
 	}{
+		"fail to get the diff": {
+			inVars: packageSvcVars{
+				name:             "api",
+				clientConfigured: true,
+				showDiff:         true,
+			},
+			setupMocks: func(m *svcPackageExecuteMock) {
+				m.ws.EXPECT().ReadWorkloadManifest("api").Return([]byte(lbwsMft), nil)
+				m.interpolator.EXPECT().Interpolate(lbwsMft).Return(lbwsMft, nil)
+				m.mft = &mockWorkloadMft{
+					mockRequiredEnvironmentFeatures: func() []string {
+						return []string{}
+					},
+				}
+				m.envFeaturesDescriber.EXPECT().Version().Return("v1.mock", nil)
+				m.envFeaturesDescriber.EXPECT().AvailableFeatures().Return([]string{}, nil)
+				m.generator.EXPECT().GenerateCloudFormationTemplate(gomock.Any()).Return(&deploy.GenerateCloudFormationTemplateOutput{
+					Template:   "mystack",
+					Parameters: "myparams",
+				}, nil)
+				m.generator.EXPECT().DeployDiff(gomock.Eq("mystack")).Return("", errors.New("some error"))
+			},
+			wantedErr: errors.New("some error"),
+		},
+		"writes the diff": {
+			inVars: packageSvcVars{
+				name:             "api",
+				clientConfigured: true,
+				showDiff:         true,
+			},
+			setupMocks: func(m *svcPackageExecuteMock) {
+				m.ws.EXPECT().ReadWorkloadManifest("api").Return([]byte(lbwsMft), nil)
+				m.interpolator.EXPECT().Interpolate(lbwsMft).Return(lbwsMft, nil)
+				m.mft = &mockWorkloadMft{
+					mockRequiredEnvironmentFeatures: func() []string {
+						return []string{}
+					},
+				}
+				m.envFeaturesDescriber.EXPECT().Version().Return("v1.mock", nil)
+				m.envFeaturesDescriber.EXPECT().AvailableFeatures().Return([]string{}, nil)
+				m.generator.EXPECT().GenerateCloudFormationTemplate(gomock.Any()).Return(&deploy.GenerateCloudFormationTemplateOutput{
+					Template:   "mystack",
+					Parameters: "myparams",
+				}, nil)
+				m.generator.EXPECT().DeployDiff(gomock.Eq("mystack")).Return("mock diff", nil)
+			},
+			wantedDiff: "mock diff",
+		},
 		"writes service template without addons": {
 			inVars: packageSvcVars{
 				appName:          "ecs-kudos",
@@ -313,6 +362,7 @@ count: 1`
 			stackBuf := new(bytes.Buffer)
 			paramsBuf := new(bytes.Buffer)
 			addonsBuf := new(bytes.Buffer)
+			diffBuff := new(bytes.Buffer)
 
 			m := &svcPackageExecuteMock{
 				ws:                   mocks.NewMockwsWlDirReader(ctrl),
@@ -327,6 +377,8 @@ count: 1`
 				templateWriter: mockWriteCloser{w: stackBuf},
 				paramsWriter:   mockWriteCloser{w: paramsBuf},
 				addonsWriter:   mockWriteCloser{w: addonsBuf},
+				diffWriter:     mockWriteCloser{w: diffBuff},
+
 				unmarshal: func(b []byte) (manifest.DynamicWorkload, error) {
 					return m.mft, nil
 				},
@@ -348,10 +400,11 @@ count: 1`
 			err := opts.Execute()
 
 			// THEN
-			require.Equal(t, tc.wantedErr, err)
-			require.Equal(t, tc.wantedStack, stackBuf.String())
-			require.Equal(t, tc.wantedParams, paramsBuf.String())
-			require.Equal(t, tc.wantedAddons, addonsBuf.String())
+			require.EqualError(t, err, tc.wantedErr.Error())
+			require.Equal(t, stackBuf.String(), tc.wantedStack)
+			require.Equal(t, paramsBuf.String(), tc.wantedParams)
+			require.Equal(t, addonsBuf.String(), tc.wantedAddons)
+			require.Equal(t, diffBuff.String(), tc.wantedDiff)
 		})
 	}
 }

--- a/internal/pkg/cli/svc_package_test.go
+++ b/internal/pkg/cli/svc_package_test.go
@@ -5,6 +5,7 @@ package cli
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"testing"
 
@@ -18,7 +19,45 @@ import (
 )
 
 func TestPackageSvcOpts_Validate(t *testing.T) {
-	// NOTE: no optional flag needs to be validated for this command.
+	testCases := map[string]struct {
+		inShowDiff     bool
+		inOutputDir    string
+		inUploadAssets bool
+		wantedErr      error
+	}{
+		"error if diff is specified with output-dir": {
+			inShowDiff:  true,
+			inOutputDir: "what/a/dir",
+			wantedErr:   errors.New("`--diff` cannot be specified together with `--output-dir`"),
+		},
+		"error if diff is specified with upload-assets": {
+			inShowDiff:     true,
+			inUploadAssets: true,
+			wantedErr:      errors.New("`--diff` cannot be specified together with `--upload-assets`"),
+		},
+		"no diff": {},
+		"diff": {
+			inShowDiff: true,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			opts := &packageSvcOpts{
+				packageSvcVars: packageSvcVars{
+					showDiff:     tc.inShowDiff,
+					outputDir:    tc.inOutputDir,
+					uploadAssets: tc.inUploadAssets,
+				},
+			}
+			// WHEN
+			err := opts.Validate()
+			if tc.wantedErr != nil {
+				require.EqualError(t, err, tc.wantedErr.Error())
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }
 
 type svcPackageAskMock struct {

--- a/internal/pkg/cli/svc_package_test.go
+++ b/internal/pkg/cli/svc_package_test.go
@@ -400,7 +400,11 @@ count: 1`
 			err := opts.Execute()
 
 			// THEN
-			require.EqualError(t, err, tc.wantedErr.Error())
+			if tc.wantedErr != nil {
+				require.EqualError(t, err, tc.wantedErr.Error())
+			} else {
+				require.NoError(t, err)
+			}
 			require.Equal(t, stackBuf.String(), tc.wantedStack)
 			require.Equal(t, paramsBuf.String(), tc.wantedParams)
 			require.Equal(t, addonsBuf.String(), tc.wantedAddons)


### PR DESCRIPTION
Large PR but the real logic is repetitive across the three commands. So consider #additions as #additions/3 additions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
