### PR TITLE
chore(templates): remove unnecessary !Sub in Aurora Serverless v2 template

### DIFF
--- a/internal/pkg/template/templates/addons/aurora/env/serverlessv2.yml
+++ b/internal/pkg/template/templates/addons/aurora/env/serverlessv2.yml
@@ -44,7 +44,7 @@ Resources:
       'aws:copilot:description': 'A security group for one or more workloads to access the Aurora Serverless v2 cluster {{logicalIDSafe .ClusterName}}'
     Type: 'AWS::EC2::SecurityGroup'
     Properties:
-      GroupDescription: !Sub 'The Security Group to access Aurora Serverless v2 cluster {{logicalIDSafe .ClusterName}}.'
+      GroupDescription: 'The Security Group to access Aurora Serverless v2 cluster {{logicalIDSafe .ClusterName}}.'
       VpcId: !Ref VPCID
       Tags:
         - Key: Name


### PR DESCRIPTION
!Sub not needed here as the string does not use CF-variables?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
