### PR TITLE
chore: include hidden file in embed

### DIFF
--- a/internal/pkg/template/template.go
+++ b/internal/pkg/template/template.go
@@ -18,7 +18,7 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/template/artifactpath"
 )
 
-//go:embed templates
+//go:embed templates templates/overrides/cdk/.gitignore
 var templateFS embed.FS
 
 // File names under "templates/".


### PR DESCRIPTION
Any hidden files are not included by default in `embed/` :cool-crying: I couldn't find a more elegant way of including the file, so I've listed the path explicitly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
