### PR TITLE
chore(cli): highlight individual URIs rather than string of URIs

### DIFF
--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -518,7 +518,7 @@ func (o *deploySvcOpts) uriRecommendedActions() ([]string, error) {
 	}
 
 	return []string{
-		fmt.Sprintf("You can access your service at %s %s", color.HighlightResource(uri.URI), network),
+		fmt.Sprintf("You can access your service at %s %s", uri.URI, network),
 	}, nil
 }
 

--- a/internal/pkg/describe/uri.go
+++ b/internal/pkg/describe/uri.go
@@ -5,6 +5,7 @@ package describe
 
 import (
 	"fmt"
+	"github.com/aws/copilot-cli/internal/pkg/term/color"
 	"strings"
 
 	"github.com/dustin/go-humanize/english"
@@ -372,7 +373,7 @@ type nlbURI struct {
 func (u *LBWebServiceURI) String() string {
 	uris := u.access.strings()
 	for _, dnsName := range u.nlbURI.DNSNames {
-		uris = append(uris, fmt.Sprintf("%s:%s", dnsName, u.nlbURI.Port))
+		uris = append(uris, color.HighlightResource(fmt.Sprintf("%s:%s", dnsName, u.nlbURI.Port)))
 	}
 	return english.OxfordWordSeries(uris, "or")
 }
@@ -388,7 +389,7 @@ func (u *accessURI) strings() []string {
 		if u.Path != "/" {
 			path = fmt.Sprintf("/%s", u.Path)
 		}
-		uris = append(uris, protocol+dnsName+path)
+		uris = append(uris, color.HighlightResource(protocol+dnsName+path))
 	}
 	return uris
 }


### PR DESCRIPTION
Tiny UX improvement.
Previously, when outputting URIs at which services can be accessed, we would highlight the entire list:
<img width="1169" alt="Screenshot 2023-05-23 at 10 44 24 AM" src="https://github.com/aws/copilot-cli/assets/60631893/efd209c3-7f52-4a33-afdd-df0dc6443473">
This made it hard to individuate the URIs at a glance. This change highlights the URIs individually before stringing them together.
<img width="1165" alt="Screenshot 2023-05-23 at 10 47 42 AM" src="https://github.com/aws/copilot-cli/assets/60631893/6bd2d559-5d64-4037-a988-641fef234dc9">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
