### PR TITLE
chore(test): use mock instead of real stack struct for static site unit test

### DIFF
--- a/internal/pkg/cli/deploy/static_site.go
+++ b/internal/pkg/cli/deploy/static_site.go
@@ -36,7 +36,8 @@ type staticSiteDeployer struct {
 	staticSiteMft    *manifest.StaticSite
 	fs               afero.Fs
 	uploader         fileUploader
-	newStack         func(*stack.StaticSiteConfig) (*stack.StaticSite, error)
+	newStack         func(*stack.StaticSiteConfig) (cloudformation.StackConfiguration, error)
+
 	// cached.
 	wsRoot string
 }
@@ -74,8 +75,10 @@ func NewStaticSiteDeployer(in *WorkloadDeployerInput) (*staticSiteDeployer, erro
 				return err
 			},
 		},
-		wsRoot:   ws.ProjectRoot(),
-		newStack: stack.NewStaticSite,
+		wsRoot: ws.ProjectRoot(),
+		newStack: func(config *stack.StaticSiteConfig) (cloudformation.StackConfiguration, error) {
+			return stack.NewStaticSite(config)
+		},
 	}, nil
 }
 


### PR DESCRIPTION
Currently, the static site unit test is using the real `stack.StaticSite` struct in the `cli/deploy` unit test. This requires the `custom-resource` to be built from real FS, i.e. you have to build first in order to run the unit test.

This PR uses mocks instead of the real `stack.StaticSite` struct 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
