### PR TITLE
fix: change DNS alias in cloudfront test to match cert

### DIFF
--- a/e2e/cloudfront/copilot/frontend/manifest.yml
+++ b/e2e/cloudfront/copilot/frontend/manifest.yml
@@ -10,7 +10,7 @@ image:
 http:
   path: '/'
   redirect_to_https: false
-  alias: ["cloudfront-${TIMENOW}.${DOMAINNAME}"]
+  alias: ["e2e-cloudfront-${TIMENOW}.${DOMAINNAME}"]
 
 cpu: 256
 memory: 512


### PR DESCRIPTION
<!-- Provide summary of changes -->
This PR fixes a recurring issue with the Cloudfront e2e test. The Certificate created in the test does not match the dns alias of the frontend service, so the CF deployment fails. 
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
