### PR TITLE
revert(e2e): revert 4698-- use unique CloudFront domain name

### DIFF
--- a/e2e/cloudfront/cloudfront_suite_test.go
+++ b/e2e/cloudfront/cloudfront_suite_test.go
@@ -25,7 +25,7 @@ var s3Client *s3.S3
 var s3Manager *s3manager.Uploader
 var staticPath string
 
-var domainName = fmt.Sprintf("%d.copilot-e2e-tests.ecs.aws.dev", time.Now().Unix())
+const domainName = "copilot-e2e-tests.ecs.aws.dev"
 
 func TestCloudFront(t *testing.T) {
 	RegisterFailHandler(Fail)


### PR DESCRIPTION
Reverts aws/copilot-cli#4698