### PR TITLE
chore: ignore `Metadata.Manifest` in diff tree

### DIFF
--- a/internal/pkg/cli/deploy/env.go
+++ b/internal/pkg/cli/deploy/env.go
@@ -229,7 +229,7 @@ func (d *envDeployer) DeployDiff(template string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("retrieve the deployed template for %q: %w", d.env.Name, err)
 	}
-	diffTree, err := diff.From(tmpl).ParseWithIgnorer([]byte(template), diff.CFNIgnorer())
+	diffTree, err := diff.From(tmpl).ParseWithCFNIgnorer([]byte(template))
 	if err != nil {
 		return "", fmt.Errorf("parse the diff against the deployed env stack %q: %w", d.env.Name, err)
 	}

--- a/internal/pkg/cli/deploy/env.go
+++ b/internal/pkg/cli/deploy/env.go
@@ -229,7 +229,7 @@ func (d *envDeployer) DeployDiff(template string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("retrieve the deployed template for %q: %w", d.env.Name, err)
 	}
-	diffTree, err := diff.From(tmpl).Parse([]byte(template))
+	diffTree, err := diff.From(tmpl).Parse([]byte(template), diff.CFNOverrider())
 	if err != nil {
 		return "", fmt.Errorf("parse the diff against the deployed env stack %q: %w", d.env.Name, err)
 	}

--- a/internal/pkg/cli/deploy/env.go
+++ b/internal/pkg/cli/deploy/env.go
@@ -229,7 +229,7 @@ func (d *envDeployer) DeployDiff(template string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("retrieve the deployed template for %q: %w", d.env.Name, err)
 	}
-	diffTree, err := diff.From(tmpl).Parse([]byte(template), diff.CFNOverrider())
+	diffTree, err := diff.From(tmpl).ParseWithIgnorer([]byte(template), diff.CFNIgnorer())
 	if err != nil {
 		return "", fmt.Errorf("parse the diff against the deployed env stack %q: %w", d.env.Name, err)
 	}

--- a/internal/pkg/cli/deploy/workload.go
+++ b/internal/pkg/cli/deploy/workload.go
@@ -289,7 +289,7 @@ func (d *workloadDeployer) DeployDiff(template string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("retrieve the deployed template for %q: %w", d.name, err)
 	}
-	diffTree, err := diff.From(tmpl).Parse([]byte(template))
+	diffTree, err := diff.From(tmpl).Parse([]byte(template), diff.CFNOverrider())
 	if err != nil {
 		return "", fmt.Errorf("parse the diff against the deployed %q in environment %q: %w", d.name, d.env.Name, err)
 	}

--- a/internal/pkg/cli/deploy/workload.go
+++ b/internal/pkg/cli/deploy/workload.go
@@ -289,7 +289,7 @@ func (d *workloadDeployer) DeployDiff(template string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("retrieve the deployed template for %q: %w", d.name, err)
 	}
-	diffTree, err := diff.From(tmpl).Parse([]byte(template), diff.CFNOverrider())
+	diffTree, err := diff.From(tmpl).ParseWithIgnorer([]byte(template), diff.CFNIgnorer())
 	if err != nil {
 		return "", fmt.Errorf("parse the diff against the deployed %q in environment %q: %w", d.name, d.env.Name, err)
 	}

--- a/internal/pkg/cli/deploy/workload.go
+++ b/internal/pkg/cli/deploy/workload.go
@@ -289,7 +289,7 @@ func (d *workloadDeployer) DeployDiff(template string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("retrieve the deployed template for %q: %w", d.name, err)
 	}
-	diffTree, err := diff.From(tmpl).ParseWithIgnorer([]byte(template), diff.CFNIgnorer())
+	diffTree, err := diff.From(tmpl).ParseWithCFNIgnorer([]byte(template))
 	if err != nil {
 		return "", fmt.Errorf("parse the diff against the deployed %q in environment %q: %w", d.name, d.env.Name, err)
 	}

