### PR TITLE
docs: fix the `nlb.additional_listeners` field in the "expose multiple ports" example

### DIFF
--- a/site/content/docs/manifest/lb-web-service.en.md
+++ b/site/content/docs/manifest/lb-web-service.en.md
@@ -241,7 +241,7 @@ List of all available properties for a `'Load Balanced Web Service'` manifest. T
 
         nlb:
           port: 8080/tcp              # Traffic on port 8080/tcp is forwarded to the main container, on port 8080.
-          additional_rules:  
+          additional_listeners:  
             - port: 8084/tcp          # Traffic on port 8084/tcp is forwarded to the main container, on port 8084.
             - port: 8085/tcp          # Traffic on port 8085/tcp is forwarded to the sidecar "envoy", on port 3000.
               target_port: 3000         


### PR DESCRIPTION
The doc in https://aws.github.io/copilot-cli/docs/manifest/lb-web-service/ uses `additional_listeners`, and based on my usage it should be `additional_listeners`, not `additional_rules`.