### PR TITLE
refactor: fetch docker build label in `workload` and  ` taskrun`

### DIFF
--- a/internal/pkg/cli/deploy/mocks/mock_workload.go
+++ b/internal/pkg/cli/deploy/mocks/mock_workload.go
@@ -90,32 +90,18 @@ func (mr *MockrepositoryServiceMockRecorder) BuildAndPush(args interface{}) *gom
 }
 
 // Login mocks base method.
-func (m *MockrepositoryService) Login() error {
+func (m *MockrepositoryService) Login() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Login")
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Login indicates an expected call of Login.
 func (mr *MockrepositoryServiceMockRecorder) Login() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Login", reflect.TypeOf((*MockrepositoryService)(nil).Login))
-}
-
-// URI mocks base method.
-func (m *MockrepositoryService) URI() (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "URI")
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// URI indicates an expected call of URI.
-func (mr *MockrepositoryServiceMockRecorder) URI() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "URI", reflect.TypeOf((*MockrepositoryService)(nil).URI))
 }
 
 // Mocktemplater is a mock of templater interface.

--- a/internal/pkg/cli/deploy/mocks/mock_workload.go
+++ b/internal/pkg/cli/deploy/mocks/mock_workload.go
@@ -103,6 +103,21 @@ func (mr *MockrepositoryServiceMockRecorder) Login() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Login", reflect.TypeOf((*MockrepositoryService)(nil).Login))
 }
 
