### PR TITLE
fix: svc package should apply override when static site

### DIFF
--- a/internal/pkg/cli/deploy/static_site.go
+++ b/internal/pkg/cli/deploy/static_site.go
@@ -108,9 +108,7 @@ func (d *staticSiteDeployer) DeployWorkload(in *DeployWorkloadInput) (ActionReco
 	if err != nil {
 		return nil, err
 	}
-	if err := d.deploy(in.Options, svcStackConfigurationOutput{
-		conf: cloudformation.WrapWithTemplateOverrider(conf, d.overrider),
-	}); err != nil {
+	if err := d.deploy(in.Options, svcStackConfigurationOutput{conf: conf}); err != nil {
 		return nil, err
 	}
 	return noopActionRecommender{}, nil
@@ -176,7 +174,7 @@ func (d *staticSiteDeployer) stackConfiguration(in *StackRuntimeConfiguration) (
 	if err != nil {
 		return nil, fmt.Errorf("create stack configuration: %w", err)
 	}
-	return conf, nil
+	return cloudformation.WrapWithTemplateOverrider(conf, d.overrider), nil
 }
 
 func (d *staticSiteDeployer) validateSources() error {


### PR DESCRIPTION
<!-- Provide summary of changes -->
currently override doesn't get applied to svc package output when svc type is static site. This PR fixes this issue.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
