### PR TITLE
chore(e2e): switch to ignoring err

### DIFF
--- a/e2e/apprunner/apprunner_suite_test.go
+++ b/e2e/apprunner/apprunner_suite_test.go
@@ -44,8 +44,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	err = command.Run("aws", []string{"ssm", "add-tags-to-resource", "--resource-type", "Parameter", "--resource-id", ssmName, "--tags", "[{\"Key\":\"copilot-application\",\"Value\":\"" + appName + "\"},{\"Key\":\"copilot-environment\", \"Value\":\"" + envName + "\"}]"})
 	Expect(err).NotTo(HaveOccurred())
-	err = command.Run("aws", []string{"secretsmanager", "create-secret", "--name", secretName, "--force-overwrite-replica-secret", "--secret-string", "\"{\"user\":\"diegor\",\"password\":\"EXAMPLE-PASSWORD\"}\"", "--tags", "[{\"Key\":\"copilot-application\",\"Value\":\"" + appName + "\"},{\"Key\":\"copilot-environment\", \"Value\":\"" + envName + "\"}]"})
-	Expect(err).NotTo(HaveOccurred())
+	_ = command.Run("aws", []string{"secretsmanager", "create-secret", "--name", secretName, "--secret-string", "\"{\"user\":\"diegor\",\"password\":\"EXAMPLE-PASSWORD\"}\"", "--tags", "[{\"Key\":\"copilot-application\",\"Value\":\"" + appName + "\"},{\"Key\":\"copilot-environment\", \"Value\":\"" + envName + "\"}]"})
 })
 
 var _ = AfterSuite(func() {


### PR DESCRIPTION
Going back to the solution presented in #4871. The `--force-overwrite-replica-secret` apparently overwrites secrets for replica regions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
