### PR TITLE
chore: static site copy should use correct content-type

### DIFF
--- a/cf-custom-resources/lib/copy-assets.js
+++ b/cf-custom-resources/lib/copy-assets.js
@@ -9,10 +9,19 @@ const aws = require("aws-sdk");
  * Main handler, invoked by Lambda
  */
 exports.handler = async function (event, context, callback) {
-	const s3 = new aws.S3();
-	await s3.copyObject({
-		CopySource: event.srcBucket + "/" + event.mapping.path,
-		Bucket: event.destBucket,
-		Key: event.mapping.destPath
-	}).promise();
+  const s3 = new aws.S3();
+  await s3
+    .copyObject({
+      CopySource: event.srcBucket + "/" + event.mapping.path,
+      Bucket: event.destBucket,
+      Key: event.mapping.destPath,
+      ContentType:
+        event.mapping.contentType !== ""
+          ? event.mapping.contentType
+          : undefined,
+      // Required otherwise ContentType won't be applied.
+      // See https://github.com/aws/aws-sdk-js/issues/1092 for more.
+      MetadataDirective: "REPLACE",
+    })
+    .promise();
 };

--- a/cf-custom-resources/test/copy-assets-test.js
+++ b/cf-custom-resources/test/copy-assets-test.js
@@ -24,13 +24,16 @@ describe("copy assets", () => {
         mapping: {
           path: "mockPath",
           destPath: "mockDestPath",
-        }
+          contentType: "",
+        },
       })
-      .expectResolve(result => {
+      .expectResolve((result) => {
         sinon.assert.calledWith(fake, {
           CopySource: "mockSrcBucket/mockPath",
           Bucket: "mockDestBucket",
-          Key: "mockDestPath"
+          Key: "mockDestPath",
+          ContentType: undefined,
+          MetadataDirective: "REPLACE",
         });
       });
   });
@@ -46,13 +49,16 @@ describe("copy assets", () => {
         mapping: {
           path: "mockPath",
           destPath: "mockDestPath",
-        }
+          contentType: "mockContentType",
+        },
       })
-      .expectReject(err => {
+      .expectReject((err) => {
         sinon.assert.calledWith(fake, {
           CopySource: "mockSrcBucket/mockPath",
           Bucket: "mockDestBucket",
-          Key: "mockDestPath"
+          Key: "mockDestPath",
+          ContentType: "mockContentType",
+          MetadataDirective: "REPLACE",
         });
         expect(err).toEqual(new Error("some error"));
       });

--- a/internal/pkg/deploy/upload/asset/asset.go
+++ b/internal/pkg/deploy/upload/asset/asset.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"mime"
 	"path"
 	"path/filepath"
 	"sort"
@@ -43,6 +44,7 @@ type asset struct {
 
 	ArtifactBucketPath string `json:"path"`
 	ServiceBucketPath  string `json:"destPath"`
+	ContentType        string `json:"contentType"`
 }
 
 // UploadFiles hashes each of the files specified in files and uploads
@@ -121,6 +123,7 @@ func (u *ArtifactBucketUploader) walkFn(sourcePath, destPath string, recursive b
 			content:            buf,
 			ArtifactBucketPath: path.Join(u.AssetDir, hex.EncodeToString(hash.Sum(nil))),
 			ServiceBucketPath:  filepath.ToSlash(dest),
+			ContentType:        mime.TypeByExtension(filepath.Ext(fpath)),
 		})
 		return nil
 	}
@@ -180,12 +183,12 @@ func (u *ArtifactBucketUploader) uploadAssetMappingFile(assets []asset) (string,
 
 // dedupe returns a copy of assets with duplicate entries removed.
 func dedupe(assets []asset) []asset {
-	type key struct{ a, b string }
+	type key struct{ a, b, c string }
 	has := make(map[key]bool)
 	out := make([]asset, 0, len(assets))
 
 	for i := range assets {
-		key := key{assets[i].ArtifactBucketPath, assets[i].ServiceBucketPath}
+		key := key{assets[i].ArtifactBucketPath, assets[i].ServiceBucketPath, assets[i].ContentType}
 		if has[key] {
 			continue
 		}

--- a/internal/pkg/deploy/upload/asset/asset_test.go
+++ b/internal/pkg/deploy/upload/asset/asset_test.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"mime"
 	"path"
 	"sync"
 	"testing"
@@ -116,7 +117,7 @@ func Test_UploadFiles(t *testing.T) {
 			},
 			expected: []asset{
 				newAsset("foo", mockContent3, ""),
-				newAsset("manifest.yaml", mockContent2, ""),
+				newAsset("manifest.yaml", mockContent2, mime.TypeByExtension(".yaml")),
 			},
 		},
 		"success with include only": {
@@ -177,7 +178,7 @@ func Test_UploadFiles(t *testing.T) {
 				afero.WriteFile(fs, "copilot/prod/foo.yaml", []byte(mockContent3), 0644)
 			},
 			expected: []asset{
-				newAsset("files/copilot/prod/manifest.yaml", mockContent2, ""),
+				newAsset("files/copilot/prod/manifest.yaml", mockContent2, mime.TypeByExtension(".yaml")),
 				newAsset("files/test/copilot/.workspace", mockContent1, ""),
 			},
 		},
@@ -230,8 +231,8 @@ func Test_UploadFiles(t *testing.T) {
 				afero.WriteFile(fs, "dir/file.txt", []byte(mockContent1), 0644)
 			},
 			expected: []asset{
-				newAsset("dir/file.json", mockContent1, "application/json"),
-				newAsset("dir/file.txt", mockContent1, "text/plain; charset=utf-8"),
+				newAsset("dir/file.json", mockContent1, mime.TypeByExtension(".json")),
+				newAsset("dir/file.txt", mockContent1, mime.TypeByExtension(".txt")),
 			},
 		},
 		"duplicate content to separate destinations sorted": {
@@ -249,8 +250,8 @@ func Test_UploadFiles(t *testing.T) {
 			},
 			expected: []asset{
 				// dir/file.txt sorts before file.txt
-				newAsset("dir/file.txt", mockContent1, "text/plain; charset=utf-8"),
-				newAsset("file.txt", mockContent1, "text/plain; charset=utf-8"),
+				newAsset("dir/file.txt", mockContent1, mime.TypeByExtension(".txt")),
+				newAsset("file.txt", mockContent1, mime.TypeByExtension(".txt")),
 			},
 		},
 	}


### PR DESCRIPTION
<!-- Provide summary of changes -->
An alternative way solving content-type issue instead of https://github.com/aws/copilot-cli/pull/4857. Resolving the possible edge case when two identical files use different extensions.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
