### PR TITLE
fix: revert PR #4760 (syncbuffer package)

### DIFF
--- a/internal/pkg/cli/deploy/mocks/mock_workload.go
+++ b/internal/pkg/cli/deploy/mocks/mock_workload.go
@@ -5,8 +5,6 @@
 package mocks
 
 import (
-	context "context"
-	io "io"
 	reflect "reflect"
 
 	addon "github.com/aws/copilot-cli/internal/pkg/addon"
@@ -77,18 +75,18 @@ func (m *MockrepositoryService) EXPECT() *MockrepositoryServiceMockRecorder {
 }
 
 // BuildAndPush mocks base method.
-func (m *MockrepositoryService) BuildAndPush(ctx context.Context, args *dockerengine.BuildArguments, w io.Writer) (string, error) {
+func (m *MockrepositoryService) BuildAndPush(args *dockerengine.BuildArguments) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BuildAndPush", ctx, args, w)
+	ret := m.ctrl.Call(m, "BuildAndPush", args)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // BuildAndPush indicates an expected call of BuildAndPush.
-func (mr *MockrepositoryServiceMockRecorder) BuildAndPush(ctx, args, w interface{}) *gomock.Call {
+func (mr *MockrepositoryServiceMockRecorder) BuildAndPush(args interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildAndPush", reflect.TypeOf((*MockrepositoryService)(nil).BuildAndPush), ctx, args, w)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildAndPush", reflect.TypeOf((*MockrepositoryService)(nil).BuildAndPush), args)
 }
 
 // Login mocks base method.
@@ -104,21 +102,6 @@ func (m *MockrepositoryService) Login() (string, error) {
 func (mr *MockrepositoryServiceMockRecorder) Login() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Login", reflect.TypeOf((*MockrepositoryService)(nil).Login))
-}
-
-// URI mocks base method.
-func (m *MockrepositoryService) URI() (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "URI")
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// URI indicates an expected call of URI.
-func (mr *MockrepositoryServiceMockRecorder) URI() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "URI", reflect.TypeOf((*MockrepositoryService)(nil).URI))
 }
 
 // Mocktemplater is a mock of templater interface.
@@ -442,57 +425,6 @@ func (m *Mockspinner) Stop(label string) {
 func (mr *MockspinnerMockRecorder) Stop(label interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*Mockspinner)(nil).Stop), label)
-}
-
-// MocklabeledTermPrinter is a mock of labeledTermPrinter interface.
-type MocklabeledTermPrinter struct {
-	ctrl     *gomock.Controller
-	recorder *MocklabeledTermPrinterMockRecorder
-}
-
-// MocklabeledTermPrinterMockRecorder is the mock recorder for MocklabeledTermPrinter.
-type MocklabeledTermPrinterMockRecorder struct {
-	mock *MocklabeledTermPrinter
-}
-
-// NewMocklabeledTermPrinter creates a new mock instance.
-func NewMocklabeledTermPrinter(ctrl *gomock.Controller) *MocklabeledTermPrinter {
-	mock := &MocklabeledTermPrinter{ctrl: ctrl}
-	mock.recorder = &MocklabeledTermPrinterMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MocklabeledTermPrinter) EXPECT() *MocklabeledTermPrinterMockRecorder {
-	return m.recorder
-}
-
-// IsDone mocks base method.
-func (m *MocklabeledTermPrinter) IsDone() bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsDone")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// IsDone indicates an expected call of IsDone.
-func (mr *MocklabeledTermPrinterMockRecorder) IsDone() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsDone", reflect.TypeOf((*MocklabeledTermPrinter)(nil).IsDone))
-}
-
-// Print mocks base method.
-func (m *MocklabeledTermPrinter) Print() error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Print")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Print indicates an expected call of Print.
-func (mr *MocklabeledTermPrinterMockRecorder) Print() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Print", reflect.TypeOf((*MocklabeledTermPrinter)(nil).Print))
 }
 
 // MocktimeoutError is a mock of timeoutError interface.

--- a/internal/pkg/cli/deploy/workload.go
+++ b/internal/pkg/cli/deploy/workload.go
@@ -5,15 +5,12 @@ package deploy
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -38,14 +35,11 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/template/artifactpath"
 	"github.com/aws/copilot-cli/internal/pkg/template/diff"
 	"github.com/aws/copilot-cli/internal/pkg/term/color"
-	"github.com/aws/copilot-cli/internal/pkg/term/cursor"
 	"github.com/aws/copilot-cli/internal/pkg/term/log"
 	termprogress "github.com/aws/copilot-cli/internal/pkg/term/progress"
-	"github.com/aws/copilot-cli/internal/pkg/term/syncbuffer"
 	"github.com/aws/copilot-cli/internal/pkg/version"
 	"github.com/aws/copilot-cli/internal/pkg/workspace"
 	"github.com/spf13/afero"
