### PR TITLE
chore: revert "refactor: Login to docker client only once for all images"

### DIFF
--- a/internal/pkg/cli/deploy/mocks/mock_workload.go
+++ b/internal/pkg/cli/deploy/mocks/mock_workload.go
@@ -52,31 +52,31 @@ func (mr *MockActionRecommenderMockRecorder) RecommendedActions() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecommendedActions", reflect.TypeOf((*MockActionRecommender)(nil).RecommendedActions))
 }
 
-// MockrepositoryService is a mock of repositoryService interface.
-type MockrepositoryService struct {
+// MockimageBuilderPusher is a mock of imageBuilderPusher interface.
+type MockimageBuilderPusher struct {
 	ctrl     *gomock.Controller
-	recorder *MockrepositoryServiceMockRecorder
+	recorder *MockimageBuilderPusherMockRecorder
 }
 
-// MockrepositoryServiceMockRecorder is the mock recorder for MockrepositoryService.
-type MockrepositoryServiceMockRecorder struct {
-	mock *MockrepositoryService
+// MockimageBuilderPusherMockRecorder is the mock recorder for MockimageBuilderPusher.
+type MockimageBuilderPusherMockRecorder struct {
+	mock *MockimageBuilderPusher
 }
 
-// NewMockrepositoryService creates a new mock instance.
-func NewMockrepositoryService(ctrl *gomock.Controller) *MockrepositoryService {
-	mock := &MockrepositoryService{ctrl: ctrl}
-	mock.recorder = &MockrepositoryServiceMockRecorder{mock}
+// NewMockimageBuilderPusher creates a new mock instance.
+func NewMockimageBuilderPusher(ctrl *gomock.Controller) *MockimageBuilderPusher {
+	mock := &MockimageBuilderPusher{ctrl: ctrl}
+	mock.recorder = &MockimageBuilderPusherMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockrepositoryService) EXPECT() *MockrepositoryServiceMockRecorder {
+func (m *MockimageBuilderPusher) EXPECT() *MockimageBuilderPusherMockRecorder {
 	return m.recorder
 }
 
 // BuildAndPush mocks base method.
-func (m *MockrepositoryService) BuildAndPush(docker repository.ContainerLoginBuildPusher, args *dockerengine.BuildArguments) (string, error) {
+func (m *MockimageBuilderPusher) BuildAndPush(docker repository.ContainerLoginBuildPusher, args *dockerengine.BuildArguments) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BuildAndPush", docker, args)
 	ret0, _ := ret[0].(string)
@@ -85,24 +85,9 @@ func (m *MockrepositoryService) BuildAndPush(docker repository.ContainerLoginBui
 }
 
 // BuildAndPush indicates an expected call of BuildAndPush.
-func (mr *MockrepositoryServiceMockRecorder) BuildAndPush(docker, args interface{}) *gomock.Call {
+func (mr *MockimageBuilderPusherMockRecorder) BuildAndPush(docker, args interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildAndPush", reflect.TypeOf((*MockrepositoryService)(nil).BuildAndPush), docker, args)
-}
-
-// Login mocks base method.
-func (m *MockrepositoryService) Login(docker repository.ContainerLoginBuildPusher) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Login", docker)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Login indicates an expected call of Login.
-func (mr *MockrepositoryServiceMockRecorder) Login(docker interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Login", reflect.TypeOf((*MockrepositoryService)(nil).Login), docker)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildAndPush", reflect.TypeOf((*MockimageBuilderPusher)(nil).BuildAndPush), docker, args)
 }
 
 // Mocktemplater is a mock of templater interface.

--- a/internal/pkg/cli/deploy/workload_test.go
+++ b/internal/pkg/cli/deploy/workload_test.go
@@ -36,7 +36,7 @@ import (
 )
 
 type deployMocks struct {
-	mockRepositoryService      *mocks.MockrepositoryService
+	mockImageBuilderPusher     *mocks.MockimageBuilderPusher
 	mockEndpointGetter         *mocks.MockendpointGetter
 	mockSpinner                *mocks.Mockspinner
 	mockPublicCIDRBlocksGetter *mocks.MockpublicCIDRBlocksGetter
@@ -201,7 +201,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 				},
 			},
 			mock: func(t *testing.T, m *deployMocks) {
-				m.mockRepositoryService.EXPECT().BuildAndPush(gomock.Any(), &dockerengine.BuildArguments{
+				m.mockImageBuilderPusher.EXPECT().BuildAndPush(gomock.Any(), &dockerengine.BuildArguments{
 					Dockerfile: "mockDockerfile",
 					Context:    "mockContext",
 					Platform:   "mockContainerPlatform",
@@ -224,7 +224,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 				},
 			},
 			mock: func(t *testing.T, m *deployMocks) {
-				m.mockRepositoryService.EXPECT().BuildAndPush(gomock.Any(), &dockerengine.BuildArguments{
+				m.mockImageBuilderPusher.EXPECT().BuildAndPush(gomock.Any(), &dockerengine.BuildArguments{
 					Dockerfile: "mockDockerfile",
 					Context:    "mockContext",
 					Platform:   "mockContainerPlatform",
@@ -254,7 +254,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 				},
 			},
 			mock: func(t *testing.T, m *deployMocks) {
-				m.mockRepositoryService.EXPECT().BuildAndPush(gomock.Any(), &dockerengine.BuildArguments{
+				m.mockImageBuilderPusher.EXPECT().BuildAndPush(gomock.Any(), &dockerengine.BuildArguments{
 					Dockerfile: "mockDockerfile",
 					Context:    "mockContext",
 					Platform:   "mockContainerPlatform",
@@ -286,7 +286,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 			},
 			inMockGitTag: "gitTag",
 			mock: func(t *testing.T, m *deployMocks) {
-				m.mockRepositoryService.EXPECT().BuildAndPush(gomock.Any(), &dockerengine.BuildArguments{
+				m.mockImageBuilderPusher.EXPECT().BuildAndPush(gomock.Any(), &dockerengine.BuildArguments{
 					Dockerfile: "sidecarMockDockerfile",
 					Context:    "sidecarMockContext",
 					Platform:   "mockContainerPlatform",
@@ -296,7 +296,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 						"com.aws.copilot.image.container.name": "nginx",
 					},
 				}).Return("sidecarMockDigest1", nil)
-				m.mockRepositoryService.EXPECT().BuildAndPush(gomock.Any(), &dockerengine.BuildArguments{
+				m.mockImageBuilderPusher.EXPECT().BuildAndPush(gomock.Any(), &dockerengine.BuildArguments{
 					Dockerfile: "web/Dockerfile",
 					Context:    "Users/bowie",
 					Platform:   "mockContainerPlatform",
@@ -586,10 +586,10 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 			defer ctrl.Finish()
 
 			m := &deployMocks{
-				mockUploader:          mocks.NewMockuploader(ctrl),
-				mockAddons:            mocks.NewMockstackBuilder(ctrl),
-				mockRepositoryService: mocks.NewMockrepositoryService(ctrl),
-				mockFileReader:        mocks.NewMockfileReader(ctrl),
+				mockUploader:           mocks.NewMockuploader(ctrl),
+				mockAddons:             mocks.NewMockstackBuilder(ctrl),
+				mockImageBuilderPusher: mocks.NewMockimageBuilderPusher(ctrl),
+				mockFileReader:         mocks.NewMockfileReader(ctrl),
 			}
 			tc.mock(t, m)
 
@@ -621,12 +621,12 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 					customEnvFiles:  tc.customEnvFiles,
 					dockerBuildArgs: tc.inDockerBuildArgs,
 				},
-				fs:              m.mockFileReader,
-				s3Client:        m.mockUploader,
-				repository:      m.mockRepositoryService,
-				templateFS:      fakeTemplateFS(),
-				overrider:       new(override.Noop),
-				customResources: crFn,
+				fs:                 m.mockFileReader,
+				s3Client:           m.mockUploader,
+				imageBuilderPusher: m.mockImageBuilderPusher,
+				templateFS:         fakeTemplateFS(),
+				overrider:          new(override.Noop),
+				customResources:    crFn,
 			}
 			if m.mockAddons != nil {
 				wkldDeployer.addons = m.mockAddons

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -173,13 +173,8 @@ type repositoryURIGetter interface {
 	URI() (string, error)
 }
 
-type dockerLogin interface {
-	Login(docker repository.ContainerLoginBuildPusher) (string, error)
-}
-
 type repositoryService interface {
 	repositoryURIGetter
-	dockerLogin
 	imageBuilderPusher
 }
 

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -1615,44 +1615,6 @@ func (mr *MockrepositoryURIGetterMockRecorder) URI() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "URI", reflect.TypeOf((*MockrepositoryURIGetter)(nil).URI))
 }
 
-// MockdockerLogin is a mock of dockerLogin interface.
-type MockdockerLogin struct {
-	ctrl     *gomock.Controller
-	recorder *MockdockerLoginMockRecorder
-}
-
-// MockdockerLoginMockRecorder is the mock recorder for MockdockerLogin.
-type MockdockerLoginMockRecorder struct {
-	mock *MockdockerLogin
-}
-
-// NewMockdockerLogin creates a new mock instance.
-func NewMockdockerLogin(ctrl *gomock.Controller) *MockdockerLogin {
-	mock := &MockdockerLogin{ctrl: ctrl}
-	mock.recorder = &MockdockerLoginMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockdockerLogin) EXPECT() *MockdockerLoginMockRecorder {
-	return m.recorder
-}
-
-// Login mocks base method.
-func (m *MockdockerLogin) Login(docker repository.ContainerLoginBuildPusher) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Login", docker)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Login indicates an expected call of Login.
-func (mr *MockdockerLoginMockRecorder) Login(docker interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Login", reflect.TypeOf((*MockdockerLogin)(nil).Login), docker)
-}
-
 // MockrepositoryService is a mock of repositoryService interface.
 type MockrepositoryService struct {
 	ctrl     *gomock.Controller
@@ -1689,21 +1651,6 @@ func (m *MockrepositoryService) BuildAndPush(docker repository.ContainerLoginBui
 func (mr *MockrepositoryServiceMockRecorder) BuildAndPush(docker, args interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildAndPush", reflect.TypeOf((*MockrepositoryService)(nil).BuildAndPush), docker, args)
-}
-
-// Login mocks base method.
-func (m *MockrepositoryService) Login(docker repository.ContainerLoginBuildPusher) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Login", docker)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Login indicates an expected call of Login.
-func (mr *MockrepositoryServiceMockRecorder) Login(docker interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Login", reflect.TypeOf((*MockrepositoryService)(nil).Login), docker)
 }
 
 // URI mocks base method.

--- a/internal/pkg/repository/repository.go
+++ b/internal/pkg/repository/repository.go
@@ -61,6 +61,18 @@ func (r *Repository) BuildAndPush(docker ContainerLoginBuildPusher, args *docker
 		return "", fmt.Errorf("build Dockerfile at %s: %w", args.Dockerfile, err)
 	}
 
+	// Perform docker login only if credStore attribute value != ecr-login
+	if !docker.IsEcrCredentialHelperEnabled(args.URI) {
+		username, password, err := r.registry.Auth()
+		if err != nil {
+			return "", fmt.Errorf("get auth: %w", err)
+		}
+
+		if err := docker.Login(args.URI, username, password); err != nil {
+			return "", fmt.Errorf("login to repo %s: %w", r.name, err)
+		}
+	}
+
 	digest, err = docker.Push(args.URI, args.Tags...)
 	if err != nil {
 		return "", fmt.Errorf("push to repo %s: %w", r.name, err)
@@ -76,28 +88,6 @@ func (r *Repository) URI() (string, error) {
 	uri, err := r.registry.RepositoryURI(r.name)
 	if err != nil {
 		return "", fmt.Errorf("get repository URI: %w", err)
-	}
-	return uri, nil
-}
-
-// Login authenticates with a ECR registry by performing a Docker login,
-// but only if the `credStore` attribute value is not set to `ecr-login`.
-// If the `credStore` value is `ecr-login`, no login is performed.
-// Returns a URI or an error, if any occurs during the login process.
-func (r *Repository) Login(docker ContainerLoginBuildPusher) (string, error) {
-	uri, err := r.URI()
-	if err != nil {
-		return "", fmt.Errorf("retrieve URI for repository: %w", err)
-	}
-	if !docker.IsEcrCredentialHelperEnabled(uri) {
-		username, password, err := r.registry.Auth()
-		if err != nil {
-			return "", fmt.Errorf("get auth: %w", err)
-		}
-
-		if err := docker.Login(uri, username, password); err != nil {
-			return "", fmt.Errorf("login to repo %s: %w", uri, err)
-		}
 	}
 	return uri, nil
 }

--- a/internal/pkg/repository/repository_test.go
+++ b/internal/pkg/repository/repository_test.go
@@ -46,6 +46,19 @@ func TestRepository_BuildAndPush(t *testing.T) {
 			inMockDocker: func(m *mocks.MockContainerLoginBuildPusher) {},
 			wantedError:  errors.New("get repository URI: some error"),
 		},
+		"failed to get auth": {
+			inURI: defaultDockerArguments.URI,
+			mockRegistry: func(m *mocks.MockRegistry) {
+				m.EXPECT().Auth().Return("", "", errors.New("error getting auth"))
+			},
+			inMockDocker: func(m *mocks.MockContainerLoginBuildPusher) {
+				m.EXPECT().Build(gomock.Any()).AnyTimes()
+				m.EXPECT().IsEcrCredentialHelperEnabled(defaultDockerArguments.URI).Return(false)
+				m.EXPECT().Login(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+				m.EXPECT().Push(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+			},
+			wantedError: errors.New("get auth: error getting auth"),
+		},
 		"failed to build image": {
 			inURI: defaultDockerArguments.URI,
 			mockRegistry: func(m *mocks.MockRegistry) {
@@ -53,14 +66,33 @@ func TestRepository_BuildAndPush(t *testing.T) {
 			},
 			inMockDocker: func(m *mocks.MockContainerLoginBuildPusher) {
 				m.EXPECT().Build(&defaultDockerArguments).Return(errors.New("error building image"))
+				m.EXPECT().Login(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 				m.EXPECT().Push(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 			},
 			wantedError: fmt.Errorf("build Dockerfile at %s: error building image", inDockerfilePath),
 		},
+		"failed to login": {
+			inURI: defaultDockerArguments.URI,
+			mockRegistry: func(m *mocks.MockRegistry) {
+				m.EXPECT().Auth().Return("my-name", "my-pwd", nil)
+			},
+			inMockDocker: func(m *mocks.MockContainerLoginBuildPusher) {
+				m.EXPECT().Build(gomock.Any()).AnyTimes()
+				m.EXPECT().IsEcrCredentialHelperEnabled(defaultDockerArguments.URI).Return(false)
+				m.EXPECT().Login(mockRepoURI, "my-name", "my-pwd").Return(errors.New("error logging in"))
+				m.EXPECT().Push(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+			},
+			wantedError: fmt.Errorf("login to repo %s: error logging in", inRepoName),
+		},
 		"failed to push": {
 			inURI: defaultDockerArguments.URI,
+			mockRegistry: func(m *mocks.MockRegistry) {
+				m.EXPECT().Auth().Times(1)
+			},
 			inMockDocker: func(m *mocks.MockContainerLoginBuildPusher) {
 				m.EXPECT().Build(&defaultDockerArguments).Times(1)
+				m.EXPECT().IsEcrCredentialHelperEnabled(defaultDockerArguments.URI).Return(false)
+				m.EXPECT().Login(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 				m.EXPECT().Push(mockRepoURI, mockTag1, mockTag2, mockTag3).Return("", errors.New("error pushing image"))
 			},
 			wantedError: errors.New("push to repo my-repo: error pushing image"),
@@ -69,6 +101,7 @@ func TestRepository_BuildAndPush(t *testing.T) {
 			inURI: defaultDockerArguments.URI,
 			inMockDocker: func(m *mocks.MockContainerLoginBuildPusher) {
 				m.EXPECT().Build(&defaultDockerArguments).Return(nil).Times(1)
+				m.EXPECT().IsEcrCredentialHelperEnabled(defaultDockerArguments.URI).Return(true)
 				m.EXPECT().Push(mockRepoURI, mockTag1, mockTag2, mockTag3).Return("sha256:f1d4ae3f7261a72e98c6ebefe9985cf10a0ea5bd762585a43e0700ed99863807", nil)
 			},
 			wantedDigest: "sha256:f1d4ae3f7261a72e98c6ebefe9985cf10a0ea5bd762585a43e0700ed99863807",
@@ -76,9 +109,12 @@ func TestRepository_BuildAndPush(t *testing.T) {
 		"success": {
 			mockRegistry: func(m *mocks.MockRegistry) {
 				m.EXPECT().RepositoryURI(inRepoName).Return(defaultDockerArguments.URI, nil)
+				m.EXPECT().Auth().Return("my-name", "my-pwd", nil).Times(1)
 			},
 			inMockDocker: func(m *mocks.MockContainerLoginBuildPusher) {
 				m.EXPECT().Build(&defaultDockerArguments).Return(nil).Times(1)
+				m.EXPECT().IsEcrCredentialHelperEnabled(defaultDockerArguments.URI).Return(false)
+				m.EXPECT().Login(mockRepoURI, "my-name", "my-pwd").Return(nil).Times(1)
 				m.EXPECT().Push(mockRepoURI, mockTag1, mockTag2, mockTag3).Return("sha256:f1d4ae3f7261a72e98c6ebefe9985cf10a0ea5bd762585a43e0700ed99863807", nil)
 			},
 			wantedDigest: "sha256:f1d4ae3f7261a72e98c6ebefe9985cf10a0ea5bd762585a43e0700ed99863807",
@@ -115,75 +151,6 @@ func TestRepository_BuildAndPush(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tc.wantedDigest, digest)
-			}
-		})
-	}
-}
-
-func Test_Login(t *testing.T) {
-	const mockRepoURI = "mockRepoURI"
-	testCases := map[string]struct {
-		inMockDocker func(m *mocks.MockContainerLoginBuildPusher)
-		mockRegistry func(m *mocks.MockRegistry)
-		wantedURI    string
-		wantedError  error
-	}{
-		"failed to get auth": {
-			mockRegistry: func(m *mocks.MockRegistry) {
-				m.EXPECT().Auth().Return("", "", errors.New("error getting auth"))
-			},
-			inMockDocker: func(m *mocks.MockContainerLoginBuildPusher) {
-				m.EXPECT().IsEcrCredentialHelperEnabled("mockRepoURI").Return(false)
-				m.EXPECT().Login(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
-			},
-			wantedError: errors.New("get auth: error getting auth"),
-		},
-		"failed to login": {
-			mockRegistry: func(m *mocks.MockRegistry) {
-				m.EXPECT().Auth().Return("my-name", "my-pwd", nil)
-			},
-			inMockDocker: func(m *mocks.MockContainerLoginBuildPusher) {
-				m.EXPECT().IsEcrCredentialHelperEnabled("mockRepoURI").Return(false)
-				m.EXPECT().Login("mockRepoURI", "my-name", "my-pwd").Return(errors.New("error logging in"))
-			},
-			wantedError: fmt.Errorf("login to repo %s: error logging in", mockRepoURI),
-		},
-		"no error when performing login": {
-			mockRegistry: func(m *mocks.MockRegistry) {
-				m.EXPECT().Auth().Return("my-name", "my-pwd", nil)
-			},
-			inMockDocker: func(m *mocks.MockContainerLoginBuildPusher) {
-				m.EXPECT().IsEcrCredentialHelperEnabled("mockRepoURI").Return(false)
-				m.EXPECT().Login("mockRepoURI", "my-name", "my-pwd").Return(nil)
-			},
-			wantedURI: mockRepoURI,
-		},
-	}
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
-			mockRepoGetter := mocks.NewMockRegistry(ctrl)
-			mockDocker := mocks.NewMockContainerLoginBuildPusher(ctrl)
-
-			if tc.mockRegistry != nil {
-				tc.mockRegistry(mockRepoGetter)
-			}
-			if tc.inMockDocker != nil {
-				tc.inMockDocker(mockDocker)
-			}
-
-			repo := &Repository{
-				registry: mockRepoGetter,
-				uri:      mockRepoURI,
-			}
-
-			got, gotErr := repo.Login(mockDocker)
-			if tc.wantedError != nil {
-				require.EqualError(t, tc.wantedError, gotErr.Error())
-			} else {
-				require.NoError(t, tc.wantedError, got)
-				require.Equal(t, tc.wantedURI, got)
 			}
 		})
 	}


### PR DESCRIPTION
Reverts aws/copilot-cli#4653
With this previous change Login to ECR is performed even when we run `copilot svc override` because the Login happens in the workload constructor and the `docker login` command prints `Login Succeeded`.
![image](https://user-images.githubusercontent.com/71282729/228046416-2c457184-8e85-4bf7-98fe-762c4d96d000.png)
