### PR TITLE
chore(cli): add S3 bucket object tree to `svc show`

### DIFF
--- a/internal/pkg/aws/ecr/ecr_test.go
+++ b/internal/pkg/aws/ecr/ecr_test.go
@@ -413,7 +413,7 @@ func TestClearRepository(t *testing.T) {
 			},
 			wantError: nil,
 		},
-		"returns error if fail to check repo existance": {
+		"returns error if fail to check repo existence": {
 			mockECRClient: func(m *mocks.Mockapi) {
 				m.EXPECT().DescribeImages(&ecr.DescribeImagesInput{
 					RepositoryName: aws.String(mockRepoName),
@@ -421,7 +421,7 @@ func TestClearRepository(t *testing.T) {
 			},
 			wantError: fmt.Errorf("ecr repo mockRepoName describe images: %w", mockAwsError),
 		},
-		"returns error if fail to check repo existance because of non-awserr error type": {
+		"returns error if fail to check repo existence because of non-awserr error type": {
 			mockECRClient: func(m *mocks.Mockapi) {
 				m.EXPECT().DescribeImages(&ecr.DescribeImagesInput{
 					RepositoryName: aws.String(mockRepoName),

--- a/internal/pkg/aws/s3/mocks/mock_s3.go
+++ b/internal/pkg/aws/s3/mocks/mock_s3.go
@@ -123,6 +123,21 @@ func (mr *Mocks3APIMockRecorder) ListObjectVersions(input interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListObjectVersions", reflect.TypeOf((*Mocks3API)(nil).ListObjectVersions), input)
 }
 
+// ListObjectsV2 mocks base method.
+func (m *Mocks3API) ListObjectsV2(input *s3.ListObjectsV2Input) (*s3.ListObjectsV2Output, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListObjectsV2", input)
+	ret0, _ := ret[0].(*s3.ListObjectsV2Output)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListObjectsV2 indicates an expected call of ListObjectsV2.
+func (mr *Mocks3APIMockRecorder) ListObjectsV2(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListObjectsV2", reflect.TypeOf((*Mocks3API)(nil).ListObjectsV2), input)
+}
+
 // MockNamedBinary is a mock of NamedBinary interface.
 type MockNamedBinary struct {
 	ctrl     *gomock.Controller

--- a/internal/pkg/aws/s3/s3.go
+++ b/internal/pkg/aws/s3/s3.go
@@ -82,12 +82,12 @@ func (s *S3) EmptyBucket(bucket string) error {
 	var listResp *s3.ListObjectVersionsOutput
 	var err error
 
-	isBucket, err := s.isBucket(bucket)
+	bucketExists, err := s.bucketExists(bucket)
 	if err != nil {
 		return fmt.Errorf("unable to determine the existence of bucket %s: %w", bucket, err)
 	}
 
-	if !isBucket {
+	if !bucketExists {
 		return nil
 	}
 
@@ -194,7 +194,7 @@ func FormatARN(partition, location string) string {
 	return fmt.Sprintf("arn:%s:s3:::%s", partition, location)
 }
 
-func (s *S3) isBucket(bucket string) (bool, error) {
+func (s *S3) bucketExists(bucket string) (bool, error) {
 	input := &s3.HeadBucketInput{
 		Bucket: aws.String(bucket),
 	}
@@ -211,7 +211,7 @@ func (s *S3) isBucket(bucket string) (bool, error) {
 
 // GetBucketTree retrieves the objects in an S3 bucket and creates an ASCII tree representing their folder structure.
 func (s *S3) GetBucketTree(bucket string) (string, error) {
-	exists, err := s.isBucket(bucket)
+	exists, err := s.bucketExists(bucket)
 	if err != nil {
 		return "", fmt.Errorf("unable to determine the existence of bucket %s: %w", bucket, err)
 	}

--- a/internal/pkg/aws/s3/s3.go
+++ b/internal/pkg/aws/s3/s3.go
@@ -213,7 +213,7 @@ func (s *S3) bucketExists(bucket string) (bool, error) {
 func (s *S3) GetBucketTree(bucket string) (string, error) {
 	exists, err := s.bucketExists(bucket)
 	if err != nil {
-		return "", fmt.Errorf("unable to determine the existence of bucket %s: %w", bucket, err)
+		return "", err
 	}
 	if !exists {
 		return "", nil

--- a/internal/pkg/aws/s3/s3_test.go
+++ b/internal/pkg/aws/s3/s3_test.go
@@ -612,7 +612,7 @@ func TestS3_GetBucketTree(t *testing.T) {
 			setupMocks: func(m s3Mocks) {
 				m.s3API.EXPECT().HeadBucket(&s3.HeadBucketInput{Bucket: mockBucket}).Return(&s3.HeadBucketOutput{}, errors.New("some error"))
 			},
-			wantErr: errors.New("unable to determine the existence of bucket bucketName: some error"),
+			wantErr: errors.New("some error"),
 		},
 		"should wrap error if fail to list objects": {
 			setupMocks: func(m s3Mocks) {

--- a/internal/pkg/aws/s3/s3_test.go
+++ b/internal/pkg/aws/s3/s3_test.go
@@ -274,7 +274,7 @@ func TestS3_EmptyBucket(t *testing.T) {
 				}).Return(nil, awserr.New("Unknown", "message", nil))
 			},
 
-			wantErr: fmt.Errorf("unable to determine the existance of bucket %s: %w", "mockBucket",
+			wantErr: fmt.Errorf("unable to determine the existence of bucket %s: %w", "mockBucket",
 				awserr.New("Unknown", "message", nil)),
 		},
 		"some objects failed to delete": {

--- a/internal/pkg/describe/mocks/mock_service.go
+++ b/internal/pkg/describe/mocks/mock_service.go
@@ -708,3 +708,79 @@ func (mr *MockcwAlarmDescriberMockRecorder) AlarmDescriptions(arg0 interface{}) 
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AlarmDescriptions", reflect.TypeOf((*MockcwAlarmDescriber)(nil).AlarmDescriptions), arg0)
 }
+
+// MockbucketDescriber is a mock of bucketDescriber interface.
+type MockbucketDescriber struct {
+	ctrl     *gomock.Controller
+	recorder *MockbucketDescriberMockRecorder
+}
+
+// MockbucketDescriberMockRecorder is the mock recorder for MockbucketDescriber.
+type MockbucketDescriberMockRecorder struct {
+	mock *MockbucketDescriber
+}
+
+// NewMockbucketDescriber creates a new mock instance.
+func NewMockbucketDescriber(ctrl *gomock.Controller) *MockbucketDescriber {
+	mock := &MockbucketDescriber{ctrl: ctrl}
+	mock.recorder = &MockbucketDescriberMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockbucketDescriber) EXPECT() *MockbucketDescriberMockRecorder {
+	return m.recorder
+}
+
+// GetBucketTree mocks base method.
+func (m *MockbucketDescriber) GetBucketTree(bucket string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBucketTree", bucket)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBucketTree indicates an expected call of GetBucketTree.
+func (mr *MockbucketDescriberMockRecorder) GetBucketTree(bucket interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBucketTree", reflect.TypeOf((*MockbucketDescriber)(nil).GetBucketTree), bucket)
+}
+
+// MockbucketNameGetter is a mock of bucketNameGetter interface.
+type MockbucketNameGetter struct {
+	ctrl     *gomock.Controller
+	recorder *MockbucketNameGetterMockRecorder
+}
+
+// MockbucketNameGetterMockRecorder is the mock recorder for MockbucketNameGetter.
+type MockbucketNameGetterMockRecorder struct {
+	mock *MockbucketNameGetter
+}
+
+// NewMockbucketNameGetter creates a new mock instance.
+func NewMockbucketNameGetter(ctrl *gomock.Controller) *MockbucketNameGetter {
+	mock := &MockbucketNameGetter{ctrl: ctrl}
+	mock.recorder = &MockbucketNameGetterMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockbucketNameGetter) EXPECT() *MockbucketNameGetterMockRecorder {
+	return m.recorder
+}
+
+// BucketName mocks base method.
+func (m *MockbucketNameGetter) BucketName(app, env, svc string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BucketName", app, env, svc)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// BucketName indicates an expected call of BucketName.
+func (mr *MockbucketNameGetterMockRecorder) BucketName(app, env, svc interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BucketName", reflect.TypeOf((*MockbucketNameGetter)(nil).BucketName), app, env, svc)
+}

--- a/internal/pkg/describe/service.go
+++ b/internal/pkg/describe/service.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/xlab/treeprint"
 	"io"
 	"net/url"
 	"sort"
@@ -93,7 +92,7 @@ type cwAlarmDescriber interface {
 }
 
 type bucketDescriber interface {
-	GetBucketTree(bucket string) (treeprint.Tree, error)
+	GetBucketTree(bucket string) (string, error)
 }
 
 type bucketNameGetter interface {

--- a/internal/pkg/describe/service.go
+++ b/internal/pkg/describe/service.go
@@ -91,6 +91,10 @@ type cwAlarmDescriber interface {
 	AlarmDescriptions([]string) ([]*cloudwatch.AlarmDescription, error)
 }
 
+type bucketDescriber interface {
+	GetBucketTree(bucket string) error
+}
+
 type ecsSvcDesc struct {
 	Service           string                         `json:"service"`
 	Type              string                         `json:"type"`

--- a/internal/pkg/describe/service.go
+++ b/internal/pkg/describe/service.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/aws/apprunner"
 	"github.com/aws/copilot-cli/internal/pkg/aws/cloudwatch"
 	awsecs "github.com/aws/copilot-cli/internal/pkg/aws/ecs"
+	"github.com/aws/copilot-cli/internal/pkg/aws/sessions"
 	"github.com/aws/copilot-cli/internal/pkg/config"
 	"github.com/aws/copilot-cli/internal/pkg/describe/stack"
 	"github.com/aws/copilot-cli/internal/pkg/ecs"
@@ -127,9 +128,10 @@ type appRunnerServiceDescriber struct {
 
 // NewServiceConfig contains fields that initiates service describer struct.
 type NewServiceConfig struct {
-	App         string
-	Svc         string
-	ConfigStore ConfigStoreSvc
+	App             string
+	Svc             string
+	ConfigStore     ConfigStoreSvc
+	SessionProvider *sessions.Provider
 
 	EnableResources bool
 	DeployStore     DeployedEnvServicesLister

--- a/internal/pkg/describe/service.go
+++ b/internal/pkg/describe/service.go
@@ -95,6 +95,10 @@ type bucketDescriber interface {
 	GetBucketTree(bucket string) error
 }
 
+type bucketNameGetter interface {
+	BucketName(app, env, svc string) (string, error)
+}
+
 type ecsSvcDesc struct {
 	Service           string                         `json:"service"`
 	Type              string                         `json:"type"`

--- a/internal/pkg/describe/service.go
+++ b/internal/pkg/describe/service.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/xlab/treeprint"
 	"io"
 	"net/url"
 	"sort"
@@ -92,7 +93,7 @@ type cwAlarmDescriber interface {
 }
 
 type bucketDescriber interface {
-	GetBucketTree(bucket string) error
+	GetBucketTree(bucket string) (treeprint.Tree, error)
 }
 
 type bucketNameGetter interface {

--- a/internal/pkg/describe/service.go
+++ b/internal/pkg/describe/service.go
@@ -17,7 +17,6 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/aws/apprunner"
 	"github.com/aws/copilot-cli/internal/pkg/aws/cloudwatch"
 	awsecs "github.com/aws/copilot-cli/internal/pkg/aws/ecs"
-	"github.com/aws/copilot-cli/internal/pkg/aws/sessions"
 	"github.com/aws/copilot-cli/internal/pkg/config"
 	"github.com/aws/copilot-cli/internal/pkg/describe/stack"
 	"github.com/aws/copilot-cli/internal/pkg/ecs"
@@ -128,10 +127,9 @@ type appRunnerServiceDescriber struct {
 
 // NewServiceConfig contains fields that initiates service describer struct.
 type NewServiceConfig struct {
-	App             string
-	Svc             string
-	ConfigStore     ConfigStoreSvc
-	SessionProvider *sessions.Provider
+	App         string
+	Svc         string
+	ConfigStore ConfigStoreSvc
 
 	EnableResources bool
 	DeployStore     DeployedEnvServicesLister

--- a/internal/pkg/describe/static_site.go
+++ b/internal/pkg/describe/static_site.go
@@ -104,6 +104,9 @@ func (d *StaticSiteDescriber) Describe() (HumanJSONStringer, error) {
 	var objects []*S3ObjectTree
 	for _, env := range environments {
 		bucketDescriber, bucketNameDescriber, err := d.initS3Client(env)
+		if err != nil {
+			return nil, err
+		}
 		uri, err := d.URI(env)
 		if err != nil {
 			return nil, fmt.Errorf("retrieve service URI: %w", err)

--- a/internal/pkg/describe/static_site_test.go
+++ b/internal/pkg/describe/static_site_test.go
@@ -17,6 +17,8 @@ import (
 type staticSiteDescriberMocks struct {
 	wkldDescriber *mocks.MockworkloadDescriber
 	store         *mocks.MockDeployedEnvServicesLister
+	awsS3Client   *mocks.MockbucketDescriber
+	s3Client      *mocks.MockbucketNameGetter
 }
 
 func TestStaticSiteDescriber_URI(t *testing.T) {
@@ -107,6 +109,7 @@ func TestStaticSiteDescriber_Describe(t *testing.T) {
 		mockSvc = "static"
 	)
 	mockErr := errors.New("some error")
+	mockBucket := "bucketName"
 	testCases := map[string]struct {
 		shouldOutputResources bool
 
@@ -124,13 +127,15 @@ func TestStaticSiteDescriber_Describe(t *testing.T) {
 			},
 			wantedError: fmt.Errorf(`list deployed environments for service "static": some error`),
 		},
-		"success without resources flag": {
+		"success without resources flag or objects in bucket": {
 			setupMocks: func(m staticSiteDescriberMocks) {
 				gomock.InOrder(
 					m.store.EXPECT().ListEnvironmentsDeployedTo(mockApp, mockSvc).Return([]string{"test"}, nil),
 					m.wkldDescriber.EXPECT().Outputs().Return(map[string]string{
 						"CloudFrontDistributionDomainName": "dut843shvcmvn.cloudfront.net",
 					}, nil),
+					m.s3Client.EXPECT().BucketName(mockApp, mockEnv, mockSvc).Return(mockBucket, nil),
+					m.awsS3Client.EXPECT().GetBucketTree(mockBucket).Return("", nil),
 				)
 			},
 			wantedHuman: `About
@@ -155,12 +160,14 @@ Routes
 					m.wkldDescriber.EXPECT().Outputs().Return(map[string]string{
 						"CloudFrontDistributionDomainName": "dut843shvcmvn.cloudfront.net",
 					}, nil),
+					m.s3Client.EXPECT().BucketName(mockApp, mockEnv, mockSvc).Return(mockBucket, nil),
+					m.awsS3Client.EXPECT().GetBucketTree(mockBucket).Return("", nil),
 					m.wkldDescriber.EXPECT().StackResources().Return(nil, mockErr),
 				)
 			},
 			wantedError: fmt.Errorf("retrieve service resources: some error"),
 		},
-		"success with resources flag": {
+		"success with resources flag and objects in bucket": {
 			shouldOutputResources: true,
 			setupMocks: func(m staticSiteDescriberMocks) {
 				gomock.InOrder(
@@ -168,6 +175,21 @@ Routes
 					m.wkldDescriber.EXPECT().Outputs().Return(map[string]string{
 						"CloudFrontDistributionDomainName": "dut843shvcmvn.cloudfront.net",
 					}, nil),
+					m.s3Client.EXPECT().BucketName(mockApp, mockEnv, mockSvc).Return(mockBucket, nil),
+					m.awsS3Client.EXPECT().GetBucketTree(mockBucket).Return(`.
+├── README.md
+├── error.html
+├── index.html
+├── Images
+│   ├── firstImage.PNG
+│   └── secondImage.PNG
+├── css
+│   ├── Style.css
+│   └── bootstrap.min.css
+└── top
+    └── middle
+        └── bottom.html
+`, nil),
 					m.wkldDescriber.EXPECT().StackResources().Return([]*stack.Resource{
 						{
 							Type:       "AWS::S3::Bucket",
@@ -194,13 +216,30 @@ Routes
   -----------  ---
   test         dut843shvcmvn.cloudfront.net
 
+S3 Bucket Objects
+
+  Environment  test
+.
+├── README.md
+├── error.html
+├── index.html
+├── Images
+│   ├── firstImage.PNG
+│   └── secondImage.PNG
+├── css
+│   ├── Style.css
+│   └── bootstrap.min.css
+└── top
+    └── middle
+        └── bottom.html
+
 Resources
 
   test
     AWS::S3::Bucket        demo-test-mystatic-bucket-h69vu7y72ga9
     AWS::S3::BucketPolicy  demo-test-mystatic-BucketPolicyForCloudFront-8AITX9Q7K13R
 `,
-			wantedJSON: "{\"service\":\"static\",\"type\":\"Static Site\",\"application\":\"phonetool\",\"routes\":[{\"environment\":\"test\",\"url\":\"dut843shvcmvn.cloudfront.net\"}],\"resources\":{\"test\":[{\"type\":\"AWS::S3::Bucket\",\"physicalID\":\"demo-test-mystatic-bucket-h69vu7y72ga9\",\"logicalID\":\"Bucket\"},{\"type\":\"AWS::S3::BucketPolicy\",\"physicalID\":\"demo-test-mystatic-BucketPolicyForCloudFront-8AITX9Q7K13R\",\"logicalID\":\"BucketPolicy\"}]}}\n",
+			wantedJSON: "{\"service\":\"static\",\"type\":\"Static Site\",\"application\":\"phonetool\",\"routes\":[{\"environment\":\"test\",\"url\":\"dut843shvcmvn.cloudfront.net\"}],\"objects\":[{\"Environment\":\"test\",\"Tree\":\".\\n├── README.md\\n├── error.html\\n├── index.html\\n├── Images\\n│   ├── firstImage.PNG\\n│   └── secondImage.PNG\\n├── css\\n│   ├── Style.css\\n│   └── bootstrap.min.css\\n└── top\\n    └── middle\\n        └── bottom.html\\n\"}],\"resources\":{\"test\":[{\"type\":\"AWS::S3::Bucket\",\"physicalID\":\"demo-test-mystatic-bucket-h69vu7y72ga9\",\"logicalID\":\"Bucket\"},{\"type\":\"AWS::S3::BucketPolicy\",\"physicalID\":\"demo-test-mystatic-BucketPolicyForCloudFront-8AITX9Q7K13R\",\"logicalID\":\"BucketPolicy\"}]}}\n",
 		},
 	}
 
@@ -212,6 +251,8 @@ Resources
 			mocks := staticSiteDescriberMocks{
 				store:         mocks.NewMockDeployedEnvServicesLister(ctrl),
 				wkldDescriber: mocks.NewMockworkloadDescriber(ctrl),
+				awsS3Client:   mocks.NewMockbucketDescriber(ctrl),
+				s3Client:      mocks.NewMockbucketNameGetter(ctrl),
 			}
 
 			tc.setupMocks(mocks)
@@ -223,6 +264,8 @@ Resources
 				store:                  mocks.store,
 				initWkldStackDescriber: func(string) (workloadDescriber, error) { return mocks.wkldDescriber, nil },
 				wkldDescribers:         make(map[string]workloadDescriber),
+				awsS3Client:            mocks.awsS3Client,
+				s3Client:               mocks.s3Client,
 			}
 
 			// WHEN

--- a/internal/pkg/describe/static_site_test.go
+++ b/internal/pkg/describe/static_site_test.go
@@ -264,8 +264,7 @@ Resources
 				store:                  mocks.store,
 				initWkldStackDescriber: func(string) (workloadDescriber, error) { return mocks.wkldDescriber, nil },
 				wkldDescribers:         make(map[string]workloadDescriber),
-				awsS3Client:            mocks.awsS3Client,
-				s3Client:               mocks.s3Client,
+				initS3Client:           func(string) (bucketDescriber, bucketNameGetter, error) { return mocks.awsS3Client, mocks.s3Client, nil },
 			}
 
 			// WHEN


### PR DESCRIPTION
sample output:
```
% copilot svc show 
Service name: static-site
About

  Application  bugbash-static
  Name         static-site
  Type         Static Site

Routes

  Environment  URL
  -----------  ---
  test         d1vwytbnh1k1gy.cloudfront.net
  prod         d1yb44q5409rdj.cloudfront.net

S3 Bucket Objects

  Environment  test
.
├── error.html
├── index.html
├── css
│   ├── Style.css
│   ├── all.min.css
│   └── bootstrap.min.css
└── images
    ├── bg-masthead.jpg
    └── new
        └── hi.html

  Environment  prod
.
├── ReadMe.md
├── error.html
├── index.html
├── Images
│   ├── AWS-free.PNG
│   ├── S3WebsiteHosting-Architecture.PNG
│   ├── SampleWebsite.PNG
│   ├── Step1-CreateBucket-B.PNG
│   ├── Step1-CreateBucket-C.PNG
│   ├── Step1-CreateBucket-D.PNG
│   ├── Step1-CreateBucket-E.PNG
│   ├── Step1-CreateBucket.PNG
│   ├── Step2-UploadContents.PNG
│   ├── Step3-BucketPolicy-A.PNG
│   ├── Step3-BucketPolicy-B.PNG
│   ├── Step3-BucketPolicy.PNG
│   ├── Step4-A.PNG
│   └── Step4-B.PNG
├── css
│   ├── Style.css
│   ├── all.min.css
│   └── bootstrap.min.css
└── images
    ├── bg-masthead.jpg
    └── new
        └── hi.html
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
