### PR TITLE
chore: perform parallel build for all container images without context cancellation

### DIFF
--- a/internal/pkg/cli/deploy/mocks/mock_workload.go
+++ b/internal/pkg/cli/deploy/mocks/mock_workload.go
@@ -99,6 +99,7 @@ func (mr *MockrepositoryServiceMockRecorder) BuildAndPush(args interface{}) *gom
 
 // Login mocks base method.
 <<<<<<< HEAD
+<<<<<<< HEAD
 func (m *MockrepositoryService) Login() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Login")
@@ -113,6 +114,14 @@ func (m *MockrepositoryService) Login() (string, string, error) {
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 >>>>>>> 918aa4d8 (addr danny fb: move docckerCmdClient to repository struct)
+=======
+func (m *MockrepositoryService) Login() (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Login")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+>>>>>>> cafd5b3f (remove Login() from workload constructor and perform in uploadcontainerImages())
 }
 
 // Login indicates an expected call of Login.

--- a/internal/pkg/cli/deploy/mocks/mock_workload.go
+++ b/internal/pkg/cli/deploy/mocks/mock_workload.go
@@ -465,6 +465,44 @@ func (mr *MockfileReaderMockRecorder) ReadFile(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadFile", reflect.TypeOf((*MockfileReader)(nil).ReadFile), arg0)
 }
 
+// MockterminalPrinter is a mock of terminalPrinter interface.
+type MockterminalPrinter struct {
+	ctrl     *gomock.Controller
+	recorder *MockterminalPrinterMockRecorder
+}
+
+// MockterminalPrinterMockRecorder is the mock recorder for MockterminalPrinter.
+type MockterminalPrinterMockRecorder struct {
+	mock *MockterminalPrinter
+}
+
+// NewMockterminalPrinter creates a new mock instance.
+func NewMockterminalPrinter(ctrl *gomock.Controller) *MockterminalPrinter {
+	mock := &MockterminalPrinter{ctrl: ctrl}
+	mock.recorder = &MockterminalPrinterMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockterminalPrinter) EXPECT() *MockterminalPrinterMockRecorder {
+	return m.recorder
+}
+
+// TerminalWidth mocks base method.
+func (m *MockterminalPrinter) TerminalWidth() (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TerminalWidth")
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// TerminalWidth indicates an expected call of TerminalWidth.
+func (mr *MockterminalPrinterMockRecorder) TerminalWidth() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TerminalWidth", reflect.TypeOf((*MockterminalPrinter)(nil).TerminalWidth))
+}
+
 // MocktimeoutError is a mock of timeoutError interface.
 type MocktimeoutError struct {
 	ctrl     *gomock.Controller

--- a/internal/pkg/cli/deploy/mocks/mock_workload.go
+++ b/internal/pkg/cli/deploy/mocks/mock_workload.go
@@ -76,10 +76,14 @@ func (m *MockrepositoryService) EXPECT() *MockrepositoryServiceMockRecorder {
 
 // BuildAndPush mocks base method.
 <<<<<<< HEAD
+<<<<<<< HEAD
 func (m *MockrepositoryService) BuildAndPush(args *dockerengine.BuildArguments) (string, error) {
 =======
 func (m *MockrepositoryService) BuildAndPush(docker repository.ContainerLoginBuildPusher, args *dockerengine.BuildArguments) (string, error) {
 >>>>>>> 25baff92 (perform login only once per repo)
+=======
+func (m *MockrepositoryService) BuildAndPush(args *dockerengine.BuildArguments) (string, error) {
+>>>>>>> 918aa4d8 (addr danny fb: move docckerCmdClient to repository struct)
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BuildAndPush", args)
 	ret0, _ := ret[0].(string)
@@ -94,11 +98,21 @@ func (mr *MockrepositoryServiceMockRecorder) BuildAndPush(args interface{}) *gom
 }
 
 // Login mocks base method.
+<<<<<<< HEAD
 func (m *MockrepositoryService) Login() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Login")
 	ret0, _ := ret[0].(error)
 	return ret0
+=======
+func (m *MockrepositoryService) Login() (string, string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Login")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+>>>>>>> 918aa4d8 (addr danny fb: move docckerCmdClient to repository struct)
 }
 
 // Login indicates an expected call of Login.

--- a/internal/pkg/cli/deploy/mocks/mock_workload.go
+++ b/internal/pkg/cli/deploy/mocks/mock_workload.go
@@ -76,19 +76,7 @@ func (m *MockrepositoryService) EXPECT() *MockrepositoryServiceMockRecorder {
 }
 
 // BuildAndPush mocks base method.
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-func (m *MockrepositoryService) BuildAndPush(args *dockerengine.BuildArguments) (string, error) {
-=======
-func (m *MockrepositoryService) BuildAndPush(docker repository.ContainerLoginBuildPusher, args *dockerengine.BuildArguments) (string, error) {
->>>>>>> 25baff92 (perform login only once per repo)
-=======
-func (m *MockrepositoryService) BuildAndPush(args *dockerengine.BuildArguments) (string, error) {
->>>>>>> 918aa4d8 (addr danny fb: move docckerCmdClient to repository struct)
-=======
 func (m *MockrepositoryService) BuildAndPush(args *dockerengine.BuildArguments, w io.Writer) (string, error) {
->>>>>>> b97d674e (modify workload and taskrun testcases)
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BuildAndPush", args, w)
 	ret0, _ := ret[0].(string)
@@ -103,30 +91,11 @@ func (mr *MockrepositoryServiceMockRecorder) BuildAndPush(args, w interface{}) *
 }
 
 // Login mocks base method.
-<<<<<<< HEAD
-<<<<<<< HEAD
 func (m *MockrepositoryService) Login() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Login")
 	ret0, _ := ret[0].(error)
 	return ret0
-=======
-func (m *MockrepositoryService) Login() (string, string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Login")
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(string)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
->>>>>>> 918aa4d8 (addr danny fb: move docckerCmdClient to repository struct)
-=======
-func (m *MockrepositoryService) Login() (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Login")
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
->>>>>>> cafd5b3f (remove Login() from workload constructor and perform in uploadcontainerImages())
 }
 
 // Login indicates an expected call of Login.

--- a/internal/pkg/cli/deploy/mocks/mock_workload.go
+++ b/internal/pkg/cli/deploy/mocks/mock_workload.go
@@ -75,7 +75,11 @@ func (m *MockrepositoryService) EXPECT() *MockrepositoryServiceMockRecorder {
 }
 
 // BuildAndPush mocks base method.
+<<<<<<< HEAD
 func (m *MockrepositoryService) BuildAndPush(args *dockerengine.BuildArguments) (string, error) {
+=======
+func (m *MockrepositoryService) BuildAndPush(docker repository.ContainerLoginBuildPusher, args *dockerengine.BuildArguments) (string, error) {
+>>>>>>> 25baff92 (perform login only once per repo)
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BuildAndPush", args)
 	ret0, _ := ret[0].(string)

--- a/internal/pkg/cli/deploy/mocks/mock_workload.go
+++ b/internal/pkg/cli/deploy/mocks/mock_workload.go
@@ -5,6 +5,7 @@
 package mocks
 
 import (
+	io "io"
 	reflect "reflect"
 
 	addon "github.com/aws/copilot-cli/internal/pkg/addon"
@@ -77,6 +78,7 @@ func (m *MockrepositoryService) EXPECT() *MockrepositoryServiceMockRecorder {
 // BuildAndPush mocks base method.
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
 func (m *MockrepositoryService) BuildAndPush(args *dockerengine.BuildArguments) (string, error) {
 =======
 func (m *MockrepositoryService) BuildAndPush(docker repository.ContainerLoginBuildPusher, args *dockerengine.BuildArguments) (string, error) {
@@ -84,17 +86,20 @@ func (m *MockrepositoryService) BuildAndPush(docker repository.ContainerLoginBui
 =======
 func (m *MockrepositoryService) BuildAndPush(args *dockerengine.BuildArguments) (string, error) {
 >>>>>>> 918aa4d8 (addr danny fb: move docckerCmdClient to repository struct)
+=======
+func (m *MockrepositoryService) BuildAndPush(args *dockerengine.BuildArguments, w io.Writer) (string, error) {
+>>>>>>> b97d674e (modify workload and taskrun testcases)
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BuildAndPush", args)
+	ret := m.ctrl.Call(m, "BuildAndPush", args, w)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // BuildAndPush indicates an expected call of BuildAndPush.
-func (mr *MockrepositoryServiceMockRecorder) BuildAndPush(args interface{}) *gomock.Call {
+func (mr *MockrepositoryServiceMockRecorder) BuildAndPush(args, w interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildAndPush", reflect.TypeOf((*MockrepositoryService)(nil).BuildAndPush), args)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildAndPush", reflect.TypeOf((*MockrepositoryService)(nil).BuildAndPush), args, w)
 }
 
 // Login mocks base method.

--- a/internal/pkg/cli/deploy/mocks/mock_workload.go
+++ b/internal/pkg/cli/deploy/mocks/mock_workload.go
@@ -465,31 +465,31 @@ func (mr *MockfileReaderMockRecorder) ReadFile(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadFile", reflect.TypeOf((*MockfileReader)(nil).ReadFile), arg0)
 }
 
-// MockterminalPrinter is a mock of terminalPrinter interface.
-type MockterminalPrinter struct {
+// MockterminalWidthGetter is a mock of terminalWidthGetter interface.
+type MockterminalWidthGetter struct {
 	ctrl     *gomock.Controller
-	recorder *MockterminalPrinterMockRecorder
+	recorder *MockterminalWidthGetterMockRecorder
 }
 
-// MockterminalPrinterMockRecorder is the mock recorder for MockterminalPrinter.
-type MockterminalPrinterMockRecorder struct {
-	mock *MockterminalPrinter
+// MockterminalWidthGetterMockRecorder is the mock recorder for MockterminalWidthGetter.
+type MockterminalWidthGetterMockRecorder struct {
+	mock *MockterminalWidthGetter
 }
 
-// NewMockterminalPrinter creates a new mock instance.
-func NewMockterminalPrinter(ctrl *gomock.Controller) *MockterminalPrinter {
-	mock := &MockterminalPrinter{ctrl: ctrl}
-	mock.recorder = &MockterminalPrinterMockRecorder{mock}
+// NewMockterminalWidthGetter creates a new mock instance.
+func NewMockterminalWidthGetter(ctrl *gomock.Controller) *MockterminalWidthGetter {
+	mock := &MockterminalWidthGetter{ctrl: ctrl}
+	mock.recorder = &MockterminalWidthGetterMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockterminalPrinter) EXPECT() *MockterminalPrinterMockRecorder {
+func (m *MockterminalWidthGetter) EXPECT() *MockterminalWidthGetterMockRecorder {
 	return m.recorder
 }
 
 // TerminalWidth mocks base method.
-func (m *MockterminalPrinter) TerminalWidth() (int, error) {
+func (m *MockterminalWidthGetter) TerminalWidth() (int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TerminalWidth")
 	ret0, _ := ret[0].(int)
@@ -498,9 +498,9 @@ func (m *MockterminalPrinter) TerminalWidth() (int, error) {
 }
 
 // TerminalWidth indicates an expected call of TerminalWidth.
-func (mr *MockterminalPrinterMockRecorder) TerminalWidth() *gomock.Call {
+func (mr *MockterminalWidthGetterMockRecorder) TerminalWidth() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TerminalWidth", reflect.TypeOf((*MockterminalPrinter)(nil).TerminalWidth))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TerminalWidth", reflect.TypeOf((*MockterminalWidthGetter)(nil).TerminalWidth))
 }
 
 // MocktimeoutError is a mock of timeoutError interface.

--- a/internal/pkg/cli/deploy/workload.go
+++ b/internal/pkg/cli/deploy/workload.go
@@ -234,10 +234,6 @@ func newWorkloadDeployer(in *WorkloadDeployerInput) (*workloadDeployer, error) {
 	repoName := fmt.Sprintf("%s/%s", in.App.Name, in.Name)
 	repository := repository.NewWithURI(
 		ecr.New(defaultSessEnvRegion), repoName, resources.RepositoryURLs[in.Name])
-	uri, loginOut, err := repository.Login()
-	if err != nil {
-		return nil, fmt.Errorf("login to docker %s: %w", loginOut, err)
-	}
 	store := config.NewSSMStore(identity.New(defaultSession), ssm.New(defaultSession), aws.StringValue(defaultSession.Config.Region))
 	envDescriber, err := describe.NewEnvDescriber(describe.NewEnvDescriberConfig{
 		App:         in.App.Name,
@@ -282,8 +278,6 @@ func newWorkloadDeployer(in *WorkloadDeployerInput) (*workloadDeployer, error) {
 		envSess:                  envSession,
 		store:                    store,
 		envConfig:                envConfig,
-		uri:                      uri,
-		dockerLoginOut:           loginOut,
 
 		mft:    in.Mft,
 		rawMft: in.RawMft,
@@ -372,13 +366,19 @@ func (d *workloadDeployer) uploadContainerImages(out *UploadArtifactsOutput) err
 	if len(buildArgsPerContainer) == 0 {
 		return nil
 	}
+<<<<<<< HEAD
 	err = d.repository.Login()
 	if err != nil {
 		return fmt.Errorf("login to image repository: %w", err)
+=======
+	uri, err := d.repository.Login()
+	if err != nil {
+		return fmt.Errorf("login to docker: %w", err)
+>>>>>>> cafd5b3f (remove Login() from workload constructor and perform in uploadcontainerImages())
 	}
 	out.ImageDigests = make(map[string]ContainerImageIdentifier, len(buildArgsPerContainer))
-	fmt.Print(d.dockerLoginOut)
 	for name, buildArgs := range buildArgsPerContainer {
+		buildArgs.URI = uri
 		digest, err := d.repository.BuildAndPush(buildArgs)
 		if err != nil {
 			return fmt.Errorf("build and push image: %w", err)

--- a/internal/pkg/cli/deploy/workload.go
+++ b/internal/pkg/cli/deploy/workload.go
@@ -82,7 +82,7 @@ func (noopActionRecommender) RecommendedActions() []string {
 
 type repositoryService interface {
 	Login() error
-	BuildAndPush(args *dockerengine.BuildArguments) (string, error)
+	BuildAndPush(args *dockerengine.BuildArguments, w io.Writer) (string, error)
 }
 
 type templater interface {
@@ -442,7 +442,6 @@ func (d *workloadDeployer) uploadContainerImages(out *UploadArtifactsOutput) err
 	// mutex for synchronizing access to the output map.
 	var mux sync.Mutex
 	for name, buildArgs := range buildArgsPerContainer {
-		buildArgs.URI = uri
 		// create a copy of loop variables to avoid data race.
 		name := name
 		buildArgs := buildArgs

--- a/internal/pkg/cli/deploy/workload.go
+++ b/internal/pkg/cli/deploy/workload.go
@@ -532,7 +532,7 @@ func copyOutputToBuffer(pr io.Reader, buffer *syncbuffer.TermPrinter, name strin
 	return nil
 }
 
-// printAndErase prints the build and push output from the list of buildPushOutputBuffer buffers.
+// printAndErase prints the build and push output from the list of TermPrinter buffers.
 // It polls each buffer until all build and push calls are completed,
 // and erases the previous output after sleeping for a short duration.
 func printAndErase(t terminalWidthGetter, termPrinters []*syncbuffer.TermPrinter) error {
@@ -568,7 +568,7 @@ func printAndErase(t terminalWidthGetter, termPrinters []*syncbuffer.TermPrinter
 	return nil
 }
 
-// PrintAllprints all contents from given TermPrinter buffers once they have finished writing.
+// PrintAll prints all contents from given TermPrinter buffers once they have finished writing.
 func printAll(printers []*syncbuffer.TermPrinter) error {
 	count := 0
 	for {

--- a/internal/pkg/cli/deploy/workload.go
+++ b/internal/pkg/cli/deploy/workload.go
@@ -440,7 +440,7 @@ func (d *workloadDeployer) uploadContainerImages(out *UploadArtifactsOutput) err
 		})
 	} else {
 		g.Go(func() error {
-			return printOutputFromBuffers(termPrinters)
+			return printAndEraseFromBuffers(termPrinters)
 		})
 	}
 
@@ -520,10 +520,10 @@ func copyOutputToBuffer(pr io.Reader, buffer *syncbuffer.TermPrinter, name strin
 	return nil
 }
 
-// printOutputFromBuffers prints the build and push output from the list of buildPushOutputBuffer buffers to stderr.
+// printAndEraseFromBuffers prints the build and push output from the list of buildPushOutputBuffer buffers to stderr.
 // It polls each buffer until all build and push calls are completed,
 // and erases the previous output after sleeping for a short duration.
-func printOutputFromBuffers(termPrinters []*syncbuffer.TermPrinter) error {
+func printAndEraseFromBuffers(termPrinters []*syncbuffer.TermPrinter) error {
 	for {
 		totalWrittenLines := 0
 		// check whether all build and push calls are completed.

--- a/internal/pkg/cli/deploy/workload.go
+++ b/internal/pkg/cli/deploy/workload.go
@@ -270,9 +270,7 @@ func newWorkloadDeployer(in *WorkloadDeployerInput) (*workloadDeployer, error) {
 
 	cfn := cloudformation.New(envSession, cloudformation.WithProgressTracker(os.Stderr))
 	terminalWidthGetter := syncbuffer.NewTermPrinter(log.DiagnosticWriter)
-	if err != nil {
-		return nil, err
-	}
+
 	return &workloadDeployer{
 		name:                     in.Name,
 		app:                      in.App,

--- a/internal/pkg/cli/deploy/workload.go
+++ b/internal/pkg/cli/deploy/workload.go
@@ -142,16 +142,14 @@ type GenerateCloudFormationTemplateOutput struct {
 }
 
 type workloadDeployer struct {
-	name           string
-	app            *config.Application
-	env            *config.Environment
-	image          ContainerImageIdentifier
-	resources      *stack.AppRegionalResources
-	mft            interface{}
-	rawMft         []byte
-	workspacePath  string
-	uri            string
-	dockerLoginOut string
+	name          string
+	app           *config.Application
+	env           *config.Environment
+	image         ContainerImageIdentifier
+	resources     *stack.AppRegionalResources
+	mft           interface{}
+	rawMft        []byte
+	workspacePath string
 
 	// Dependencies.
 	fs               fileReader
@@ -359,7 +357,7 @@ func (img ContainerImageIdentifier) Tag() string {
 
 func (d *workloadDeployer) uploadContainerImages(out *UploadArtifactsOutput) error {
 	// If it is built from local Dockerfile, build and push to the ECR repo.
-	buildArgsPerContainer, err := buildArgsPerContainer(d.name, d.workspacePath, d.uri, d.image, d.mft)
+	buildArgsPerContainer, err := buildArgsPerContainer(d.name, d.workspacePath, d.image, d.mft)
 	if err != nil {
 		return err
 	}
@@ -392,7 +390,7 @@ func (d *workloadDeployer) uploadContainerImages(out *UploadArtifactsOutput) err
 	return nil
 }
 
-func buildArgsPerContainer(name, workspacePath, uri string, img ContainerImageIdentifier, unmarshaledManifest interface{}) (map[string]*dockerengine.BuildArguments, error) {
+func buildArgsPerContainer(name, workspacePath string, img ContainerImageIdentifier, unmarshaledManifest interface{}) (map[string]*dockerengine.BuildArguments, error) {
 	type dfArgs interface {
 		BuildArgs(rootDirectory string) (map[string]*manifest.DockerBuildArgs, error)
 		ContainerPlatform() string
@@ -424,7 +422,6 @@ func buildArgsPerContainer(name, workspacePath, uri string, img ContainerImageId
 		}
 		labels[labelForContainerName] = container
 		dArgs[container] = &dockerengine.BuildArguments{
-			URI:        uri,
 			Dockerfile: aws.StringValue(buildArgs.Dockerfile),
 			Context:    aws.StringValue(buildArgs.Context),
 			Args:       buildArgs.Args,

--- a/internal/pkg/cli/deploy/workload.go
+++ b/internal/pkg/cli/deploy/workload.go
@@ -517,15 +517,15 @@ func isCIEnvironment() bool {
 	return false
 }
 
-// copyOutputToBuffer copies the build and push output from the given io.Reader to the buildPushOutputBuffer buffer.
+// copyOutputToBuffer copies the build and push output from the given io.Reader to the TermPrinter buffer.
 // return an error if copying fails or if the reader returns an unexpected error.
-func copyOutputToBuffer(pr io.Reader, buffer *syncbuffer.TermPrinter, name string) error {
+func copyOutputToBuffer(pr io.Reader, printer *syncbuffer.TermPrinter, name string) error {
 	defer func() {
-		buffer.Buf.MarkDone()
+		printer.Buf.MarkDone()
 	}()
 
 	// copy the build and push output to the output buffer
-	_, err := io.Copy(buffer.Buf, pr)
+	_, err := io.Copy(printer.Buf, pr)
 	if err != nil && !errors.Is(err, io.EOF) {
 		return fmt.Errorf("copying build and push output for container %s: %w", name, err)
 	}

--- a/internal/pkg/cli/deploy/workload.go
+++ b/internal/pkg/cli/deploy/workload.go
@@ -548,7 +548,7 @@ func printAndErase(t terminalPrinter, termPrinters []*syncbuffer.TermPrinter) er
 			// calculate the terminal width everytime just before printing to the terminal.
 			width, err := t.TerminalWidth()
 			if err != nil {
-				return err
+				return fmt.Errorf("get terminal width: %w", err)
 			}
 			printer.TermWidth = width
 

--- a/internal/pkg/cli/deploy/workload.go
+++ b/internal/pkg/cli/deploy/workload.go
@@ -418,9 +418,6 @@ func (d *workloadDeployer) uploadContainerImages(out *UploadArtifactsOutput) err
 		pr, pw := io.Pipe()
 
 		termPrinter := syncbuffer.NewTermPrinter(log.DiagnosticWriter)
-		if err != nil {
-			return err
-		}
 		termPrinters[count] = termPrinter
 		count++
 

--- a/internal/pkg/cli/deploy/workload.go
+++ b/internal/pkg/cli/deploy/workload.go
@@ -239,7 +239,7 @@ func newWorkloadDeployer(in *WorkloadDeployerInput) (*workloadDeployer, error) {
 	dockerCmdClient := dockerengine.New(exec.NewCmd())
 	uri, loginOut, err := repository.Login(dockerCmdClient)
 	if err != nil {
-		return nil, fmt.Errorf("login to docker: %w", err)
+		return nil, fmt.Errorf("login to docker %s: %w", loginOut, err)
 	}
 	store := config.NewSSMStore(identity.New(defaultSession), ssm.New(defaultSession), aws.StringValue(defaultSession.Config.Region))
 	envDescriber, err := describe.NewEnvDescriber(describe.NewEnvDescriberConfig{
@@ -381,6 +381,7 @@ func (d *workloadDeployer) uploadContainerImages(out *UploadArtifactsOutput) err
 		return fmt.Errorf("login to image repository: %w", err)
 	}
 	out.ImageDigests = make(map[string]ContainerImageIdentifier, len(buildArgsPerContainer))
+	fmt.Print(d.dockerLoginOut)
 	for name, buildArgs := range buildArgsPerContainer {
 		digest, err := d.repository.BuildAndPush(buildArgs)
 		if err != nil {

--- a/internal/pkg/cli/deploy/workload.go
+++ b/internal/pkg/cli/deploy/workload.go
@@ -552,9 +552,8 @@ func printAndErase(t terminalWidthGetter, termPrinters []*syncbuffer.TermPrinter
 			}
 			printer.TermWidth = width
 
-			if err := printer.PrintLastFiveLines(); err != nil {
-				return fmt.Errorf("printing output from the buffers: %w", err)
-			}
+			// print label and last five logs.
+			printer.PrintLastFiveLines()
 			totalWrittenLines = totalWrittenLines + printer.PrevWrittenLines
 		}
 		if allDone {

--- a/internal/pkg/cli/deploy/workload.go
+++ b/internal/pkg/cli/deploy/workload.go
@@ -28,7 +28,6 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/deploy/upload/customresource"
 	"github.com/aws/copilot-cli/internal/pkg/describe"
 	"github.com/aws/copilot-cli/internal/pkg/docker/dockerengine"
-	"github.com/aws/copilot-cli/internal/pkg/exec"
 	"github.com/aws/copilot-cli/internal/pkg/manifest"
 	"github.com/aws/copilot-cli/internal/pkg/repository"
 	"github.com/aws/copilot-cli/internal/pkg/template"
@@ -174,7 +173,6 @@ type workloadDeployer struct {
 	envSess                  *session.Session
 	store                    *config.Store
 	envConfig                *manifest.Environment
-	dockerCmdClient          dockerengine.CmdClient
 }
 
 // WorkloadDeployerInput is the input to for workloadDeployer constructor.
@@ -236,8 +234,7 @@ func newWorkloadDeployer(in *WorkloadDeployerInput) (*workloadDeployer, error) {
 	repoName := fmt.Sprintf("%s/%s", in.App.Name, in.Name)
 	repository := repository.NewWithURI(
 		ecr.New(defaultSessEnvRegion), repoName, resources.RepositoryURLs[in.Name])
-	dockerCmdClient := dockerengine.New(exec.NewCmd())
-	uri, loginOut, err := repository.Login(dockerCmdClient)
+	uri, loginOut, err := repository.Login()
 	if err != nil {
 		return nil, fmt.Errorf("login to docker %s: %w", loginOut, err)
 	}
@@ -285,7 +282,6 @@ func newWorkloadDeployer(in *WorkloadDeployerInput) (*workloadDeployer, error) {
 		envSess:                  envSession,
 		store:                    store,
 		envConfig:                envConfig,
-		dockerCmdClient:          dockerCmdClient,
 		uri:                      uri,
 		dockerLoginOut:           loginOut,
 

--- a/internal/pkg/cli/deploy/workload.go
+++ b/internal/pkg/cli/deploy/workload.go
@@ -591,7 +591,7 @@ func printOutputFromBuffers(buffers []*buildPushOutputBuffer) error {
 
 		// sleep for a short time and erase the previous output.
 		time.Sleep(pollInterval)
-		// erase 5 lines from buffer and 2 lines of label.
+		// erase all the written lines to the terminal.
 		cursor.EraseLinesAbove(os.Stderr, writtenLines)
 	}
 	return nil

--- a/internal/pkg/cli/deploy/workload_test.go
+++ b/internal/pkg/cli/deploy/workload_test.go
@@ -155,7 +155,6 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 		mockName            = "mockWkld"
 		mockEnvName         = "test"
 		mockAppName         = "press"
-		mockURI             = "mockRepoURI"
 		mockWorkspacePath   = "."
 		mockEnvFile         = "foo.env"
 		mockS3Bucket        = "mockBucket"
@@ -204,7 +203,6 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 			mock: func(t *testing.T, m *deployMocks) {
 				m.mockRepositoryService.EXPECT().Login().Return(nil)
 				m.mockRepositoryService.EXPECT().BuildAndPush(&dockerengine.BuildArguments{
-					URI:        mockURI,
 					Dockerfile: "mockDockerfile",
 					Context:    "mockContext",
 					Platform:   "mockContainerPlatform",
@@ -229,7 +227,6 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 			mock: func(t *testing.T, m *deployMocks) {
 				m.mockRepositoryService.EXPECT().Login().Return(nil)
 				m.mockRepositoryService.EXPECT().BuildAndPush(&dockerengine.BuildArguments{
-					URI:        mockURI,
 					Dockerfile: "mockDockerfile",
 					Context:    "mockContext",
 					Platform:   "mockContainerPlatform",
@@ -261,7 +258,6 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 			mock: func(t *testing.T, m *deployMocks) {
 				m.mockRepositoryService.EXPECT().Login().Return(nil)
 				m.mockRepositoryService.EXPECT().BuildAndPush(&dockerengine.BuildArguments{
-					URI:        mockURI,
 					Dockerfile: "mockDockerfile",
 					Context:    "mockContext",
 					Platform:   "mockContainerPlatform",
@@ -295,7 +291,6 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 			mock: func(t *testing.T, m *deployMocks) {
 				m.mockRepositoryService.EXPECT().Login().Return(nil)
 				m.mockRepositoryService.EXPECT().BuildAndPush(&dockerengine.BuildArguments{
-					URI:        mockURI,
 					Dockerfile: "sidecarMockDockerfile",
 					Context:    "sidecarMockContext",
 					Platform:   "mockContainerPlatform",
@@ -306,7 +301,6 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 					},
 				}, gomock.Any()).Return("sidecarMockDigest1", nil)
 				m.mockRepositoryService.EXPECT().BuildAndPush(&dockerengine.BuildArguments{
-					URI:        mockURI,
 					Dockerfile: "web/Dockerfile",
 					Context:    "Users/bowie",
 					Platform:   "mockContainerPlatform",

--- a/internal/pkg/cli/deploy/workload_test.go
+++ b/internal/pkg/cli/deploy/workload_test.go
@@ -49,6 +49,7 @@ type deployMocks struct {
 	mockEnvVersionGetter       *mocks.MockversionGetter
 	mockFileReader             *mocks.MockfileReader
 	mockValidator              *mocks.MockaliasCertValidator
+	mockTerminalPrinter        *mocks.MockterminalPrinter
 }
 
 type mockTemplateFS struct {
@@ -212,6 +213,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 						"com.aws.copilot.image.container.name": "mockWkld",
 					},
 				}, gomock.Any()).Return("", mockError)
+				m.mockTerminalPrinter.EXPECT().TerminalWidth().Return(80, nil).AnyTimes()
 			},
 			wantErr: fmt.Errorf("build and push image: some error"),
 		},
@@ -226,6 +228,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 			},
 			mock: func(t *testing.T, m *deployMocks) {
 				m.mockRepositoryService.EXPECT().Login().Return(nil)
+				m.mockTerminalPrinter.EXPECT().TerminalWidth().Return(80, nil).AnyTimes()
 				m.mockRepositoryService.EXPECT().BuildAndPush(&dockerengine.BuildArguments{
 					Dockerfile: "mockDockerfile",
 					Context:    "mockContext",
@@ -267,6 +270,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 						"com.aws.copilot.image.container.name": "mockWkld",
 					},
 				}, gomock.Any()).Return("mockDigest", nil)
+				m.mockTerminalPrinter.EXPECT().TerminalWidth().Return(80, nil).AnyTimes()
 				m.mockAddons = nil
 			},
 			wantImages: map[string]ContainerImageIdentifier{
@@ -300,6 +304,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 						"com.aws.copilot.image.container.name": "nginx",
 					},
 				}, gomock.Any()).Return("sidecarMockDigest1", nil)
+				m.mockTerminalPrinter.EXPECT().TerminalWidth().Return(80, nil).AnyTimes()
 				m.mockRepositoryService.EXPECT().BuildAndPush(&dockerengine.BuildArguments{
 					Dockerfile: "web/Dockerfile",
 					Context:    "Users/bowie",
@@ -594,6 +599,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 				mockAddons:            mocks.NewMockstackBuilder(ctrl),
 				mockRepositoryService: mocks.NewMockrepositoryService(ctrl),
 				mockFileReader:        mocks.NewMockfileReader(ctrl),
+				mockTerminalPrinter:   mocks.NewMockterminalPrinter(ctrl),
 			}
 			tc.mock(t, m)
 
@@ -631,6 +637,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 				templateFS:      fakeTemplateFS(),
 				overrider:       new(override.Noop),
 				customResources: crFn,
+				terminalPrinter: m.mockTerminalPrinter,
 			}
 			if m.mockAddons != nil {
 				wkldDeployer.addons = m.mockAddons

--- a/internal/pkg/cli/deploy/workload_test.go
+++ b/internal/pkg/cli/deploy/workload_test.go
@@ -155,6 +155,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 		mockName            = "mockWkld"
 		mockEnvName         = "test"
 		mockAppName         = "press"
+		mockURI             = "mockRepoURI"
 		mockWorkspacePath   = "."
 		mockEnvFile         = "foo.env"
 		mockS3Bucket        = "mockBucket"
@@ -203,6 +204,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 			mock: func(t *testing.T, m *deployMocks) {
 				m.mockRepositoryService.EXPECT().Login().Return(nil)
 				m.mockRepositoryService.EXPECT().BuildAndPush(&dockerengine.BuildArguments{
+					URI:        mockURI,
 					Dockerfile: "mockDockerfile",
 					Context:    "mockContext",
 					Platform:   "mockContainerPlatform",
@@ -227,6 +229,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 			mock: func(t *testing.T, m *deployMocks) {
 				m.mockRepositoryService.EXPECT().Login().Return(nil)
 				m.mockRepositoryService.EXPECT().BuildAndPush(&dockerengine.BuildArguments{
+					URI:        mockURI,
 					Dockerfile: "mockDockerfile",
 					Context:    "mockContext",
 					Platform:   "mockContainerPlatform",
@@ -258,6 +261,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 			mock: func(t *testing.T, m *deployMocks) {
 				m.mockRepositoryService.EXPECT().Login().Return(nil)
 				m.mockRepositoryService.EXPECT().BuildAndPush(&dockerengine.BuildArguments{
+					URI:        mockURI,
 					Dockerfile: "mockDockerfile",
 					Context:    "mockContext",
 					Platform:   "mockContainerPlatform",
@@ -291,6 +295,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 			mock: func(t *testing.T, m *deployMocks) {
 				m.mockRepositoryService.EXPECT().Login().Return(nil)
 				m.mockRepositoryService.EXPECT().BuildAndPush(&dockerengine.BuildArguments{
+					URI:        mockURI,
 					Dockerfile: "sidecarMockDockerfile",
 					Context:    "sidecarMockContext",
 					Platform:   "mockContainerPlatform",
@@ -301,6 +306,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 					},
 				}).Return("sidecarMockDigest1", nil)
 				m.mockRepositoryService.EXPECT().BuildAndPush(&dockerengine.BuildArguments{
+					URI:        mockURI,
 					Dockerfile: "web/Dockerfile",
 					Context:    "Users/bowie",
 					Platform:   "mockContainerPlatform",

--- a/internal/pkg/cli/deploy/workload_test.go
+++ b/internal/pkg/cli/deploy/workload_test.go
@@ -213,7 +213,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 						"com.aws.copilot.image.builder":        "copilot-cli",
 						"com.aws.copilot.image.container.name": "mockWkld",
 					},
-				}).Return("", mockError)
+				}, gomock.Any()).Return("", mockError)
 			},
 			wantErr: fmt.Errorf("build and push image: some error"),
 		},
@@ -238,7 +238,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 						"com.aws.copilot.image.builder":        "copilot-cli",
 						"com.aws.copilot.image.container.name": "mockWkld",
 					},
-				}).Return("mockDigest", nil)
+				}, gomock.Any()).Return("mockDigest", nil)
 				m.mockAddons = nil
 			},
 			wantImages: map[string]ContainerImageIdentifier{
@@ -270,7 +270,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 						"com.aws.copilot.image.builder":        "copilot-cli",
 						"com.aws.copilot.image.container.name": "mockWkld",
 					},
-				}).Return("mockDigest", nil)
+				}, gomock.Any()).Return("mockDigest", nil)
 				m.mockAddons = nil
 			},
 			wantImages: map[string]ContainerImageIdentifier{
@@ -304,7 +304,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 						"com.aws.copilot.image.builder":        "copilot-cli",
 						"com.aws.copilot.image.container.name": "nginx",
 					},
-				}).Return("sidecarMockDigest1", nil)
+				}, gomock.Any()).Return("sidecarMockDigest1", nil)
 				m.mockRepositoryService.EXPECT().BuildAndPush(&dockerengine.BuildArguments{
 					URI:        mockURI,
 					Dockerfile: "web/Dockerfile",
@@ -315,7 +315,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 						"com.aws.copilot.image.builder":        "copilot-cli",
 						"com.aws.copilot.image.container.name": "logging",
 					},
-				}).Return("sidecarMockDigest2", nil)
+				}, gomock.Any()).Return("sidecarMockDigest2", nil)
 				m.mockAddons = nil
 			},
 			wantImages: map[string]ContainerImageIdentifier{

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -27,6 +27,7 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/initialize"
 	"github.com/aws/copilot-cli/internal/pkg/logging"
 	"github.com/aws/copilot-cli/internal/pkg/manifest"
+	"github.com/aws/copilot-cli/internal/pkg/repository"
 	"github.com/aws/copilot-cli/internal/pkg/task"
 	"github.com/aws/copilot-cli/internal/pkg/template"
 	"github.com/aws/copilot-cli/internal/pkg/term/prompt"
@@ -169,6 +170,9 @@ type imageBuilderPusher interface {
 }
 type repositoryURIGetter interface {
 	URI() (string, error)
+}
+type dockerLogin interface {
+	Login(docker repository.ContainerLoginBuildPusher) (string, string, error)
 }
 
 type repositoryLogin interface {

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -27,7 +27,6 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/initialize"
 	"github.com/aws/copilot-cli/internal/pkg/logging"
 	"github.com/aws/copilot-cli/internal/pkg/manifest"
-	"github.com/aws/copilot-cli/internal/pkg/repository"
 	"github.com/aws/copilot-cli/internal/pkg/task"
 	"github.com/aws/copilot-cli/internal/pkg/template"
 	"github.com/aws/copilot-cli/internal/pkg/term/prompt"
@@ -172,7 +171,7 @@ type repositoryURIGetter interface {
 	URI() (string, error)
 }
 type dockerLogin interface {
-	Login(docker repository.ContainerLoginBuildPusher) (string, string, error)
+	Login() (string, string, error)
 }
 
 type repositoryLogin interface {

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -170,9 +170,6 @@ type imageBuilderPusher interface {
 type repositoryURIGetter interface {
 	URI() (string, error)
 }
-type dockerLogin interface {
-	Login() (string, error)
-}
 
 type repositoryLogin interface {
 	Login() error

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -171,7 +171,7 @@ type repositoryURIGetter interface {
 	URI() (string, error)
 }
 type dockerLogin interface {
-	Login() (string, string, error)
+	Login() (string, error)
 }
 
 type repositoryLogin interface {

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -165,7 +165,7 @@ type secretDeleter interface {
 }
 
 type imageBuilderPusher interface {
-	BuildAndPush(args *dockerengine.BuildArguments) (string, error)
+	BuildAndPush(args *dockerengine.BuildArguments, w io.Writer) (string, error)
 }
 type repositoryURIGetter interface {
 	URI() (string, error)

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -1562,18 +1562,18 @@ func (m *MockimageBuilderPusher) EXPECT() *MockimageBuilderPusherMockRecorder {
 }
 
 // BuildAndPush mocks base method.
-func (m *MockimageBuilderPusher) BuildAndPush(args *dockerengine.BuildArguments) (string, error) {
+func (m *MockimageBuilderPusher) BuildAndPush(args *dockerengine.BuildArguments, w io.Writer) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BuildAndPush", args)
+	ret := m.ctrl.Call(m, "BuildAndPush", args, w)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // BuildAndPush indicates an expected call of BuildAndPush.
-func (mr *MockimageBuilderPusherMockRecorder) BuildAndPush(args interface{}) *gomock.Call {
+func (mr *MockimageBuilderPusherMockRecorder) BuildAndPush(args, w interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildAndPush", reflect.TypeOf((*MockimageBuilderPusher)(nil).BuildAndPush), args)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildAndPush", reflect.TypeOf((*MockimageBuilderPusher)(nil).BuildAndPush), args, w)
 }
 
 // MockrepositoryURIGetter is a mock of repositoryURIGetter interface.
@@ -1675,17 +1675,18 @@ func (m *MockrepositoryService) EXPECT() *MockrepositoryServiceMockRecorder {
 }
 
 // BuildAndPush mocks base method.
-func (m *MockrepositoryService) BuildAndPush(args *dockerengine.BuildArguments) (string, error) {
+func (m *MockrepositoryService) BuildAndPush(args *dockerengine.BuildArguments, w io.Writer) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BuildAndPush", args)
+	ret := m.ctrl.Call(m, "BuildAndPush", args, w)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // BuildAndPush indicates an expected call of BuildAndPush.
-func (mr *MockrepositoryServiceMockRecorder) BuildAndPush(args interface{}) *gomock.Call {
+func (mr *MockrepositoryServiceMockRecorder) BuildAndPush(args, w interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
+<<<<<<< HEAD
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildAndPush", reflect.TypeOf((*MockrepositoryService)(nil).BuildAndPush), args)
 <<<<<<< HEAD
 }
@@ -1704,6 +1705,9 @@ func (mr *MockrepositoryServiceMockRecorder) Login() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Login", reflect.TypeOf((*MockrepositoryService)(nil).Login))
 =======
 >>>>>>> 918aa4d8 (addr danny fb: move docckerCmdClient to repository struct)
+=======
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildAndPush", reflect.TypeOf((*MockrepositoryService)(nil).BuildAndPush), args, w)
+>>>>>>> b97d674e (modify workload and taskrun testcases)
 }
 
 // Login mocks base method.

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -1687,6 +1687,7 @@ func (m *MockrepositoryService) BuildAndPush(args *dockerengine.BuildArguments) 
 func (mr *MockrepositoryServiceMockRecorder) BuildAndPush(args interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildAndPush", reflect.TypeOf((*MockrepositoryService)(nil).BuildAndPush), args)
+<<<<<<< HEAD
 }
 
 // Login mocks base method.
@@ -1701,12 +1702,14 @@ func (m *MockrepositoryService) Login() error {
 func (mr *MockrepositoryServiceMockRecorder) Login() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Login", reflect.TypeOf((*MockrepositoryService)(nil).Login))
+=======
+>>>>>>> 918aa4d8 (addr danny fb: move docckerCmdClient to repository struct)
 }
 
 // Login mocks base method.
-func (m *MockrepositoryService) Login(docker repository.ContainerLoginBuildPusher) (string, string, error) {
+func (m *MockrepositoryService) Login() (string, string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Login", docker)
+	ret := m.ctrl.Call(m, "Login")
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(error)
@@ -1714,9 +1717,9 @@ func (m *MockrepositoryService) Login(docker repository.ContainerLoginBuildPushe
 }
 
 // Login indicates an expected call of Login.
-func (mr *MockrepositoryServiceMockRecorder) Login(docker interface{}) *gomock.Call {
+func (mr *MockrepositoryServiceMockRecorder) Login() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Login", reflect.TypeOf((*MockrepositoryService)(nil).Login), docker)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Login", reflect.TypeOf((*MockrepositoryService)(nil).Login))
 }
 
 // URI mocks base method.

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -1614,44 +1614,6 @@ func (mr *MockrepositoryURIGetterMockRecorder) URI() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "URI", reflect.TypeOf((*MockrepositoryURIGetter)(nil).URI))
 }
 
-// MockdockerLogin is a mock of dockerLogin interface.
-type MockdockerLogin struct {
-	ctrl     *gomock.Controller
-	recorder *MockdockerLoginMockRecorder
-}
-
-// MockdockerLoginMockRecorder is the mock recorder for MockdockerLogin.
-type MockdockerLoginMockRecorder struct {
-	mock *MockdockerLogin
-}
-
-// NewMockdockerLogin creates a new mock instance.
-func NewMockdockerLogin(ctrl *gomock.Controller) *MockdockerLogin {
-	mock := &MockdockerLogin{ctrl: ctrl}
-	mock.recorder = &MockdockerLoginMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockdockerLogin) EXPECT() *MockdockerLoginMockRecorder {
-	return m.recorder
-}
-
-// Login mocks base method.
-func (m *MockdockerLogin) Login() (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Login")
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Login indicates an expected call of Login.
-func (mr *MockdockerLoginMockRecorder) Login() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Login", reflect.TypeOf((*MockdockerLogin)(nil).Login))
-}
-
 // MockrepositoryLogin is a mock of repositoryLogin interface.
 type MockrepositoryLogin struct {
 	ctrl     *gomock.Controller

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -1703,6 +1703,22 @@ func (mr *MockrepositoryServiceMockRecorder) Login() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Login", reflect.TypeOf((*MockrepositoryService)(nil).Login))
 }
 
+// Login mocks base method.
+func (m *MockrepositoryService) Login(docker repository.ContainerLoginBuildPusher) (string, string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Login", docker)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// Login indicates an expected call of Login.
+func (mr *MockrepositoryServiceMockRecorder) Login(docker interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Login", reflect.TypeOf((*MockrepositoryService)(nil).Login), docker)
+}
+
 // URI mocks base method.
 func (m *MockrepositoryService) URI() (string, error) {
 	m.ctrl.T.Helper()

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -1721,21 +1721,6 @@ func (mr *MockrepositoryServiceMockRecorder) Login() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Login", reflect.TypeOf((*MockrepositoryService)(nil).Login))
 }
 
-// URI mocks base method.
-func (m *MockrepositoryService) URI() (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "URI")
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// URI indicates an expected call of URI.
-func (mr *MockrepositoryServiceMockRecorder) URI() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "URI", reflect.TypeOf((*MockrepositoryService)(nil).URI))
-}
-
 // MocklogEventsWriter is a mock of logEventsWriter interface.
 type MocklogEventsWriter struct {
 	ctrl     *gomock.Controller

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -1707,13 +1707,12 @@ func (mr *MockrepositoryServiceMockRecorder) Login() *gomock.Call {
 }
 
 // Login mocks base method.
-func (m *MockrepositoryService) Login() (string, string, error) {
+func (m *MockrepositoryService) Login() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Login")
 	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(string)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Login indicates an expected call of Login.

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -1614,6 +1614,44 @@ func (mr *MockrepositoryURIGetterMockRecorder) URI() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "URI", reflect.TypeOf((*MockrepositoryURIGetter)(nil).URI))
 }
 
+// MockdockerLogin is a mock of dockerLogin interface.
+type MockdockerLogin struct {
+	ctrl     *gomock.Controller
+	recorder *MockdockerLoginMockRecorder
+}
+
+// MockdockerLoginMockRecorder is the mock recorder for MockdockerLogin.
+type MockdockerLoginMockRecorder struct {
+	mock *MockdockerLogin
+}
+
+// NewMockdockerLogin creates a new mock instance.
+func NewMockdockerLogin(ctrl *gomock.Controller) *MockdockerLogin {
+	mock := &MockdockerLogin{ctrl: ctrl}
+	mock.recorder = &MockdockerLoginMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockdockerLogin) EXPECT() *MockdockerLoginMockRecorder {
+	return m.recorder
+}
+
+// Login mocks base method.
+func (m *MockdockerLogin) Login() (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Login")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Login indicates an expected call of Login.
+func (mr *MockdockerLoginMockRecorder) Login() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Login", reflect.TypeOf((*MockdockerLogin)(nil).Login))
+}
+
 // MockrepositoryLogin is a mock of repositoryLogin interface.
 type MockrepositoryLogin struct {
 	ctrl     *gomock.Controller
@@ -1686,9 +1724,7 @@ func (m *MockrepositoryService) BuildAndPush(args *dockerengine.BuildArguments, 
 // BuildAndPush indicates an expected call of BuildAndPush.
 func (mr *MockrepositoryServiceMockRecorder) BuildAndPush(args, w interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-<<<<<<< HEAD
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildAndPush", reflect.TypeOf((*MockrepositoryService)(nil).BuildAndPush), args)
-<<<<<<< HEAD
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildAndPush", reflect.TypeOf((*MockrepositoryService)(nil).BuildAndPush), args, w)
 }
 
 // Login mocks base method.
@@ -1703,26 +1739,21 @@ func (m *MockrepositoryService) Login() error {
 func (mr *MockrepositoryServiceMockRecorder) Login() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Login", reflect.TypeOf((*MockrepositoryService)(nil).Login))
-=======
->>>>>>> 918aa4d8 (addr danny fb: move docckerCmdClient to repository struct)
-=======
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildAndPush", reflect.TypeOf((*MockrepositoryService)(nil).BuildAndPush), args, w)
->>>>>>> b97d674e (modify workload and taskrun testcases)
 }
 
-// Login mocks base method.
-func (m *MockrepositoryService) Login() (string, error) {
+// URI mocks base method.
+func (m *MockrepositoryService) URI() (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Login")
+	ret := m.ctrl.Call(m, "URI")
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// Login indicates an expected call of Login.
-func (mr *MockrepositoryServiceMockRecorder) Login() *gomock.Call {
+// URI indicates an expected call of URI.
+func (mr *MockrepositoryServiceMockRecorder) URI() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Login", reflect.TypeOf((*MockrepositoryService)(nil).Login))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "URI", reflect.TypeOf((*MockrepositoryService)(nil).URI))
 }
 
 // MocklogEventsWriter is a mock of logEventsWriter interface.

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -10,18 +10,14 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-<<<<<<< HEAD
 
 	"github.com/aws/copilot-cli/internal/pkg/aws/partitions"
 	"github.com/aws/copilot-cli/internal/pkg/aws/s3"
 	"github.com/aws/copilot-cli/internal/pkg/template/artifactpath"
 	"golang.org/x/mod/semver"
-=======
->>>>>>> 25baff92 (perform login only once per repo)
 
 	"github.com/aws/copilot-cli/internal/pkg/aws/partitions"
 	"github.com/aws/copilot-cli/internal/pkg/aws/s3"
-	"github.com/aws/copilot-cli/internal/pkg/exec"
 	"github.com/aws/copilot-cli/internal/pkg/template/artifactpath"
 	"golang.org/x/mod/semver"
 
@@ -173,7 +169,6 @@ type runTaskOpts struct {
 	provider          sessionProvider
 	sess              *session.Session
 	targetEnvironment *config.Environment
-	dockerCmdClient   dockerengine.CmdClient
 
 	// Configurer functions.
 	configureRuntimeOpts func() error
@@ -232,10 +227,9 @@ func newTaskRunOpts(vars runTaskVars) (*runTaskOpts, error) {
 	}
 
 	opts.configureRepository = func() error {
-		opts.dockerCmdClient = dockerengine.New(exec.NewCmd())
 		repoName := fmt.Sprintf(deploy.FmtTaskECRRepoName, opts.groupName)
 		opts.repository = repository.New(ecr.New(opts.sess), repoName)
-		uri, loginOut, err := opts.repository.Login(opts.dockerCmdClient)
+		uri, loginOut, err := opts.repository.Login()
 		if err != nil {
 			return fmt.Errorf("login to docker %s: %w", loginOut, err)
 		}

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -237,7 +237,7 @@ func newTaskRunOpts(vars runTaskVars) (*runTaskOpts, error) {
 		opts.repository = repository.New(ecr.New(opts.sess), repoName)
 		uri, loginOut, err := opts.repository.Login(opts.dockerCmdClient)
 		if err != nil {
-			return err
+			return fmt.Errorf("login to docker %s: %w", loginOut, err)
 		}
 		opts.uri = uri
 		opts.dockerLoginOut = loginOut

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -979,7 +979,7 @@ func (o *runTaskOpts) buildAndPushImage(uri string) error {
 		Dockerfile: o.dockerfilePath,
 		Context:    ctx,
 		Tags:       append([]string{imageTagLatest}, additionalTags...),
-	}); err != nil {
+	}, os.Stderr); err != nil {
 		return fmt.Errorf("build and push image: %w", err)
 	}
 	return nil

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -148,8 +148,6 @@ type runTaskOpts struct {
 	runTaskVars
 	isDockerfileSet bool
 	nFlag           int
-	uri             string
-	dockerLoginOut  string
 
 	// Interfaces to interact with dependencies.
 	fs      afero.Fs
@@ -229,12 +227,6 @@ func newTaskRunOpts(vars runTaskVars) (*runTaskOpts, error) {
 	opts.configureRepository = func() error {
 		repoName := fmt.Sprintf(deploy.FmtTaskECRRepoName, opts.groupName)
 		opts.repository = repository.New(ecr.New(opts.sess), repoName)
-		uri, loginOut, err := opts.repository.Login()
-		if err != nil {
-			return fmt.Errorf("login to docker %s: %w", loginOut, err)
-		}
-		opts.uri = uri
-		opts.dockerLoginOut = loginOut
 		return nil
 	}
 
@@ -968,7 +960,7 @@ func (o *runTaskOpts) showPublicIPs(tasks []*task.Task) {
 
 }
 
-func (o *runTaskOpts) buildAndPushImage() error {
+func (o *runTaskOpts) buildAndPushImage(uri string) error {
 	var additionalTags []string
 	if o.imageTag != "" {
 		additionalTags = append(additionalTags, o.imageTag)
@@ -980,6 +972,10 @@ func (o *runTaskOpts) buildAndPushImage() error {
 	}
 
 	if _, err := o.repository.BuildAndPush(&dockerengine.BuildArguments{
+<<<<<<< HEAD
+=======
+		URI:        uri,
+>>>>>>> cafd5b3f (remove Login() from workload constructor and perform in uploadcontainerImages())
 		Dockerfile: o.dockerfilePath,
 		Context:    ctx,
 		Tags:       append([]string{imageTagLatest}, additionalTags...),

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -16,11 +16,6 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/template/artifactpath"
 	"golang.org/x/mod/semver"
 
-	"github.com/aws/copilot-cli/internal/pkg/aws/partitions"
-	"github.com/aws/copilot-cli/internal/pkg/aws/s3"
-	"github.com/aws/copilot-cli/internal/pkg/template/artifactpath"
-	"golang.org/x/mod/semver"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/aws/copilot-cli/internal/pkg/aws/identity"
@@ -960,7 +955,7 @@ func (o *runTaskOpts) showPublicIPs(tasks []*task.Task) {
 
 }
 
-func (o *runTaskOpts) buildAndPushImage(uri string) error {
+func (o *runTaskOpts) buildAndPushImage() error {
 	var additionalTags []string
 	if o.imageTag != "" {
 		additionalTags = append(additionalTags, o.imageTag)
@@ -972,10 +967,6 @@ func (o *runTaskOpts) buildAndPushImage(uri string) error {
 	}
 
 	if _, err := o.repository.BuildAndPush(&dockerengine.BuildArguments{
-<<<<<<< HEAD
-=======
-		URI:        uri,
->>>>>>> cafd5b3f (remove Login() from workload constructor and perform in uploadcontainerImages())
 		Dockerfile: o.dockerfilePath,
 		Context:    ctx,
 		Tags:       append([]string{imageTagLatest}, additionalTags...),

--- a/internal/pkg/cli/task_run_test.go
+++ b/internal/pkg/cli/task_run_test.go
@@ -762,7 +762,7 @@ func mockHasDefaultCluster(m runTaskMocks) {
 func mockRepositoryAnytime(m runTaskMocks) {
 	m.repository.EXPECT().URI().AnyTimes()
 	m.repository.EXPECT().Login().AnyTimes()
-	m.repository.EXPECT().BuildAndPush(gomock.Any()).AnyTimes()
+	m.repository.EXPECT().BuildAndPush(gomock.Any(), gomock.Any()).AnyTimes()
 }
 
 func TestTaskRunOpts_Execute(t *testing.T) {
@@ -921,6 +921,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 						Context: filepath.Dir(defaultDockerfilePath),
 						Tags:    []string{imageTagLatest, tag},
 					}),
+					gomock.Any(),
 				)
 				m.runner.EXPECT().Run().AnyTimes()
 				mockHasDefaultCluster(m)
@@ -940,6 +941,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 						Context: "../../other",
 						Tags:    []string{imageTagLatest},
 					}),
+					gomock.Any(),
 				)
 				m.runner.EXPECT().Run().AnyTimes()
 				mockHasDefaultCluster(m)

--- a/internal/pkg/cli/task_run_test.go
+++ b/internal/pkg/cli/task_run_test.go
@@ -772,7 +772,6 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 		tag         = "tag"
 	)
 	defaultBuildArguments := dockerengine.BuildArguments{
-		URI:     mockRepoURI,
 		Context: filepath.Dir(defaultDockerfilePath),
 		Tags:    []string{imageTagLatest},
 	}
@@ -917,7 +916,6 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 				m.repository.EXPECT().Login().Return(nil)
 				m.repository.EXPECT().BuildAndPush(gomock.Eq(
 					&dockerengine.BuildArguments{
-						URI:     mockRepoURI,
 						Context: filepath.Dir(defaultDockerfilePath),
 						Tags:    []string{imageTagLatest, tag},
 					}),
@@ -937,7 +935,6 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 				m.repository.EXPECT().Login().Return(nil)
 				m.repository.EXPECT().BuildAndPush(gomock.Eq(
 					&dockerengine.BuildArguments{
-						URI:     mockRepoURI,
 						Context: "../../other",
 						Tags:    []string{imageTagLatest},
 					}),

--- a/internal/pkg/cli/task_run_test.go
+++ b/internal/pkg/cli/task_run_test.go
@@ -772,6 +772,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 		tag         = "tag"
 	)
 	defaultBuildArguments := dockerengine.BuildArguments{
+		URI:     mockRepoURI,
 		Context: filepath.Dir(defaultDockerfilePath),
 		Tags:    []string{imageTagLatest},
 	}
@@ -916,6 +917,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 				m.repository.EXPECT().Login().Return(nil)
 				m.repository.EXPECT().BuildAndPush(gomock.Eq(
 					&dockerengine.BuildArguments{
+						URI:     mockRepoURI,
 						Context: filepath.Dir(defaultDockerfilePath),
 						Tags:    []string{imageTagLatest, tag},
 					}),
@@ -934,6 +936,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 				m.repository.EXPECT().Login().Return(nil)
 				m.repository.EXPECT().BuildAndPush(gomock.Eq(
 					&dockerengine.BuildArguments{
+						URI:     mockRepoURI,
 						Context: "../../other",
 						Tags:    []string{imageTagLatest},
 					}),

--- a/internal/pkg/cli/task_run_test.go
+++ b/internal/pkg/cli/task_run_test.go
@@ -861,7 +861,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 				}).Return(nil)
 				m.repository.EXPECT().URI().Return(mockRepoURI, nil)
 				m.repository.EXPECT().Login().Return(nil)
-				m.repository.EXPECT().BuildAndPush(gomock.Any())
+				m.repository.EXPECT().BuildAndPush(gomock.Any(), gomock.Any())
 				m.deployer.EXPECT().DeployTask(&deploy.CreateTaskResourcesInput{
 					Name:       inGroupName,
 					Image:      "uri/repo:latest",
@@ -961,7 +961,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 				}).Times(1).Return(nil)
 				m.repository.EXPECT().URI().Return(mockRepoURI, nil)
 				m.repository.EXPECT().Login().Return(nil)
-				m.repository.EXPECT().BuildAndPush(gomock.Eq(&defaultBuildArguments))
+				m.repository.EXPECT().BuildAndPush(gomock.Eq(&defaultBuildArguments), gomock.Any())
 				m.deployer.EXPECT().DeployTask(&deploy.CreateTaskResourcesInput{
 					Name:       inGroupName,
 					Image:      "uri/repo:latest",

--- a/internal/pkg/docker/dockerengine/dockerengine.go
+++ b/internal/pkg/docker/dockerengine/dockerengine.go
@@ -141,7 +141,10 @@ func (c CmdClient) Build(in *BuildArguments, w io.Writer) error {
 	// If host platform is not linux/amd64, show the user how the container image is being built; if the build fails (if their docker server doesn't have multi-platform-- and therefore `--platform` capability, for instance) they may see why.
 	if in.Platform != "" {
 		buildLabel := fmt.Sprintf("Building and pushing your container image: docker %s\n", strings.Join(args, " "))
-		io.WriteString(w, buildLabel)
+		_, err := io.WriteString(w, buildLabel)
+		if err != nil {
+			return fmt.Errorf("build label to writer :%w", err)
+		}
 	}
 	if err := c.runner.Run("docker", args, exec.Stdout(w), exec.Stderr(w)); err != nil {
 		return fmt.Errorf("building image: %w", err)

--- a/internal/pkg/docker/dockerengine/dockerengine.go
+++ b/internal/pkg/docker/dockerengine/dockerengine.go
@@ -149,17 +149,20 @@ func (c CmdClient) Build(in *BuildArguments) error {
 	return nil
 }
 
-// Login will run a `docker login` command against the Service repository URI with the input uri and auth data.
-func (c CmdClient) Login(uri, username, password string) error {
+// Login runs a `docker login` command against the specified Docker registry using the input credentials.
+// The function returns the standard output and standard error message from the `docker login` command as a string.
+// If the login process fails, an error is returned from the `docker login` command.
+func (c CmdClient) Login(uri, username, password string) (string, error) {
+	buf := new(strings.Builder)
 	err := c.runner.Run("docker",
 		[]string{"login", "-u", username, "--password-stdin", uri},
-		exec.Stdin(strings.NewReader(password)))
+		exec.Stdin(strings.NewReader(password)), exec.Stdout(buf), exec.Stderr(buf))
 
 	if err != nil {
-		return fmt.Errorf("authenticate to ECR: %w", err)
+		return buf.String(), fmt.Errorf("authenticate to ECR: %w", err)
 	}
 
-	return nil
+	return buf.String(), nil
 }
 
 // Push pushes the images with the specified tags and ecr repository URI, and returns the image digest on success.

--- a/internal/pkg/docker/dockerengine/dockerengine.go
+++ b/internal/pkg/docker/dockerengine/dockerengine.go
@@ -149,20 +149,17 @@ func (c CmdClient) Build(in *BuildArguments) error {
 	return nil
 }
 
-// Login runs a `docker login` command against the specified Docker registry using the input credentials.
-// The function returns the standard output and standard error message from the `docker login` command as a string.
-// If the login process fails, an error is returned from the `docker login` command.
-func (c CmdClient) Login(uri, username, password string) (string, error) {
-	buf := new(strings.Builder)
+// Login will run a `docker login` command against the Service repository URI with the input uri and auth data.
+func (c CmdClient) Login(uri, username, password string) error {
 	err := c.runner.Run("docker",
 		[]string{"login", "-u", username, "--password-stdin", uri},
-		exec.Stdin(strings.NewReader(password)), exec.Stdout(buf), exec.Stderr(buf))
+		exec.Stdin(strings.NewReader(password)))
 
 	if err != nil {
-		return buf.String(), fmt.Errorf("authenticate to ECR: %w", err)
+		return fmt.Errorf("authenticate to ECR: %w", err)
 	}
 
-	return buf.String(), nil
+	return nil
 }
 
 // Push pushes the images with the specified tags and ecr repository URI, and returns the image digest on success.

--- a/internal/pkg/docker/dockerengine/dockerengine_test.go
+++ b/internal/pkg/docker/dockerengine/dockerengine_test.go
@@ -227,10 +227,6 @@ func TestDockerCommand_Build(t *testing.T) {
 }
 
 func TestDockerCommand_Login(t *testing.T) {
-	const mockLoginOut = `Login Succeeded
-Logging in with your password grants your terminal complete access to your account. 
-For better security, log in with a limited-privilege personal access token. Learn more at https://docs.docker.com/go/access-tokens/
-`
 	mockError := errors.New("mockError")
 
 	mockURI := "mockURI"
@@ -240,41 +236,25 @@ For better security, log in with a limited-privilege personal access token. Lear
 	var mockCmd *MockCmd
 
 	tests := map[string]struct {
-		setupMocks     func(controller *gomock.Controller)
-		wantedLoginOut string
-		wantedErr      error
+		setupMocks func(controller *gomock.Controller)
+
+		want error
 	}{
 		"wrap error returned from Run()": {
 			setupMocks: func(controller *gomock.Controller) {
 				mockCmd = NewMockCmd(controller)
 
-				mockCmd.EXPECT().Run("docker", []string{"login", "-u", mockUsername, "--password-stdin", mockURI}, gomock.Any()).Do(func(_ string, _ []string, opts ...exec.CmdOption) {
-					cmd := &osexec.Cmd{}
-					for _, opt := range opts {
-						opt(cmd)
-					}
-					_, _ = cmd.Stdout.Write([]byte(`error response from daemon: login attempt to https://registry-1.docker.io/v2/ failed with status: 401 Unauthorized`))
-				}).Return(mockError)
+				mockCmd.EXPECT().Run("docker", []string{"login", "-u", mockUsername, "--password-stdin", mockURI}, gomock.Any()).Return(mockError)
 			},
-			wantedLoginOut: "error response from daemon: login attempt to https://registry-1.docker.io/v2/ failed with status: 401 Unauthorized",
-			wantedErr:      fmt.Errorf("authenticate to ECR: %w", mockError),
+			want: fmt.Errorf("authenticate to ECR: %w", mockError),
 		},
 		"happy path": {
 			setupMocks: func(controller *gomock.Controller) {
 				mockCmd = NewMockCmd(controller)
-				mockCmd.EXPECT().Run("docker", []string{"login", "-u", mockUsername, "--password-stdin", mockURI}, gomock.Any()).Do(func(_ string, _ []string, opts ...exec.CmdOption) {
-					cmd := &osexec.Cmd{}
-					for _, opt := range opts {
-						opt(cmd)
-					}
-					_, _ = cmd.Stdout.Write([]byte(`Login Succeeded
-Logging in with your password grants your terminal complete access to your account. 
-For better security, log in with a limited-privilege personal access token. Learn more at https://docs.docker.com/go/access-tokens/
-`))
-				}).Return(nil)
+
+				mockCmd.EXPECT().Run("docker", []string{"login", "-u", mockUsername, "--password-stdin", mockURI}, gomock.Any()).Return(nil)
 			},
-			wantedErr:      nil,
-			wantedLoginOut: mockLoginOut,
+			want: nil,
 		},
 	}
 
@@ -286,9 +266,9 @@ For better security, log in with a limited-privilege personal access token. Lear
 				runner: mockCmd,
 			}
 
-			gotLoginOutput, gotErr := s.Login(mockURI, mockUsername, mockPassword)
-			require.Equal(t, test.wantedLoginOut, gotLoginOutput)
-			require.Equal(t, test.wantedErr, gotErr)
+			got := s.Login(mockURI, mockUsername, mockPassword)
+
+			require.Equal(t, test.want, got)
 		})
 	}
 }

--- a/internal/pkg/repository/mocks/mock_repository.go
+++ b/internal/pkg/repository/mocks/mock_repository.go
@@ -5,6 +5,7 @@
 package mocks
 
 import (
+	io "io"
 	reflect "reflect"
 
 	dockerengine "github.com/aws/copilot-cli/internal/pkg/docker/dockerengine"
@@ -35,17 +36,17 @@ func (m *MockContainerLoginBuildPusher) EXPECT() *MockContainerLoginBuildPusherM
 }
 
 // Build mocks base method.
-func (m *MockContainerLoginBuildPusher) Build(args *dockerengine.BuildArguments) error {
+func (m *MockContainerLoginBuildPusher) Build(args *dockerengine.BuildArguments, w io.Writer) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Build", args)
+	ret := m.ctrl.Call(m, "Build", args, w)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Build indicates an expected call of Build.
-func (mr *MockContainerLoginBuildPusherMockRecorder) Build(args interface{}) *gomock.Call {
+func (mr *MockContainerLoginBuildPusherMockRecorder) Build(args, w interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Build", reflect.TypeOf((*MockContainerLoginBuildPusher)(nil).Build), args)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Build", reflect.TypeOf((*MockContainerLoginBuildPusher)(nil).Build), args, w)
 }
 
 // IsEcrCredentialHelperEnabled mocks base method.
@@ -77,9 +78,9 @@ func (mr *MockContainerLoginBuildPusherMockRecorder) Login(uri, username, passwo
 }
 
 // Push mocks base method.
-func (m *MockContainerLoginBuildPusher) Push(uri string, tags ...string) (string, error) {
+func (m *MockContainerLoginBuildPusher) Push(uri string, w io.Writer, tags ...string) (string, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{uri}
+	varargs := []interface{}{uri, w}
 	for _, a := range tags {
 		varargs = append(varargs, a)
 	}
@@ -90,9 +91,9 @@ func (m *MockContainerLoginBuildPusher) Push(uri string, tags ...string) (string
 }
 
 // Push indicates an expected call of Push.
-func (mr *MockContainerLoginBuildPusherMockRecorder) Push(uri interface{}, tags ...interface{}) *gomock.Call {
+func (mr *MockContainerLoginBuildPusherMockRecorder) Push(uri, w interface{}, tags ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{uri}, tags...)
+	varargs := append([]interface{}{uri, w}, tags...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Push", reflect.TypeOf((*MockContainerLoginBuildPusher)(nil).Push), varargs...)
 }
 

--- a/internal/pkg/repository/mocks/mock_repository.go
+++ b/internal/pkg/repository/mocks/mock_repository.go
@@ -63,11 +63,12 @@ func (mr *MockContainerLoginBuildPusherMockRecorder) IsEcrCredentialHelperEnable
 }
 
 // Login mocks base method.
-func (m *MockContainerLoginBuildPusher) Login(uri, username, password string) error {
+func (m *MockContainerLoginBuildPusher) Login(uri, username, password string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Login", uri, username, password)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Login indicates an expected call of Login.

--- a/internal/pkg/repository/mocks/mock_repository.go
+++ b/internal/pkg/repository/mocks/mock_repository.go
@@ -63,12 +63,11 @@ func (mr *MockContainerLoginBuildPusherMockRecorder) IsEcrCredentialHelperEnable
 }
 
 // Login mocks base method.
-func (m *MockContainerLoginBuildPusher) Login(uri, username, password string) (string, error) {
+func (m *MockContainerLoginBuildPusher) Login(uri, username, password string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Login", uri, username, password)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // Login indicates an expected call of Login.

--- a/internal/pkg/repository/repository.go
+++ b/internal/pkg/repository/repository.go
@@ -15,7 +15,7 @@ import (
 // ContainerLoginBuildPusher provides support for logging in to repositories, building images and pushing images to repositories.
 type ContainerLoginBuildPusher interface {
 	Build(args *dockerengine.BuildArguments) error
-	Login(uri, username, password string) (string, error)
+	Login(uri, username, password string) error
 	Push(uri string, tags ...string) (digest string, err error)
 	IsEcrCredentialHelperEnabled(uri string) bool
 }

--- a/internal/pkg/repository/repository.go
+++ b/internal/pkg/repository/repository.go
@@ -6,6 +6,7 @@ package repository
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/aws/copilot-cli/internal/pkg/exec"
 
@@ -14,9 +15,9 @@ import (
 
 // ContainerLoginBuildPusher provides support for logging in to repositories, building images and pushing images to repositories.
 type ContainerLoginBuildPusher interface {
-	Build(args *dockerengine.BuildArguments) error
+	Build(args *dockerengine.BuildArguments, w io.Writer) error
 	Login(uri, username, password string) error
-	Push(uri string, tags ...string) (digest string, err error)
+	Push(uri string, w io.Writer, tags ...string) (digest string, err error)
 	IsEcrCredentialHelperEnabled(uri string) bool
 }
 
@@ -54,7 +55,7 @@ func NewWithURI(registry Registry, name, uri string) *Repository {
 }
 
 // BuildAndPush builds the image from Dockerfile and pushes it to the repository with tags.
-func (r *Repository) BuildAndPush(args *dockerengine.BuildArguments) (digest string, err error) {
+func (r *Repository) BuildAndPush(args *dockerengine.BuildArguments, w io.Writer) (digest string, err error) {
 	if args.URI == "" {
 		uri, err := r.URI()
 		if err != nil {
@@ -62,11 +63,11 @@ func (r *Repository) BuildAndPush(args *dockerengine.BuildArguments) (digest str
 		}
 		args.URI = uri
 	}
-	if err := r.docker.Build(args); err != nil {
+	if err := r.docker.Build(args, w); err != nil {
 		return "", fmt.Errorf("build Dockerfile at %s: %w", args.Dockerfile, err)
 	}
 
-	digest, err = r.docker.Push(args.URI, args.Tags...)
+	digest, err = r.docker.Push(args.URI, w, args.Tags...)
 	if err != nil {
 		return "", fmt.Errorf("push to repo %s: %w", r.name, err)
 	}

--- a/internal/pkg/repository/repository.go
+++ b/internal/pkg/repository/repository.go
@@ -15,7 +15,7 @@ import (
 // ContainerLoginBuildPusher provides support for logging in to repositories, building images and pushing images to repositories.
 type ContainerLoginBuildPusher interface {
 	Build(args *dockerengine.BuildArguments) error
-	Login(uri, username, password string) error
+	Login(uri, username, password string) (string, error)
 	Push(uri string, tags ...string) (digest string, err error)
 	IsEcrCredentialHelperEnabled(uri string) bool
 }

--- a/internal/pkg/repository/repository_test.go
+++ b/internal/pkg/repository/repository_test.go
@@ -180,20 +180,11 @@ func Test_Login(t *testing.T) {
 				docker:   mockDocker,
 			}
 
-<<<<<<< HEAD
 			gotErr := repo.Login()
 			if tc.wantedError != nil {
 				require.EqualError(t, tc.wantedError, gotErr.Error())
 			} else {
 				require.NoError(t, tc.wantedError)
-=======
-			got, gotErr := repo.Login()
-			if tc.wantedError != nil {
-				require.EqualError(t, tc.wantedError, gotErr.Error())
-			} else {
-				require.NoError(t, tc.wantedError, got)
-				require.Equal(t, tc.wantedURI, got)
->>>>>>> cafd5b3f (remove Login() from workload constructor and perform in uploadcontainerImages())
 			}
 		})
 	}

--- a/internal/pkg/repository/repository_test.go
+++ b/internal/pkg/repository/repository_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/aws/copilot-cli/internal/pkg/docker/dockerengine"
@@ -52,24 +53,23 @@ func TestRepository_BuildAndPush(t *testing.T) {
 				m.EXPECT().Auth().Return("", "", nil).AnyTimes()
 			},
 			inMockDocker: func(m *mocks.MockContainerLoginBuildPusher) {
-				m.EXPECT().Build(&defaultDockerArguments).Return(errors.New("error building image"))
-				m.EXPECT().Push(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+				m.EXPECT().Build(&defaultDockerArguments, gomock.Any()).Return(errors.New("error building image"))
 			},
 			wantedError: fmt.Errorf("build Dockerfile at %s: error building image", inDockerfilePath),
 		},
 		"failed to push": {
 			inURI: defaultDockerArguments.URI,
 			inMockDocker: func(m *mocks.MockContainerLoginBuildPusher) {
-				m.EXPECT().Build(&defaultDockerArguments).Times(1)
-				m.EXPECT().Push(mockRepoURI, mockTag1, mockTag2, mockTag3).Return("", errors.New("error pushing image"))
+				m.EXPECT().Build(&defaultDockerArguments, gomock.Any()).Times(1)
+				m.EXPECT().Push(mockRepoURI, gomock.Any(), mockTag1, mockTag2, mockTag3).Return("", errors.New("error pushing image"))
 			},
 			wantedError: errors.New("push to repo my-repo: error pushing image"),
 		},
 		"push with ecr-login": {
 			inURI: defaultDockerArguments.URI,
 			inMockDocker: func(m *mocks.MockContainerLoginBuildPusher) {
-				m.EXPECT().Build(&defaultDockerArguments).Return(nil).Times(1)
-				m.EXPECT().Push(mockRepoURI, mockTag1, mockTag2, mockTag3).Return("sha256:f1d4ae3f7261a72e98c6ebefe9985cf10a0ea5bd762585a43e0700ed99863807", nil)
+				m.EXPECT().Build(&defaultDockerArguments, gomock.Any()).Return(nil).Times(1)
+				m.EXPECT().Push(mockRepoURI, gomock.Any(), mockTag1, mockTag2, mockTag3).Return("sha256:f1d4ae3f7261a72e98c6ebefe9985cf10a0ea5bd762585a43e0700ed99863807", nil)
 			},
 			wantedDigest: "sha256:f1d4ae3f7261a72e98c6ebefe9985cf10a0ea5bd762585a43e0700ed99863807",
 		},
@@ -78,8 +78,8 @@ func TestRepository_BuildAndPush(t *testing.T) {
 				m.EXPECT().RepositoryURI(inRepoName).Return(defaultDockerArguments.URI, nil)
 			},
 			inMockDocker: func(m *mocks.MockContainerLoginBuildPusher) {
-				m.EXPECT().Build(&defaultDockerArguments).Return(nil).Times(1)
-				m.EXPECT().Push(mockRepoURI, mockTag1, mockTag2, mockTag3).Return("sha256:f1d4ae3f7261a72e98c6ebefe9985cf10a0ea5bd762585a43e0700ed99863807", nil)
+				m.EXPECT().Build(&defaultDockerArguments, gomock.Any()).Return(nil).Times(1)
+				m.EXPECT().Push(mockRepoURI, gomock.Any(), mockTag1, mockTag2, mockTag3).Return("sha256:f1d4ae3f7261a72e98c6ebefe9985cf10a0ea5bd762585a43e0700ed99863807", nil)
 			},
 			wantedDigest: "sha256:f1d4ae3f7261a72e98c6ebefe9985cf10a0ea5bd762585a43e0700ed99863807",
 		},
@@ -105,12 +105,12 @@ func TestRepository_BuildAndPush(t *testing.T) {
 				uri:      tc.inURI,
 				docker:   mockDocker,
 			}
-
+			buf := new(strings.Builder)
 			digest, err := repo.BuildAndPush(&dockerengine.BuildArguments{
 				Dockerfile: inDockerfilePath,
 				Context:    filepath.Dir(inDockerfilePath),
 				Tags:       []string{mockTag1, mockTag2, mockTag3},
-			})
+			}, buf)
 			if tc.wantedError != nil {
 				require.EqualError(t, tc.wantedError, err.Error())
 			} else {

--- a/internal/pkg/repository/repository_test.go
+++ b/internal/pkg/repository/repository_test.go
@@ -180,11 +180,20 @@ func Test_Login(t *testing.T) {
 				docker:   mockDocker,
 			}
 
+<<<<<<< HEAD
 			gotErr := repo.Login()
 			if tc.wantedError != nil {
 				require.EqualError(t, tc.wantedError, gotErr.Error())
 			} else {
 				require.NoError(t, tc.wantedError)
+=======
+			got, gotErr := repo.Login()
+			if tc.wantedError != nil {
+				require.EqualError(t, tc.wantedError, gotErr.Error())
+			} else {
+				require.NoError(t, tc.wantedError, got)
+				require.Equal(t, tc.wantedURI, got)
+>>>>>>> cafd5b3f (remove Login() from workload constructor and perform in uploadcontainerImages())
 			}
 		})
 	}

--- a/internal/pkg/term/syncbuffer/syncbuffer.go
+++ b/internal/pkg/term/syncbuffer/syncbuffer.go
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 // Package syncbuffer provides a synchronized buffer to store and access logs from multiple goroutines.
 package syncbuffer
 
@@ -15,6 +18,11 @@ import (
 
 // maxLogLines is the maximum number of lines to display in the terminal.
 const maxLogLines = 5
+
+// fileWriter is the interface to write to a file.
+type fileWriter interface {
+	io.Writer
+}
 
 // SyncBuffer is a synchronized buffer used to store the output of build and push operations.
 type SyncBuffer struct {
@@ -55,11 +63,6 @@ func (b *SyncBuffer) IsDone() bool {
 // MarkDone closes the Done channel, indicating that the build and push is completed.
 func (b *SyncBuffer) MarkDone() {
 	close(b.Done)
-}
-
-// fileWriter is the interface to write to a file.
-type fileWriter interface {
-	io.Writer
 }
 
 // TermPrinter is a printer to display logs in the terminal.

--- a/internal/pkg/term/syncbuffer/syncbuffer.go
+++ b/internal/pkg/term/syncbuffer/syncbuffer.go
@@ -1,0 +1,151 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package syncbuffer provides a synchronized buffer to store and access logs from multiple goroutines.
+package syncbuffer
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"strings"
+	"sync"
+
+	"golang.org/x/term"
+)
+
+// maxLogLines is the maximum number of lines to display in the terminal.
+const maxLogLines = 5
+
+// SyncBuffer is a synchronized buffer used to store the output of build and push operations.
+type SyncBuffer struct {
+	BufMu sync.Mutex   // bufMu is a mutex to protect access to the buffer.
+	Buf   bytes.Buffer // buf is the buffer containing the output of build and push.
+
+	Done chan struct{} // done is a channel indicating whether the build and push is completed.
+}
+
+// Write appends the given bytes to the buffer.
+func (b *SyncBuffer) Write(p []byte) (n int, err error) {
+	b.BufMu.Lock()
+	defer b.BufMu.Unlock()
+	return b.Buf.Write(p)
+}
+
+// Strings returns the label (i.e., the first line of the buffer) and the last five lines of the buffer.
+func (b *SyncBuffer) strings() []string {
+	b.BufMu.Lock()
+	defer b.BufMu.Unlock()
+
+	// Split the buffer bytes into lines.
+	lines := strings.Split(strings.TrimSpace(b.Buf.String()), "\n")
+
+	return lines
+}
+
+// IsDone returns true if the Done channel has been closed, indicating that the build and push is completed.
+func (b *SyncBuffer) IsDone() bool {
+	select {
+	case <-b.Done:
+		return true
+	default:
+		return false
+	}
+}
+
+// MarkDone closes the Done channel, indicating that the build and push is completed.
+func (b *SyncBuffer) MarkDone() {
+	close(b.Done)
+}
+
+// fileWriter is the interface to write to a file.
+type fileWriter interface {
+	io.Writer
+}
+
+// TermPrinter is a printer to display logs in the terminal.
+type TermPrinter struct {
+	Term             fileWriter
+	Buf              *SyncBuffer
+	PrevWrittenLines int
+}
+
+// NewTermPrinter returns a new instance of TermPrinter that writes logs to the given file writer and reads logs from a new synchronized buffer.
+func NewTermPrinter(fw fileWriter) *TermPrinter {
+	return &TermPrinter{
+		Term: fw,
+		Buf: &SyncBuffer{
+			Done: make(chan struct{}),
+		},
+	}
+}
+
+// Print prints the last five lines of logs to the terminal.
+func (t *TermPrinter) Print() error {
+	logs := t.Buf.strings()
+	outputLogs := t.lastFiveLogLines(logs)
+	if len(outputLogs) > 0 {
+		fmt.Fprintln(t.Term, logs[0])
+		for _, logLine := range outputLogs {
+			fmt.Fprintln(t.Term, logLine)
+		}
+		writtenLines, err := t.numLines(append(outputLogs[:], logs[0]))
+		if err != nil {
+			return fmt.Errorf("get terminal size: %w", err)
+		}
+		t.PrevWrittenLines = writtenLines
+	}
+	return nil
+}
+
+// lastFiveLogLines returns the last five lines of the given logs, or all the logs if there are less than five lines.
+func (t *TermPrinter) lastFiveLogLines(logs []string) [maxLogLines]string {
+	// Determine the start and end index to extract last 5 lines
+	start := 1
+	if len(logs) > maxLogLines {
+		start = len(logs) - maxLogLines
+	}
+	end := len(logs)
+
+	// Extract the last 5 lines
+	var logLines [maxLogLines]string
+	idx := 0
+	for start < end {
+		logLines[idx] = strings.TrimSpace(logs[start])
+		start++
+		idx++
+	}
+	return logLines
+}
+
+// numLines calculates the actual number of lines needed to print the given string slice based on the terminal width
+// It returns the sum of these line counts or an error occurs while getting the terminal size.
+func (t *TermPrinter) numLines(lines []string) (int, error) {
+	// Get the terminal width
+	width, _, err := term.GetSize(int(os.Stderr.Fd()))
+	if err != nil {
+		return 0, err
+	}
+
+	// Calculate the number of lines needed to print the given lines.
+	var numLines float64
+	for _, line := range lines {
+		// Empty line should be considered as a new line
+		if line == "" {
+			numLines = numLines + 1
+		}
+		numLines += math.Ceil(float64(len(line)) / float64(width))
+	}
+
+	return int(numLines), nil
+}
+
+// PrintAll writes the entire contents of the buffer to the file writer if the build and push operation is completed.
+func (t *TermPrinter) PrintAll() {
+	outputLogs := t.Buf.strings()
+	for _, logLine := range outputLogs {
+		fmt.Fprintln(t.Term, logLine)
+	}
+}

--- a/internal/pkg/term/syncbuffer/syncbuffer.go
+++ b/internal/pkg/term/syncbuffer/syncbuffer.go
@@ -1,6 +1,3 @@
-// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
-
 // Package syncbuffer provides a synchronized buffer to store and access logs from multiple goroutines.
 package syncbuffer
 

--- a/internal/pkg/term/syncbuffer/syncbuffer.go
+++ b/internal/pkg/term/syncbuffer/syncbuffer.go
@@ -24,12 +24,12 @@ type fileWriter interface {
 	io.Writer
 }
 
-// SyncBuffer is a synchronized buffer used to store the output of build and push operations.
+// SyncBuffer is a synchronized buffer that can be used to store output data and coordinate between multiple goroutines.
 type SyncBuffer struct {
-	BufMu sync.Mutex   // BufMu is a mutex to protect access to the buffer.
-	Buf   bytes.Buffer // Buf is the buffer containing the output of build and push.
+	BufMu sync.Mutex   // BufMu is a mutex that can be used to protect access to the buffer.
+	Buf   bytes.Buffer // Buf is the buffer that stores the data.
 
-	Done chan struct{} // done is a channel indicating whether the build and push is completed.
+	Done chan struct{} // Done is a channel that can be used to signal when the operations are complete.
 }
 
 // Write appends the given bytes to the buffer.
@@ -39,7 +39,8 @@ func (b *SyncBuffer) Write(p []byte) (n int, err error) {
 	return b.Buf.Write(p)
 }
 
-// Strings returns the label (i.e., the first line of the buffer) and the last five lines of the buffer.
+// Strings returns an empty slice if the buffer is empty.
+// Otherwise, it returns a slice of all the lines stored in the buffer.
 func (b *SyncBuffer) strings() []string {
 	b.BufMu.Lock()
 	defer b.BufMu.Unlock()
@@ -50,7 +51,7 @@ func (b *SyncBuffer) strings() []string {
 	return lines
 }
 
-// IsDone returns true if the Done channel has been closed.
+// IsDone returns true if the Done channel has been closed, otherwise return false.
 func (b *SyncBuffer) IsDone() bool {
 	select {
 	case <-b.Done:

--- a/internal/pkg/term/syncbuffer/syncbuffer.go
+++ b/internal/pkg/term/syncbuffer/syncbuffer.go
@@ -118,8 +118,7 @@ func (t *TermPrinter) lastFiveLogLines(logs []string) [maxLogLines]string {
 	return logLines
 }
 
-// numLines calculates the actual number of lines needed to print the given string slice based on the terminal width
-// It returns the sum of these line counts or an error occurs while getting the terminal size.
+// numLines calculates and returns the actual number of lines needed to print the given string slice based on the terminal width.
 func (t *TermPrinter) numLines(lines []string) int {
 	var numLines float64
 	for _, line := range lines {

--- a/internal/pkg/term/syncbuffer/syncbuffer.go
+++ b/internal/pkg/term/syncbuffer/syncbuffer.go
@@ -84,7 +84,7 @@ func NewTermPrinter(fw fileWriter) *TermPrinter {
 }
 
 // PrintLastFiveLines prints the label and the last five lines of logs to the termPrinter fileWriter.
-func (t *TermPrinter) PrintLastFiveLines() error {
+func (t *TermPrinter) PrintLastFiveLines() {
 	logs := t.Buf.strings()
 	outputLogs := t.lastFiveLogLines(logs)
 	if len(outputLogs) > 0 {
@@ -95,7 +95,6 @@ func (t *TermPrinter) PrintLastFiveLines() error {
 		writtenLines := t.numLines(append(outputLogs[:], logs[0]))
 		t.PrevWrittenLines = writtenLines
 	}
-	return nil
 }
 
 // lastFiveLogLines returns the last five lines of the given logs, or all the logs if there are less than five lines.

--- a/internal/pkg/term/syncbuffer/syncbuffer_test.go
+++ b/internal/pkg/term/syncbuffer/syncbuffer_test.go
@@ -134,7 +134,7 @@ func TestTermPrinter_lastFiveLogLines(t *testing.T) {
 	}
 }
 
-func TestTermPrinter_Print(t *testing.T) {
+func TestTermPrinter_PrintLastFiveLines(t *testing.T) {
 	testCases := map[string]struct {
 		logs   []string
 		wanted string
@@ -164,8 +164,7 @@ line 8
 		t.Run(name, func(t *testing.T) {
 			// GIVEN
 			buf := &SyncBuffer{
-				Buf:  bytes.Buffer{},
-				Done: make(chan struct{}),
+				Buf: bytes.Buffer{},
 			}
 			buf.Buf.Write([]byte(strings.Join(tc.logs, "\n")))
 			termOut := &bytes.Buffer{}
@@ -175,7 +174,7 @@ line 8
 			}
 
 			// WHEN
-			printer.Print()
+			printer.PrintLastFiveLines()
 
 			// THEN
 			require.Equal(t, tc.wanted, termOut.String())
@@ -215,8 +214,7 @@ line 8
 		t.Run(name, func(t *testing.T) {
 			// GIVEN
 			buf := &SyncBuffer{
-				Buf:  bytes.Buffer{},
-				Done: make(chan struct{}),
+				Buf: bytes.Buffer{},
 			}
 			buf.Buf.Write([]byte(strings.Join(tc.logs, "\n")))
 			termOut := &bytes.Buffer{}

--- a/internal/pkg/term/syncbuffer/syncbuffer_test.go
+++ b/internal/pkg/term/syncbuffer/syncbuffer_test.go
@@ -1,0 +1,232 @@
+package syncbuffer
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSyncBuffer_Write(t *testing.T) {
+	testCases := map[string]struct {
+		input        []byte
+		wantedOutput string
+	}{
+		"append to custom buffer with simple input": {
+			input:        []byte("hello world"),
+			wantedOutput: "hello world",
+		},
+		"append to custom buffer with empty input": {
+			input:        []byte(""),
+			wantedOutput: "",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// GIVEN
+			sb := &SyncBuffer{}
+
+			// WHEN
+			sb.Write(tc.input)
+
+			// THEN
+			require.Equal(t, tc.wantedOutput, sb.Buf.String())
+		})
+	}
+}
+
+func TestSyncBuffer_IsDone(t *testing.T) {
+	testCases := map[string]struct {
+		buffer     *SyncBuffer
+		wantedDone bool
+	}{
+		"Buffer is done": {
+			buffer:     &SyncBuffer{Done: make(chan struct{}), Buf: bytes.Buffer{}},
+			wantedDone: true,
+		},
+		"Buffer is not done": {
+			buffer: &SyncBuffer{Done: make(chan struct{}), Buf: bytes.Buffer{}},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// GIVEN
+			if tc.wantedDone {
+				tc.buffer.MarkDone()
+			}
+
+			// WHEN
+			actual := tc.buffer.IsDone()
+
+			// THEN
+			require.Equal(t, tc.wantedDone, actual)
+
+		})
+	}
+}
+
+func TestSyncBuffer_strings(t *testing.T) {
+	testCases := map[string]struct {
+		input  []byte
+		wanted []string
+	}{
+		"single line": {
+			input:  []byte("hello"),
+			wanted: []string{"hello"},
+		},
+		"multiple lines": {
+			input:  []byte("hello\nworld\n"),
+			wanted: []string{"hello", "world"},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+
+			// GIVEN
+			sb := &SyncBuffer{}
+			sb.Write(tc.input)
+
+			// WHEN
+			actual := sb.strings()
+			require.Equal(t, tc.wanted, actual)
+		})
+	}
+}
+
+func TestTermPrinter_lastFiveLogLines(t *testing.T) {
+	testCases := map[string]struct {
+		logs   []string
+		wanted [5]string
+	}{
+		"more than five lines": {
+			logs:   []string{"label", "line1", "line2", "line3", "line4", "line5", "line6", "line7"},
+			wanted: [5]string{"line3", "line4", "line5", "line6", "line7"},
+		},
+		"less than five lines": {
+			logs:   []string{"label", "line1", "line2"},
+			wanted: [5]string{"line1", "line2"},
+		},
+		"empty log": {
+			logs: []string{},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// GIVEN
+			tp := &TermPrinter{}
+
+			// WHEN
+			actual := tp.lastFiveLogLines(tc.logs)
+
+			// THEN
+			require.Equal(t, tc.wanted, actual)
+		})
+	}
+}
+
+func TestTermPrinter_Print(t *testing.T) {
+	testCases := map[string]struct {
+		logs   []string
+		wanted string
+	}{
+		"display label and last five log lines": {
+			logs: []string{
+				"label",
+				"line 2",
+				"line 3",
+				"line 4",
+				"line 5",
+				"line 6",
+				"line 7",
+				"line 8",
+			},
+			wanted: `label
+line 4
+line 5
+line 6
+line 7
+line 8
+`,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// GIVEN
+
+			buf := &SyncBuffer{
+				Buf:  bytes.Buffer{},
+				Done: make(chan struct{}),
+			}
+			buf.Buf.Write([]byte(strings.Join(tc.logs, "\n")))
+			termOut := &bytes.Buffer{}
+			printer := TermPrinter{
+				Buf:  buf,
+				Term: termOut,
+			}
+			// WHEN
+
+			printer.Print()
+
+			// THEN
+			require.Equal(t, tc.wanted, termOut.String())
+		})
+	}
+}
+
+func TestTermPrinter_PrintAll(t *testing.T) {
+	testCases := map[string]struct {
+		logs   []string
+		wanted string
+	}{
+		"display all the output at once": {
+			logs: []string{
+				"label",
+				"line 2",
+				"line 3",
+				"line 4",
+				"line 5",
+				"line 6",
+				"line 7",
+				"line 8",
+			},
+			wanted: `label
+line 2
+line 3
+line 4
+line 5
+line 6
+line 7
+line 8
+`,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// GIVEN
+
+			buf := &SyncBuffer{
+				Buf:  bytes.Buffer{},
+				Done: make(chan struct{}),
+			}
+			buf.Buf.Write([]byte(strings.Join(tc.logs, "\n")))
+			termOut := &bytes.Buffer{}
+			printer := TermPrinter{
+				Buf:  buf,
+				Term: termOut,
+			}
+			// WHEN
+
+			printer.PrintAll()
+
+			// THEN
+			require.Equal(t, tc.wanted, termOut.String())
+		})
+	}
+}

--- a/internal/pkg/term/syncbuffer/syncbuffer_test.go
+++ b/internal/pkg/term/syncbuffer/syncbuffer_test.go
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package syncbuffer
 
 import (
@@ -92,6 +95,8 @@ func TestSyncBuffer_strings(t *testing.T) {
 
 			// WHEN
 			actual := sb.strings()
+
+			// THEN
 			require.Equal(t, tc.wanted, actual)
 		})
 	}
@@ -158,7 +163,6 @@ line 8
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			// GIVEN
-
 			buf := &SyncBuffer{
 				Buf:  bytes.Buffer{},
 				Done: make(chan struct{}),
@@ -169,8 +173,8 @@ line 8
 				Buf:  buf,
 				Term: termOut,
 			}
-			// WHEN
 
+			// WHEN
 			printer.Print()
 
 			// THEN
@@ -210,7 +214,6 @@ line 8
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			// GIVEN
-
 			buf := &SyncBuffer{
 				Buf:  bytes.Buffer{},
 				Done: make(chan struct{}),
@@ -222,7 +225,6 @@ line 8
 				Term: termOut,
 			}
 			// WHEN
-
 			printer.PrintAll()
 
 			// THEN


### PR DESCRIPTION
<!-- Provide summary of changes -->
This PR adds the logic to parallel build and push images with out context cancellation i.e if one of the go routine exits with an error, the other will still perform build and push of images.

The logic for context Cancellation will be added in the next PR.

Below are the screenshots of how the UI looks in different scenarios.

1. All the images are successfully build and pushed
![Screenshot 2023-03-29 at 9 50 02 PM](https://user-images.githubusercontent.com/71282729/228984695-6de0bfb7-55a5-402d-a1bb-fee10a0775f9.png)

2. If path of Dockerfile is incorrect.
![Screenshot 2023-03-29 at 9 45 27 PM](https://user-images.githubusercontent.com/71282729/228984769-fc29d621-7152-460c-85ac-7c499bdac7aa.png)

3. If one of the docker build gives an error.
![Screenshot 2023-03-29 at 9 53 58 PM](https://user-images.githubusercontent.com/71282729/228984903-48f30bc7-a480-4be8-b7bc-5fc7cfa13754.png)

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
