### PR TITLE
feat: upgrade pipeline CodeBuild project deps to std4 versions

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/bb_pipeline_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/bb_pipeline_integration_test.go
@@ -11,13 +11,11 @@ import (
 	"testing"
 
 	"github.com/aws/copilot-cli/internal/pkg/config"
-
+	"github.com/aws/copilot-cli/internal/pkg/deploy"
+	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation/stack"
 	"github.com/aws/copilot-cli/internal/pkg/manifest"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
-
-	"github.com/aws/copilot-cli/internal/pkg/deploy"
-	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation/stack"
 )
 
 // TestBB_Pipeline_Template ensures that the CloudFormation template generated for a pipeline matches our pre-defined template.

--- a/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/bb_template.yaml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/bb_template.yaml
@@ -123,7 +123,7 @@ Resources:
         Type: LINUX_CONTAINER
         ComputeType: BUILD_GENERAL1_SMALL
         PrivilegedMode: true
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
         EnvironmentVariables:
           - Name: AWS_ACCOUNT_ID
             Value: !Sub '${AWS::AccountId}'
@@ -235,7 +235,7 @@ Resources:
         Type: NO_ARTIFACTS
       Environment:
         Type: LINUX_CONTAINER
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
         ComputeType: BUILD_GENERAL1_SMALL
         PrivilegedMode: true
       Source:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/cc_template.yaml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/cc_template.yaml
@@ -118,7 +118,7 @@ Resources:
         Type: LINUX_CONTAINER
         ComputeType: BUILD_GENERAL1_SMALL
         PrivilegedMode: true
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
         EnvironmentVariables:
           - Name: AWS_ACCOUNT_ID
             Value: !Sub '${AWS::AccountId}'
@@ -209,7 +209,7 @@ Resources:
         Type: NO_ARTIFACTS
       Environment:
         Type: LINUX_CONTAINER
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
         ComputeType: BUILD_GENERAL1_SMALL
         PrivilegedMode: true
       Source:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/dd_manifest.yaml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/dd_manifest.yaml
@@ -9,7 +9,7 @@ name: exampleapppipeline
 version: 1
 
 build:
-  image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+  image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
   additional_policy:
     PolicyDocument:
       Version: '2012-10-17'

--- a/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/dd_stack_template.yaml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/dd_stack_template.yaml
@@ -134,7 +134,7 @@ Resources:
         Type: LINUX_CONTAINER
         ComputeType: BUILD_GENERAL1_SMALL
         PrivilegedMode: true
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
         EnvironmentVariables:
           - Name: AWS_ACCOUNT_ID
             Value: !Sub '${AWS::AccountId}'
@@ -246,7 +246,7 @@ Resources:
         Type: NO_ARTIFACTS
       Environment:
         Type: LINUX_CONTAINER
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
         ComputeType: BUILD_GENERAL1_SMALL
         PrivilegedMode: true
       Source:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/gh_template.yaml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/gh_template.yaml
@@ -119,7 +119,7 @@ Resources:
         Type: LINUX_CONTAINER
         ComputeType: BUILD_GENERAL1_SMALL
         PrivilegedMode: true
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
         EnvironmentVariables:
           - Name: AWS_ACCOUNT_ID
             Value: !Sub '${AWS::AccountId}'
@@ -231,7 +231,7 @@ Resources:
         Type: NO_ARTIFACTS
       Environment:
         Type: LINUX_CONTAINER
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
         ComputeType: BUILD_GENERAL1_SMALL
         PrivilegedMode: true
       Source:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/ghv1_template.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/ghv1_template.yml
@@ -204,7 +204,7 @@ Resources:
         Type: NO_ARTIFACTS
       Environment:
         Type: LINUX_CONTAINER
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
         ComputeType: BUILD_GENERAL1_SMALL
         PrivilegedMode: true
       Source:

--- a/internal/pkg/deploy/pipeline.go
+++ b/internal/pkg/deploy/pipeline.go
@@ -8,12 +8,13 @@ package deploy
 import (
 	"errors"
 	"fmt"
-	"gopkg.in/yaml.v3"
 	"path"
 	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 
 	"github.com/aws/copilot-cli/internal/pkg/graph"
 
@@ -32,7 +33,7 @@ const (
 	fmtErrMissingProperty    = "missing `%s` in properties"
 	fmtErrPropertyNotAString = "property `%s` is not a string"
 
-	defaultPipelineBuildImage      = "aws/codebuild/amazonlinux2-x86_64-standard:3.0"
+	defaultPipelineBuildImage      = "aws/codebuild/amazonlinux2-x86_64-standard:4.0"
 	defaultPipelineEnvironmentType = "LINUX_CONTAINER"
 
 	DefaultPipelineArtifactsDir = "infrastructure"

--- a/internal/pkg/deploy/pipeline_test.go
+++ b/internal/pkg/deploy/pipeline_test.go
@@ -5,8 +5,9 @@ package deploy
 
 import (
 	"errors"
-	"gopkg.in/yaml.v3"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 
 	"github.com/aws/copilot-cli/internal/pkg/config"
 
@@ -201,7 +202,7 @@ func TestPipelineSourceFromManifest(t *testing.T) {
 
 func TestPipelineBuild_Init(t *testing.T) {
 	const (
-		defaultImage   = "aws/codebuild/amazonlinux2-x86_64-standard:3.0"
+		defaultImage   = "aws/codebuild/amazonlinux2-x86_64-standard:4.0"
 		defaultEnvType = "LINUX_CONTAINER"
 	)
 	yamlNode := yaml.Node{}

--- a/internal/pkg/template/templates/cicd/buildspec.yml
+++ b/internal/pkg/template/templates/cicd/buildspec.yml
@@ -3,8 +3,9 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      docker: 19
-      ruby: 2.6
+      docker: 20
+      ruby: 3.1
+      nodejs: 16
     commands:
       - echo "cd into $CODEBUILD_SRC_DIR"
       - cd $CODEBUILD_SRC_DIR

--- a/internal/pkg/template/templates/cicd/pipeline_cfn.yml
+++ b/internal/pkg/template/templates/cicd/pipeline_cfn.yml
@@ -291,7 +291,7 @@ Resources:
         Type: NO_ARTIFACTS
       Environment:
         Type: LINUX_CONTAINER
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
         ComputeType: BUILD_GENERAL1_SMALL
         PrivilegedMode: true
       Source:


### PR DESCRIPTION
Update CodeBuild buildspec dependency versions and default project image, so that Copilot overrides with the CDK can be synthesized.

Related #4208 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
