### PR TITLE
fix: add default terminal width incase of terminal unavailable

### DIFF
--- a/internal/pkg/cli/deploy/mocks/mock_workload.go
+++ b/internal/pkg/cli/deploy/mocks/mock_workload.go
@@ -106,21 +106,6 @@ func (mr *MockrepositoryServiceMockRecorder) Login() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Login", reflect.TypeOf((*MockrepositoryService)(nil).Login))
 }
 
-// URI mocks base method.
-func (m *MockrepositoryService) URI() (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "URI")
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// URI indicates an expected call of URI.
-func (mr *MockrepositoryServiceMockRecorder) URI() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "URI", reflect.TypeOf((*MockrepositoryService)(nil).URI))
-}
-
 // Mocktemplater is a mock of templater interface.
 type Mocktemplater struct {
 	ctrl     *gomock.Controller
@@ -482,11 +467,9 @@ func (mr *MocklabeledTermPrinterMockRecorder) IsDone() *gomock.Call {
 }
 
 // Print mocks base method.
-func (m *MocklabeledTermPrinter) Print() error {
+func (m *MocklabeledTermPrinter) Print() {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Print")
-	ret0, _ := ret[0].(error)
-	return ret0
+	m.ctrl.Call(m, "Print")
 }
 
 // Print indicates an expected call of Print.

--- a/internal/pkg/cli/deploy/workload_test.go
+++ b/internal/pkg/cli/deploy/workload_test.go
@@ -218,7 +218,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 					},
 				}, gomock.Any()).Return("", mockError)
 				m.mockLabeledTermPrinter.EXPECT().IsDone().Return(true).AnyTimes()
-				m.mockLabeledTermPrinter.EXPECT().Print().Return(nil).AnyTimes()
+				m.mockLabeledTermPrinter.EXPECT().Print().AnyTimes()
 			},
 			wantErr: fmt.Errorf("build and push the image \"mockWkld\": some error"),
 		},
@@ -245,7 +245,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 					},
 				}, gomock.Any()).Return("mockDigest", nil)
 				m.mockLabeledTermPrinter.EXPECT().IsDone().Return(true).AnyTimes()
-				m.mockLabeledTermPrinter.EXPECT().Print().Return(nil).AnyTimes()
+				m.mockLabeledTermPrinter.EXPECT().Print().AnyTimes()
 				m.mockAddons = nil
 			},
 			wantImages: map[string]ContainerImageIdentifier{
@@ -278,7 +278,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 					},
 				}, gomock.Any()).Return("mockDigest", nil)
 				m.mockLabeledTermPrinter.EXPECT().IsDone().Return(true).AnyTimes()
-				m.mockLabeledTermPrinter.EXPECT().Print().Return(nil).AnyTimes()
+				m.mockLabeledTermPrinter.EXPECT().Print().AnyTimes()
 				m.mockAddons = nil
 			},
 			wantImages: map[string]ContainerImageIdentifier{
@@ -325,7 +325,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 					},
 				}, gomock.Any()).Return("sidecarMockDigest2", nil)
 				m.mockLabeledTermPrinter.EXPECT().IsDone().Return(true).AnyTimes()
