### PR TITLE
chore(cicd): fix the wrong secretsmanager name in e2e buildspec

### DIFF
--- a/.release/buildspec_e2e.yml
+++ b/.release/buildspec_e2e.yml
@@ -4,7 +4,7 @@ env:
   secrets-manager:
     DOCKERHUB_USERNAME: prod/ecs-cicd-bot/dockerhub-account-info:username
     DOCKERHUB_TOKEN: prod/ecs-cicd-bot/dockerhub-token:dockerhub-token
-    IMPORTED_CERT_ARN: e2e/account/import-certs:cert_arn
+    IMPORTED_CERT_ARN: e2e/account/import_certs:cert_arn
 
 # We increased the number of VPCs limit to 15 from 5 in the e2e test's app account/region pair.
 # If the number of tests running in a region is larger than 15, this comment should be updated.


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