-	"golang.org/x/sync/errgroup"
 )
 
 const (
@@ -62,11 +56,6 @@ const (
 	labelForVersion       = "com.aws.copilot.image.version"
 	labelForContainerName = "com.aws.copilot.image.container.name"
 )
-const (
-	paddingInSpacesForBuildAndPush = 5
-	pollIntervalForBuildAndPush    = 60 * time.Millisecond
-	defaultNumLinesForBuildAndPush = 5
-)
 
 // ActionRecommender contains methods that output action recommendation.
 type ActionRecommender interface {
@@ -81,7 +70,7 @@ func (noopActionRecommender) RecommendedActions() []string {
 
 type repositoryService interface {
 	Login() (string, error)
-	BuildAndPush(ctx context.Context, args *dockerengine.BuildArguments, w io.Writer) (string, error)
+	BuildAndPush(args *dockerengine.BuildArguments) (string, error)
 }
 
 type templater interface {
@@ -114,11 +103,6 @@ type deployedTemplateGetter interface {
 type spinner interface {
 	Start(label string)
 	Stop(label string)
-}
-
-type labeledTermPrinter interface {
-	IsDone() bool
-	Print() error
 }
 
 // StackRuntimeConfiguration contains runtime configuration for a workload CloudFormation stack.
@@ -166,19 +150,18 @@ type workloadDeployer struct {
 	workspacePath string
 
 	// Dependencies.
-	fs                 afero.Fs
-	s3Client           uploader
-	addons             stackBuilder
-	repository         repositoryService
-	deployer           serviceDeployer
-	tmplGetter         deployedTemplateGetter
-	endpointGetter     endpointGetter
-	spinner            spinner
-	templateFS         template.Reader
-	envVersionGetter   versionGetter
-	overrider          Overrider
-	customResources    customResourcesFunc
-	labeledTermPrinter func(fw syncbuffer.FileWriter, bufs []*syncbuffer.LabeledSyncBuffer, opts ...syncbuffer.LabeledTermPrinterOption) labeledTermPrinter
+	fs               afero.Fs
+	s3Client         uploader
+	addons           stackBuilder
+	repository       repositoryService
+	deployer         serviceDeployer
+	tmplGetter       deployedTemplateGetter
+	endpointGetter   endpointGetter
+	spinner          spinner
+	templateFS       template.Reader
+	envVersionGetter versionGetter
+	overrider        Overrider
+	customResources  customResourcesFunc
 
 	// Cached variables.
 	defaultSess              *session.Session
@@ -268,9 +251,6 @@ func newWorkloadDeployer(in *WorkloadDeployerInput) (*workloadDeployer, error) {
 
 	cfn := cloudformation.New(envSession, cloudformation.WithProgressTracker(os.Stderr))
 
-	labeledTermPrinter := func(fw syncbuffer.FileWriter, bufs []*syncbuffer.LabeledSyncBuffer, opts ...syncbuffer.LabeledTermPrinterOption) labeledTermPrinter {
-		return syncbuffer.NewLabeledTermPrinter(fw, bufs, opts...)
-	}
 	return &workloadDeployer{
 		name:                     in.Name,
 		app:                      in.App,
@@ -295,7 +275,6 @@ func newWorkloadDeployer(in *WorkloadDeployerInput) (*workloadDeployer, error) {
 		envSess:                  envSession,
 		store:                    store,
 		envConfig:                envConfig,
-		labeledTermPrinter:       labeledTermPrinter,
 
 		mft:    in.Mft,
 		rawMft: in.RawMft,
@@ -388,66 +367,24 @@ func (d *workloadDeployer) uploadContainerImages(out *UploadArtifactsOutput) err
 	if err != nil {
 		return fmt.Errorf("login to image repository: %w", err)
 	}
-
-	var digestsMu sync.Mutex
 	out.ImageDigests = make(map[string]ContainerImageIdentifier, len(buildArgsPerContainer))
-	var labeledBuffers []*syncbuffer.LabeledSyncBuffer
-	g, ctx := errgroup.WithContext(context.Background())
-	cursor := cursor.New()
-	cursor.Hide()
 	for name, buildArgs := range buildArgsPerContainer {
-		// create a copy of loop variables to avoid data race.
-		name := name
-		buildArgs := buildArgs
-
 		buildArgs.URI = uri
 		buildArgsList, err := buildArgs.GenerateDockerBuildArgs(dockerengine.New(exec.NewCmd()))
 		if err != nil {
-			return fmt.Errorf("generate docker build args for %q: %w", name, err)
+			return fmt.Errorf("generate docker build args: %w", err)
 		}
-		buf := syncbuffer.New()
-		labeledBuffers = append(labeledBuffers, buf.WithLabel(fmt.Sprintf("Building your container image %q: docker %s", name, strings.Join(buildArgsList, " "))))
-		pr, pw := io.Pipe()
-		g.Go(func() error {
-			defer pw.Close()
-			digest, err := d.repository.BuildAndPush(ctx, buildArgs, pw)
-			if err != nil {
-				return fmt.Errorf("build and push the image %q: %w", name, err)
-			}
-			digestsMu.Lock()
-			defer digestsMu.Unlock()
-			out.ImageDigests[name] = ContainerImageIdentifier{
-				Digest:            digest,
-				CustomTag:         d.image.CustomTag,
-				GitShortCommitTag: d.image.GitShortCommitTag,
-			}
-			return nil
-		})
-		g.Go(func() error {
-			if err := buf.Copy(pr); err != nil {
-				return fmt.Errorf("copy build and push output for %q: %w", name, err)
-			}
-			return nil
-		})
-	}
-	opts := []syncbuffer.LabeledTermPrinterOption{syncbuffer.WithPadding(paddingInSpacesForBuildAndPush)}
-	if os.Getenv("CI") != "true" {
-		opts = append(opts, syncbuffer.WithNumLines(defaultNumLinesForBuildAndPush))
-	}
-	ltp := d.labeledTermPrinter(os.Stderr, labeledBuffers, opts...)
-	g.Go(func() error {
-		for {
-			if err := ltp.Print(); err != nil {
-				return fmt.Errorf("print logs: %w", err)
-			}
-			if ltp.IsDone() {
-				return nil
-			}
-			time.Sleep(pollIntervalForBuildAndPush)
+		// TODO(adi) handle this log in syncBuffer's Print function
+		log.Infof("Building your container image: docker %s\n", strings.Join(buildArgsList, " "))
+		digest, err := d.repository.BuildAndPush(buildArgs)
+		if err != nil {
+			return fmt.Errorf("build and push image: %w", err)
 		}
-	})
-	if err := g.Wait(); err != nil {
-		return err
+		out.ImageDigests[name] = ContainerImageIdentifier{
+			Digest:            digest,
+			CustomTag:         d.image.CustomTag,
+			GitShortCommitTag: d.image.GitShortCommitTag,
+		}
 	}
 	return nil
 }

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -4,7 +4,6 @@
 package cli
 
 import (
-	"context"
 	"encoding"
 	"io"
 
@@ -166,7 +165,7 @@ type secretDeleter interface {
 }
 
 type imageBuilderPusher interface {
-	BuildAndPush(ctx context.Context, args *dockerengine.BuildArguments, w io.Writer) (string, error)
+	BuildAndPush(args *dockerengine.BuildArguments) (string, error)
 }
 
 type repositoryLogin interface {

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -5,7 +5,6 @@
 package mocks
 
 import (
-	context "context"
 	encoding "encoding"
 	io "io"
 	reflect "reflect"
@@ -1563,18 +1562,18 @@ func (m *MockimageBuilderPusher) EXPECT() *MockimageBuilderPusherMockRecorder {
 }
 
 // BuildAndPush mocks base method.
-func (m *MockimageBuilderPusher) BuildAndPush(ctx context.Context, args *dockerengine.BuildArguments, w io.Writer) (string, error) {
+func (m *MockimageBuilderPusher) BuildAndPush(args *dockerengine.BuildArguments) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BuildAndPush", ctx, args, w)
+	ret := m.ctrl.Call(m, "BuildAndPush", args)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // BuildAndPush indicates an expected call of BuildAndPush.
-func (mr *MockimageBuilderPusherMockRecorder) BuildAndPush(ctx, args, w interface{}) *gomock.Call {
+func (mr *MockimageBuilderPusherMockRecorder) BuildAndPush(args interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildAndPush", reflect.TypeOf((*MockimageBuilderPusher)(nil).BuildAndPush), ctx, args, w)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildAndPush", reflect.TypeOf((*MockimageBuilderPusher)(nil).BuildAndPush), args)
 }
 
 // MockrepositoryLogin is a mock of repositoryLogin interface.
@@ -1639,18 +1638,18 @@ func (m *MockrepositoryService) EXPECT() *MockrepositoryServiceMockRecorder {
 }
 
 // BuildAndPush mocks base method.
-func (m *MockrepositoryService) BuildAndPush(ctx context.Context, args *dockerengine.BuildArguments, w io.Writer) (string, error) {
+func (m *MockrepositoryService) BuildAndPush(args *dockerengine.BuildArguments) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BuildAndPush", ctx, args, w)
+	ret := m.ctrl.Call(m, "BuildAndPush", args)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // BuildAndPush indicates an expected call of BuildAndPush.
-func (mr *MockrepositoryServiceMockRecorder) BuildAndPush(ctx, args, w interface{}) *gomock.Call {
+func (mr *MockrepositoryServiceMockRecorder) BuildAndPush(args interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildAndPush", reflect.TypeOf((*MockrepositoryService)(nil).BuildAndPush), ctx, args, w)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildAndPush", reflect.TypeOf((*MockrepositoryService)(nil).BuildAndPush), args)
 }
 
 // Login mocks base method.

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -5,7 +5,6 @@ package cli
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -974,7 +973,7 @@ func (o *runTaskOpts) buildAndPushImage(uri string) error {
 		return fmt.Errorf("generate docker build args: %w", err)
 	}
 	log.Infof("Building your container image: docker %s\n", strings.Join(buildArgsList, " "))
-	if _, err := o.repository.BuildAndPush(context.Background(), buildArgs, log.DiagnosticWriter); err != nil {
+	if _, err := o.repository.BuildAndPush(buildArgs); err != nil {
 		return fmt.Errorf("build and push image: %w", err)
 	}
 	return nil

--- a/internal/pkg/cli/task_run_test.go
+++ b/internal/pkg/cli/task_run_test.go
@@ -5,7 +5,6 @@ package cli
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"fmt"
 	"path/filepath"
@@ -762,7 +761,7 @@ func mockHasDefaultCluster(m runTaskMocks) {
 
 func mockRepositoryAnytime(m runTaskMocks) {
 	m.repository.EXPECT().Login().AnyTimes()
-	m.repository.EXPECT().BuildAndPush(context.Background(), gomock.Any(), gomock.Any()).AnyTimes()
+	m.repository.EXPECT().BuildAndPush(gomock.Any()).AnyTimes()
 }
 
 func TestTaskRunOpts_Execute(t *testing.T) {
@@ -771,7 +770,6 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 		mockRepoURI = "uri/repo"
 		tag         = "tag"
 	)
-	ctx := context.Background()
 	defaultBuildArguments := dockerengine.BuildArguments{
 		URI:     mockRepoURI,
 		Context: filepath.Dir(defaultDockerfilePath),
@@ -861,7 +859,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 					EntryPoint: []string{},
 				}).Return(nil)
 				m.repository.EXPECT().Login().Return(mockRepoURI, nil)
-				m.repository.EXPECT().BuildAndPush(ctx, gomock.Any(), gomock.Any())
+				m.repository.EXPECT().BuildAndPush(gomock.Any())
 				m.deployer.EXPECT().DeployTask(&deploy.CreateTaskResourcesInput{
 					Name:       inGroupName,
 					Image:      "uri/repo:latest",
@@ -914,12 +912,12 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 				m.store.EXPECT().GetEnvironment(gomock.Any(), gomock.Any()).AnyTimes()
 				m.deployer.EXPECT().DeployTask(gomock.Any()).AnyTimes()
 				m.repository.EXPECT().Login().Return(mockRepoURI, nil)
-				m.repository.EXPECT().BuildAndPush(ctx, gomock.Eq(
+				m.repository.EXPECT().BuildAndPush(gomock.Eq(
 					&dockerengine.BuildArguments{
 						URI:     mockRepoURI,
 						Context: filepath.Dir(defaultDockerfilePath),
 						Tags:    []string{imageTagLatest, tag},
-					}), gomock.Any(),
+					}),
 				)
 				m.runner.EXPECT().Run().AnyTimes()
 				mockHasDefaultCluster(m)
@@ -932,12 +930,12 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 				m.store.EXPECT().GetEnvironment(gomock.Any(), gomock.Any()).AnyTimes()
 				m.deployer.EXPECT().DeployTask(gomock.Any()).AnyTimes()
 				m.repository.EXPECT().Login().Return(mockRepoURI, nil)
-				m.repository.EXPECT().BuildAndPush(ctx, gomock.Eq(
+				m.repository.EXPECT().BuildAndPush(gomock.Eq(
 					&dockerengine.BuildArguments{
 						URI:     mockRepoURI,
 						Context: "../../other",
 						Tags:    []string{imageTagLatest},
-					}), gomock.Any(),
+					}),
 				)
 				m.runner.EXPECT().Run().AnyTimes()
 				mockHasDefaultCluster(m)
@@ -956,7 +954,7 @@ func TestTaskRunOpts_Execute(t *testing.T) {
 					EntryPoint: []string{"exec", "some command"},
 				}).Times(1).Return(nil)
 				m.repository.EXPECT().Login().Return(mockRepoURI, nil)
-				m.repository.EXPECT().BuildAndPush(ctx, gomock.Eq(&defaultBuildArguments), gomock.Any())
+				m.repository.EXPECT().BuildAndPush(gomock.Eq(&defaultBuildArguments))
 				m.deployer.EXPECT().DeployTask(&deploy.CreateTaskResourcesInput{
 					Name:       inGroupName,
 					Image:      "uri/repo:latest",

--- a/internal/pkg/docker/dockerengine/dockerengine_test.go
+++ b/internal/pkg/docker/dockerengine/dockerengine_test.go
@@ -5,12 +5,10 @@ package dockerengine
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"fmt"
 	osexec "os/exec"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/aws/copilot-cli/internal/pkg/exec"
@@ -31,7 +29,6 @@ func TestDockerCommand_Build(t *testing.T) {
 	mockTag2 := "tag2"
 	mockTag3 := "tag3"
 	mockContainerName := "mockWkld"
-	ctx := context.Background()
 
 	var mockCmd *MockCmd
 
@@ -62,10 +59,10 @@ func TestDockerCommand_Build(t *testing.T) {
 			tags:    []string{mockTag1},
 			setupMocks: func(controller *gomock.Controller) {
 				mockCmd = NewMockCmd(controller)
-				mockCmd.EXPECT().RunWithContext(ctx, "docker", []string{"build",
+				mockCmd.EXPECT().Run("docker", []string{"build",
 					"-t", mockURI + ":" + mockTag1,
 					filepath.FromSlash("mockPath/to"),
-					"-f", "mockPath/to/mockDockerfile"}, gomock.Any(), gomock.Any()).Return(mockError)
+					"-f", "mockPath/to/mockDockerfile"}).Return(mockError)
 			},
 			wantedError: fmt.Errorf("building image: %w", mockError),
 		},
@@ -76,9 +73,9 @@ func TestDockerCommand_Build(t *testing.T) {
 			setupMocks: func(controller *gomock.Controller) {
 				mockCmd = NewMockCmd(controller)
 
-				mockCmd.EXPECT().RunWithContext(ctx, "docker", []string{"build",
+				mockCmd.EXPECT().Run("docker", []string{"build",
 					"-t", "mockURI:tag1", filepath.FromSlash("mockPath/to"),
-					"-f", "mockPath/to/mockDockerfile"}, gomock.Any(), gomock.Any()).Return(nil)
+					"-f", "mockPath/to/mockDockerfile"}).Return(nil)
 			},
 		},
 		"should display quiet progress updates when in a CI environment": {
@@ -91,10 +88,10 @@ func TestDockerCommand_Build(t *testing.T) {
 			setupMocks: func(controller *gomock.Controller) {
 				mockCmd = NewMockCmd(controller)
 
-				mockCmd.EXPECT().RunWithContext(ctx, "docker", []string{"build",
+				mockCmd.EXPECT().Run("docker", []string{"build",
 					"-t", fmt.Sprintf("%s:%s", mockURI, mockTag1),
 					"--progress", "plain",
-					filepath.FromSlash("mockPath/to"), "-f", "mockPath/to/mockDockerfile"}, gomock.Any(), gomock.Any()).
+					filepath.FromSlash("mockPath/to"), "-f", "mockPath/to/mockDockerfile"}).
 					Return(nil)
 			},
 		},
@@ -104,10 +101,10 @@ func TestDockerCommand_Build(t *testing.T) {
 			context: mockContext,
 			setupMocks: func(controller *gomock.Controller) {
 				mockCmd = NewMockCmd(controller)
-				mockCmd.EXPECT().RunWithContext(ctx, "docker", []string{"build",
+				mockCmd.EXPECT().Run("docker", []string{"build",
 					"-t", fmt.Sprintf("%s:%s", mockURI, mockTag1),
 					"mockPath",
-					"-f", "mockPath/to/mockDockerfile"}, gomock.Any(), gomock.Any()).Return(nil)
+					"-f", "mockPath/to/mockDockerfile"}).Return(nil)
 			},
 		},
 		"behaves the same if context is DF dir": {
@@ -117,10 +114,10 @@ func TestDockerCommand_Build(t *testing.T) {
 			setupMocks: func(controller *gomock.Controller) {
 				mockCmd = NewMockCmd(controller)
 
-				mockCmd.EXPECT().RunWithContext(ctx, "docker", []string{"build",
+				mockCmd.EXPECT().Run("docker", []string{"build",
 					"-t", mockURI + ":" + mockTag1,
 					"mockPath/to",
-					"-f", "mockPath/to/mockDockerfile"}, gomock.Any(), gomock.Any()).Return(nil)
+					"-f", "mockPath/to/mockDockerfile"}).Return(nil)
 			},
 		},
 
@@ -129,12 +126,12 @@ func TestDockerCommand_Build(t *testing.T) {
 			tags: []string{mockTag1, mockTag2, mockTag3},
 			setupMocks: func(controller *gomock.Controller) {
 				mockCmd = NewMockCmd(controller)
-				mockCmd.EXPECT().RunWithContext(ctx, "docker", []string{"build",
+				mockCmd.EXPECT().Run("docker", []string{"build",
 					"-t", mockURI + ":" + mockTag1,
 					"-t", mockURI + ":" + mockTag2,
 					"-t", mockURI + ":" + mockTag3,
 					filepath.FromSlash("mockPath/to"),
-					"-f", "mockPath/to/mockDockerfile"}, gomock.Any(), gomock.Any()).Return(nil)
+					"-f", "mockPath/to/mockDockerfile"}).Return(nil)
 			},
 		},
 		"success with build args": {
@@ -147,13 +144,13 @@ func TestDockerCommand_Build(t *testing.T) {
 			},
 			setupMocks: func(c *gomock.Controller) {
 				mockCmd = NewMockCmd(c)
-				mockCmd.EXPECT().RunWithContext(ctx, "docker", []string{"build",
+				mockCmd.EXPECT().Run("docker", []string{"build",
 					"-t", fmt.Sprintf("%s:%s", mockURI, "latest"),
 					"--build-arg", "GOPROXY=direct",
 					"--build-arg", "abc=def",
 					"--build-arg", "key=value",
 					filepath.FromSlash("mockPath/to"),
-					"-f", "mockPath/to/mockDockerfile"}, gomock.Any(), gomock.Any()).Return(nil)
+					"-f", "mockPath/to/mockDockerfile"}).Return(nil)
 			},
 		},
 
@@ -167,13 +164,13 @@ func TestDockerCommand_Build(t *testing.T) {
 			},
 			setupMocks: func(c *gomock.Controller) {
 				mockCmd = NewMockCmd(c)
-				mockCmd.EXPECT().RunWithContext(ctx, "docker", []string{"build",
+				mockCmd.EXPECT().Run("docker", []string{"build",
 					"-t", fmt.Sprintf("%s:%s", mockURI, "latest"),
 					"--label", "com.aws.copilot.image.builder=copilot-cli",
 					"--label", "com.aws.copilot.image.container.name=mockWkld",
 					"--label", "com.aws.copilot.image.version=v1.26.0",
 					filepath.FromSlash("mockPath/to"),
-					"-f", "mockPath/to/mockDockerfile"}, gomock.Any(), gomock.Any()).Return(nil)
+					"-f", "mockPath/to/mockDockerfile"}).Return(nil)
 			},
 		},
 
@@ -184,13 +181,13 @@ func TestDockerCommand_Build(t *testing.T) {
 			cacheFrom: []string{"foo/bar:latest", "foo/bar/baz:1.2.3"},
 			setupMocks: func(c *gomock.Controller) {
 				mockCmd = NewMockCmd(c)
-				mockCmd.EXPECT().RunWithContext(ctx, "docker", []string{"build",
+				mockCmd.EXPECT().Run("docker", []string{"build",
 					"-t", fmt.Sprintf("%s:%s", mockURI, "latest"),
 					"--cache-from", "foo/bar:latest",
 					"--cache-from", "foo/bar/baz:1.2.3",
 					"--target", "foobar",
 					filepath.FromSlash("mockPath/to"),
-					"-f", "mockPath/to/mockDockerfile"}, gomock.Any(), gomock.Any()).Return(nil)
+					"-f", "mockPath/to/mockDockerfile"}).Return(nil)
 			},
 		},
 	}
@@ -218,8 +215,7 @@ func TestDockerCommand_Build(t *testing.T) {
 				Tags:       tc.tags,
 				Labels:     tc.labels,
 			}
-			buf := new(strings.Builder)
-			got := s.Build(ctx, &buildInput, buf)
+			got := s.Build(&buildInput)
 
 			if tc.wantedError != nil {
 				require.EqualError(t, tc.wantedError, got.Error())
@@ -281,16 +277,15 @@ func TestDockerCommand_Push(t *testing.T) {
 	emptyLookupEnv := func(key string) (string, bool) {
 		return "", false
 	}
-	ctx := context.Background()
 	t.Run("pushes an image with multiple tags and returns its digest", func(t *testing.T) {
 		// GIVEN
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 		m := NewMockCmd(ctrl)
-		m.EXPECT().RunWithContext(ctx, "docker", []string{"push", "aws_account_id.dkr.ecr.region.amazonaws.com/my-web-app:latest"}, gomock.Any(), gomock.Any()).Return(nil)
-		m.EXPECT().RunWithContext(ctx, "docker", []string{"push", "aws_account_id.dkr.ecr.region.amazonaws.com/my-web-app:g123bfc"}, gomock.Any(), gomock.Any()).Return(nil)
-		m.EXPECT().RunWithContext(ctx, "docker", []string{"inspect", "--format", "'{{json (index .RepoDigests 0)}}'", "aws_account_id.dkr.ecr.region.amazonaws.com/my-web-app:latest"}, gomock.Any()).
-			Do(func(ctx context.Context, _ string, _ []string, opt exec.CmdOption) {
+		m.EXPECT().Run("docker", []string{"push", "aws_account_id.dkr.ecr.region.amazonaws.com/my-web-app:latest"}).Return(nil)
+		m.EXPECT().Run("docker", []string{"push", "aws_account_id.dkr.ecr.region.amazonaws.com/my-web-app:g123bfc"}).Return(nil)
+		m.EXPECT().Run("docker", []string{"inspect", "--format", "'{{json (index .RepoDigests 0)}}'", "aws_account_id.dkr.ecr.region.amazonaws.com/my-web-app:latest"}, gomock.Any()).
+			Do(func(_ string, _ []string, opt exec.CmdOption) {
 				cmd := &osexec.Cmd{}
 				opt(cmd)
 				_, _ = cmd.Stdout.Write([]byte("\"aws_account_id.dkr.ecr.region.amazonaws.com/my-web-app@sha256:f1d4ae3f7261a72e98c6ebefe9985cf10a0ea5bd762585a43e0700ed99863807\"\n"))
@@ -301,8 +296,7 @@ func TestDockerCommand_Push(t *testing.T) {
 			runner:    m,
 			lookupEnv: emptyLookupEnv,
 		}
-		buf := new(strings.Builder)
-		digest, err := cmd.Push(ctx, "aws_account_id.dkr.ecr.region.amazonaws.com/my-web-app", buf, "latest", "g123bfc")
+		digest, err := cmd.Push("aws_account_id.dkr.ecr.region.amazonaws.com/my-web-app", "latest", "g123bfc")
 
 		// THEN
 		require.NoError(t, err)
@@ -313,9 +307,9 @@ func TestDockerCommand_Push(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 		m := NewMockCmd(ctrl)
-		m.EXPECT().RunWithContext(ctx, "docker", []string{"push", "aws_account_id.dkr.ecr.region.amazonaws.com/my-web-app:latest", "--quiet"}, gomock.Any(), gomock.Any()).Return(nil)
-		m.EXPECT().RunWithContext(ctx, "docker", []string{"inspect", "--format", "'{{json (index .RepoDigests 0)}}'", "aws_account_id.dkr.ecr.region.amazonaws.com/my-web-app:latest"}, gomock.Any()).
-			Do(func(ctx context.Context, _ string, _ []string, opt exec.CmdOption) {
+		m.EXPECT().Run("docker", []string{"push", "aws_account_id.dkr.ecr.region.amazonaws.com/my-web-app:latest", "--quiet"}).Return(nil)
+		m.EXPECT().Run("docker", []string{"inspect", "--format", "'{{json (index .RepoDigests 0)}}'", "aws_account_id.dkr.ecr.region.amazonaws.com/my-web-app:latest"}, gomock.Any()).
+			Do(func(_ string, _ []string, opt exec.CmdOption) {
 				cmd := &osexec.Cmd{}
 				opt(cmd)
 				_, _ = cmd.Stdout.Write([]byte("\"aws_account_id.dkr.ecr.region.amazonaws.com/my-web-app@sha256:f1d4ae3f7261a72e98c6ebefe9985cf10a0ea5bd762585a43e0700ed99863807\"\n"))
@@ -331,8 +325,7 @@ func TestDockerCommand_Push(t *testing.T) {
 				return "", false
 			},
 		}
-		buf := new(strings.Builder)
-		digest, err := cmd.Push(context.Background(), "aws_account_id.dkr.ecr.region.amazonaws.com/my-web-app", buf, "latest")
+		digest, err := cmd.Push("aws_account_id.dkr.ecr.region.amazonaws.com/my-web-app", "latest")
 
 		// THEN
 		require.NoError(t, err)
@@ -343,15 +336,14 @@ func TestDockerCommand_Push(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 		m := NewMockCmd(ctrl)
-		m.EXPECT().RunWithContext(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("some error"))
+		m.EXPECT().Run(gomock.Any(), gomock.Any()).Return(errors.New("some error"))
 
 		// WHEN
 		cmd := DockerCmdClient{
 			runner:    m,
 			lookupEnv: emptyLookupEnv,
 		}
-		buf := new(strings.Builder)
-		_, err := cmd.Push(ctx, "uri", buf, "latest")
+		_, err := cmd.Push("uri", "latest")
 
 		// THEN
 		require.EqualError(t, err, "docker push uri:latest: some error")
@@ -361,16 +353,15 @@ func TestDockerCommand_Push(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 		m := NewMockCmd(ctrl)
-		m.EXPECT().RunWithContext(ctx, "docker", []string{"push", "uri:latest"}, gomock.Any(), gomock.Any()).Return(nil)
-		m.EXPECT().RunWithContext(ctx, "docker", []string{"inspect", "--format", "'{{json (index .RepoDigests 0)}}'", "uri:latest"}, gomock.Any()).Return(errors.New("some error"))
+		m.EXPECT().Run("docker", []string{"push", "uri:latest"}).Return(nil)
+		m.EXPECT().Run("docker", []string{"inspect", "--format", "'{{json (index .RepoDigests 0)}}'", "uri:latest"}, gomock.Any()).Return(errors.New("some error"))
 
 		// WHEN
 		cmd := DockerCmdClient{
 			runner:    m,
 			lookupEnv: emptyLookupEnv,
 		}
-		buf := new(strings.Builder)
-		_, err := cmd.Push(ctx, "uri", buf, "latest")
+		_, err := cmd.Push("uri", "latest")
 
 		// THEN
 		require.EqualError(t, err, "inspect image digest for uri: some error")
@@ -380,10 +371,10 @@ func TestDockerCommand_Push(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 		m := NewMockCmd(ctrl)
-		m.EXPECT().RunWithContext(ctx, "docker", []string{"push", "aws_account_id.dkr.ecr.region.amazonaws.com/my-web-app:latest"}, gomock.Any(), gomock.Any()).Return(nil)
-		m.EXPECT().RunWithContext(ctx, "docker", []string{"push", "aws_account_id.dkr.ecr.region.amazonaws.com/my-web-app:g123bfc"}, gomock.Any(), gomock.Any()).Return(nil)
-		m.EXPECT().RunWithContext(ctx, "docker", []string{"inspect", "--format", "'{{json (index .RepoDigests 0)}}'", "aws_account_id.dkr.ecr.region.amazonaws.com/my-web-app:latest"}, gomock.Any()).
-			Do(func(ctx context.Context, _ string, _ []string, opt exec.CmdOption) {
+		m.EXPECT().Run("docker", []string{"push", "aws_account_id.dkr.ecr.region.amazonaws.com/my-web-app:latest"}).Return(nil)
+		m.EXPECT().Run("docker", []string{"push", "aws_account_id.dkr.ecr.region.amazonaws.com/my-web-app:g123bfc"}).Return(nil)
+		m.EXPECT().Run("docker", []string{"inspect", "--format", "'{{json (index .RepoDigests 0)}}'", "aws_account_id.dkr.ecr.region.amazonaws.com/my-web-app:latest"}, gomock.Any()).
+			Do(func(_ string, _ []string, opt exec.CmdOption) {
 				cmd := &osexec.Cmd{}
 				opt(cmd)
 				_, _ = cmd.Stdout.Write([]byte(""))
@@ -394,8 +385,7 @@ func TestDockerCommand_Push(t *testing.T) {
 			runner:    m,
 			lookupEnv: emptyLookupEnv,
 		}
-		buf := new(strings.Builder)
-		_, err := cmd.Push(ctx, "aws_account_id.dkr.ecr.region.amazonaws.com/my-web-app", buf, "latest", "g123bfc")
+		_, err := cmd.Push("aws_account_id.dkr.ecr.region.amazonaws.com/my-web-app", "latest", "g123bfc")
 
 		// THEN
 		require.EqualError(t, err, "parse the digest from the repo digest ''")

--- a/internal/pkg/docker/dockerengine/mock_dockerengine.go
+++ b/internal/pkg/docker/dockerengine/mock_dockerengine.go
@@ -5,7 +5,6 @@
 package dockerengine
 
 import (
-	context "context"
 	reflect "reflect"
 
 	exec "github.com/aws/copilot-cli/internal/pkg/exec"
@@ -52,23 +51,4 @@ func (mr *MockCmdMockRecorder) Run(name, args interface{}, options ...interface{
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{name, args}, options...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Run", reflect.TypeOf((*MockCmd)(nil).Run), varargs...)
-}
-
-// RunWithContext mocks base method.
-func (m *MockCmd) RunWithContext(ctx context.Context, name string, args []string, opts ...exec.CmdOption) error {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{ctx, name, args}
-	for _, a := range opts {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "RunWithContext", varargs...)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RunWithContext indicates an expected call of RunWithContext.
-func (mr *MockCmdMockRecorder) RunWithContext(ctx, name, args interface{}, opts ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{ctx, name, args}, opts...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunWithContext", reflect.TypeOf((*MockCmd)(nil).RunWithContext), varargs...)
 }

--- a/internal/pkg/repository/mocks/mock_repository.go
+++ b/internal/pkg/repository/mocks/mock_repository.go
@@ -5,8 +5,6 @@
 package mocks
 
 import (
-	context "context"
-	io "io"
 	reflect "reflect"
 
 	dockerengine "github.com/aws/copilot-cli/internal/pkg/docker/dockerengine"
@@ -37,17 +35,17 @@ func (m *MockContainerLoginBuildPusher) EXPECT() *MockContainerLoginBuildPusherM
 }
 
 // Build mocks base method.
-func (m *MockContainerLoginBuildPusher) Build(ctx context.Context, args *dockerengine.BuildArguments, w io.Writer) error {
+func (m *MockContainerLoginBuildPusher) Build(args *dockerengine.BuildArguments) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Build", ctx, args, w)
+	ret := m.ctrl.Call(m, "Build", args)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Build indicates an expected call of Build.
-func (mr *MockContainerLoginBuildPusherMockRecorder) Build(ctx, args, w interface{}) *gomock.Call {
+func (mr *MockContainerLoginBuildPusherMockRecorder) Build(args interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Build", reflect.TypeOf((*MockContainerLoginBuildPusher)(nil).Build), ctx, args, w)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Build", reflect.TypeOf((*MockContainerLoginBuildPusher)(nil).Build), args)
 }
 
 // IsEcrCredentialHelperEnabled mocks base method.
@@ -79,9 +77,9 @@ func (mr *MockContainerLoginBuildPusherMockRecorder) Login(uri, username, passwo
 }
 
 // Push mocks base method.
-func (m *MockContainerLoginBuildPusher) Push(ctx context.Context, uri string, w io.Writer, tags ...string) (string, error) {
+func (m *MockContainerLoginBuildPusher) Push(uri string, tags ...string) (string, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{ctx, uri, w}
+	varargs := []interface{}{uri}
 	for _, a := range tags {
 		varargs = append(varargs, a)
 	}
@@ -92,9 +90,9 @@ func (m *MockContainerLoginBuildPusher) Push(ctx context.Context, uri string, w 
 }
 
 // Push indicates an expected call of Push.
-func (mr *MockContainerLoginBuildPusherMockRecorder) Push(ctx, uri, w interface{}, tags ...interface{}) *gomock.Call {
+func (mr *MockContainerLoginBuildPusherMockRecorder) Push(uri interface{}, tags ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{ctx, uri, w}, tags...)
+	varargs := append([]interface{}{uri}, tags...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Push", reflect.TypeOf((*MockContainerLoginBuildPusher)(nil).Push), varargs...)
 }
 

--- a/internal/pkg/repository/repository_test.go
+++ b/internal/pkg/repository/repository_test.go
@@ -4,11 +4,9 @@
 package repository
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/aws/copilot-cli/internal/pkg/docker/dockerengine"
@@ -24,7 +22,6 @@ func TestRepository_BuildAndPush(t *testing.T) {
 
 	mockTag1, mockTag2, mockTag3 := "tag1", "tag2", "tag3"
 	mockRepoURI := "mockRepoURI"
-	ctx := context.Background()
 
 	defaultDockerArguments := dockerengine.BuildArguments{
 		URI:        mockRepoURI,
@@ -55,7 +52,7 @@ func TestRepository_BuildAndPush(t *testing.T) {
 				m.EXPECT().Auth().Return("", "", nil).AnyTimes()
 			},
 			inMockDocker: func(m *mocks.MockContainerLoginBuildPusher) {
-				m.EXPECT().Build(ctx, &defaultDockerArguments, gomock.Any()).Return(errors.New("error building image"))
+				m.EXPECT().Build(&defaultDockerArguments).Return(errors.New("error building image"))
 				m.EXPECT().Push(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 			},
 			wantedError: fmt.Errorf("build Dockerfile at %s: error building image", inDockerfilePath),
@@ -63,16 +60,16 @@ func TestRepository_BuildAndPush(t *testing.T) {
 		"failed to push": {
 			inURI: defaultDockerArguments.URI,
 			inMockDocker: func(m *mocks.MockContainerLoginBuildPusher) {
-				m.EXPECT().Build(ctx, &defaultDockerArguments, gomock.Any()).Times(1)
-				m.EXPECT().Push(ctx, mockRepoURI, gomock.Any(), mockTag1, mockTag2, mockTag3).Return("", errors.New("error pushing image"))
+				m.EXPECT().Build(&defaultDockerArguments).Times(1)
+				m.EXPECT().Push(mockRepoURI, mockTag1, mockTag2, mockTag3).Return("", errors.New("error pushing image"))
 			},
 			wantedError: errors.New("push to repo my-repo: error pushing image"),
 		},
 		"push with ecr-login": {
 			inURI: defaultDockerArguments.URI,
 			inMockDocker: func(m *mocks.MockContainerLoginBuildPusher) {
-				m.EXPECT().Build(ctx, &defaultDockerArguments, gomock.Any()).Return(nil).Times(1)
-				m.EXPECT().Push(ctx, mockRepoURI, gomock.Any(), mockTag1, mockTag2, mockTag3).Return("sha256:f1d4ae3f7261a72e98c6ebefe9985cf10a0ea5bd762585a43e0700ed99863807", nil)
+				m.EXPECT().Build(&defaultDockerArguments).Return(nil).Times(1)
+				m.EXPECT().Push(mockRepoURI, mockTag1, mockTag2, mockTag3).Return("sha256:f1d4ae3f7261a72e98c6ebefe9985cf10a0ea5bd762585a43e0700ed99863807", nil)
 			},
 			wantedDigest: "sha256:f1d4ae3f7261a72e98c6ebefe9985cf10a0ea5bd762585a43e0700ed99863807",
 		},
@@ -81,8 +78,8 @@ func TestRepository_BuildAndPush(t *testing.T) {
 				m.EXPECT().RepositoryURI(inRepoName).Return(defaultDockerArguments.URI, nil)
 			},
 			inMockDocker: func(m *mocks.MockContainerLoginBuildPusher) {
-				m.EXPECT().Build(ctx, &defaultDockerArguments, gomock.Any()).Return(nil).Times(1)
-				m.EXPECT().Push(ctx, mockRepoURI, gomock.Any(), mockTag1, mockTag2, mockTag3).Return("sha256:f1d4ae3f7261a72e98c6ebefe9985cf10a0ea5bd762585a43e0700ed99863807", nil)
+				m.EXPECT().Build(&defaultDockerArguments).Return(nil).Times(1)
+				m.EXPECT().Push(mockRepoURI, mockTag1, mockTag2, mockTag3).Return("sha256:f1d4ae3f7261a72e98c6ebefe9985cf10a0ea5bd762585a43e0700ed99863807", nil)
 			},
 			wantedDigest: "sha256:f1d4ae3f7261a72e98c6ebefe9985cf10a0ea5bd762585a43e0700ed99863807",
 		},
@@ -108,12 +105,12 @@ func TestRepository_BuildAndPush(t *testing.T) {
 				uri:      tc.inURI,
 				docker:   mockDocker,
 			}
-			buf := new(strings.Builder)
-			digest, err := repo.BuildAndPush(ctx, &dockerengine.BuildArguments{
+
+			digest, err := repo.BuildAndPush(&dockerengine.BuildArguments{
 				Dockerfile: inDockerfilePath,
 				Context:    filepath.Dir(inDockerfilePath),
 				Tags:       []string{mockTag1, mockTag2, mockTag3},
-			}, buf)
+			})
 			if tc.wantedError != nil {
 				require.EqualError(t, tc.wantedError, err.Error())
 			} else {

--- a/internal/pkg/term/syncbuffer/syncbuffer.go
+++ b/internal/pkg/term/syncbuffer/syncbuffer.go
@@ -65,7 +65,7 @@ func (buf *SyncBuffer) WithLabel(label string) *LabeledSyncBuffer {
 // Copy reads all the content of an io.Reader into a SyncBuffer and an error if copy is failed.
 func (buf *SyncBuffer) Copy(r io.Reader) error {
 	defer buf.MarkDone()
-	_, err := io.Copy(buf, r)
+	_, err := io.Copy(&buf.buf, r)
 	if err != nil && !errors.Is(err, io.EOF) {
 		return err
 	}

--- a/internal/pkg/term/syncbuffer/termprinter.go
+++ b/internal/pkg/term/syncbuffer/termprinter.go
@@ -108,16 +108,14 @@ func (ltp *LabeledTermPrinter) Print() error {
 // If one of the buffer gets done then print entire content of the buffer.
 // Until all the buffers are written to file writer.
 func (ltp *LabeledTermPrinter) printAll() error {
-	for idx := 0; idx < len(ltp.buffers); idx++ {
-		if !ltp.buffers[idx].IsDone() {
+	for idx, buf := range ltp.buffers {
+		if !buf.IsDone() {
 			continue
 		}
 		outputLogs := ltp.buffers[idx].lines()
-		if _, err := ltp.writeLines(ltp.buffers[idx].label, outputLogs); err != nil {
+		if _, err := ltp.writeLines(buf.label, outputLogs); err != nil {
 			return fmt.Errorf("write logs: %w", err)
 		}
-		ltp.buffers = append(ltp.buffers[:idx], ltp.buffers[idx+1:]...)
-		idx--
 	}
 	return nil
 }

--- a/internal/pkg/term/syncbuffer/termprinter_test.go
+++ b/internal/pkg/term/syncbuffer/termprinter_test.go
@@ -23,7 +23,6 @@ func TestLabeledTermPrinter_Print(t *testing.T) {
 	testCases := map[string]struct {
 		inNumLines int
 		inPadding  int
-		printAll   bool
 		wanted     string
 	}{
 		"display label with given numLines": {
@@ -41,7 +40,6 @@ Building your container image 2
 		"display all the lines if numLines set to -1": {
 			inNumLines: -1,
 			inPadding:  5,
-			printAll:   true,
 			wanted: `Building your container image 1
      line1 from image1
      line2 from image1
@@ -92,14 +90,6 @@ line4 from image2`)
 				buf.MarkDone()
 			}
 			ltp.Print()
-
-			// checking multiple calls to Print will result in
-			// printing a buffer only once when it enters printAll.
-			if tc.printAll {
-				for i := 0; i < 3; i++ {
-					ltp.Print()
-				}
-			}
 
 			// THEN
 			require.Equal(t, tc.wanted, termOut.String())


### PR DESCRIPTION
This reverts commit 8175be324cdffc797b585c6ed8f67ac6941b6980 so we can have a clear pipeline this morning while we work on a fix for the e2e failure from last night.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->
Reverts #4760
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
