### PR TITLE
chore(cicd): add fail-fast flag for regression test

### DIFF
--- a/.release/buildspec_regression.yml
+++ b/.release/buildspec_regression.yml
@@ -40,4 +40,4 @@ phases:
       - chmod +x ./copilot-linux-${FROM_VERSION}
       - export REGRESSION_TEST_FROM_PATH=../../copilot-linux-${FROM_VERSION}
       - export REGRESSION_TEST_TO_PATH=../../bin/local/copilot-linux-amd64
-      - cd regression/${TEST_SUITE} && ginkgo -v -r -noColor --timeout=1h30m
+      - cd regression/${TEST_SUITE} && ginkgo -v -r -noColor --timeout=1h30m --fail-fast


### PR DESCRIPTION
Same as #4890

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