-				m.mockLabeledTermPrinter.EXPECT().Print().Return(nil).AnyTimes()
+				m.mockLabeledTermPrinter.EXPECT().Print().AnyTimes()
 				m.mockAddons = nil
 			},
 			wantImages: map[string]ContainerImageIdentifier{

--- a/internal/pkg/term/syncbuffer/termprinter.go
+++ b/internal/pkg/term/syncbuffer/termprinter.go
@@ -157,6 +157,7 @@ func (ltp *LabeledTermPrinter) writeLines(label string, lines []string) int {
 func terminalWidth(fw FileWriter) int {
 	terminalWidth := defaultTerminalWidth
 	if term.IsTerminal(int(fw.Fd())) {
+		// Swallow the error as we do not want propogate the error up to call stack.
 		if width, _, err := term.GetSize(int(fw.Fd())); err == nil {
 			terminalWidth = width
 		}

--- a/internal/pkg/term/syncbuffer/termprinter.go
+++ b/internal/pkg/term/syncbuffer/termprinter.go
@@ -36,9 +36,6 @@ type LabeledTermPrinter struct {
 	numLines         int                  // number of lines that has to be written from each buffer.
 	padding          int                  // Leading spaces before rendering to terminal.
 	prevWrittenLines int                  // number of lines written from all the buffers.
-
-	// override in unit tests.
-	terminalWidth func(fw FileWriter) int
 }
 
 // LabeledTermPrinterOption is a type alias to configure LabeledTermPrinter.
@@ -47,10 +44,9 @@ type LabeledTermPrinterOption func(ltp *LabeledTermPrinter)
 // NewLabeledTermPrinter returns a LabeledTermPrinter that can print to the terminal filewriter from buffers.
 func NewLabeledTermPrinter(fw FileWriter, bufs []*LabeledSyncBuffer, opts ...LabeledTermPrinterOption) *LabeledTermPrinter {
 	ltp := &LabeledTermPrinter{
-		term:          fw,
-		buffers:       bufs,
-		numLines:      printAllLinesInBuf, // By default set numlines to -1 to print all from buffers.
-		terminalWidth: terminalWidth,
+		term:     fw,
+		buffers:  bufs,
+		numLines: printAllLinesInBuf, // By default set numlines to -1 to print all from buffers.
 	}
 	for _, opt := range opts {
 		opt(ltp)
@@ -147,7 +143,7 @@ func (ltp *LabeledTermPrinter) writeLines(label string, lines []string) int {
 			numLines++
 			return
 		}
-		numLines += math.Ceil(float64(len(line)) / float64(ltp.terminalWidth(ltp.term)))
+		numLines += math.Ceil(float64(len(line)) / float64(terminalWidth(ltp.term)))
 	}
 	writeLine(label)
 	for _, line := range lines {

--- a/internal/pkg/term/syncbuffer/termprinter.go
+++ b/internal/pkg/term/syncbuffer/termprinter.go
@@ -156,8 +156,8 @@ func (ltp *LabeledTermPrinter) writeLines(label string, lines []string) int {
 	return int(numLines)
 }
 
-// terminalWidth returns the width of the terminal or an error if failed to get the width of terminal.
-// If the file writer is not associated with a terminal, it returns a default value of 80.
+// terminalWidth returns the width of the terminal associated with the given FileWriter.
+// If the FileWriter is not associated with a terminal, it returns a default terminal width.
 func terminalWidth(fw FileWriter) int {
 	terminalWidth := defaultTerminalWidth
 	if term.IsTerminal(int(fw.Fd())) {

--- a/internal/pkg/term/syncbuffer/termprinter.go
+++ b/internal/pkg/term/syncbuffer/termprinter.go
@@ -19,6 +19,10 @@ const (
 	printAllLinesInBuf = -1
 )
 
+const (
+	defaultTerminalWidth = 80
+)
+
 // FileWriter is the interface to write to a file.
 type FileWriter interface {
 	io.Writer
@@ -34,7 +38,7 @@ type LabeledTermPrinter struct {
 	prevWrittenLines int                  // number of lines written from all the buffers.
 
 	// override in unit tests.
-	terminalWidth func(fw FileWriter) (int, error)
+	terminalWidth func(fw FileWriter) int
 }
 
 // LabeledTermPrinterOption is a type alias to configure LabeledTermPrinter.
@@ -81,12 +85,10 @@ func (ltp *LabeledTermPrinter) IsDone() bool {
 // Print prints the label and the last N lines of logs from each buffer
 // to the LabeledTermPrinter fileWriter and erases the previous output.
 // If numLines is -1 then print all the values from buffers.
-func (ltp *LabeledTermPrinter) Print() error {
+func (ltp *LabeledTermPrinter) Print() {
 	if ltp.numLines == printAllLinesInBuf {
-		if err := ltp.printAll(); err != nil {
-			return err
-		}
-		return nil
+		ltp.printAll()
+		return
 	}
 	if ltp.prevWrittenLines > 0 {
 		cursor.EraseLinesAbove(ltp.term, ltp.prevWrittenLines)
@@ -95,31 +97,23 @@ func (ltp *LabeledTermPrinter) Print() error {
 	for _, buf := range ltp.buffers {
 		logs := buf.lines()
 		outputLogs := ltp.lastNLines(logs)
-		writtenLines, err := ltp.writeLines(buf.label, outputLogs)
-		if err != nil {
-			return fmt.Errorf("write logs: %w", err)
-		}
-		ltp.prevWrittenLines += writtenLines
+		ltp.prevWrittenLines += ltp.writeLines(buf.label, outputLogs)
 	}
-	return nil
 }
 
 // printAll writes the entire contents of all the buffers to the file writer.
 // If one of the buffer gets done then print entire content of the buffer.
 // Until all the buffers are written to file writer.
-func (ltp *LabeledTermPrinter) printAll() error {
+func (ltp *LabeledTermPrinter) printAll() {
 	for idx := 0; idx < len(ltp.buffers); idx++ {
 		if !ltp.buffers[idx].IsDone() {
 			continue
 		}
 		outputLogs := ltp.buffers[idx].lines()
-		if _, err := ltp.writeLines(ltp.buffers[idx].label, outputLogs); err != nil {
-			return fmt.Errorf("write logs: %w", err)
-		}
+		ltp.writeLines(ltp.buffers[idx].label, outputLogs)
 		ltp.buffers = append(ltp.buffers[:idx], ltp.buffers[idx+1:]...)
 		idx--
 	}
-	return nil
 }
 
 // lastNLines returns the last N lines of the given logs where N is the value of tp.numLines.
@@ -144,13 +138,8 @@ func (ltp *LabeledTermPrinter) lastNLines(logs []string) []string {
 }
 
 // writeLines writes a label and output logs to the terminal associated with the TermPrinter.
-// Returns the number of lines needed to erase based on terminal width,
-// or an error when failed to fetch terminal width.
-func (ltp *LabeledTermPrinter) writeLines(label string, lines []string) (int, error) {
-	width, err := ltp.terminalWidth(ltp.term)
-	if err != nil {
-		return 0, fmt.Errorf("get terminal width: %w", err)
-	}
+// Returns the number of lines needed to erase based on terminal width.
+func (ltp *LabeledTermPrinter) writeLines(label string, lines []string) int {
 	var numLines float64
 	writeLine := func(line string) {
 		fmt.Fprintln(ltp.term, line)
@@ -158,20 +147,23 @@ func (ltp *LabeledTermPrinter) writeLines(label string, lines []string) (int, er
 			numLines++
 			return
 		}
-		numLines += math.Ceil(float64(len(line)) / float64(width))
+		numLines += math.Ceil(float64(len(line)) / float64(ltp.terminalWidth(ltp.term)))
 	}
 	writeLine(label)
 	for _, line := range lines {
 		writeLine(fmt.Sprintf("%s%s", strings.Repeat(" ", ltp.padding), line))
 	}
-	return int(numLines), nil
+	return int(numLines)
 }
 
 // terminalWidth returns the width of the terminal or an error if failed to get the width of terminal.
-func terminalWidth(fw FileWriter) (int, error) {
-	width, _, err := term.GetSize(int(fw.Fd()))
-	if err != nil {
-		return 0, err
+// If the file writer is not associated with a terminal, it returns a default value of 80.
+func terminalWidth(fw FileWriter) int {
+	terminalWidth := defaultTerminalWidth
+	if term.IsTerminal(int(fw.Fd())) {
+		if width, _, err := term.GetSize(int(fw.Fd())); err == nil {
+			terminalWidth = width
+		}
 	}
-	return width, nil
+	return terminalWidth
 }

--- a/internal/pkg/term/syncbuffer/termprinter_test.go
+++ b/internal/pkg/term/syncbuffer/termprinter_test.go
@@ -73,18 +73,14 @@ line4 from image2`)
 			var mockLabeledSyncbufs []*LabeledSyncBuffer
 			mockLabeledSyncbufs = append(mockLabeledSyncbufs, mockSyncBuf1.WithLabel("Building your container image 1"),
 				mockSyncBuf2.WithLabel("Building your container image 2"))
-			mockTerminalWidth := func(fw FileWriter) int {
-				return 80
-			}
 
 			termOut := &bytes.Buffer{}
 
 			ltp := LabeledTermPrinter{
-				term:          mockFileWriter{termOut},
-				buffers:       mockLabeledSyncbufs,
-				numLines:      tc.inNumLines,
-				padding:       tc.inPadding,
-				terminalWidth: mockTerminalWidth,
+				term:     mockFileWriter{termOut},
+				buffers:  mockLabeledSyncbufs,
+				numLines: tc.inNumLines,
+				padding:  tc.inPadding,
 			}
 
 			// WHEN

--- a/internal/pkg/term/syncbuffer/termprinter_test.go
+++ b/internal/pkg/term/syncbuffer/termprinter_test.go
@@ -73,8 +73,8 @@ line4 from image2`)
 			var mockLabeledSyncbufs []*LabeledSyncBuffer
 			mockLabeledSyncbufs = append(mockLabeledSyncbufs, mockSyncBuf1.WithLabel("Building your container image 1"),
 				mockSyncBuf2.WithLabel("Building your container image 2"))
-			mockTerminalWidth := func(fw FileWriter) (int, error) {
-				return 80, nil
+			mockTerminalWidth := func(fw FileWriter) int {
+				return 80
 			}
 
 			termOut := &bytes.Buffer{}


### PR DESCRIPTION
<!-- Provide summary of changes -->
This PR adds a default terminal width of `80` in case if the given file descriptor is not a terminal.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
