### PR TITLE
fix: access override templates using forward slashes

### DIFF
--- a/internal/pkg/template/template.go
+++ b/internal/pkg/template/template.go
@@ -244,12 +244,12 @@ func (t *Template) parse(name, path string, options ...ParseOption) (*template.T
 type WalkDirFunc func(name string, content *Content) error
 
 func (t *Template) walkDir(basePath, curPath string, data any, fn WalkDirFunc, parseOpts ...ParseOption) error {
-	entries, err := t.fs.ReadDir(filepath.Join("templates", curPath))
+	entries, err := t.fs.ReadDir(path.Join("templates", curPath))
 	if err != nil {
 		return fmt.Errorf("read dir %q: %w", curPath, err)
 	}
 	for _, entry := range entries {
-		targetPath := filepath.Join(curPath, entry.Name())
+		targetPath := path.Join(curPath, entry.Name())
 		if entry.IsDir() {
 			if err := t.walkDir(basePath, targetPath, data, fn); err != nil {
 				return err


### PR DESCRIPTION
Fix #4791 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
