### PR TITLE
chore(s3): allow content type override for upload

### DIFF
--- a/internal/pkg/addon/mocks/mock_package.go
+++ b/internal/pkg/addon/mocks/mock_package.go
@@ -8,6 +8,7 @@ import (
 	io "io"
 	reflect "reflect"
 
+	s3 "github.com/aws/copilot-cli/internal/pkg/aws/s3"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -35,16 +36,21 @@ func (m *Mockuploader) EXPECT() *MockuploaderMockRecorder {
 }
 
 // Upload mocks base method.
-func (m *Mockuploader) Upload(bucket, key string, data io.Reader) (string, error) {
+func (m *Mockuploader) Upload(bucket, key string, data io.Reader, overriders ...s3.UploadOverrider) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Upload", bucket, key, data)
+	varargs := []interface{}{bucket, key, data}
+	for _, a := range overriders {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Upload", varargs...)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Upload indicates an expected call of Upload.
-func (mr *MockuploaderMockRecorder) Upload(bucket, key, data interface{}) *gomock.Call {
+func (mr *MockuploaderMockRecorder) Upload(bucket, key, data interface{}, overriders ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upload", reflect.TypeOf((*Mockuploader)(nil).Upload), bucket, key, data)
+	varargs := append([]interface{}{bucket, key, data}, overriders...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upload", reflect.TypeOf((*Mockuploader)(nil).Upload), varargs...)
 }

--- a/internal/pkg/addon/package.go
+++ b/internal/pkg/addon/package.go
@@ -22,31 +22,34 @@ import (
 )
 
 type uploader interface {
-	Upload(bucket, key string, data io.Reader) (string, error)
+	Upload(bucket, key string, data io.Reader, overriders ...s3.UploadOverrider) (string, error)
 }
 
 // packagePropertyConfig defines how to package a particular property in a cloudformation resource.
 // There are two ways replacements occur. Given a resource configuration like:
-//  MyResource:
-//    Type: AWS::Resource::Type
-//    Properties:
-//      <Property>: file/path
+//
+//	MyResource:
+//	  Type: AWS::Resource::Type
+//	  Properties:
+//	    <Property>: file/path
 //
 // Without BucketNameProperty and ObjectKeyProperty, `file/path` is directly replaced with
 // the S3 location the contents were uploaded to, resulting in this:
-//  MyResource:
-//    Type: AWS::Resource::Type
-//    Properties:
-//      <Property>: s3://bucket/hash
+//
+//	MyResource:
+//	  Type: AWS::Resource::Type
+//	  Properties:
+//	    <Property>: s3://bucket/hash
 //
 // If BucketNameProperty and ObjectKeyProperty are set, the value of <Property> is changed to a map
 // with BucketNameProperty and ObjectKeyProperty as the keys.
-//  MyResource:
-//    Type: AWS::Resource::Type
-//    Properties:
-//      <Property>:
-//        <BucketNameProperty>: bucket
-//        <ObjectKeyProperty>: hash
+//
+//	MyResource:
+//	  Type: AWS::Resource::Type
+//	  Properties:
+//	    <Property>:
+//	      <BucketNameProperty>: bucket
+//	      <ObjectKeyProperty>: hash
 type packagePropertyConfig struct {
 	// PropertyPath is the key in a cloudformation resource's 'Properties' map to be packaged.
 	// Nested properties are represented by multiple keys in the slice, so the field

--- a/internal/pkg/cli/deploy/env_test.go
+++ b/internal/pkg/cli/deploy/env_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	cfnclient "github.com/aws/copilot-cli/internal/pkg/aws/cloudformation"
+	"github.com/aws/copilot-cli/internal/pkg/aws/s3"
 	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation"
 	cfnmocks "github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation/mocks"
 
@@ -185,7 +186,7 @@ func TestEnvDeployer_UploadArtifacts(t *testing.T) {
 				m.patcher.EXPECT().EnsureManagerRoleIsAllowedToUpload("mockS3Bucket").Return(nil)
 				crs, err := customresource.Env(fakeTemplateFS())
 				require.NoError(t, err)
-				m.s3.EXPECT().Upload("mockS3Bucket", gomock.Any(), gomock.Any()).DoAndReturn(func(_, key string, _ io.Reader) (url string, err error) {
+				m.s3.EXPECT().Upload("mockS3Bucket", gomock.Any(), gomock.Any()).DoAndReturn(func(_, key string, _ io.Reader, _ ...s3.UploadOverrider) (url string, err error) {
 					for _, cr := range crs {
 						if strings.Contains(key, strings.ToLower(cr.Name())) {
 							return "", nil

--- a/internal/pkg/cli/deploy/mocks/mock_svc.go
+++ b/internal/pkg/cli/deploy/mocks/mock_svc.go
@@ -9,6 +9,7 @@ import (
 	reflect "reflect"
 	time "time"
 
+	s3 "github.com/aws/copilot-cli/internal/pkg/aws/s3"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -36,18 +37,23 @@ func (m *Mockuploader) EXPECT() *MockuploaderMockRecorder {
 }
 
 // Upload mocks base method.
-func (m *Mockuploader) Upload(bucket, key string, data io.Reader) (string, error) {
+func (m *Mockuploader) Upload(bucket, key string, data io.Reader, overrider ...s3.UploadOverrider) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Upload", bucket, key, data)
+	varargs := []interface{}{bucket, key, data}
+	for _, a := range overrider {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Upload", varargs...)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Upload indicates an expected call of Upload.
-func (mr *MockuploaderMockRecorder) Upload(bucket, key, data interface{}) *gomock.Call {
+func (mr *MockuploaderMockRecorder) Upload(bucket, key, data interface{}, overrider ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upload", reflect.TypeOf((*Mockuploader)(nil).Upload), bucket, key, data)
+	varargs := append([]interface{}{bucket, key, data}, overrider...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upload", reflect.TypeOf((*Mockuploader)(nil).Upload), varargs...)
 }
 
 // MockversionGetter is a mock of versionGetter interface.

--- a/internal/pkg/cli/deploy/static_site.go
+++ b/internal/pkg/cli/deploy/static_site.go
@@ -60,7 +60,11 @@ func NewStaticSiteDeployer(in *WorkloadDeployerInput) (*staticSiteDeployer, erro
 			FS:                  svcDeployer.fs,
 			AssetDir:            artifactBucketAssetsDir,
 			AssetMappingFileDir: fmt.Sprintf("%s/environments/%s/workloads/%s/mapping", artifactBucketAssetsDir, svcDeployer.env.Name, svcDeployer.name),
-			Upload: func(path string, data io.Reader) error {
+			Upload: func(path string, data io.Reader, contentType ...string) error {
+				if len(contentType) != 0 {
+					_, err := svcDeployer.s3Client.Upload(svcDeployer.resources.S3Bucket, path, data, s3.CustomContentType(contentType[0]))
+					return err
+				}
 				_, err := svcDeployer.s3Client.Upload(svcDeployer.resources.S3Bucket, path, data)
 				return err
 			},

--- a/internal/pkg/cli/deploy/svc.go
+++ b/internal/pkg/cli/deploy/svc.go
@@ -15,6 +15,7 @@ import (
 	"golang.org/x/mod/semver"
 
 	awscloudformation "github.com/aws/copilot-cli/internal/pkg/aws/cloudformation"
+	"github.com/aws/copilot-cli/internal/pkg/aws/s3"
 	"github.com/aws/copilot-cli/internal/pkg/config"
 	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation"
 	"github.com/aws/copilot-cli/internal/pkg/term/color"
@@ -22,7 +23,7 @@ import (
 )
 
 type uploader interface {
-	Upload(bucket, key string, data io.Reader) (string, error)
+	Upload(bucket, key string, data io.Reader, overrider ...s3.UploadOverrider) (string, error)
 }
 
 type versionGetter interface {

--- a/internal/pkg/cli/deploy/workload_test.go
+++ b/internal/pkg/cli/deploy/workload_test.go
@@ -21,6 +21,7 @@ import (
 	sdkcfn "github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/copilot-cli/internal/pkg/aws/cloudformation"
 	"github.com/aws/copilot-cli/internal/pkg/aws/ecs"
+	"github.com/aws/copilot-cli/internal/pkg/aws/s3"
 	"github.com/aws/copilot-cli/internal/pkg/cli/deploy/mocks"
 	"github.com/aws/copilot-cli/internal/pkg/config"
 	"github.com/aws/copilot-cli/internal/pkg/deploy"
@@ -355,7 +356,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 				// Ensure all custom resources were uploaded.
 				crs, err := customresource.LBWS(fakeTemplateFS())
 				require.NoError(t, err)
-				m.mockUploader.EXPECT().Upload(mockS3Bucket, gomock.Any(), gomock.Any()).DoAndReturn(func(_, key string, _ io.Reader) (url string, err error) {
+				m.mockUploader.EXPECT().Upload(mockS3Bucket, gomock.Any(), gomock.Any()).DoAndReturn(func(_, key string, _ io.Reader, _ ...s3.UploadOverrider) (url string, err error) {
 					for _, cr := range crs {
 						if strings.Contains(key, strings.ToLower(cr.Name())) {
 							return "", nil
@@ -383,7 +384,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 				// Ensure all custom resources were uploaded.
 				crs, err := customresource.Backend(fakeTemplateFS())
 				require.NoError(t, err)
-				m.mockUploader.EXPECT().Upload(mockS3Bucket, gomock.Any(), gomock.Any()).DoAndReturn(func(_, key string, _ io.Reader) (url string, err error) {
+				m.mockUploader.EXPECT().Upload(mockS3Bucket, gomock.Any(), gomock.Any()).DoAndReturn(func(_, key string, _ io.Reader, _ ...s3.UploadOverrider) (url string, err error) {
 					for _, cr := range crs {
 						if strings.Contains(key, strings.ToLower(cr.Name())) {
 							return "", nil
@@ -411,7 +412,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 				// Ensure all custom resources were uploaded.
 				crs, err := customresource.Worker(fakeTemplateFS())
 				require.NoError(t, err)
-				m.mockUploader.EXPECT().Upload(mockS3Bucket, gomock.Any(), gomock.Any()).DoAndReturn(func(_, key string, _ io.Reader) (url string, err error) {
+				m.mockUploader.EXPECT().Upload(mockS3Bucket, gomock.Any(), gomock.Any()).DoAndReturn(func(_, key string, _ io.Reader, _ ...s3.UploadOverrider) (url string, err error) {
 					for _, cr := range crs {
 						if strings.Contains(key, strings.ToLower(cr.Name())) {
 							return "", nil
@@ -439,7 +440,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 				// Ensure all custom resources were uploaded.
 				crs, err := customresource.RDWS(fakeTemplateFS())
 				require.NoError(t, err)
-				m.mockUploader.EXPECT().Upload(mockS3Bucket, gomock.Any(), gomock.Any()).DoAndReturn(func(_, key string, _ io.Reader) (url string, err error) {
+				m.mockUploader.EXPECT().Upload(mockS3Bucket, gomock.Any(), gomock.Any()).DoAndReturn(func(_, key string, _ io.Reader, _ ...s3.UploadOverrider) (url string, err error) {
 					for _, cr := range crs {
 						if strings.Contains(key, strings.ToLower(cr.Name())) {
 							return "", nil
@@ -467,7 +468,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 				// Ensure all custom resources were uploaded.
 				crs, err := customresource.ScheduledJob(fakeTemplateFS())
 				require.NoError(t, err)
-				m.mockUploader.EXPECT().Upload(mockS3Bucket, gomock.Any(), gomock.Any()).DoAndReturn(func(_, key string, _ io.Reader) (url string, err error) {
+				m.mockUploader.EXPECT().Upload(mockS3Bucket, gomock.Any(), gomock.Any()).DoAndReturn(func(_, key string, _ io.Reader, _ ...s3.UploadOverrider) (url string, err error) {
 					for _, cr := range crs {
 						if strings.Contains(key, strings.ToLower(cr.Name())) {
 							return "", nil

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/aws/codepipeline"
 	"github.com/aws/copilot-cli/internal/pkg/aws/ec2"
 	awsecs "github.com/aws/copilot-cli/internal/pkg/aws/ecs"
+	"github.com/aws/copilot-cli/internal/pkg/aws/s3"
 	"github.com/aws/copilot-cli/internal/pkg/aws/secretsmanager"
 	"github.com/aws/copilot-cli/internal/pkg/aws/ssm"
 	clideploy "github.com/aws/copilot-cli/internal/pkg/cli/deploy"
@@ -346,7 +347,7 @@ type wsWriter interface {
 }
 
 type uploader interface {
-	Upload(bucket, key string, data io.Reader) (string, error)
+	Upload(bucket, key string, data io.Reader, overriders ...s3.UploadOverrider) (string, error)
 }
 
 type bucketEmptier interface {

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -15,6 +15,7 @@ import (
 	codepipeline "github.com/aws/copilot-cli/internal/pkg/aws/codepipeline"
 	ec2 "github.com/aws/copilot-cli/internal/pkg/aws/ec2"
 	ecs "github.com/aws/copilot-cli/internal/pkg/aws/ecs"
+	s3 "github.com/aws/copilot-cli/internal/pkg/aws/s3"
 	secretsmanager "github.com/aws/copilot-cli/internal/pkg/aws/secretsmanager"
 	ssm "github.com/aws/copilot-cli/internal/pkg/aws/ssm"
 	deploy "github.com/aws/copilot-cli/internal/pkg/cli/deploy"
@@ -3666,18 +3667,23 @@ func (m *Mockuploader) EXPECT() *MockuploaderMockRecorder {
 }
 
 // Upload mocks base method.
-func (m *Mockuploader) Upload(bucket, key string, data io.Reader) (string, error) {
+func (m *Mockuploader) Upload(bucket, key string, data io.Reader, overriders ...s3.UploadOverrider) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Upload", bucket, key, data)
+	varargs := []interface{}{bucket, key, data}
+	for _, a := range overriders {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Upload", varargs...)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Upload indicates an expected call of Upload.
-func (mr *MockuploaderMockRecorder) Upload(bucket, key, data interface{}) *gomock.Call {
+func (mr *MockuploaderMockRecorder) Upload(bucket, key, data interface{}, overriders ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upload", reflect.TypeOf((*Mockuploader)(nil).Upload), bucket, key, data)
+	varargs := append([]interface{}{bucket, key, data}, overriders...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upload", reflect.TypeOf((*Mockuploader)(nil).Upload), varargs...)
 }
 
 // MockbucketEmptier is a mock of bucketEmptier interface.

--- a/internal/pkg/deploy/cloudformation/cloudformation.go
+++ b/internal/pkg/deploy/cloudformation/cloudformation.go
@@ -129,7 +129,7 @@ type codePipelineClient interface {
 }
 
 type s3Client interface {
-	Upload(bucket, fileName string, data io.Reader) (string, error)
+	Upload(bucket, fileName string, data io.Reader, overriders ...s3.UploadOverrider) (string, error)
 }
 
 type stackSetClient interface {

--- a/internal/pkg/deploy/cloudformation/mocks/mock_cloudformation.go
+++ b/internal/pkg/deploy/cloudformation/mocks/mock_cloudformation.go
@@ -14,6 +14,7 @@ import (
 	stackset "github.com/aws/copilot-cli/internal/pkg/aws/cloudformation/stackset"
 	cloudwatch "github.com/aws/copilot-cli/internal/pkg/aws/cloudwatch"
 	ecs "github.com/aws/copilot-cli/internal/pkg/aws/ecs"
+	s3 "github.com/aws/copilot-cli/internal/pkg/aws/s3"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -645,18 +646,23 @@ func (m *Mocks3Client) EXPECT() *Mocks3ClientMockRecorder {
 }
 
 // Upload mocks base method.
-func (m *Mocks3Client) Upload(bucket, fileName string, data io.Reader) (string, error) {
+func (m *Mocks3Client) Upload(bucket, fileName string, data io.Reader, overriders ...s3.UploadOverrider) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Upload", bucket, fileName, data)
+	varargs := []interface{}{bucket, fileName, data}
+	for _, a := range overriders {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Upload", varargs...)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Upload indicates an expected call of Upload.
-func (mr *Mocks3ClientMockRecorder) Upload(bucket, fileName, data interface{}) *gomock.Call {
+func (mr *Mocks3ClientMockRecorder) Upload(bucket, fileName, data interface{}, overriders ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upload", reflect.TypeOf((*Mocks3Client)(nil).Upload), bucket, fileName, data)
+	varargs := append([]interface{}{bucket, fileName, data}, overriders...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upload", reflect.TypeOf((*Mocks3Client)(nil).Upload), varargs...)
 }
 
 // MockstackSetClient is a mock of stackSetClient interface.


### PR DESCRIPTION
<!-- Provide summary of changes -->
After https://github.com/aws/copilot-cli/pull/4847 we upload with default content type based on the key. However, for static assets upload, we always use hashed key when uploading to the cache bucket. Thus, we need a way to specify the content type for the original object.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
