### PR TITLE
fix: do record updates in parallel

### DIFF
--- a/cf-custom-resources/lib/custom-domain.js
+++ b/cf-custom-resources/lib/custom-domain.js
@@ -100,43 +100,45 @@ const writeCustomDomainRecord = async function (
   aliasTypes,
   action
 ) {
+  const actions = [];
   for (const alias of aliases) {
     const aliasType = await getAliasType(aliasTypes, alias);
     switch (aliasType) {
       case aliasTypes.EnvDomainZone:
-        await writeARecord(
+        actions.push(writeARecord(
           envRoute53,
           alias,
           accessDNS,
           accessHostedZone,
           aliasType.domain,
           action
-        );
+        ));
         break;
       case aliasTypes.AppDomainZone:
-        await writeARecord(
+        actions.push(writeARecord(
           appRoute53,
           alias,
           accessDNS,
           accessHostedZone,
           aliasType.domain,
           action
-        );
+        ));
         break;
       case aliasTypes.RootDomainZone:
-        await writeARecord(
+        actions.push(writeARecord(
           appRoute53,
           alias,
           accessDNS,
           accessHostedZone,
           aliasType.domain,
           action
-        );
+        ));
         break;
       // We'll skip if it is the other alias type since it will be in another account's route53.
       default:
     }
   }
+  await Promise.all(actions);
 };
 
 const writeARecord = async function (


### PR DESCRIPTION
<!-- Provide summary of changes -->
This PR implements the "small" changes in #4711, running the Custom Domain record updates in parallel. It does not implement the large changes, which would imply modifying the cert rather than deleting and recreating it. 
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->
Fixes #4711 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
