### PR TITLE
chore: workload stack deletion should use cfn execution role

### DIFF
--- a/internal/pkg/cli/job_delete.go
+++ b/internal/pkg/cli/job_delete.go
@@ -252,7 +252,7 @@ func (o *deleteJobOpts) deleteJobs(envs []*config.Environment) error {
 			return err
 		}
 		// Delete job stack
-		if err = o.deleteStack(sess, env.Name); err != nil {
+		if err = o.deleteStack(sess, env); err != nil {
 			return err
 		}
 		// Delete orphan tasks
@@ -263,12 +263,13 @@ func (o *deleteJobOpts) deleteJobs(envs []*config.Environment) error {
 	return nil
 }
 
-func (o *deleteJobOpts) deleteStack(sess *session.Session, env string) error {
+func (o *deleteJobOpts) deleteStack(sess *session.Session, env *config.Environment) error {
 	cfClient := o.newWlDeleter(sess)
 	if err := cfClient.DeleteWorkload(deploy.DeleteWorkloadInput{
-		Name:    o.name,
-		EnvName: env,
-		AppName: o.appName,
+		Name:             o.name,
+		EnvName:          env.Name,
+		AppName:          o.appName,
+		ExecutionRoleARN: env.ExecutionRoleARN,
 	}); err != nil {
 		return fmt.Errorf("delete job stack: %w", err)
 	}

--- a/internal/pkg/cli/svc_delete.go
+++ b/internal/pkg/cli/svc_delete.go
@@ -254,9 +254,10 @@ func (o *deleteSvcOpts) deleteStacks(envs []*config.Environment) error {
 
 		cfClient := o.getSvcCFN(sess)
 		if err := cfClient.DeleteWorkload(deploy.DeleteWorkloadInput{
-			Name:    o.name,
-			EnvName: env.Name,
-			AppName: o.appName,
+			Name:             o.name,
+			EnvName:          env.Name,
+			AppName:          o.appName,
+			ExecutionRoleARN: env.ExecutionRoleARN,
 		}); err != nil {
 			return fmt.Errorf("delete service: %w", err)
 		}

--- a/internal/pkg/deploy/cloudformation/workload.go
+++ b/internal/pkg/deploy/cloudformation/workload.go
@@ -66,6 +66,6 @@ func (cf CloudFormation) DeleteWorkload(in deploy.DeleteWorkloadInput) error {
 	stackName := fmt.Sprintf("%s-%s-%s", in.AppName, in.EnvName, in.Name)
 	description := fmt.Sprintf("Delete stack %s", stackName)
 	return cf.deleteAndRenderStack(stackName, description, func() error {
-		return cf.cfnClient.DeleteAndWait(stackName)
+		return cf.cfnClient.DeleteAndWaitWithRoleARN(stackName, in.ExecutionRoleARN)
 	})
 }

--- a/internal/pkg/deploy/cloudformation/workload_test.go
+++ b/internal/pkg/deploy/cloudformation/workload_test.go
@@ -155,7 +155,7 @@ func TestCloudFormation_DeleteWorkload(t *testing.T) {
 				m.EXPECT().Describe(gomock.Any()).Return(&cloudformation.StackDescription{
 					StackId: aws.String("stack/webhook/1111"),
 				}, nil)
-				m.EXPECT().DeleteAndWait(gomock.Any()).Return(errors.New("some error"))
+				m.EXPECT().DeleteAndWaitWithRoleARN(gomock.Any(), gomock.Any()).Return(errors.New("some error"))
 				m.EXPECT().DescribeStackEvents(gomock.Any()).Return(&sdkcloudformation.DescribeStackEventsOutput{}, nil).AnyTimes()
 				return m
 			},
@@ -168,7 +168,7 @@ func TestCloudFormation_DeleteWorkload(t *testing.T) {
 				m.EXPECT().Describe(gomock.Any()).Return(&cloudformation.StackDescription{
 					StackId: aws.String("stack/webhook/1111"),
 				}, nil)
-				m.EXPECT().DeleteAndWait(gomock.Any()).Return(nil)
+				m.EXPECT().DeleteAndWaitWithRoleARN(gomock.Any(), gomock.Any()).Return(nil)
 				m.EXPECT().DescribeStackEvents(gomock.Any()).Return(nil, errors.New("some error"))
 				return m
 			},
@@ -181,7 +181,7 @@ func TestCloudFormation_DeleteWorkload(t *testing.T) {
 				m.EXPECT().Describe(gomock.Any()).Return(&cloudformation.StackDescription{
 					StackId: aws.String("stack/webhook/1111"),
 				}, nil)
-				m.EXPECT().DeleteAndWait(gomock.Any()).Return(&cloudformation.ErrStackNotFound{})
+				m.EXPECT().DeleteAndWaitWithRoleARN(gomock.Any(), gomock.Any()).Return(&cloudformation.ErrStackNotFound{})
 				m.EXPECT().DescribeStackEvents(gomock.Any()).Return(&sdkcloudformation.DescribeStackEventsOutput{}, nil).AnyTimes()
 				return m
 			},

--- a/internal/pkg/deploy/workload.go
+++ b/internal/pkg/deploy/workload.go
@@ -20,7 +20,8 @@ const (
 
 // DeleteWorkloadInput holds the fields required to delete a workload.
 type DeleteWorkloadInput struct {
-	Name    string // Name of the workload that needs to be deleted.
-	EnvName string // Name of the environment the service is deployed in.
-	AppName string // Name of the application the service belongs to.
+	Name             string
+	EnvName          string
+	AppName          string
+	ExecutionRoleARN string
 }


### PR DESCRIPTION
<!-- Provide summary of changes -->
Right now use env manager role to delete workload stacks which are created by CFN execution role. Also for env stack deletion we use CFN execution role.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
