### PR TITLE
docs: add grace_period field to the NLB main listener 

### DIFF
--- a/site/content/docs/include/http-additionalrules-healthcheck.en.md
+++ b/site/content/docs/include/http-additionalrules-healthcheck.en.md
@@ -18,7 +18,6 @@
             unhealthy_threshold: 2
             interval: 15s
             timeout: 10s
-            grace_period: 60s
     ```
     
     <span class="parent-field">http.additional_rules.healthcheck.</span><a id="http-additional-rules-healthcheck-path" href="#http-additional-rules-healthcheck-path" class="field">`path`</a> <span class="type">String</span>  
@@ -42,6 +41,3 @@
     
     <span class="parent-field">http.additional_rules.healthcheck.</span><a id="http-additional-rules-healthcheck-timeout" href="#http-additional-rules-healthcheck-timeout" class="field">`timeout`</a> <span class="type">Duration</span>  
     The amount of time, in seconds, during which no response from a target means a failed health check. The default is 5s. Range 5s-300s.
-    
-    <span class="parent-field">http.additional_rules.healthcheck.</span><a id="http-additional-rules-healthcheck-grace-period" href="#http-additional-rules-healthcheck-grace-period" class="field">`grace_period`</a> <span class="type">Duration</span>  
-    The amount of time to ignore failing target group healthchecks on container start. The default is 60s. This can be useful to fix deployment issues for containers which take a while to become healthy and begin listening for incoming connections, or to speed up deployment of containers guaranteed to start quickly.

--- a/site/content/docs/include/nlb.en.md
+++ b/site/content/docs/include/nlb.en.md
@@ -47,6 +47,9 @@ The number of consecutive health check successes required before considering an 
 <span class="parent-field">nlb.healthcheck.</span><a id="nlb-healthcheck-unhealthy-threshold" href="#nlb-healthcheck-unhealthy-threshold" class="field">`unhealthy_threshold`</a> <span class="type">Integer</span>  
 The number of consecutive health check failures required before considering a target unhealthy. The default is 3. Range: 2-10.
 
+<span class="parent-field">nlb.healthcheck.</span><a id="nlb-healthcheck-grace-period" href="#nlb-healthcheck-grace-period" class="field">`grace_period`</a> <span class="type">Duration</span>  
+The amount of time to ignore failing target group healthchecks on container start. The default is 60s. This can be useful to fix deployment issues for containers which take a while to become healthy and begin listening for incoming connections, or to speed up deployment of containers guaranteed to start quickly.
+
 !!! info
     Per the [docs](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/target-group-health-checks.html) at the time of this writing, 'unhealthy threshold' is required to be equal to 'healthy threshold' for a Network Load Balancer.
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
https://github.com/aws/copilot-cli/pull/4734
This PR adds `grace_period` field to the NLB main listener and also removes this field from the additional listener rules for the ALB.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