--- a/internal/pkg/template/diff/diff.go
+++ b/internal/pkg/template/diff/diff.go
@@ -207,7 +207,6 @@ func parseSequence(fromNode, toNode *yaml.Node) ([]diffNode, error) {
 				matchCount = 0
 			}
 		case actionMod:
-			// TODO(lou1415926): handle list of maps modification
 			diff := cachedDiff[cacheKey(inspector.fromIndex(), inspector.toIndex())]
 			if diff.err != nil {
 				return nil, diff.err

--- a/internal/pkg/template/diff/diff.go
+++ b/internal/pkg/template/diff/diff.go
@@ -86,8 +86,17 @@ type seqItemNode struct {
 // From is the YAML document that another YAML document is compared against.
 type From []byte
 
+// ParseWithIgnorer constructs a diff tree that represent the differences of a YAML document against the From document, ignoring certain paths.
+func (from From) ParseWithIgnorer(to []byte, ignorer *Ignorer) (Tree, error) {
+	return from.parseRoot(to, ignorer)
+}
+
 // Parse constructs a diff tree that represent the differences of a YAML document against the From document.
-func (from From) Parse(to []byte, overrider Overrider) (Tree, error) {
+func (from From) Parse(to []byte) (Tree, error) {
+	return from.parseRoot(to, &noneOverrider{})
+}
+
+func (from From) parseRoot(to []byte, overrider overrider) (Tree, error) {
 	var toNode, fromNode yaml.Node
 	if err := yaml.Unmarshal(to, &toNode); err != nil {
 		return Tree{}, fmt.Errorf("unmarshal current template: %w", err)
@@ -117,12 +126,11 @@ func (from From) Parse(to []byte, overrider Overrider) (Tree, error) {
 	return Tree{
 		root: root,
 	}, nil
-
 }
 
-func parse(from, to *yaml.Node, key string, overrider Overrider) (diffNode, error) {
-	if overrider.Match(from, to, key) {
-		return overrider.Parse(from, to, key)
+func parse(from, to *yaml.Node, key string, overrider overrider) (diffNode, error) {
+	if overrider.match(from, to, key) {
+		return overrider.parse(from, to, key)
 	}
 	// Handle base cases.
 	if to == nil || from == nil || to.Kind != from.Kind {
@@ -171,7 +179,7 @@ func isYAMLLeaf(node *yaml.Node) bool {
 	return len(node.Content) == 0
 }
 
-func parseSequence(fromNode, toNode *yaml.Node, overrider Overrider) ([]diffNode, error) {
+func parseSequence(fromNode, toNode *yaml.Node, overrider overrider) ([]diffNode, error) {
 	fromSeq, toSeq := make([]yaml.Node, len(fromNode.Content)), make([]yaml.Node, len(toNode.Content)) // NOTE: should be the same as calling `Decode`.
 	for idx, v := range fromNode.Content {
 		fromSeq[idx] = *v
@@ -242,7 +250,7 @@ func parseSequence(fromNode, toNode *yaml.Node, overrider Overrider) ([]diffNode
 	return children, nil
 }
 
-func parseMap(from, to *yaml.Node, overrider Overrider) ([]diffNode, error) {
+func parseMap(from, to *yaml.Node, overrider overrider) ([]diffNode, error) {
 	currMap, oldMap := make(map[string]yaml.Node), make(map[string]yaml.Node)
 	if err := to.Decode(currMap); err != nil {
 		return nil, err

--- a/internal/pkg/template/diff/diff.go
+++ b/internal/pkg/template/diff/diff.go
@@ -101,7 +101,7 @@ func (from From) ParseWithCFNIgnorer(to []byte) (Tree, error) {
 
 // Parse constructs a diff tree that represent the differences of a YAML document against the From document.
 func (from From) Parse(to []byte) (Tree, error) {
-	return from.parseRoot(to, &noneOverrider{})
+	return from.parseRoot(to, &noopOverrider{})
 }
 
 func (from From) parseRoot(to []byte, overrider overrider) (Tree, error) {

--- a/internal/pkg/template/diff/diff.go
+++ b/internal/pkg/template/diff/diff.go
@@ -87,7 +87,7 @@ type seqItemNode struct {
 type From []byte
 
 // Parse constructs a diff tree that represent the differences of a YAML document against the From document.
-func (from From) Parse(to []byte, overrider overrider) (Tree, error) {
+func (from From) Parse(to []byte, overrider Overrider) (Tree, error) {
 	var toNode, fromNode yaml.Node
 	if err := yaml.Unmarshal(to, &toNode); err != nil {
 		return Tree{}, fmt.Errorf("unmarshal current template: %w", err)
@@ -120,9 +120,9 @@ func (from From) Parse(to []byte, overrider overrider) (Tree, error) {
 
 }
 
-func parse(from, to *yaml.Node, key string, overrider overrider) (diffNode, error) {
-	if overrider.match(from, to, key) {
-		return overrider.parse(from, to, key)
+func parse(from, to *yaml.Node, key string, overrider Overrider) (diffNode, error) {
+	if overrider.Match(from, to, key) {
+		return overrider.Parse(from, to, key)
 	}
 	// Handle base cases.
 	if to == nil || from == nil || to.Kind != from.Kind {
@@ -171,7 +171,7 @@ func isYAMLLeaf(node *yaml.Node) bool {
 	return len(node.Content) == 0
 }
 
-func parseSequence(fromNode, toNode *yaml.Node, overrider overrider) ([]diffNode, error) {
+func parseSequence(fromNode, toNode *yaml.Node, overrider Overrider) ([]diffNode, error) {
 	fromSeq, toSeq := make([]yaml.Node, len(fromNode.Content)), make([]yaml.Node, len(toNode.Content)) // NOTE: should be the same as calling `Decode`.
 	for idx, v := range fromNode.Content {
 		fromSeq[idx] = *v
@@ -242,7 +242,7 @@ func parseSequence(fromNode, toNode *yaml.Node, overrider overrider) ([]diffNode
 	return children, nil
 }
 
-func parseMap(from, to *yaml.Node, overrider overrider) ([]diffNode, error) {
+func parseMap(from, to *yaml.Node, overrider Overrider) ([]diffNode, error) {
 	currMap, oldMap := make(map[string]yaml.Node), make(map[string]yaml.Node)
 	if err := to.Decode(currMap); err != nil {
 		return nil, err

--- a/internal/pkg/template/diff/diff.go
+++ b/internal/pkg/template/diff/diff.go
@@ -86,8 +86,16 @@ type seqItemNode struct {
 // From is the YAML document that another YAML document is compared against.
 type From []byte
 
-// ParseWithIgnorer constructs a diff tree that represent the differences of a YAML document against the From document, ignoring certain paths.
-func (from From) ParseWithIgnorer(to []byte, ignorer *Ignorer) (Tree, error) {
+// ParseWithCFNIgnorer constructs a diff tree that represent the differences of a YAML document against the From document, ignoring certain CFN paths.
+func (from From) ParseWithCFNIgnorer(to []byte) (Tree, error) {
+	ignorer := &ignorer{
+		curr: &ignoreSegment{
+			key: "Metadata",
+			next: &ignoreSegment{
+				key: "Manifest",
+			},
+		},
+	}
 	return from.parseRoot(to, ignorer)
 }
 

--- a/internal/pkg/template/diff/diff_test.go
+++ b/internal/pkg/template/diff/diff_test.go
@@ -392,7 +392,7 @@ Metadata:
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			got, err := From(tc.old).ParseWithIgnorer([]byte(tc.curr), CFNIgnorer())
+			got, err := From(tc.old).ParseWithCFNIgnorer([]byte(tc.curr))
 			if tc.wantedError != nil {
 				require.EqualError(t, err, tc.wantedError.Error())
 			} else {

--- a/internal/pkg/template/diff/diff_test.go
+++ b/internal/pkg/template/diff/diff_test.go
@@ -228,22 +228,6 @@ func TestFrom_Parse(t *testing.T) {
 				}
 			},
 		},
-		"list with a map value changed": { // TODO(lou1415926): handle list of maps modification
-			old: `StrawberryPopularitySurvey:
-- Name: Dog
-  LikeStrawberry: ver much
-- Name: Bear
-  LikeStrawberry: meh
-- Name: Cat
-  LikeStrawberry: ew`,
-			curr: `StrawberryPopularitySurvey:
-- Name: Dog
-  LikeStrawberry: ver much
-- Name: Bear
-  LikeStrawberry: ok
-- Name: Cat
-  LikeStrawberry: ew`,
-		},
 		"change a map to scalar": {
 			curr: `Mary:
   Dialogue: "Said bear: 'I know I'm supposed to keep an eye on you"`,

--- a/internal/pkg/template/diff/diff_test.go
+++ b/internal/pkg/template/diff/diff_test.go
@@ -334,7 +334,7 @@ Dog: (pleased) "ikr"`, t),
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			got, err := From(tc.old).Parse([]byte(tc.curr), &noneOverrider{})
+			got, err := From(tc.old).Parse([]byte(tc.curr))
 			if tc.wantedError != nil {
 				require.EqualError(t, err, tc.wantedError.Error())
 			} else {
@@ -392,7 +392,7 @@ Metadata:
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			got, err := From(tc.old).Parse([]byte(tc.curr), CFNOverrider())
+			got, err := From(tc.old).ParseWithIgnorer([]byte(tc.curr), CFNIgnorer())
 			if tc.wantedError != nil {
 				require.EqualError(t, err, tc.wantedError.Error())
 			} else {

--- a/internal/pkg/template/diff/diff_test.go
+++ b/internal/pkg/template/diff/diff_test.go
@@ -345,7 +345,7 @@ Dog: (pleased) "ikr"`, t),
 	}
 }
 
-func TestFrom_Parse_CFN(t *testing.T) {
+func TestFrom_ParseWithCFNIgnorer(t *testing.T) {
 	testCases := map[string]struct {
 		curr        string
 		old         string

--- a/internal/pkg/template/diff/diff_test.go
+++ b/internal/pkg/template/diff/diff_test.go
@@ -378,7 +378,7 @@ Metadata:
 				}
 			},
 		},
-		"no": {
+		"no diff": {
 			old: `Description: CloudFormation environment template for infrastructure shared among Copilot workloads.
 Metadata:
   Manifest: I don't see any difference.`,

--- a/internal/pkg/template/diff/override.go
+++ b/internal/pkg/template/diff/override.go
@@ -46,6 +46,6 @@ func (_ *noopOverrider) match(_, _ *yaml.Node, _ string) bool {
 }
 
 // Parse is a no-op for a noopOverrider.
-func (m *noopOverrider) parse(_, _ *yaml.Node, _ string) (diffNode, error) {
+func (*noopOverrider) parse(_, _ *yaml.Node, _ string) (diffNode, error) {
 	return nil, nil
 }

--- a/internal/pkg/template/diff/override.go
+++ b/internal/pkg/template/diff/override.go
@@ -5,13 +5,13 @@ package diff
 
 import "gopkg.in/yaml.v3"
 
-type overrider interface {
-	match(from, to *yaml.Node, key string) bool
-	parse(from, to *yaml.Node, key string) (diffNode, error)
+type Overrider interface {
+	Match(from, to *yaml.Node, key string) bool
+	Parse(from, to *yaml.Node, key string) (diffNode, error)
 }
 
-// CFNOverrider returns an overrider that handles special behaviors when parsing the diff tree of two CFN documents written in YAML.
-func CFNOverrider() overrider {
+// CFNOverrider returns an Overrider that handles special behaviors when parsing the diff tree of two CFN documents written in YAML.
+func CFNOverrider() Overrider {
 	// return &noneOverrider{}
 	return &ignorer{
 		curr: &ignoreSegment{
@@ -32,7 +32,8 @@ type ignorer struct {
 	curr *ignoreSegment
 }
 
-func (m *ignorer) match(_, _ *yaml.Node, key string) bool {
+// Match returns true if the difference between the from and to at the key should be ignored.
+func (m *ignorer) Match(_, _ *yaml.Node, key string) bool {
 	if key != m.curr.key {
 		return false
 	}
@@ -43,15 +44,19 @@ func (m *ignorer) match(_, _ *yaml.Node, key string) bool {
 	return false
 }
 
-func (m *ignorer) parse(from, to *yaml.Node, key string) (diffNode, error) {
+// Parse is a no-op for an ignorer.
+func (m *ignorer) Parse(_, _ *yaml.Node, _ string) (diffNode, error) {
 	return nil, nil
 }
 
 type noneOverrider struct{}
 
-func (_ *noneOverrider) match(_, _ *yaml.Node, _ string) bool {
+// Match always returns false for a noneOverrider.
+func (_ *noneOverrider) Match(_, _ *yaml.Node, _ string) bool {
 	return false
 }
-func (m *noneOverrider) parse(_, _ *yaml.Node, _ string) (diffNode, error) {
+
+// Parse is a no-op for a noneOverrider.
+func (m *noneOverrider) Parse(_, _ *yaml.Node, _ string) (diffNode, error) {
 	return nil, nil
 }

--- a/internal/pkg/template/diff/override.go
+++ b/internal/pkg/template/diff/override.go
@@ -1,0 +1,57 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package diff
+
+import "gopkg.in/yaml.v3"
+
+type overrider interface {
+	match(from, to *yaml.Node, key string) bool
+	parse(from, to *yaml.Node, key string) (diffNode, error)
+}
+
+// CFNOverrider returns an overrider that handles special behaviors when parsing the diff tree of two CFN documents written in YAML.
+func CFNOverrider() overrider {
+	// return &noneOverrider{}
+	return &ignorer{
+		curr: &ignoreSegment{
+			key: "Metadata",
+			next: &ignoreSegment{
+				key: "Manifest",
+			},
+		},
+	}
+}
+
+type ignoreSegment struct {
+	key  string
+	next *ignoreSegment
+}
+
+type ignorer struct {
+	curr *ignoreSegment
+}
+
+func (m *ignorer) match(_, _ *yaml.Node, key string) bool {
+	if key != m.curr.key {
+		return false
+	}
+	if m.curr.next == nil {
+		return true
+	}
+	m.curr = m.curr.next
+	return false
+}
+
+func (m *ignorer) parse(from, to *yaml.Node, key string) (diffNode, error) {
+	return nil, nil
+}
+
+type noneOverrider struct{}
+
+func (_ *noneOverrider) match(_, _ *yaml.Node, _ string) bool {
+	return false
+}
+func (m *noneOverrider) parse(_, _ *yaml.Node, _ string) (diffNode, error) {
+	return nil, nil
+}

--- a/internal/pkg/template/diff/override.go
+++ b/internal/pkg/template/diff/override.go
@@ -5,15 +5,15 @@ package diff
 
 import "gopkg.in/yaml.v3"
 
-type Overrider interface {
-	Match(from, to *yaml.Node, key string) bool
-	Parse(from, to *yaml.Node, key string) (diffNode, error)
+// overrider overrides the parsing behavior between two yaml nodes under certain keys.
+type overrider interface {
+	match(from, to *yaml.Node, key string) bool
+	parse(from, to *yaml.Node, key string) (diffNode, error)
 }
 
-// CFNOverrider returns an Overrider that handles special behaviors when parsing the diff tree of two CFN documents written in YAML.
-func CFNOverrider() Overrider {
-	// return &noneOverrider{}
-	return &ignorer{
+// CFNIgnorer returns an ignorer that ignores the diff of some parts of two CFN documents written in YAML.
+func CFNIgnorer() *Ignorer {
+	return &Ignorer{
 		curr: &ignoreSegment{
 			key: "Metadata",
 			next: &ignoreSegment{
@@ -28,12 +28,13 @@ type ignoreSegment struct {
 	next *ignoreSegment
 }
 
-type ignorer struct {
+// Ignorer ignores the diff between two yaml nodes under specified key paths.
+type Ignorer struct {
 	curr *ignoreSegment
 }
 
-// Match returns true if the difference between the from and to at the key should be ignored.
-func (m *ignorer) Match(_, _ *yaml.Node, key string) bool {
+// match returns true if the difference between the from and to at the key should be ignored.
+func (m *Ignorer) match(_, _ *yaml.Node, key string) bool {
 	if key != m.curr.key {
 		return false
 	}
@@ -44,19 +45,19 @@ func (m *ignorer) Match(_, _ *yaml.Node, key string) bool {
 	return false
 }
 
-// Parse is a no-op for an ignorer.
-func (m *ignorer) Parse(_, _ *yaml.Node, _ string) (diffNode, error) {
+// Parse is a no-op for an Ignorer.
+func (m *Ignorer) parse(_, _ *yaml.Node, _ string) (diffNode, error) {
 	return nil, nil
 }
 
 type noneOverrider struct{}
 
 // Match always returns false for a noneOverrider.
-func (_ *noneOverrider) Match(_, _ *yaml.Node, _ string) bool {
+func (_ *noneOverrider) match(_, _ *yaml.Node, _ string) bool {
 	return false
 }
 
 // Parse is a no-op for a noneOverrider.
-func (m *noneOverrider) Parse(_, _ *yaml.Node, _ string) (diffNode, error) {
+func (m *noneOverrider) parse(_, _ *yaml.Node, _ string) (diffNode, error) {
 	return nil, nil
 }

--- a/internal/pkg/template/diff/override.go
+++ b/internal/pkg/template/diff/override.go
@@ -41,7 +41,7 @@ func (m *ignorer) parse(_, _ *yaml.Node, _ string) (diffNode, error) {
 type noopOverrider struct{}
 
 // Match always returns false for a noopOverrider.
-func (_ *noopOverrider) match(_, _ *yaml.Node, _ string) bool {
+func (*noopOverrider) match(_, _ *yaml.Node, _ string) bool {
 	return false
 }
 

--- a/internal/pkg/template/diff/override.go
+++ b/internal/pkg/template/diff/override.go
@@ -38,14 +38,14 @@ func (m *ignorer) parse(_, _ *yaml.Node, _ string) (diffNode, error) {
 	return nil, nil
 }
 
-type noneOverrider struct{}
+type noopOverrider struct{}
 
-// Match always returns false for a noneOverrider.
-func (_ *noneOverrider) match(_, _ *yaml.Node, _ string) bool {
+// Match always returns false for a noopOverrider.
+func (_ *noopOverrider) match(_, _ *yaml.Node, _ string) bool {
 	return false
 }
 
-// Parse is a no-op for a noneOverrider.
-func (m *noneOverrider) parse(_, _ *yaml.Node, _ string) (diffNode, error) {
+// Parse is a no-op for a noopOverrider.
+func (m *noopOverrider) parse(_, _ *yaml.Node, _ string) (diffNode, error) {
 	return nil, nil
 }

--- a/internal/pkg/template/diff/override.go
+++ b/internal/pkg/template/diff/override.go
@@ -11,30 +11,18 @@ type overrider interface {
 	parse(from, to *yaml.Node, key string) (diffNode, error)
 }
 
-// CFNIgnorer returns an ignorer that ignores the diff of some parts of two CFN documents written in YAML.
-func CFNIgnorer() *Ignorer {
-	return &Ignorer{
-		curr: &ignoreSegment{
-			key: "Metadata",
-			next: &ignoreSegment{
-				key: "Manifest",
-			},
-		},
-	}
-}
-
 type ignoreSegment struct {
 	key  string
 	next *ignoreSegment
 }
 
-// Ignorer ignores the diff between two yaml nodes under specified key paths.
-type Ignorer struct {
+// ignorer ignores the diff between two yaml nodes under specified key paths.
+type ignorer struct {
 	curr *ignoreSegment
 }
 
 // match returns true if the difference between the from and to at the key should be ignored.
-func (m *Ignorer) match(_, _ *yaml.Node, key string) bool {
+func (m *ignorer) match(_, _ *yaml.Node, key string) bool {
 	if key != m.curr.key {
 		return false
 	}
@@ -45,8 +33,8 @@ func (m *Ignorer) match(_, _ *yaml.Node, key string) bool {
 	return false
 }
 
-// Parse is a no-op for an Ignorer.
-func (m *Ignorer) parse(_, _ *yaml.Node, _ string) (diffNode, error) {
+// Parse is a no-op for an ignorer.
+func (m *ignorer) parse(_, _ *yaml.Node, _ string) (diffNode, error) {
 	return nil, nil
 }
 

--- a/internal/pkg/template/diff/write_test.go
+++ b/internal/pkg/template/diff/write_test.go
@@ -223,7 +223,7 @@ func Test_Integration_Parse_Write_WithOverride(t *testing.T) {
 	testCases := map[string]struct {
 		curr      string
 		old       string
-		overrider overrider
+		overrider Overrider
 		wanted    string
 	}{
 		"no override": {

--- a/internal/pkg/template/diff/write_test.go
+++ b/internal/pkg/template/diff/write_test.go
@@ -207,7 +207,7 @@ Mary:
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			gotTree, err := From(tc.old).Parse([]byte(tc.curr), &noneOverrider{})
+			gotTree, err := From(tc.old).Parse([]byte(tc.curr))
 			require.NoError(t, err)
 
 			buf := strings.Builder{}
@@ -223,7 +223,7 @@ func Test_Integration_Parse_Write_WithOverride(t *testing.T) {
 	testCases := map[string]struct {
 		curr      string
 		old       string
-		overrider Overrider
+		overrider overrider
 		wanted    string
 	}{
 		"no override": {
@@ -251,7 +251,7 @@ Metadata:
 Metadata:
   Version: v1.27.0
   Manifest: There is definitely a difference.`,
-			overrider: CFNOverrider(),
+			overrider: CFNIgnorer(),
 			wanted: `
 ~ Metadata:
     ~ Version: v1.26.0 -> v1.27.0
@@ -264,12 +264,12 @@ Metadata:
 			curr: `Description: CloudFormation environment template for infrastructure shared among Copilot workloads.
 Metadata:
   Manifest: There is definitely a difference.`,
-			overrider: CFNOverrider(),
+			overrider: CFNIgnorer(),
 		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			gotTree, err := From(tc.old).Parse([]byte(tc.curr), tc.overrider)
+			gotTree, err := From(tc.old).parseRoot([]byte(tc.curr), tc.overrider)
 			require.NoError(t, err)
 			buf := strings.Builder{}
 			err = gotTree.Write(&buf)

--- a/internal/pkg/template/diff/write_test.go
+++ b/internal/pkg/template/diff/write_test.go
@@ -71,11 +71,6 @@ Mary:
 			old:  `Alphabet: [a,b,c,d]`,
 			curr: `Alphabet: [a,b,c,d]`,
 		},
-		"list reordered": {
-			// TODO(lou1425926): complete the test.
-			old:  `SizeRank: [bear,dog,cat,mouse]`,
-			curr: `SizeRank: [bear,cat,dog,mouse]`,
-		},
 		"list with insertion": {
 			old:  `DanceCompetition: [dog,bear,cat]`,
 			curr: `DanceCompetition: [dog,bear,mouse,cat]`,
@@ -105,31 +100,6 @@ Mary:
     ~ - circle -> ellipse
     (1 unchanged item)
 `,
-		},
-		"list with a map value changed": { // TODO(lou1415926): handle list of maps modification
-			old: `StrawberryPopularitySurvey:
-- Name: Dog
-  LikeStrawberry: ver much
-- Name: Bear
-  LikeStrawberry: meh
-  D: 
-     - One
-     - Three:
-          Wow: what
-- Name: Cat
-  LikeStrawberry: ew`,
-			curr: `StrawberryPopularitySurvey:
-- Name: Dog
-  LikeStrawberry: ver much
-- Name: Bear
-  LikeStrawberry: ok
-  Hey: wow
-  D:
-     - Two
-     - Three: 
-         Wow: hey
-- Name: Cat
-  LikeStrawberry: ew`,
 		},
 		"change a map to scalar": {
 			curr: `


### PR DESCRIPTION


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
