### PR TITLE
chore: add function to delete single stackset instance

### DIFF
--- a/internal/pkg/cli/deploy/workload.go
+++ b/internal/pkg/cli/deploy/workload.go
@@ -159,6 +159,11 @@ type GenerateCloudFormationTemplateOutput struct {
 	Parameters string
 }
 
+// RepoName returns the name of a Copilot-managed ECR repository given an application and workload.
+func RepoName(app, workload string) string {
+	return fmt.Sprintf("%s/%s", app, workload)
+}
+
 type workloadDeployer struct {
 	name          string
 	app           *config.Application
@@ -249,7 +254,7 @@ func newWorkloadDeployer(in *WorkloadDeployerInput) (*workloadDeployer, error) {
 		addons = nil // so that we can check for no addons with nil comparison
 	}
 
-	repoName := fmt.Sprintf("%s/%s", in.App.Name, in.Name)
+	repoName := RepoName(in.App.Name, in.Name)
 	repository := repository.NewWithURI(
 		ecr.New(defaultSessEnvRegion), repoName, resources.RepositoryURLs[in.Name])
 	store := config.NewSSMStore(identity.New(defaultSession), ssm.New(defaultSession), aws.StringValue(defaultSession.Config.Region))

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -111,6 +111,7 @@ type environmentStore interface {
 	environmentGetter
 	environmentLister
 	environmentDeleter
+	applicationGetter
 }
 
 type environmentCreator interface {
@@ -405,6 +406,11 @@ type appDeployer interface {
 type appResourcesGetter interface {
 	GetAppResourcesByRegion(app *config.Application, region string) (*stack.AppRegionalResources, error)
 	GetRegionalAppResources(app *config.Application) ([]*stack.AppRegionalResources, error)
+}
+
+type envDeleterFromApp interface {
+	appResourcesGetter
+	RemoveEnvFromApp(opts *cloudformation.RemoveEnvFromAppOpts) error
 }
 
 type taskDeployer interface {

--- a/internal/pkg/cli/job_delete.go
+++ b/internal/pkg/cli/job_delete.go
@@ -21,6 +21,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/copilot-cli/internal/pkg/aws/ecr"
 	"github.com/aws/copilot-cli/internal/pkg/aws/sessions"
+	clideploy "github.com/aws/copilot-cli/internal/pkg/cli/deploy"
 	"github.com/aws/copilot-cli/internal/pkg/config"
 	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation"
 	"github.com/aws/copilot-cli/internal/pkg/term/color"
@@ -303,8 +304,7 @@ func (o *deleteJobOpts) emptyECRRepos(envs []*config.Environment) error {
 		}
 	}
 
-	// TODO: centralized ECR repo name
-	repoName := fmt.Sprintf("%s/%s", o.appName, o.name)
+	repoName := clideploy.RepoName(o.appName, o.name)
 	for _, region := range uniqueRegions {
 		sess, err := o.sess.DefaultWithRegion(region)
 		if err != nil {

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -767,6 +767,21 @@ func (mr *MockenvironmentStoreMockRecorder) DeleteEnvironment(appName, environme
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteEnvironment", reflect.TypeOf((*MockenvironmentStore)(nil).DeleteEnvironment), appName, environmentName)
 }
 
+// GetApplication mocks base method.
+func (m *MockenvironmentStore) GetApplication(appName string) (*config.Application, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetApplication", appName)
+	ret0, _ := ret[0].(*config.Application)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetApplication indicates an expected call of GetApplication.
+func (mr *MockenvironmentStoreMockRecorder) GetApplication(appName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplication", reflect.TypeOf((*MockenvironmentStore)(nil).GetApplication), appName)
+}
+
 // GetEnvironment mocks base method.
 func (m *MockenvironmentStore) GetEnvironment(appName, environmentName string) (*config.Environment, error) {
 	m.ctrl.T.Helper()
@@ -4304,6 +4319,73 @@ func (m *MockappResourcesGetter) GetRegionalAppResources(app *config.Application
 func (mr *MockappResourcesGetterMockRecorder) GetRegionalAppResources(app interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegionalAppResources", reflect.TypeOf((*MockappResourcesGetter)(nil).GetRegionalAppResources), app)
+}
+
+// MockenvDeleterFromApp is a mock of envDeleterFromApp interface.
+type MockenvDeleterFromApp struct {
+	ctrl     *gomock.Controller
+	recorder *MockenvDeleterFromAppMockRecorder
+}
+
+// MockenvDeleterFromAppMockRecorder is the mock recorder for MockenvDeleterFromApp.
+type MockenvDeleterFromAppMockRecorder struct {
+	mock *MockenvDeleterFromApp
+}
+
+// NewMockenvDeleterFromApp creates a new mock instance.
+func NewMockenvDeleterFromApp(ctrl *gomock.Controller) *MockenvDeleterFromApp {
+	mock := &MockenvDeleterFromApp{ctrl: ctrl}
+	mock.recorder = &MockenvDeleterFromAppMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockenvDeleterFromApp) EXPECT() *MockenvDeleterFromAppMockRecorder {
+	return m.recorder
+}
+
+// GetAppResourcesByRegion mocks base method.
+func (m *MockenvDeleterFromApp) GetAppResourcesByRegion(app *config.Application, region string) (*stack.AppRegionalResources, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAppResourcesByRegion", app, region)
+	ret0, _ := ret[0].(*stack.AppRegionalResources)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAppResourcesByRegion indicates an expected call of GetAppResourcesByRegion.
+func (mr *MockenvDeleterFromAppMockRecorder) GetAppResourcesByRegion(app, region interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAppResourcesByRegion", reflect.TypeOf((*MockenvDeleterFromApp)(nil).GetAppResourcesByRegion), app, region)
+}
+
+// GetRegionalAppResources mocks base method.
+func (m *MockenvDeleterFromApp) GetRegionalAppResources(app *config.Application) ([]*stack.AppRegionalResources, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRegionalAppResources", app)
+	ret0, _ := ret[0].([]*stack.AppRegionalResources)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRegionalAppResources indicates an expected call of GetRegionalAppResources.
+func (mr *MockenvDeleterFromAppMockRecorder) GetRegionalAppResources(app interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegionalAppResources", reflect.TypeOf((*MockenvDeleterFromApp)(nil).GetRegionalAppResources), app)
+}
+
+// RemoveEnvFromApp mocks base method.
+func (m *MockenvDeleterFromApp) RemoveEnvFromApp(opts *cloudformation0.RemoveEnvFromAppOpts) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveEnvFromApp", opts)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoveEnvFromApp indicates an expected call of RemoveEnvFromApp.
+func (mr *MockenvDeleterFromAppMockRecorder) RemoveEnvFromApp(opts interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveEnvFromApp", reflect.TypeOf((*MockenvDeleterFromApp)(nil).RemoveEnvFromApp), opts)
 }
 
 // MocktaskDeployer is a mock of taskDeployer interface.

--- a/internal/pkg/cli/svc_delete.go
+++ b/internal/pkg/cli/svc_delete.go
@@ -8,6 +8,7 @@ package cli
 import (
 	"errors"
 	"fmt"
+	clideploy "github.com/aws/copilot-cli/internal/pkg/cli/deploy"
 	"os"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -300,7 +301,7 @@ func (o *deleteSvcOpts) emptyECRRepos(envs []*config.Environment) error {
 	}
 
 	// TODO: centralized ECR repo name
-	repoName := fmt.Sprintf("%s/%s", o.appName, o.name)
+	repoName := clideploy.RepoName(o.appName, o.name)
 	for _, region := range uniqueRegions {
 		sess, err := o.sess.DefaultWithRegion(region)
 		if err != nil {

--- a/internal/pkg/deploy/cloudformation/app.go
+++ b/internal/pkg/deploy/cloudformation/app.go
@@ -312,6 +312,51 @@ func (cf CloudFormation) RemoveJobFromApp(app *config.Application, jobName strin
 	return nil
 }
 
+// RemoveEnvFromAppOpts contains the parameters to call RemoveEnvFromApp.
+type RemoveEnvFromAppOpts struct {
+	App                 *config.Application
+	EnvName             string
+	EnvAccountID        string
+	EnvRegion           string
+	DeleteStackInstance bool // If this is the last environment in a region, we can delete it.
+}
+
+func (cf CloudFormation) RemoveEnvFromApp(opts *RemoveEnvFromAppOpts) error {
+	// This is a no-op if there are remaining environments in the region.
+	if !opts.DeleteStackInstance {
+		return nil
+	}
+
+	appConfig := stack.NewAppStackConfig(&deploy.CreateAppInput{
+		Name:           opts.App.Name,
+		AccountID:      opts.App.AccountID,
+		AdditionalTags: opts.App.Tags,
+		Version:        deploy.LatestAppTemplateVersion,
+	})
+	previouslyDeployedConfig, err := cf.getLastDeployedAppConfig(appConfig)
+	if err != nil {
+		return fmt.Errorf("get previous application %s config: %w", appConfig.Name, err)
+	}
+	var accountList []string
+	for _, account := range previouslyDeployedConfig.Accounts {
+		if account == opts.EnvAccountID {
+			continue
+		}
+		accountList = append(accountList, account)
+	}
+
+	newDeploymentConfig := stack.AppResourcesConfig{
+		Version:   previouslyDeployedConfig.Version + 1,
+		Workloads: previouslyDeployedConfig.Workloads,
+		Accounts:  accountList,
+		App:       appConfig.Name,
+	}
+	if err := cf.deployAppConfig(appConfig, &newDeploymentConfig, true); err != nil {
+		return err
+	}
+	return cf.deleteStackSetInstance(appConfig.StackSetName(), opts.EnvAccountID, opts.EnvRegion)
+}
+
 func (cf CloudFormation) removeWorkloadFromApp(app *config.Application, wlName string) error {
 	appConfig := stack.NewAppStackConfig(&deploy.CreateAppInput{
 		Name:           app.Name,
@@ -566,6 +611,17 @@ func (cf CloudFormation) deleteStackSetInstances(name string) error {
 		return err
 	}
 	return cf.appStackSet.WaitForOperation(name, opID)
+}
+
+func (cf CloudFormation) deleteStackSetInstance(name, account, region string) error {
+	opId, err := cf.appStackSet.DeleteInstance(name, account, region)
+	if err != nil {
+		if IsEmptyErr(err) {
+			return nil
+		}
+		return err
+	}
+	return cf.appStackSet.WaitForOperation(name, opId)
 }
 
 type renderStackSetInput struct {

--- a/internal/pkg/deploy/cloudformation/cloudformation.go
+++ b/internal/pkg/deploy/cloudformation/cloudformation.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation/stack"
 	"io"
 	"os"
 	"strings"
@@ -187,7 +188,8 @@ type CloudFormation struct {
 	cachedDeployedStack *cloudformation.StackDescription
 
 	// Overridden in tests.
-	renderStackSet func(input renderStackSetInput) error
+	renderStackSet               func(input renderStackSetInput) error
+	dnsDelegatedAccountsForStack func(stack *sdkcloudformation.Stack) []string
 }
 
 // New returns a configured CloudFormation client.
@@ -212,6 +214,7 @@ func New(sess *session.Session, opts ...OptFn) CloudFormation {
 		opt(&client)
 	}
 	client.renderStackSet = client.renderStackSetImpl
+	client.dnsDelegatedAccountsForStack = stack.DNSDelegatedAccountsForStack
 	return client
 }
 

--- a/internal/pkg/deploy/cloudformation/cloudformation.go
+++ b/internal/pkg/deploy/cloudformation/cloudformation.go
@@ -141,6 +141,7 @@ type stackSetClient interface {
 	Describe(name string) (stackset.Description, error)
 	DescribeOperation(name, opID string) (stackset.Operation, error)
 	InstanceSummaries(name string, opts ...stackset.InstanceSummariesOption) ([]stackset.InstanceSummary, error)
+	DeleteInstance(name, account, region string) (string, error)
 	DeleteAllInstances(name string) (string, error)
 	Delete(name string) error
 	WaitForStackSetLastOperationComplete(name string) error

--- a/internal/pkg/deploy/cloudformation/env.go
+++ b/internal/pkg/deploy/cloudformation/env.go
@@ -77,12 +77,9 @@ func newRenderEnvironmentInput(cfnStack *cloudformation.Stack) *executeAndRender
 func (cf CloudFormation) DeleteEnvironment(appName, envName, cfnExecRoleARN string) error {
 	stackName := stack.NameForEnv(appName, envName)
 	description := fmt.Sprintf("Delete environment stack %s", stackName)
-	if err := cf.deleteAndRenderStack(stackName, description, func() error {
+	return cf.deleteAndRenderStack(stackName, description, func() error {
 		return cf.cfnClient.DeleteAndWaitWithRoleARN(stackName, cfnExecRoleARN)
-	}); err != nil {
-		return err
-	}
-	return cf.RemoveEnvFromApp(&RemoveEnvFromAppOpts{})
+	})
 }
 
 // GetEnvironment returns the Environment metadata from the CloudFormation stack.

--- a/internal/pkg/deploy/cloudformation/env.go
+++ b/internal/pkg/deploy/cloudformation/env.go
@@ -77,9 +77,12 @@ func newRenderEnvironmentInput(cfnStack *cloudformation.Stack) *executeAndRender
 func (cf CloudFormation) DeleteEnvironment(appName, envName, cfnExecRoleARN string) error {
 	stackName := stack.NameForEnv(appName, envName)
 	description := fmt.Sprintf("Delete environment stack %s", stackName)
-	return cf.deleteAndRenderStack(stackName, description, func() error {
+	if err := cf.deleteAndRenderStack(stackName, description, func() error {
 		return cf.cfnClient.DeleteAndWaitWithRoleARN(stackName, cfnExecRoleARN)
-	})
+	}); err != nil {
+		return err
+	}
+	return cf.RemoveEnvFromApp(&RemoveEnvFromAppOpts{})
 }
 
 // GetEnvironment returns the Environment metadata from the CloudFormation stack.

--- a/internal/pkg/deploy/cloudformation/mocks/mock_cloudformation.go
+++ b/internal/pkg/deploy/cloudformation/mocks/mock_cloudformation.go
@@ -759,6 +759,21 @@ func (mr *MockstackSetClientMockRecorder) DeleteAllInstances(name interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAllInstances", reflect.TypeOf((*MockstackSetClient)(nil).DeleteAllInstances), name)
 }
 
+// DeleteInstance mocks base method.
+func (m *MockstackSetClient) DeleteInstance(name, account, region string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteInstance", name, account, region)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteInstance indicates an expected call of DeleteInstance.
+func (mr *MockstackSetClientMockRecorder) DeleteInstance(name, account, region interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteInstance", reflect.TypeOf((*MockstackSetClient)(nil).DeleteInstance), name, account, region)
+}
+
 // Describe mocks base method.
 func (m *MockstackSetClient) Describe(name string) (stackset.Description, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
- chore: add methods for removing a single stackset instance
- test: add unit tests for stackset deletion instance

<!-- Provide summary of changes -->
Modular PR 1 of 2 for conditionally cleaning up stackset instance on env delete. 
This contains "stack" functions for working with the stackset and removing only one instance.

The next one will contain the changes to the CLI logic. 

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
