### PR TITLE
chore: remove lambda principle from cfn execution role

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-basic-manifest.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-basic-manifest.yml
@@ -75,7 +75,6 @@ Resources:
             Principal:
               Service:
                 - 'cloudformation.amazonaws.com'
-                - 'lambda.amazonaws.com'
             Action: sts:AssumeRole
       Path: /
       Policies:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-cloudfront-observability.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-cloudfront-observability.yml
@@ -727,7 +727,6 @@ Resources:
             Principal:
               Service:
                 - 'cloudformation.amazonaws.com'
-                - 'lambda.amazonaws.com'
             Action: sts:AssumeRole
       Path: /
       Policies:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-custom-security-group.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-custom-security-group.yml
@@ -583,7 +583,6 @@ Resources:
             Principal:
               Service:
                 - 'cloudformation.amazonaws.com'
-                - 'lambda.amazonaws.com'
             Action: sts:AssumeRole
       Path: /
       Policies:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-default-access-log-config.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-default-access-log-config.yml
@@ -132,7 +132,6 @@ Resources:
             Principal:
               Service:
                 - 'cloudformation.amazonaws.com'
-                - 'lambda.amazonaws.com'
             Action: sts:AssumeRole
       Path: /
       Policies:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-defaultvpc-flowlogs.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-defaultvpc-flowlogs.yml
@@ -80,7 +80,6 @@ Resources:
           Principal:
             Service:
             - 'cloudformation.amazonaws.com'
-            - 'lambda.amazonaws.com'
           Action: sts:AssumeRole
       Path: /
       Policies:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-imported-certs-sslpolicy-custom-empty-security-group.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-imported-certs-sslpolicy-custom-empty-security-group.yml
@@ -560,7 +560,6 @@ Resources:
             Principal:
               Service:
                 - 'cloudformation.amazonaws.com'
-                - 'lambda.amazonaws.com'
             Action: sts:AssumeRole
       Path: /
       Policies:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-importedvpc-flowlogs.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-importedvpc-flowlogs.yml
@@ -87,7 +87,6 @@ Resources:
           Principal:
             Service:
             - 'cloudformation.amazonaws.com'
-            - 'lambda.amazonaws.com'
           Action: sts:AssumeRole
       Path: /
       Policies:

--- a/internal/pkg/template/templates/environment/partials/cfn-execution-role.yml
+++ b/internal/pkg/template/templates/environment/partials/cfn-execution-role.yml
@@ -14,7 +14,6 @@ CloudformationExecutionRole:
         Principal:
           Service:
           - 'cloudformation.amazonaws.com'
-          - 'lambda.amazonaws.com'
         Action: sts:AssumeRole
   {{- if .PermissionsBoundary}}
     PermissionsBoundary: !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/{{.PermissionsBoundary}}'


### PR DESCRIPTION
We don't need the lambda principle on the CFN execution role, it's just an artifact of the past.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
