### PR TITLE
fix: cloudfront validation should not error out when there is no lb service

### DIFF
--- a/internal/pkg/describe/env.go
+++ b/internal/pkg/describe/env.go
@@ -325,7 +325,7 @@ func (d *EnvDescriber) ValidateCFServiceDomainAliases() error {
 	}
 
 	servicesString, ok := stackDescr.Parameters[cfnstack.EnvParamALBWorkloadsKey]
-	if !ok {
+	if !ok || servicesString == "" {
 		return nil
 	}
 	services := strings.Split(servicesString, ",")

--- a/internal/pkg/describe/env_test.go
+++ b/internal/pkg/describe/env_test.go
@@ -672,6 +672,18 @@ func TestEnvDescriber_ValidateCFServiceDomainAliases(t *testing.T) {
 				}, nil)
 			},
 		},
+		"no load balanced services with empty value for the ALBWorkloads parameter": {
+			setupMock: func(m *envDescriberMocks) {
+				mockParams := map[string]string{
+					"AppName":         mockAppName,
+					"EnvironmentName": mockEnvName,
+					"ALBWorkloads":    "",
+				}
+				m.stackDescriber.EXPECT().Describe().Return(stack.StackDescription{
+					Parameters: mockParams,
+				}, nil)
+			},
+		},
 		"missing aliases parameter in env stack": {
 			setupMock: func(m *envDescriberMocks) {
 				mockParams := map[string]string{


### PR DESCRIPTION
`strings.Split` returns a slice of length 1: https://pkg.go.dev/strings#Split

Related: https://app.gitter.im/#/room/#aws_copilot-cli:gitter.im/$SJX0CXEU9-DydcbueSe7qVAQlIolNfkbTJtitaJlPR0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
