### PR TITLE
fix: remove docker runtime version for `test_commands`

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/bb_template.yaml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/bb_template.yaml
@@ -243,9 +243,6 @@ Resources:
         BuildSpec: |
           version: 0.2
           phases:
-            install:
-                runtime-versions:
-                  docker: 20
             build:
               commands:
                 - echo "test"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/bb_template.yaml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/bb_template.yaml
@@ -245,7 +245,7 @@ Resources:
           phases:
             install:
                 runtime-versions:
-                  docker: 18
+                  docker: 20
             build:
               commands:
                 - echo "test"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/cc_template.yaml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/cc_template.yaml
@@ -219,7 +219,7 @@ Resources:
           phases:
             install:
                 runtime-versions:
-                  docker: 18
+                  docker: 20
             build:
               commands:
                 - echo "test"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/cc_template.yaml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/cc_template.yaml
@@ -217,9 +217,6 @@ Resources:
         BuildSpec: |
           version: 0.2
           phases:
-            install:
-                runtime-versions:
-                  docker: 20
             build:
               commands:
                 - echo "test"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/dd_stack_template.yaml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/dd_stack_template.yaml
@@ -254,9 +254,6 @@ Resources:
         BuildSpec: |
           version: 0.2
           phases:
-            install:
-                runtime-versions:
-                  docker: 20
             build:
               commands:
                 - echo "test"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/dd_stack_template.yaml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/dd_stack_template.yaml
@@ -256,7 +256,7 @@ Resources:
           phases:
             install:
                 runtime-versions:
-                  docker: 18
+                  docker: 20
             build:
               commands:
                 - echo "test"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/gh_template.yaml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/gh_template.yaml
@@ -239,9 +239,6 @@ Resources:
         BuildSpec: |
           version: 0.2
           phases:
-            install:
-                runtime-versions:
-                  docker: 20
             build:
               commands:
                 - echo "test"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/gh_template.yaml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/gh_template.yaml
@@ -241,7 +241,7 @@ Resources:
           phases:
             install:
                 runtime-versions:
-                  docker: 18
+                  docker: 20
             build:
               commands:
                 - echo "test"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/ghv1_template.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/ghv1_template.yml
@@ -212,9 +212,6 @@ Resources:
         BuildSpec: |
           version: 0.2
           phases:
-            install:
-                runtime-versions:
-                  docker: 20
             build:
               commands:
                 - echo "test"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/ghv1_template.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/ghv1_template.yml
@@ -214,7 +214,7 @@ Resources:
           phases:
             install:
                 runtime-versions:
-                  docker: 18
+                  docker: 20
             build:
               commands:
                 - echo "test"

--- a/internal/pkg/template/templates/cicd/pipeline_cfn.yml
+++ b/internal/pkg/template/templates/cicd/pipeline_cfn.yml
@@ -299,9 +299,6 @@ Resources:
         BuildSpec: |
           version: 0.2
           phases:
-            install:
-                runtime-versions:
-                  docker: 20
             build:
               commands:
               {{- range $index, $command := $stage.Test.Commands}}

--- a/internal/pkg/template/templates/cicd/pipeline_cfn.yml
+++ b/internal/pkg/template/templates/cicd/pipeline_cfn.yml
@@ -301,7 +301,7 @@ Resources:
           phases:
             install:
                 runtime-versions:
-                  docker: 18
+                  docker: 20
             build:
               commands:
               {{- range $index, $command := $stage.Test.Commands}}


### PR DESCRIPTION
Updates docker version from 18 --> 20

Fixes #4721

To address a requirement when running test_commands

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
