### PR TITLE
fix: remove docker version from buildspec

### DIFF
--- a/internal/pkg/template/templates/cicd/buildspec.yml
+++ b/internal/pkg/template/templates/cicd/buildspec.yml
@@ -3,7 +3,6 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      docker: 20
       ruby: 3.1
       nodejs: 16
     commands:


### PR DESCRIPTION
<!-- Provide summary of changes -->
Specifying docker runtime version is deprecated. 

Below is the log when using docker version 20.

<img width="1053" alt="Screenshot 2023-05-10 at 11 57 46 AM" src="https://github.com/aws/copilot-cli/assets/71282729/b5a46931-fdf3-4586-89de-d120e880fc6e">


<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
