### PR TITLE
chore(e2e): change the alias used by `app-with-domain` 

### DIFF
--- a/e2e/app-with-domain/app_with_domain_test.go
+++ b/e2e/app-with-domain/app_with_domain_test.go
@@ -9,10 +9,8 @@ import (
 	"sync"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-
 	"github.com/aws/copilot-cli/e2e/internal/client"
+	. "github.com/onsi/ginkgo/v2"
 )
 
 var _ = Describe("App With Domain", func() {
@@ -249,7 +247,7 @@ var _ = Describe("App With Domain", func() {
 			Expect(len(svc.Routes)).To(Equal(2))
 
 			wantedURLs := map[string]string{
-				"test": "https://test.copilot-e2e-tests.ecs.aws.dev",
+				"test": "https://hello.copilot-e2e-tests.ecs.aws.dev",
 				"prod": "https://prod.copilot-e2e-tests.ecs.aws.dev",
 			}
 			for _, route := range svc.Routes {

--- a/e2e/app-with-domain/app_with_domain_test.go
+++ b/e2e/app-with-domain/app_with_domain_test.go
@@ -9,8 +9,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/aws/copilot-cli/e2e/internal/client"
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/aws/copilot-cli/e2e/internal/client"
 )
 
 var _ = Describe("App With Domain", func() {

--- a/e2e/app-with-domain/app_with_domain_test.go
+++ b/e2e/app-with-domain/app_with_domain_test.go
@@ -249,8 +249,8 @@ var _ = Describe("App With Domain", func() {
 			Expect(len(svc.Routes)).To(Equal(2))
 
 			wantedURLs := map[string]string{
-				"test": "https://hello.copilot-e2e-tests.ecs.aws.dev",
-				"prod": "https://prod.copilot-e2e-tests.ecs.aws.dev",
+				"test": "https://hello-test-app-domain.copilot-e2e-tests.ecs.aws.dev",
+				"prod": "https://hello-prod-app-domain.copilot-e2e-tests.ecs.aws.dev",
 			}
 			for _, route := range svc.Routes {
 				// Validate route has the expected HTTPS endpoint.

--- a/e2e/app-with-domain/app_with_domain_test.go
+++ b/e2e/app-with-domain/app_with_domain_test.go
@@ -278,7 +278,7 @@ var _ = Describe("App With Domain", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(svc.Routes)).To(Equal(1))
 			wantedURLs = map[string]string{
-				"test": "https://copilot-e2e-tests.ecs.aws.dev or https://frontend.copilot-e2e-tests.ecs.aws.dev",
+				"test": "https://copilot-e2e-tests.ecs.aws.dev or https://frontend-app-domain.copilot-e2e-tests.ecs.aws.dev",
 			}
 			// Validate route has the expected HTTPS endpoint.
 			route := svc.Routes[0]

--- a/e2e/app-with-domain/copilot/frontend/manifest.yml
+++ b/e2e/app-with-domain/copilot/frontend/manifest.yml
@@ -9,7 +9,7 @@ image:
 
 http:
   path: '/'
-  alias: ["frontend.copilot-e2e-tests.ecs.aws.dev", "copilot-e2e-tests.ecs.aws.dev"]
+  alias: ["frontend-app-domain.copilot-e2e-tests.ecs.aws.dev", "copilot-e2e-tests.ecs.aws.dev"]
 
 cpu: 256
 memory: 512

--- a/e2e/app-with-domain/copilot/hello/manifest.yml
+++ b/e2e/app-with-domain/copilot/hello/manifest.yml
@@ -9,7 +9,7 @@ image:
 
 http:
   path: '/'
-  alias: hello.copilot-e2e-tests.ecs.aws.dev
+  alias: hello-test-app-domain.copilot-e2e-tests.ecs.aws.dev
 
 cpu: 256
 memory: 512
@@ -18,4 +18,4 @@ count: 1
 environments:
   prod:
     http:
-      alias: prod.copilot-e2e-tests.ecs.aws.dev
+      alias: hello-prod-app-domain.copilot-e2e-tests.ecs.aws.dev

--- a/e2e/app-with-domain/copilot/hello/manifest.yml
+++ b/e2e/app-with-domain/copilot/hello/manifest.yml
@@ -9,7 +9,7 @@ image:
 
 http:
   path: '/'
-  alias: test.copilot-e2e-tests.ecs.aws.dev
+  alias: hello.copilot-e2e-tests.ecs.aws.dev
 
 cpu: 256
 memory: 512

--- a/e2e/import-certs/copilot/frontend/manifest.yml
+++ b/e2e/import-certs/copilot/frontend/manifest.yml
@@ -8,7 +8,7 @@ image:
 
 http:
   path: '/'
-  alias: "test.copilot-e2e-tests.ecs.aws.dev"
+  alias: "frontend-test-imported-cert.copilot-e2e-tests.ecs.aws.dev"
   hosted_zone: "Z0512687YJJFTKMRQUQR"
 
 cpu: 256

--- a/e2e/import-certs/import_cert_test.go
+++ b/e2e/import-certs/import_cert_test.go
@@ -101,7 +101,7 @@ var _ = Describe("Import Certificates", func() {
 			Expect(len(svc.Routes)).To(Equal(1))
 
 			wantedURLs := map[string]string{
-				"test": "https://test.copilot-e2e-tests.ecs.aws.dev",
+				"test": "https://frontend-test-imported-cert.copilot-e2e-tests.ecs.aws.dev",
 			}
 			for _, route := range svc.Routes {
 				// Validate route has the expected HTTPS endpoint.


### PR DESCRIPTION
Because it clashes with the alias used by `imported-cert` causing transient error sometimes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