+// URI mocks base method.
+func (m *MockrepositoryService) URI() (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "URI")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// URI indicates an expected call of URI.
+func (mr *MockrepositoryServiceMockRecorder) URI() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "URI", reflect.TypeOf((*MockrepositoryService)(nil).URI))
+}
+
 // Mocktemplater is a mock of templater interface.
 type Mocktemplater struct {
 	ctrl     *gomock.Controller

--- a/internal/pkg/cli/deploy/workload.go
+++ b/internal/pkg/cli/deploy/workload.go
@@ -265,7 +265,7 @@ func newWorkloadDeployer(in *WorkloadDeployerInput) (*workloadDeployer, error) {
 		resources:                resources,
 		workspacePath:            ws.Path(),
 		uri:                      uri,
-		fs:                       &afero.Afero{Fs: afero.NewOsFs()},
+		fs:                       afero.NewOsFs(),
 		s3Client:                 s3.New(envSession),
 		addons:                   addons,
 		repository:               repository,

--- a/internal/pkg/cli/deploy/workload.go
+++ b/internal/pkg/cli/deploy/workload.go
@@ -380,7 +380,7 @@ func (d *workloadDeployer) uploadContainerImages(out *UploadArtifactsOutput) err
 		if err != nil {
 			return fmt.Errorf("generate docker build args: %w", err)
 		}
-		log.Infof(dockerengine.DockerBuildLabel(buildArgs.Platform, buildArgsList))
+		log.Infof(fmt.Sprintf("Building your container image: docker %s\n", strings.Join(buildArgsList, " ")))
 		digest, err := d.repository.BuildAndPush(buildArgs)
 		if err != nil {
 			return fmt.Errorf("build and push image: %w", err)

--- a/internal/pkg/cli/deploy/workload.go
+++ b/internal/pkg/cli/deploy/workload.go
@@ -374,6 +374,7 @@ func (d *workloadDeployer) uploadContainerImages(out *UploadArtifactsOutput) err
 		if err != nil {
 			return fmt.Errorf("generate docker build args: %w", err)
 		}
+		// TODO(adi) handle this log in syncBuffer's Print function
 		log.Infof("Building your container image: docker %s\n", strings.Join(buildArgsList, " "))
 		digest, err := d.repository.BuildAndPush(buildArgs)
 		if err != nil {

--- a/internal/pkg/cli/deploy/workload.go
+++ b/internal/pkg/cli/deploy/workload.go
@@ -380,7 +380,7 @@ func (d *workloadDeployer) uploadContainerImages(out *UploadArtifactsOutput) err
 		if err != nil {
 			return fmt.Errorf("generate docker build args: %w", err)
 		}
-		log.Infof(fmt.Sprintf("Building your container image: docker %s\n", strings.Join(buildArgsList, " ")))
+		log.Infof("Building your container image: docker %s\n", strings.Join(buildArgsList, " "))
 		digest, err := d.repository.BuildAndPush(buildArgs)
 		if err != nil {
 			return fmt.Errorf("build and push image: %w", err)

--- a/internal/pkg/cli/deploy/workload_test.go
+++ b/internal/pkg/cli/deploy/workload_test.go
@@ -156,6 +156,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 		mockName            = "mockWkld"
 		mockEnvName         = "test"
 		mockAppName         = "press"
+		mockURI             = "mockRepoURI"
 		mockWorkspacePath   = "."
 		mockEnvFile         = "foo.env"
 		mockS3Bucket        = "mockBucket"
@@ -204,6 +205,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 			mock: func(t *testing.T, m *deployMocks) {
 				m.mockRepositoryService.EXPECT().Login().Return(nil)
 				m.mockRepositoryService.EXPECT().BuildAndPush(&dockerengine.BuildArguments{
+					URI:        mockURI,
 					Dockerfile: "mockDockerfile",
 					Context:    "mockContext",
 					Platform:   "mockContainerPlatform",
@@ -228,6 +230,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 			mock: func(t *testing.T, m *deployMocks) {
 				m.mockRepositoryService.EXPECT().Login().Return(nil)
 				m.mockRepositoryService.EXPECT().BuildAndPush(&dockerengine.BuildArguments{
+					URI:        mockURI,
 					Dockerfile: "mockDockerfile",
 					Context:    "mockContext",
 					Platform:   "mockContainerPlatform",
@@ -258,6 +261,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 			mock: func(t *testing.T, m *deployMocks) {
 				m.mockRepositoryService.EXPECT().Login().Return(nil)
 				m.mockRepositoryService.EXPECT().BuildAndPush(&dockerengine.BuildArguments{
+					URI:        mockURI,
 					Dockerfile: "mockDockerfile",
 					Context:    "mockContext",
 					Platform:   "mockContainerPlatform",
@@ -291,6 +295,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 			mock: func(t *testing.T, m *deployMocks) {
 				m.mockRepositoryService.EXPECT().Login().Return(nil)
 				m.mockRepositoryService.EXPECT().BuildAndPush(&dockerengine.BuildArguments{
+					URI:        mockURI,
 					Dockerfile: "sidecarMockDockerfile",
 					Context:    "sidecarMockContext",
 					Platform:   "mockContainerPlatform",
@@ -301,6 +306,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 					},
 				}).Return("sidecarMockDigest1", nil)
 				m.mockRepositoryService.EXPECT().BuildAndPush(&dockerengine.BuildArguments{
+					URI:        mockURI,
 					Dockerfile: "web/Dockerfile",
 					Context:    "Users/bowie",
 					Platform:   "mockContainerPlatform",
@@ -616,6 +622,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 					GitShortCommitTag: tc.inMockGitTag,
 				},
 				workspacePath: mockWorkspacePath,
+				uri:           mockURI,
 				mft: &mockWorkloadMft{
 					workloadName:    mockName,
 					fileName:        tc.inEnvFile,

--- a/internal/pkg/cli/deploy/workload_test.go
+++ b/internal/pkg/cli/deploy/workload_test.go
@@ -203,7 +203,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 				},
 			},
 			mock: func(t *testing.T, m *deployMocks) {
-				m.mockRepositoryService.EXPECT().Login().Return(nil)
+				m.mockRepositoryService.EXPECT().Login().Return(mockURI, nil)
 				m.mockRepositoryService.EXPECT().BuildAndPush(&dockerengine.BuildArguments{
 					URI:        mockURI,
 					Dockerfile: "mockDockerfile",
@@ -228,7 +228,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 				},
 			},
 			mock: func(t *testing.T, m *deployMocks) {
-				m.mockRepositoryService.EXPECT().Login().Return(nil)
+				m.mockRepositoryService.EXPECT().Login().Return(mockURI, nil)
 				m.mockRepositoryService.EXPECT().BuildAndPush(&dockerengine.BuildArguments{
 					URI:        mockURI,
 					Dockerfile: "mockDockerfile",
@@ -259,7 +259,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 				},
 			},
 			mock: func(t *testing.T, m *deployMocks) {
-				m.mockRepositoryService.EXPECT().Login().Return(nil)
+				m.mockRepositoryService.EXPECT().Login().Return(mockURI, nil)
 				m.mockRepositoryService.EXPECT().BuildAndPush(&dockerengine.BuildArguments{
 					URI:        mockURI,
 					Dockerfile: "mockDockerfile",
@@ -293,7 +293,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 			},
 			inMockGitTag: "gitTag",
 			mock: func(t *testing.T, m *deployMocks) {
-				m.mockRepositoryService.EXPECT().Login().Return(nil)
+				m.mockRepositoryService.EXPECT().Login().Return(mockURI, nil)
 				m.mockRepositoryService.EXPECT().BuildAndPush(&dockerengine.BuildArguments{
 					URI:        mockURI,
 					Dockerfile: "sidecarMockDockerfile",
@@ -622,7 +622,6 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 					GitShortCommitTag: tc.inMockGitTag,
 				},
 				workspacePath: mockWorkspacePath,
-				uri:           mockURI,
 				mft: &mockWorkloadMft{
 					workloadName:    mockName,
 					fileName:        tc.inEnvFile,

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -181,9 +181,6 @@ type repositoryService interface {
 	imageBuilderPusher
 }
 
-type dockerBuildArgsGenerator interface {
-	GenerateDockerBuildArgs(in *dockerengine.BuildArguments) ([]string, error)
-}
 type logEventsWriter interface {
 	WriteLogEvents(opts logging.WriteLogEventsOpts) error
 }

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -167,16 +167,12 @@ type secretDeleter interface {
 type imageBuilderPusher interface {
 	BuildAndPush(args *dockerengine.BuildArguments) (string, error)
 }
-type repositoryURIGetter interface {
-	URI() (string, error)
-}
 
 type repositoryLogin interface {
-	Login() error
+	Login() (string, error)
 }
 
 type repositoryService interface {
-	repositoryURIGetter
 	repositoryLogin
 	imageBuilderPusher
 }

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -181,6 +181,9 @@ type repositoryService interface {
 	imageBuilderPusher
 }
 
+type dockerBuildArgsGenerator interface {
+	GenerateDockerBuildArgs(in *dockerengine.BuildArguments) ([]string, error)
+}
 type logEventsWriter interface {
 	WriteLogEvents(opts logging.WriteLogEventsOpts) error
 }

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -1718,44 +1718,6 @@ func (mr *MockrepositoryServiceMockRecorder) URI() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "URI", reflect.TypeOf((*MockrepositoryService)(nil).URI))
 }
 
-// MockdockerBuildArgsGenerator is a mock of dockerBuildArgsGenerator interface.
-type MockdockerBuildArgsGenerator struct {
-	ctrl     *gomock.Controller
-	recorder *MockdockerBuildArgsGeneratorMockRecorder
-}
-
-// MockdockerBuildArgsGeneratorMockRecorder is the mock recorder for MockdockerBuildArgsGenerator.
-type MockdockerBuildArgsGeneratorMockRecorder struct {
-	mock *MockdockerBuildArgsGenerator
-}
-
-// NewMockdockerBuildArgsGenerator creates a new mock instance.
-func NewMockdockerBuildArgsGenerator(ctrl *gomock.Controller) *MockdockerBuildArgsGenerator {
-	mock := &MockdockerBuildArgsGenerator{ctrl: ctrl}
-	mock.recorder = &MockdockerBuildArgsGeneratorMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockdockerBuildArgsGenerator) EXPECT() *MockdockerBuildArgsGeneratorMockRecorder {
-	return m.recorder
-}
-
-// GenerateDockerBuildArgs mocks base method.
-func (m *MockdockerBuildArgsGenerator) GenerateDockerBuildArgs(in *dockerengine.BuildArguments) ([]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GenerateDockerBuildArgs", in)
-	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GenerateDockerBuildArgs indicates an expected call of GenerateDockerBuildArgs.
-func (mr *MockdockerBuildArgsGeneratorMockRecorder) GenerateDockerBuildArgs(in interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateDockerBuildArgs", reflect.TypeOf((*MockdockerBuildArgsGenerator)(nil).GenerateDockerBuildArgs), in)
-}
-
 // MocklogEventsWriter is a mock of logEventsWriter interface.
 type MocklogEventsWriter struct {
 	ctrl     *gomock.Controller

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -1576,44 +1576,6 @@ func (mr *MockimageBuilderPusherMockRecorder) BuildAndPush(args interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildAndPush", reflect.TypeOf((*MockimageBuilderPusher)(nil).BuildAndPush), args)
 }
 
-// MockrepositoryURIGetter is a mock of repositoryURIGetter interface.
-type MockrepositoryURIGetter struct {
-	ctrl     *gomock.Controller
-	recorder *MockrepositoryURIGetterMockRecorder
-}
-
-// MockrepositoryURIGetterMockRecorder is the mock recorder for MockrepositoryURIGetter.
-type MockrepositoryURIGetterMockRecorder struct {
-	mock *MockrepositoryURIGetter
-}
-
-// NewMockrepositoryURIGetter creates a new mock instance.
-func NewMockrepositoryURIGetter(ctrl *gomock.Controller) *MockrepositoryURIGetter {
-	mock := &MockrepositoryURIGetter{ctrl: ctrl}
-	mock.recorder = &MockrepositoryURIGetterMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockrepositoryURIGetter) EXPECT() *MockrepositoryURIGetterMockRecorder {
-	return m.recorder
-}
-
-// URI mocks base method.
-func (m *MockrepositoryURIGetter) URI() (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "URI")
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// URI indicates an expected call of URI.
-func (mr *MockrepositoryURIGetterMockRecorder) URI() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "URI", reflect.TypeOf((*MockrepositoryURIGetter)(nil).URI))
-}
-
 // MockrepositoryLogin is a mock of repositoryLogin interface.
 type MockrepositoryLogin struct {
 	ctrl     *gomock.Controller
@@ -1638,11 +1600,12 @@ func (m *MockrepositoryLogin) EXPECT() *MockrepositoryLoginMockRecorder {
 }
 
 // Login mocks base method.
-func (m *MockrepositoryLogin) Login() error {
+func (m *MockrepositoryLogin) Login() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Login")
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Login indicates an expected call of Login.
@@ -1690,32 +1653,18 @@ func (mr *MockrepositoryServiceMockRecorder) BuildAndPush(args interface{}) *gom
 }
 
 // Login mocks base method.
-func (m *MockrepositoryService) Login() error {
+func (m *MockrepositoryService) Login() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Login")
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Login indicates an expected call of Login.
 func (mr *MockrepositoryServiceMockRecorder) Login() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Login", reflect.TypeOf((*MockrepositoryService)(nil).Login))
-}
-
-// URI mocks base method.
-func (m *MockrepositoryService) URI() (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "URI")
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// URI indicates an expected call of URI.
-func (mr *MockrepositoryServiceMockRecorder) URI() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "URI", reflect.TypeOf((*MockrepositoryService)(nil).URI))
 }
 
 // MocklogEventsWriter is a mock of logEventsWriter interface.

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -1718,6 +1718,44 @@ func (mr *MockrepositoryServiceMockRecorder) URI() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "URI", reflect.TypeOf((*MockrepositoryService)(nil).URI))
 }
 
+// MockdockerBuildArgsGenerator is a mock of dockerBuildArgsGenerator interface.
+type MockdockerBuildArgsGenerator struct {
+	ctrl     *gomock.Controller
+	recorder *MockdockerBuildArgsGeneratorMockRecorder
+}
+
+// MockdockerBuildArgsGeneratorMockRecorder is the mock recorder for MockdockerBuildArgsGenerator.
+type MockdockerBuildArgsGeneratorMockRecorder struct {
+	mock *MockdockerBuildArgsGenerator
+}
+
+// NewMockdockerBuildArgsGenerator creates a new mock instance.
+func NewMockdockerBuildArgsGenerator(ctrl *gomock.Controller) *MockdockerBuildArgsGenerator {
+	mock := &MockdockerBuildArgsGenerator{ctrl: ctrl}
+	mock.recorder = &MockdockerBuildArgsGeneratorMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockdockerBuildArgsGenerator) EXPECT() *MockdockerBuildArgsGeneratorMockRecorder {
+	return m.recorder
+}
+
+// GenerateDockerBuildArgs mocks base method.
+func (m *MockdockerBuildArgsGenerator) GenerateDockerBuildArgs(in *dockerengine.BuildArguments) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GenerateDockerBuildArgs", in)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GenerateDockerBuildArgs indicates an expected call of GenerateDockerBuildArgs.
+func (mr *MockdockerBuildArgsGeneratorMockRecorder) GenerateDockerBuildArgs(in interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateDockerBuildArgs", reflect.TypeOf((*MockdockerBuildArgsGenerator)(nil).GenerateDockerBuildArgs), in)
+}
+
 // MocklogEventsWriter is a mock of logEventsWriter interface.
 type MocklogEventsWriter struct {
 	ctrl     *gomock.Controller

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -975,9 +975,9 @@ func (o *runTaskOpts) buildAndPushImage(uri string) error {
 	}
 	buildArgsList, err := buildArgs.GenerateDockerBuildArgs(dockerengine.New(exec.NewCmd()))
 	if err != nil {
-		return fmt.Errorf("generate docker build args : %w", err)
+		return fmt.Errorf("generate docker build args: %w", err)
 	}
-	log.Infof(fmt.Sprintf("Building your container image: docker %s\n", strings.Join(buildArgsList, " ")))
+	log.Infof("Building your container image: docker %s\n", strings.Join(buildArgsList, " "))
 	if _, err := o.repository.BuildAndPush(buildArgs); err != nil {
 		return fmt.Errorf("build and push image: %w", err)
 	}

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -153,13 +153,12 @@ type runTaskOpts struct {
 	prompt  prompter
 
 	// Fields below are configured at runtime.
-	deployer                 taskDeployer
-	repository               repositoryService
-	runner                   taskRunner
-	eventsWriter             eventsWriter
-	defaultClusterGetter     defaultClusterGetter
-	publicIPGetter           publicIPGetter
-	dockerBuildArgsGenerator dockerBuildArgsGenerator
+	deployer             taskDeployer
+	repository           repositoryService
+	runner               taskRunner
+	eventsWriter         eventsWriter
+	defaultClusterGetter defaultClusterGetter
+	publicIPGetter       publicIPGetter
 
 	provider          sessionProvider
 	sess              *session.Session
@@ -226,8 +225,6 @@ func newTaskRunOpts(vars runTaskVars) (*runTaskOpts, error) {
 		opts.repository = repository.New(ecr.New(opts.sess), repoName)
 		return nil
 	}
-
-	opts.dockerBuildArgsGenerator = dockerengine.New(exec.NewCmd())
 
 	opts.configureEventsWriter = func(tasks []*task.Task) {
 		opts.eventsWriter = logging.NewTaskClient(opts.sess, opts.groupName, tasks)
@@ -976,9 +973,9 @@ func (o *runTaskOpts) buildAndPushImage(uri string) error {
 		Context:    ctx,
 		Tags:       append([]string{imageTagLatest}, additionalTags...),
 	}
-	buildArgsList, err := o.dockerBuildArgsGenerator.GenerateDockerBuildArgs(buildArgs)
+	buildArgsList, err := buildArgs.GenerateDockerBuildArgs(dockerengine.New(exec.NewCmd()))
 	if err != nil {
-		return fmt.Errorf("get docker build args : %w", err)
+		return fmt.Errorf("generate docker build args : %w", err)
 	}
 	log.Infof(dockerengine.DockerBuildLabel(buildArgs.Platform, buildArgsList))
 	if _, err := o.repository.BuildAndPush(buildArgs); err != nil {

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -720,7 +720,7 @@ func (o *runTaskOpts) Execute() error {
 
 	// NOTE: if image is not provided, then we build the image and push to ECR repo
 	if o.image == "" {
-		err := o.repository.Login()
+		uri, err := o.repository.Login()
 		if err != nil {
 			return fmt.Errorf("login to docker: %w", err)
 		}
@@ -729,11 +729,6 @@ func (o *runTaskOpts) Execute() error {
 		if o.imageTag != "" {
 			tag = o.imageTag
 		}
-		uri, err := o.repository.URI()
-		if err != nil {
-			return fmt.Errorf("get ECR repository URI: %w", err)
-		}
-
 		o.image = fmt.Sprintf(fmtImageURI, uri, tag)
 
 		if err := o.buildAndPushImage(uri); err != nil {

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -977,7 +977,7 @@ func (o *runTaskOpts) buildAndPushImage(uri string) error {
 	if err != nil {
 		return fmt.Errorf("generate docker build args : %w", err)
 	}
-	log.Infof(dockerengine.DockerBuildLabel(buildArgs.Platform, buildArgsList))
+	log.Infof(fmt.Sprintf("Building your container image: docker %s\n", strings.Join(buildArgsList, " ")))
 	if _, err := o.repository.BuildAndPush(buildArgs); err != nil {
 		return fmt.Errorf("build and push image: %w", err)
 	}

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -978,9 +978,9 @@ func (o *runTaskOpts) buildAndPushImage(uri string) error {
 	}
 	buildArgsList, err := o.dockerBuildArgsGenerator.GenerateDockerBuildArgs(buildArgs)
 	if err != nil {
-		return fmt.Errorf("getting BuildArgsSlice: %w", err)
+		return fmt.Errorf("get docker build args : %w", err)
 	}
-	log.Infoln(dockerengine.DockerBuildLabel(buildArgs.Platform, buildArgsList))
+	log.Infof(dockerengine.DockerBuildLabel(buildArgs.Platform, buildArgsList))
 	if _, err := o.repository.BuildAndPush(buildArgs); err != nil {
 		return fmt.Errorf("build and push image: %w", err)
 	}

--- a/internal/pkg/cli/task_run_test.go
+++ b/internal/pkg/cli/task_run_test.go
@@ -760,7 +760,6 @@ func mockHasDefaultCluster(m runTaskMocks) {
 }
 
 func mockRepositoryAnytime(m runTaskMocks) {
-	m.repository.EXPECT().URI().AnyTimes()
 	m.repository.EXPECT().Login().AnyTimes()
 	m.repository.EXPECT().BuildAndPush(gomock.Any()).AnyTimes()
 }
@@ -844,7 +843,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 					Command:    []string{},
 					EntryPoint: []string{},
 				}).Return(nil)
-				m.repository.EXPECT().Login().Return(errors.New("some error"))
+				m.repository.EXPECT().Login().Return(mockRepoURI, errors.New("some error"))
 				mockHasDefaultCluster(m)
 			},
 			wantedError: errors.New("login to docker: some error"),
@@ -859,8 +858,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 					Command:    []string{},
 					EntryPoint: []string{},
 				}).Return(nil)
-				m.repository.EXPECT().URI().Return(mockRepoURI, nil)
-				m.repository.EXPECT().Login().Return(nil)
+				m.repository.EXPECT().Login().Return(mockRepoURI, nil)
 				m.repository.EXPECT().BuildAndPush(gomock.Any())
 				m.deployer.EXPECT().DeployTask(&deploy.CreateTaskResourcesInput{
 					Name:       inGroupName,
@@ -913,8 +911,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 				m.provider.EXPECT().Default().Return(&session.Session{}, nil)
 				m.store.EXPECT().GetEnvironment(gomock.Any(), gomock.Any()).AnyTimes()
 				m.deployer.EXPECT().DeployTask(gomock.Any()).AnyTimes()
-				m.repository.EXPECT().URI().Return(mockRepoURI, nil)
-				m.repository.EXPECT().Login().Return(nil)
+				m.repository.EXPECT().Login().Return(mockRepoURI, nil)
 				m.repository.EXPECT().BuildAndPush(gomock.Eq(
 					&dockerengine.BuildArguments{
 						URI:     mockRepoURI,
@@ -932,8 +929,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 				m.provider.EXPECT().Default().Return(&session.Session{}, nil)
 				m.store.EXPECT().GetEnvironment(gomock.Any(), gomock.Any()).AnyTimes()
 				m.deployer.EXPECT().DeployTask(gomock.Any()).AnyTimes()
-				m.repository.EXPECT().URI().Return(mockRepoURI, nil)
-				m.repository.EXPECT().Login().Return(nil)
+				m.repository.EXPECT().Login().Return(mockRepoURI, nil)
 				m.repository.EXPECT().BuildAndPush(gomock.Eq(
 					&dockerengine.BuildArguments{
 						URI:     mockRepoURI,
@@ -957,8 +953,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 					Command:    []string{"/bin/sh", "-c", "curl $ECS_CONTAINER_METADATA_URI_V4"},
 					EntryPoint: []string{"exec", "some command"},
 				}).Times(1).Return(nil)
-				m.repository.EXPECT().URI().Return(mockRepoURI, nil)
-				m.repository.EXPECT().Login().Return(nil)
+				m.repository.EXPECT().Login().Return(mockRepoURI, nil)
 				m.repository.EXPECT().BuildAndPush(gomock.Eq(&defaultBuildArguments))
 				m.deployer.EXPECT().DeployTask(&deploy.CreateTaskResourcesInput{
 					Name:       inGroupName,

--- a/internal/pkg/docker/dockerengine/dockerengine.go
+++ b/internal/pkg/docker/dockerengine/dockerengine.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 
 	"github.com/aws/copilot-cli/internal/pkg/exec"
-	"github.com/aws/copilot-cli/internal/pkg/term/log"
 )
 
 // Cmd is the interface implemented by external commands.
@@ -76,20 +75,19 @@ type dockerConfig struct {
 
 // Build will run a `docker build` command for the given ecr repo URI and build arguments.
 func (c CmdClient) Build(in *BuildArguments) error {
-	args, err := c.buildArgs(in)
+	args, err := c.GenerateDockerBuildArgs(in)
 	if err != nil {
-		return err
+		return fmt.Errorf("generate docker build args: %w", err)
 	}
-	log.Infof(DockerBuildLabel(in.Platform, args))
 	if err := c.runner.Run("docker", args); err != nil {
 		return fmt.Errorf("building image: %w", err)
 	}
 	return nil
 }
 
-// buildArgs returns command line arguments to be passed to the Docker build command based on the provided BuildArguments.
+// GenerateDockerBuildArgs returns command line arguments to be passed to the Docker build command based on the provided BuildArguments.
 // Returns an error if no tags are provided for building an image.
-func (c CmdClient) buildArgs(in *BuildArguments) ([]string, error) {
+func (c CmdClient) GenerateDockerBuildArgs(in *BuildArguments) ([]string, error) {
 	// Tags must not be empty to build an docker image.
 	if len(in.Tags) == 0 {
 		return nil, &errEmptyImageTags{

--- a/internal/pkg/docker/dockerengine/dockerengine.go
+++ b/internal/pkg/docker/dockerengine/dockerengine.go
@@ -289,16 +289,6 @@ func PlatformString(os, arch string) string {
 	return fmt.Sprintf("%s/%s", os, arch)
 }
 
-// DockerBuildLabel returns the docker build label as a string if platform is not empty.
-func DockerBuildLabel(platform string, args []string) string {
-	// If host platform is not linux/amd64, show the user how the container image is being built; if the build fails (if their docker server doesn't have multi-platform-- and therefore `--platform` capability, for instance) they may see why.
-	var buildLabel string
-	if platform != "" {
-		buildLabel = fmt.Sprintf("Building your container image: docker %s\n", strings.Join(args, " "))
-	}
-	return buildLabel
-}
-
 func parseCredFromDockerConfig(config []byte) (*dockerConfig, error) {
 	/*
 			Sample docker config file

--- a/internal/pkg/docker/dockerengine/dockerengine_test.go
+++ b/internal/pkg/docker/dockerengine/dockerengine_test.go
@@ -52,7 +52,7 @@ func TestDockerCommand_Build(t *testing.T) {
 			setupMocks: func(controller *gomock.Controller) {
 				mockCmd = NewMockCmd(controller)
 			},
-			wantedError: fmt.Errorf("tags to reference an image should not be empty for building and pushing into the ECR repository %s", mockURI),
+			wantedError: fmt.Errorf("generate docker build args: tags to reference an image should not be empty for building and pushing into the ECR repository %s", mockURI),
 		},
 		"should error if the docker build command fails": {
 			path:    mockPath,

--- a/internal/pkg/docker/dockerengine/dockerengine_test.go
+++ b/internal/pkg/docker/dockerengine/dockerengine_test.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	osexec "os/exec"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/aws/copilot-cli/internal/pkg/exec"
@@ -611,36 +610,6 @@ func TestIsEcrCredentialHelperEnabled(t *testing.T) {
 			tc.postExec(fs)
 
 			require.Equal(t, tc.isEcrRepo, credStore)
-		})
-	}
-}
-
-func Test_DockerBuildLabel(t *testing.T) {
-	testCases := map[string]struct {
-		inBuildArgs []string
-		inPlatform  string
-		wanted      string
-	}{
-		"if platform is not empty": {
-			inBuildArgs: []string{"build", "-t", "mockURI:tag1",
-				filepath.FromSlash("mockPath/to"), "-f", "mockPath/to/mockDockerfile",
-			},
-			inPlatform: "windows/x86_64",
-			wanted: fmt.Sprintf("Building your container image: docker %s\n",
-				strings.Join([]string{"build", "-t", "mockURI:tag1",
-					filepath.FromSlash("mockPath/to"), "-f", "mockPath/to/mockDockerfile"}, " ")),
-		},
-		"if platform is empty": {
-			inBuildArgs: []string{"build", "-t", "mockURI:tag1",
-				filepath.FromSlash("mockPath/to"), "-f", "mockPath/to/mockDockerfile",
-			},
-		},
-	}
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			got := DockerBuildLabel(tc.inPlatform, tc.inBuildArgs)
-			require.Equal(t, tc.wanted, got)
-
 		})
 	}
 }

--- a/internal/pkg/docker/dockerengine/dockerengine_test.go
+++ b/internal/pkg/docker/dockerengine/dockerengine_test.go
@@ -615,7 +615,7 @@ func TestIsEcrCredentialHelperEnabled(t *testing.T) {
 	}
 }
 
-func TestDockerBuildLabel(t *testing.T) {
+func Test_DockerBuildLabel(t *testing.T) {
 	testCases := map[string]struct {
 		inBuildArgs []string
 		inPlatform  string

--- a/internal/pkg/docker/dockerengine/dockerengine_test.go
+++ b/internal/pkg/docker/dockerengine/dockerengine_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	osexec "os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/aws/copilot-cli/internal/pkg/exec"
@@ -610,6 +611,36 @@ func TestIsEcrCredentialHelperEnabled(t *testing.T) {
 			tc.postExec(fs)
 
 			require.Equal(t, tc.isEcrRepo, credStore)
+		})
+	}
+}
+
+func TestDockerBuildLabel(t *testing.T) {
+	testCases := map[string]struct {
+		inBuildArgs []string
+		inPlatform  string
+		wanted      string
+	}{
+		"if platform is not empty": {
+			inBuildArgs: []string{"build", "-t", "mockURI:tag1",
+				filepath.FromSlash("mockPath/to"), "-f", "mockPath/to/mockDockerfile",
+			},
+			inPlatform: "windows/x86_64",
+			wanted: fmt.Sprintf("Building your container image: docker %s\n",
+				strings.Join([]string{"build", "-t", "mockURI:tag1",
+					filepath.FromSlash("mockPath/to"), "-f", "mockPath/to/mockDockerfile"}, " ")),
+		},
+		"if platform is empty": {
+			inBuildArgs: []string{"build", "-t", "mockURI:tag1",
+				filepath.FromSlash("mockPath/to"), "-f", "mockPath/to/mockDockerfile",
+			},
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got := DockerBuildLabel(tc.inPlatform, tc.inBuildArgs)
+			require.Equal(t, tc.wanted, got)
+
 		})
 	}
 }

--- a/internal/pkg/docker/dockerengine/dockerengine_test.go
+++ b/internal/pkg/docker/dockerengine/dockerengine_test.go
@@ -196,7 +196,7 @@ func TestDockerCommand_Build(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			controller := gomock.NewController(t)
 			tc.setupMocks(controller)
-			s := CmdClient{
+			s := DockerCmdClient{
 				runner: mockCmd,
 				lookupEnv: func(key string) (string, bool) {
 					if val, ok := tc.envVars[key]; ok {
@@ -262,7 +262,7 @@ func TestDockerCommand_Login(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			controller := gomock.NewController(t)
 			test.setupMocks(controller)
-			s := CmdClient{
+			s := DockerCmdClient{
 				runner: mockCmd,
 			}
 
@@ -292,7 +292,7 @@ func TestDockerCommand_Push(t *testing.T) {
 			}).Return(nil)
 
 		// WHEN
-		cmd := CmdClient{
+		cmd := DockerCmdClient{
 			runner:    m,
 			lookupEnv: emptyLookupEnv,
 		}
@@ -316,7 +316,7 @@ func TestDockerCommand_Push(t *testing.T) {
 			}).Return(nil)
 
 		// WHEN
-		cmd := CmdClient{
+		cmd := DockerCmdClient{
 			runner: m,
 			lookupEnv: func(key string) (string, bool) {
 				if key == "CI" {
@@ -339,7 +339,7 @@ func TestDockerCommand_Push(t *testing.T) {
 		m.EXPECT().Run(gomock.Any(), gomock.Any()).Return(errors.New("some error"))
 
 		// WHEN
-		cmd := CmdClient{
+		cmd := DockerCmdClient{
 			runner:    m,
 			lookupEnv: emptyLookupEnv,
 		}
@@ -357,7 +357,7 @@ func TestDockerCommand_Push(t *testing.T) {
 		m.EXPECT().Run("docker", []string{"inspect", "--format", "'{{json (index .RepoDigests 0)}}'", "uri:latest"}, gomock.Any()).Return(errors.New("some error"))
 
 		// WHEN
-		cmd := CmdClient{
+		cmd := DockerCmdClient{
 			runner:    m,
 			lookupEnv: emptyLookupEnv,
 		}
@@ -381,7 +381,7 @@ func TestDockerCommand_Push(t *testing.T) {
 			}).Return(nil)
 
 		// WHEN
-		cmd := CmdClient{
+		cmd := DockerCmdClient{
 			runner:    m,
 			lookupEnv: emptyLookupEnv,
 		}
@@ -442,7 +442,7 @@ func TestDockerCommand_CheckDockerEngineRunning(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			controller := gomock.NewController(t)
 			tc.setupMocks(controller)
-			s := CmdClient{
+			s := DockerCmdClient{
 				runner: mockCmd,
 			}
 
@@ -483,7 +483,7 @@ func TestDockerCommand_GetPlatform(t *testing.T) {
 					Do(func(_ string, _ []string, opt exec.CmdOption) {
 						cmd := &osexec.Cmd{}
 						opt(cmd)
-						_, _ = cmd.Stdout.Write([]byte("{\"Platform\":{\"Name\":\"Docker CmdClient - Community\"},\"Components\":[{\"Name\":\"CmdClient\",\"Version\":\"20.10.6\",\"Details\":{\"ApiVersion\":\"1.41\",\"Arch\":\"amd64\",\"BuildTime\":\"Fri Apr  9 22:44:56 2021\",\"Experimental\":\"false\",\"GitCommit\":\"8728dd2\",\"GoVersion\":\"go1.13.15\",\"KernelVersion\":\"5.10.25-linuxkit\",\"MinAPIVersion\":\"1.12\",\"Os\":\"linux\"}},{\"Name\":\"containerd\",\"Version\":\"1.4.4\",\"Details\":{\"GitCommit\":\"05f951a3781f4f2c1911b05e61c16e\"}},{\"Name\":\"runc\",\"Version\":\"1.0.0-rc93\",\"Details\":{\"GitCommit\":\"12644e614e25b05da6fd00cfe1903fdec\"}},{\"Name\":\"docker-init\",\"Version\":\"0.19.0\",\"Details\":{\"GitCommit\":\"de40ad0\"}}],\"Version\":\"20.10.6\",\"ApiVersion\":\"1.41\",\"MinAPIVersion\":\"1.12\",\"GitCommit\":\"8728dd2\",\"GoVersion\":\"go1.13.15\",\"Os\":\"linux\",\"Arch\":\"amd64\",\"KernelVersion\":\"5.10.25-linuxkit\",\"BuildTime\":\"2021-04-09T22:44:56.000000000+00:00\"}\n"))
+						_, _ = cmd.Stdout.Write([]byte("{\"Platform\":{\"Name\":\"Docker DockerCmdClient - Community\"},\"Components\":[{\"Name\":\"DockerCmdClient\",\"Version\":\"20.10.6\",\"Details\":{\"ApiVersion\":\"1.41\",\"Arch\":\"amd64\",\"BuildTime\":\"Fri Apr  9 22:44:56 2021\",\"Experimental\":\"false\",\"GitCommit\":\"8728dd2\",\"GoVersion\":\"go1.13.15\",\"KernelVersion\":\"5.10.25-linuxkit\",\"MinAPIVersion\":\"1.12\",\"Os\":\"linux\"}},{\"Name\":\"containerd\",\"Version\":\"1.4.4\",\"Details\":{\"GitCommit\":\"05f951a3781f4f2c1911b05e61c16e\"}},{\"Name\":\"runc\",\"Version\":\"1.0.0-rc93\",\"Details\":{\"GitCommit\":\"12644e614e25b05da6fd00cfe1903fdec\"}},{\"Name\":\"docker-init\",\"Version\":\"0.19.0\",\"Details\":{\"GitCommit\":\"de40ad0\"}}],\"Version\":\"20.10.6\",\"ApiVersion\":\"1.41\",\"MinAPIVersion\":\"1.12\",\"GitCommit\":\"8728dd2\",\"GoVersion\":\"go1.13.15\",\"Os\":\"linux\",\"Arch\":\"amd64\",\"KernelVersion\":\"5.10.25-linuxkit\",\"BuildTime\":\"2021-04-09T22:44:56.000000000+00:00\"}\n"))
 					}).Return(nil)
 			},
 			wantedOS:   "linux",
@@ -497,7 +497,7 @@ func TestDockerCommand_GetPlatform(t *testing.T) {
 					Do(func(_ string, _ []string, opt exec.CmdOption) {
 						cmd := &osexec.Cmd{}
 						opt(cmd)
-						_, _ = cmd.Stdout.Write([]byte("{\"Platform\":{\"Name\":\"Docker CmdClient - Community\"},\"Components\":[{\"Name\":\"CmdClient\",\"Version\":\"20.10.6\",\"Details\":{\"ApiVersion\":\"1.41\",\"Arch\":\"amd64\",\"BuildTime\":\"Fri Apr  9 22:44:56 2021\",\"Experimental\":\"false\",\"GitCommit\":\"8728dd2\",\"GoVersion\":\"go1.13.15\",\"KernelVersion\":\"5.10.25-linuxkit\",\"MinAPIVersion\":\"1.12\",\"Os\":\"linux\"}},{\"Name\":\"containerd\",\"Version\":\"1.4.4\",\"Details\":{\"GitCommit\":\"05f951a3781f4f2c1911b05e61c16e\"}},{\"Name\":\"runc\",\"Version\":\"1.0.0-rc93\",\"Details\":{\"GitCommit\":\"12644e614e25b05da6fd00cfe1903fdec\"}},{\"Name\":\"docker-init\",\"Version\":\"0.19.0\",\"Details\":{\"GitCommit\":\"de40ad0\"}}],\"Version\":\"20.10.6\",\"ApiVersion\":\"1.41\",\"MinAPIVersion\":\"1.12\",\"GitCommit\":\"8728dd2\",\"GoVersion\":\"go1.13.15\",\"Os\":\"windows\",\"Arch\":\"amd64\",\"KernelVersion\":\"5.10.25-linuxkit\",\"BuildTime\":\"2021-04-09T22:44:56.000000000+00:00\"}\n"))
+						_, _ = cmd.Stdout.Write([]byte("{\"Platform\":{\"Name\":\"Docker DockerCmdClient - Community\"},\"Components\":[{\"Name\":\"DockerCmdClient\",\"Version\":\"20.10.6\",\"Details\":{\"ApiVersion\":\"1.41\",\"Arch\":\"amd64\",\"BuildTime\":\"Fri Apr  9 22:44:56 2021\",\"Experimental\":\"false\",\"GitCommit\":\"8728dd2\",\"GoVersion\":\"go1.13.15\",\"KernelVersion\":\"5.10.25-linuxkit\",\"MinAPIVersion\":\"1.12\",\"Os\":\"linux\"}},{\"Name\":\"containerd\",\"Version\":\"1.4.4\",\"Details\":{\"GitCommit\":\"05f951a3781f4f2c1911b05e61c16e\"}},{\"Name\":\"runc\",\"Version\":\"1.0.0-rc93\",\"Details\":{\"GitCommit\":\"12644e614e25b05da6fd00cfe1903fdec\"}},{\"Name\":\"docker-init\",\"Version\":\"0.19.0\",\"Details\":{\"GitCommit\":\"de40ad0\"}}],\"Version\":\"20.10.6\",\"ApiVersion\":\"1.41\",\"MinAPIVersion\":\"1.12\",\"GitCommit\":\"8728dd2\",\"GoVersion\":\"go1.13.15\",\"Os\":\"windows\",\"Arch\":\"amd64\",\"KernelVersion\":\"5.10.25-linuxkit\",\"BuildTime\":\"2021-04-09T22:44:56.000000000+00:00\"}\n"))
 					}).Return(nil)
 			},
 			wantedOS:   "windows",
@@ -510,7 +510,7 @@ func TestDockerCommand_GetPlatform(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			controller := gomock.NewController(t)
 			tc.setupMocks(controller)
-			s := CmdClient{
+			s := DockerCmdClient{
 				runner: mockCmd,
 			}
 
@@ -600,7 +600,7 @@ func TestIsEcrCredentialHelperEnabled(t *testing.T) {
 			controller := gomock.NewController(t)
 			tc.setupMocks(controller)
 			tc.mockFileSystem(fs)
-			s := CmdClient{
+			s := DockerCmdClient{
 				runner:   mockCmd,
 				buf:      tc.inBuffer,
 				homePath: "test/copilot",

--- a/internal/pkg/repository/repository.go
+++ b/internal/pkg/repository/repository.go
@@ -89,7 +89,7 @@ func (r *Repository) URI() (string, error) {
 // Login authenticates with a ECR registry by performing a Docker login,
 // but only if the `credStore` attribute value is not set to `ecr-login`.
 // If the `credStore` value is `ecr-login`, no login is performed.
-// Returns an error, if any occurs during the login process.
+// Returns uri of the repository or an error, if any occurs during the login process.
 func (r *Repository) Login() (string, error) {
 	uri, err := r.URI()
 	if err != nil {

--- a/internal/pkg/repository/repository.go
+++ b/internal/pkg/repository/repository.go
@@ -56,7 +56,7 @@ func NewWithURI(registry Registry, name, uri string) *Repository {
 // BuildAndPush builds the image from Dockerfile and pushes it to the repository with tags.
 func (r *Repository) BuildAndPush(args *dockerengine.BuildArguments) (digest string, err error) {
 	if args.URI == "" {
-		uri, err := r.URI()
+		uri, err := r.repositoryURI()
 		if err != nil {
 			return "", err
 		}
@@ -73,8 +73,8 @@ func (r *Repository) BuildAndPush(args *dockerengine.BuildArguments) (digest str
 	return digest, nil
 }
 
-// URI returns the uri of the repository.
-func (r *Repository) URI() (string, error) {
+// repositoryURI() returns the uri of the repository.
+func (r *Repository) repositoryURI() (string, error) {
 	if r.uri != "" {
 		return r.uri, nil
 	}
@@ -91,7 +91,7 @@ func (r *Repository) URI() (string, error) {
 // If the `credStore` value is `ecr-login`, no login is performed.
 // Returns uri of the repository or an error, if any occurs during the login process.
 func (r *Repository) Login() (string, error) {
-	uri, err := r.URI()
+	uri, err := r.repositoryURI()
 	if err != nil {
 		return "", fmt.Errorf("retrieve URI for repository: %w", err)
 	}

--- a/internal/pkg/repository/repository.go
+++ b/internal/pkg/repository/repository.go
@@ -90,20 +90,20 @@ func (r *Repository) URI() (string, error) {
 // but only if the `credStore` attribute value is not set to `ecr-login`.
 // If the `credStore` value is `ecr-login`, no login is performed.
 // Returns an error, if any occurs during the login process.
-func (r *Repository) Login() error {
+func (r *Repository) Login() (string, error) {
 	uri, err := r.URI()
 	if err != nil {
-		return fmt.Errorf("retrieve URI for repository: %w", err)
+		return "", fmt.Errorf("retrieve URI for repository: %w", err)
 	}
 	if !r.docker.IsEcrCredentialHelperEnabled(uri) {
 		username, password, err := r.registry.Auth()
 		if err != nil {
-			return fmt.Errorf("get auth: %w", err)
+			return "", fmt.Errorf("get auth: %w", err)
 		}
 
 		if err := r.docker.Login(uri, username, password); err != nil {
-			return fmt.Errorf("docker login %s: %w", uri, err)
+			return "", fmt.Errorf("docker login %s: %w", uri, err)
 		}
 	}
-	return nil
+	return uri, nil
 }

--- a/internal/pkg/repository/repository_test.go
+++ b/internal/pkg/repository/repository_test.go
@@ -180,11 +180,12 @@ func Test_Login(t *testing.T) {
 				docker:   mockDocker,
 			}
 
-			gotErr := repo.Login()
+			gotURI, gotErr := repo.Login()
 			if tc.wantedError != nil {
 				require.EqualError(t, tc.wantedError, gotErr.Error())
 			} else {
-				require.NoError(t, tc.wantedError)
+				require.NoError(t, gotErr)
+				require.Equal(t, tc.wantedURI, gotURI)
 			}
 		})
 	}


### PR DESCRIPTION
<!-- Provide summary of changes -->
This PR will fetch the Docker Build label and print before before and push happens. In the next PR we will pass the label to the `syncbuffer` package.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
