### PR TITLE
fix: filter out non-active ECS clusters

### DIFF
--- a/internal/pkg/ecs/ecs_test.go
+++ b/internal/pkg/ecs/ecs_test.go
@@ -787,6 +787,7 @@ func TestClient_StopWorkloadTasks(t *testing.T) {
 			inTask: "service",
 
 			mockECS: func(m *mocks.MockecsClient) {
+				m.EXPECT().ActiveClusters(mockResource.ARN).Return([]string{mockResource.ARN}, nil).Times(2)
 				m.EXPECT().RunningTasksInFamily(mockCluster, "phonetool-pdx-service").Return(mockECSTask, nil)
 				m.EXPECT().StopTasks([]string{"deadbeef", "abcd"}, gomock.Any()).Return(nil)
 			},
@@ -803,6 +804,7 @@ func TestClient_StopWorkloadTasks(t *testing.T) {
 			inTask: "service",
 
 			mockECS: func(m *mocks.MockecsClient) {
+				m.EXPECT().ActiveClusters(mockResource.ARN).Return([]string{mockResource.ARN}, nil).Times(2)
 				m.EXPECT().RunningTasksInFamily(mockCluster, "phonetool-pdx-service").Return([]*ecs.Task{}, nil)
 				m.EXPECT().StopTasks([]string{}, gomock.Any()).Return(nil)
 			},
@@ -833,6 +835,7 @@ func TestClient_StopWorkloadTasks(t *testing.T) {
 			inTask: "service",
 
 			mockECS: func(m *mocks.MockecsClient) {
+				m.EXPECT().ActiveClusters(mockResource.ARN).Return([]string{mockResource.ARN}, nil).Times(2)
 				m.EXPECT().RunningTasksInFamily(mockCluster, "phonetool-pdx-service").Return(mockECSTask, nil)
 				m.EXPECT().StopTasks([]string{"deadbeef", "abcd"}, gomock.Any()).Return(errors.New("some error"))
 			},
@@ -906,6 +909,7 @@ func TestClient_StopOneOffTasks(t *testing.T) {
 			inTask: "cooltask",
 
 			mockECS: func(m *mocks.MockecsClient) {
+				m.EXPECT().ActiveClusters(mockResource.ARN).Return([]string{mockResource.ARN}, nil).Times(2)
 				m.EXPECT().RunningTasksInFamily(mockCluster, "copilot-cooltask").Return(mockECSTask, nil)
 				m.EXPECT().StopTasks([]string{"deadbeef"}, gomock.Any()).Return(nil)
 			},
@@ -922,6 +926,7 @@ func TestClient_StopOneOffTasks(t *testing.T) {
 			inTask: "cooltask",
 
 			mockECS: func(m *mocks.MockecsClient) {
+				m.EXPECT().ActiveClusters(mockResource.ARN).Return([]string{mockResource.ARN}, nil).Times(2)
 				m.EXPECT().RunningTasksInFamily(mockCluster, "copilot-cooltask").Return([]*ecs.Task{}, nil)
 				m.EXPECT().StopTasks([]string{}, gomock.Any()).Return(nil)
 			},
@@ -952,6 +957,7 @@ func TestClient_StopOneOffTasks(t *testing.T) {
 			inTask: "cooltask",
 
 			mockECS: func(m *mocks.MockecsClient) {
+				m.EXPECT().ActiveClusters(mockResource.ARN).Return([]string{mockResource.ARN}, nil).Times(2)
 				m.EXPECT().RunningTasksInFamily(mockCluster, "copilot-cooltask").Return(mockECSTask, nil)
 				m.EXPECT().StopTasks([]string{"deadbeef"}, gomock.Any()).Return(errors.New("some error"))
 			},
@@ -1240,9 +1246,10 @@ func Test_NetworkConfiguration(t *testing.T) {
 						Return([]*resourcegroups.Resource{
 							{ARN: "mockARN1"}, {ARN: "mockARN2"},
 						}, nil),
+					m.ecsClient.EXPECT().ActiveClusters("mockARN1", "mockARN2").Return([]string{"mockARN1", "mockARN2"}, nil),
 				)
 			},
-			wantedError: fmt.Errorf(`more than one ECS cluster are found with tags "copilot-application"="phonetool","copilot-environment"="test"`),
+			wantedError: fmt.Errorf(`more than one active ECS cluster are found with tags "copilot-application"="phonetool","copilot-environment"="test"`),
 		},
 		"successfully retrieve network configuration": {
 			setupMocks: func(m clientMocks) {
@@ -1251,6 +1258,7 @@ func Test_NetworkConfiguration(t *testing.T) {
 						Return([]*resourcegroups.Resource{
 							{ARN: "cluster-1"},
 						}, nil),
+					m.ecsClient.EXPECT().ActiveClusters("cluster-1").Return([]string{"cluster-1"}, nil),
 					m.resourceGetter.EXPECT().GetResourcesByTags(serviceResourceType, map[string]string{
 						deploy.AppTagKey:     testApp,
 						deploy.EnvTagKey:     testEnv,

--- a/internal/pkg/ecs/mocks/mock_ecs.go
+++ b/internal/pkg/ecs/mocks/mock_ecs.go
@@ -73,6 +73,25 @@ func (m *MockecsClient) EXPECT() *MockecsClientMockRecorder {
 	return m.recorder
 }
 
+// ActiveClusters mocks base method.
+func (m *MockecsClient) ActiveClusters(arns ...string) ([]string, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{}
+	for _, a := range arns {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ActiveClusters", varargs...)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ActiveClusters indicates an expected call of ActiveClusters.
+func (mr *MockecsClientMockRecorder) ActiveClusters(arns ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ActiveClusters", reflect.TypeOf((*MockecsClient)(nil).ActiveClusters), arns...)
+}
+
 // DefaultCluster mocks base method.
 func (m *MockecsClient) DefaultCluster() (string, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Fixes #5052
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.