### PR TITLE
chore(e2e): apprunner test suite should refer to secrets by the correct name

### DIFF
--- a/e2e/apprunner/apprunner_suite_test.go
+++ b/e2e/apprunner/apprunner_suite_test.go
@@ -5,6 +5,7 @@ package apprunner_test
 
 import (
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -39,10 +40,15 @@ var _ = BeforeSuite(func() {
 	var err error
 	cli, err = client.NewCLI()
 	Expect(err).NotTo(HaveOccurred())
-	Expect(err).NotTo(HaveOccurred())
+
 	appName = fmt.Sprintf("e2e-apprunner-%d", time.Now().Unix())
 	ssmName = fmt.Sprintf("%s-%s", appName, "ssm")
+	err = os.Setenv("SSM_NAME", ssmName)
+	Expect(err).NotTo(HaveOccurred())
 	secretName = fmt.Sprintf("%s-%s", appName, "secretsmanager")
+	err = os.Setenv("SECRETS_MANAGER_NAME", secretName)
+	Expect(err).NotTo(HaveOccurred())
+
 	err = command.Run("aws", []string{"ssm", "put-parameter", "--name", ssmName, "--overwrite", "--value", "abcd1234", "--type", "String"})
 	Expect(err).NotTo(HaveOccurred())
 	err = command.Run("aws", []string{"ssm", "add-tags-to-resource", "--resource-type", "Parameter", "--resource-id", ssmName, "--tags", "[{\"Key\":\"copilot-application\",\"Value\":\"" + appName + "\"},{\"Key\":\"copilot-environment\", \"Value\":\"" + envName + "\"}]"})

--- a/e2e/apprunner/copilot/front-end/manifest.yml
+++ b/e2e/apprunner/copilot/front-end/manifest.yml
@@ -31,6 +31,6 @@ memory: 2048
 # Number of tasks that should be running in your service.
 
 secrets:                      # Pass secrets from AWS Systems Manager (SSM) Parameter Store and Secrets Manager.
-  my-ssm-param: e2e-apprunner-ssm-param-secret
+  my-ssm-param: ${SSM_NAME}
   USER_CREDS: 
-    secretsmanager: 'e2e-apprunner-secrets-manager-secret'
+    secretsmanager: '${SECRETS_MANAGER_NAME}'


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
