### PR TITLE
chore: infer package manager when overriding with CDK

### DIFF
--- a/internal/pkg/override/cdk.go
+++ b/internal/pkg/override/cdk.go
@@ -235,7 +235,7 @@ func (cdk *CDK) closestProjectManager() (string, error) {
 			return afero.Exists(cdk.fs, path)
 		}, candidate.lockFile)
 		if err == nil {
-			distance := strings.Count(wd, "/") - strings.Count(path, "/")
+			distance := strings.Count(wd, string(filepath.Separator)) - strings.Count(path, string(filepath.Separator))
 			if distance < closestDistance {
 				closestCandidate = candidate.name
 				closestDistance = distance

--- a/internal/pkg/override/cdk.go
+++ b/internal/pkg/override/cdk.go
@@ -45,7 +45,6 @@ type CDKOpts struct {
 	EnvVars    map[string]string                           // Environment variables key value pairs to pass to the "cdk synth" command.
 	LookPathFn func(executable string) (string, error)     // Search for the executable under $PATH. Defaults to exec.LookPath.
 	CommandFn  func(name string, args ...string) *exec.Cmd // Create a new executable command. Defaults to exec.Command rooted at the overrides/ dir.
-	FindFn     func(startDir string, maxLevels int, matchFn workspace.TraverseUpProcessFn) (string, error)
 }
 
 // WithCDK instantiates a new CDK Overrider with root being the path to the overrides/ directory.
@@ -79,10 +78,6 @@ func WithCDK(root string, opts CDKOpts) *CDK {
 	if opts.CommandFn != nil {
 		cmdFn = opts.CommandFn
 	}
-	findFn := workspace.TraverseUp
-	if opts.FindFn != nil {
-		findFn = opts.FindFn
-	}
 	return &CDK{
 		rootAbsPath: root,
 		execWriter:  writer,
@@ -94,7 +89,7 @@ func WithCDK(root string, opts CDKOpts) *CDK {
 		}{
 			LookPath: lookPathFn,
 			Command:  cmdFn,
-			Find:     findFn,
+			Find:     workspace.TraverseUp,
 		},
 	}
 }

--- a/internal/pkg/override/cdk.go
+++ b/internal/pkg/override/cdk.go
@@ -21,6 +21,11 @@ import (
 	"github.com/spf13/afero"
 )
 
+const (
+	defaultPackageManager    = "npm"
+	maxNumberOfLevelsChecked = 5
+)
+
 // CDK is an Overrider that can transform a CloudFormation template with the Cloud Development Kit.
 type CDK struct {
 	rootAbsPath string // Absolute path to the overrides/ directory.
@@ -182,8 +187,6 @@ func (cdk *CDK) cleanUp(in []byte) ([]byte, error) {
 	return out.Bytes(), nil
 }
 
-const defaultPackageManager = "npm"
-
 type packageManager struct {
 	name     string
 	lockFile string
@@ -233,7 +236,7 @@ func (cdk *CDK) closestProjectManager() (string, error) {
 	closestDistance := math.MaxInt
 	var errTargetNotFound *workspace.ErrTargetNotFound
 	for _, candidate := range packageManagers {
-		path, err := cdk.exec.Find(wd, 5, func(path string) (bool, error) {
+		path, err := cdk.exec.Find(wd, maxNumberOfLevelsChecked, func(path string) (bool, error) {
 			return afero.Exists(cdk.fs, path)
 		}, candidate.lockFile)
 		if err == nil {

--- a/internal/pkg/override/cdk.go
+++ b/internal/pkg/override/cdk.go
@@ -263,11 +263,10 @@ func (cdk *CDK) packageManager() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if manager == "" {
-		manager = defaultPackageManager
+	if manager != "" {
+		return manager, nil
 	}
-	return manager, nil
-
+	return defaultPackageManager, nil
 }
 
 // ScaffoldWithCDK bootstraps a CDK application under dir/ to override the seed CloudFormation resources.

--- a/internal/pkg/override/cdk.go
+++ b/internal/pkg/override/cdk.go
@@ -198,7 +198,7 @@ var packageManagers = []packageManager{ // Alphabetically sorted based on name.
 	},
 }
 
-func (cdk *CDK) installedPackageManager() ([]string, []error) {
+func (cdk *CDK) installedPackageManager() ([]string, error) {
 	var lookUpExecutableErrs []error
 	var installed []string
 	for _, candidate := range packageManagers {
@@ -211,7 +211,7 @@ func (cdk *CDK) installedPackageManager() ([]string, []error) {
 			})
 		}
 	}
-	return installed, lookUpExecutableErrs
+	return installed, errors.Join(lookUpExecutableErrs...)
 }
 
 var getwd = os.Getwd
@@ -250,9 +250,9 @@ func (cdk *CDK) closestProjectManager() (string, error) {
 }
 
 func (cdk *CDK) packageManager() (string, error) {
-	installed, errs := cdk.installedPackageManager()
+	installed, err := cdk.installedPackageManager()
 	if len(installed) == 0 {
-		return "", &errPackageManagerUnavailable{parentErrors: errs}
+		return "", &errPackageManagerUnavailable{parentError: err}
 	}
 	if len(installed) == 1 {
 		return installed[0], nil

--- a/internal/pkg/override/cdk.go
+++ b/internal/pkg/override/cdk.go
@@ -197,7 +197,7 @@ var packageManagers = []packageManager{ // Alphabetically sorted based on name.
 	},
 }
 
-func (cdk *CDK) installedPackageManager() ([]string, error) {
+func (cdk *CDK) installedPackageManagers() ([]string, error) {
 	var installed []string
 	for _, candidate := range packageManagers {
 		if _, err := cdk.exec.LookPath(candidate.name); err == nil {
@@ -248,7 +248,7 @@ func (cdk *CDK) closestProjectManager() (string, error) {
 }
 
 func (cdk *CDK) packageManager() (string, error) {
-	installed, err := cdk.installedPackageManager()
+	installed, err := cdk.installedPackageManagers()
 	if err != nil {
 		return "", err
 	}

--- a/internal/pkg/override/cdk.go
+++ b/internal/pkg/override/cdk.go
@@ -182,6 +182,8 @@ func (cdk *CDK) cleanUp(in []byte) ([]byte, error) {
 	return out.Bytes(), nil
 }
 
+const defaultPackageManager = "npm"
+
 type packageManager struct {
 	name     string
 	lockFile string
@@ -262,7 +264,7 @@ func (cdk *CDK) packageManager() (string, error) {
 		return "", err
 	}
 	if manager == "" {
-		manager = "npm"
+		manager = defaultPackageManager
 	}
 	return manager, nil
 

--- a/internal/pkg/override/cdk_test.go
+++ b/internal/pkg/override/cdk_test.go
@@ -35,7 +35,7 @@ func TestCDK_Override(t *testing.T) {
 		_, err := cdk.Override(nil)
 
 		// THEN
-		require.EqualError(t, err, `cannot find a package manager to override with the Cloud Development Kit`)
+		require.EqualError(t, err, `cannot find a JavaScript package manager to override with the Cloud Development Kit`)
 	})
 	t.Run("on install: should return a wrapped error if unexpected error occurs while finding lock file", func(t *testing.T) {
 		// GIVEN

--- a/internal/pkg/override/cdk_test.go
+++ b/internal/pkg/override/cdk_test.go
@@ -36,7 +36,9 @@ func TestCDK_Override(t *testing.T) {
 		_, err := cdk.Override(nil)
 
 		// THEN
-		require.EqualError(t, err, `cannot find a package manager to override with the Cloud Development Kit: look up "npm": exec: "npm": executable file not found in $PATH; look up "yarn": exec: "yarn": executable file not found in $PATH`)
+		require.EqualError(t, err, `cannot find a package manager to override with the Cloud Development Kit:
+look up "npm": exec: "npm": executable file not found in $PATH
+look up "yarn": exec: "yarn": executable file not found in $PATH`)
 	})
 	t.Run("on install: should return a wrapped error if unexpected error occurs while finding lock file", func(t *testing.T) {
 		// GIVEN

--- a/internal/pkg/override/cdk_test.go
+++ b/internal/pkg/override/cdk_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -178,10 +177,6 @@ func TestCDK_Override(t *testing.T) {
 		require.Contains(t, string(out), fmt.Sprintf("%s synth --no-version-reporting", binPath))
 	})
 	t.Run("should invoke npm install and cdk synth, if only package-lock.json is found", func(t *testing.T) {
-		defer func() { getwd = os.Getwd }()
-		getwd = func() (dir string, err error) {
-			return "film/web/user", nil
-		}
 		buf := new(strings.Builder)
 		fs := afero.NewMemMapFs()
 		_ = fs.MkdirAll("film/web/user", 0755)
@@ -196,6 +191,9 @@ func TestCDK_Override(t *testing.T) {
 				return exec.Command("echo", fmt.Sprintf("Description: %s", strings.Join(append([]string{name}, args...), " ")))
 			},
 		})
+		cdk.exec.Getwd = func() (dir string, err error) {
+			return "film/web/user", nil
+		}
 
 		// WHEN
 		out, err := cdk.Override(nil)
@@ -206,10 +204,6 @@ func TestCDK_Override(t *testing.T) {
 		require.Contains(t, string(out), fmt.Sprintf("%s synth --no-version-reporting", filepath.Join("node_modules", ".bin", "cdk")))
 	})
 	t.Run("should invoke yarn install and cdk synth, if only yarn.lock is found", func(t *testing.T) {
-		defer func() { getwd = os.Getwd }()
-		getwd = func() (dir string, err error) {
-			return "film/web/user", nil
-		}
 		buf := new(strings.Builder)
 		fs := afero.NewMemMapFs()
 		_ = fs.MkdirAll("film/web/user", 0755)
@@ -224,6 +218,9 @@ func TestCDK_Override(t *testing.T) {
 				return exec.Command("echo", fmt.Sprintf("Description: %s", strings.Join(append([]string{name}, args...), " ")))
 			},
 		})
+		cdk.exec.Getwd = func() (dir string, err error) {
+			return "film/web/user", nil
+		}
 
 		// WHEN
 		out, err := cdk.Override(nil)
@@ -234,10 +231,6 @@ func TestCDK_Override(t *testing.T) {
 		require.Contains(t, string(out), fmt.Sprintf("%s synth --no-version-reporting", filepath.Join("node_modules", ".bin", "cdk")))
 	})
 	t.Run("should invoke yarn install and cdk synth, if yarn.lock is found closer than package-lock.json", func(t *testing.T) {
-		defer func() { getwd = os.Getwd }()
-		getwd = func() (dir string, err error) {
-			return "/film/web/user/vip", nil
-		}
 		buf := new(strings.Builder)
 		fs := afero.NewMemMapFs()
 		_ = fs.MkdirAll("/film/web/user/vip", 0755)
@@ -253,6 +246,9 @@ func TestCDK_Override(t *testing.T) {
 				return exec.Command("echo", fmt.Sprintf("Description: %s", strings.Join(append([]string{name}, args...), " ")))
 			},
 		})
+		cdk.exec.Getwd = func() (dir string, err error) {
+			return "/film/web/user/vip", nil
+		}
 
 		// WHEN
 		out, err := cdk.Override(nil)
@@ -263,10 +259,6 @@ func TestCDK_Override(t *testing.T) {
 		require.Contains(t, string(out), fmt.Sprintf("%s synth --no-version-reporting", filepath.Join("node_modules", ".bin", "cdk")))
 	})
 	t.Run("should invoke yarn install and cdk synth, if package-lock.json is found closer than yarn.lock", func(t *testing.T) {
-		defer func() { getwd = os.Getwd }()
-		getwd = func() (dir string, err error) {
-			return "/film/web/user/vip", nil
-		}
 		buf := new(strings.Builder)
 		fs := afero.NewMemMapFs()
 		_ = fs.MkdirAll("/film/web/user/vip", 0755)
@@ -282,6 +274,9 @@ func TestCDK_Override(t *testing.T) {
 				return exec.Command("echo", fmt.Sprintf("Description: %s", strings.Join(append([]string{name}, args...), " ")))
 			},
 		})
+		cdk.exec.Getwd = func() (dir string, err error) {
+			return "/film/web/user/vip", nil
+		}
 
 		// WHEN
 		out, err := cdk.Override(nil)
@@ -292,10 +287,6 @@ func TestCDK_Override(t *testing.T) {
 		require.Contains(t, string(out), fmt.Sprintf("%s synth --no-version-reporting", filepath.Join("node_modules", ".bin", "cdk")))
 	})
 	t.Run("should invoke npm install and cdk synth, if the project manager is unknown", func(t *testing.T) {
-		defer func() { getwd = os.Getwd }()
-		getwd = func() (dir string, err error) {
-			return "film/web/user", nil
-		}
 		buf := new(strings.Builder)
 		fs := afero.NewMemMapFs()
 		_ = fs.MkdirAll("film/web/user", 0755)
@@ -309,6 +300,9 @@ func TestCDK_Override(t *testing.T) {
 				return exec.Command("echo", fmt.Sprintf("Description: %s", strings.Join(append([]string{name}, args...), " ")))
 			},
 		})
+		cdk.exec.Getwd = func() (dir string, err error) {
+			return "film/web/user", nil
+		}
 
 		// WHEN
 		out, err := cdk.Override(nil)

--- a/internal/pkg/override/cdk_test.go
+++ b/internal/pkg/override/cdk_test.go
@@ -28,7 +28,7 @@ func TestCDK_Override(t *testing.T) {
 		cdk := WithCDK("", CDKOpts{
 			FS: afero.NewMemMapFs(),
 			LookPathFn: func(file string) (string, error) {
-				return "", fmt.Errorf(`exec: "%s": executable file not found in $PATH`, file)
+				return "", &exec.Error{Name: "anything", Err: exec.ErrNotFound}
 			},
 		})
 
@@ -36,9 +36,7 @@ func TestCDK_Override(t *testing.T) {
 		_, err := cdk.Override(nil)
 
 		// THEN
-		require.EqualError(t, err, `cannot find a package manager to override with the Cloud Development Kit:
-look up "npm": exec: "npm": executable file not found in $PATH
-look up "yarn": exec: "yarn": executable file not found in $PATH`)
+		require.EqualError(t, err, `cannot find a package manager to override with the Cloud Development Kit`)
 	})
 	t.Run("on install: should return a wrapped error if unexpected error occurs while finding lock file", func(t *testing.T) {
 		// GIVEN
@@ -139,7 +137,7 @@ look up "yarn": exec: "yarn": executable file not found in $PATH`)
 				if file == "npm" {
 					return "/bin/npm", nil
 				}
-				return "", fmt.Errorf(`exec: "%s": executable file not found in $PATH`, file)
+				return "", &exec.Error{Name: "yarn", Err: exec.ErrNotFound}
 			},
 			CommandFn: func(name string, args ...string) *exec.Cmd {
 				return exec.Command("echo", fmt.Sprintf("Description: %s", strings.Join(append([]string{name}, args...), " ")))
@@ -164,7 +162,7 @@ look up "yarn": exec: "yarn": executable file not found in $PATH`)
 				if file == "yarn" {
 					return "/bin/yarn", nil
 				}
-				return "", fmt.Errorf(`exec: "%s": executable file not found in $PATH`, file)
+				return "", &exec.Error{Name: "npm", Err: exec.ErrNotFound}
 			},
 			CommandFn: func(name string, args ...string) *exec.Cmd {
 				return exec.Command("echo", fmt.Sprintf("Description: %s", strings.Join(append([]string{name}, args...), " ")))

--- a/internal/pkg/override/cdk_test.go
+++ b/internal/pkg/override/cdk_test.go
@@ -47,10 +47,10 @@ look up "yarn": exec: "yarn": executable file not found in $PATH`)
 			LookPathFn: func(file string) (string, error) {
 				return "/bin/npm", nil
 			},
-			FindFn: func(_ string, _ int, _ workspace.TraverseUpProcessFn) (string, error) {
-				return "", errors.New("some error")
-			},
 		})
+		cdk.exec.Find = func(_ string, _ int, _ workspace.TraverseUpProcessFn) (string, error) {
+			return "", errors.New("some error")
+		}
 
 		// WHEN
 		_, err := cdk.Override(nil)

--- a/internal/pkg/override/cdk_test.go
+++ b/internal/pkg/override/cdk_test.go
@@ -47,7 +47,7 @@ look up "yarn": exec: "yarn": executable file not found in $PATH`)
 			LookPathFn: func(file string) (string, error) {
 				return "/bin/npm", nil
 			},
-			FindFn: func(_ string, _ int, _ workspace.MatchFn, _ string) (string, error) {
+			FindFn: func(_ string, _ int, _ workspace.TraverseUpProcessFn) (string, error) {
 				return "", errors.New("some error")
 			},
 		})
@@ -56,7 +56,7 @@ look up "yarn": exec: "yarn": executable file not found in $PATH`)
 		_, err := cdk.Override(nil)
 
 		// THEN
-		require.ErrorContains(t, err, `find "package-lock.json": some error`)
+		require.ErrorContains(t, err, `find a package lock file: some error`)
 	})
 	t.Run("on install: should return a wrapped error if npm install fails", func(t *testing.T) {
 		// GIVEN

--- a/internal/pkg/override/errors.go
+++ b/internal/pkg/override/errors.go
@@ -5,8 +5,6 @@ package override
 
 import (
 	"fmt"
-	"sort"
-	"strings"
 )
 
 type errorExecutableNotFound struct {
@@ -19,17 +17,11 @@ func (e *errorExecutableNotFound) Error() string {
 }
 
 type errPackageManagerUnavailable struct {
-	parentErrors []error
+	parentError error
 }
 
 func (err *errPackageManagerUnavailable) Error() string {
-	var parentErrStrings []string
-	for _, e := range err.parentErrors {
-		parentErrStrings = append(parentErrStrings, e.Error())
-	}
-	sort.Sort((sort.StringSlice)(parentErrStrings))
-	return fmt.Sprintf("cannot find a package manager to override with the Cloud Development Kit: %s",
-		strings.Join(parentErrStrings, "; "))
+	return fmt.Sprintf("cannot find a package manager to override with the Cloud Development Kit:\n%s", err.parentError.Error())
 }
 
 // RecommendActions implements the cli.actionRecommender interface.

--- a/internal/pkg/override/errors.go
+++ b/internal/pkg/override/errors.go
@@ -10,7 +10,7 @@ import (
 type errPackageManagerUnavailable struct{}
 
 func (err *errPackageManagerUnavailable) Error() string {
-	return fmt.Sprintf("cannot find a JavaScript package manager to override with the Cloud Development Kit")
+	return "cannot find a JavaScript package manager to override with the Cloud Development Kit"
 }
 
 // RecommendActions implements the cli.actionRecommender interface.

--- a/internal/pkg/override/errors.go
+++ b/internal/pkg/override/errors.go
@@ -7,21 +7,10 @@ import (
 	"fmt"
 )
 
-type errorExecutableNotFound struct {
-	executable string
-	error      error
-}
-
-func (e *errorExecutableNotFound) Error() string {
-	return fmt.Sprintf("look up %q: %s", e.executable, e.error.Error())
-}
-
-type errPackageManagerUnavailable struct {
-	parentError error
-}
+type errPackageManagerUnavailable struct{}
 
 func (err *errPackageManagerUnavailable) Error() string {
-	return fmt.Sprintf("cannot find a package manager to override with the Cloud Development Kit:\n%s", err.parentError.Error())
+	return fmt.Sprintf("cannot find a package manager to override with the Cloud Development Kit")
 }
 
 // RecommendActions implements the cli.actionRecommender interface.

--- a/internal/pkg/override/errors.go
+++ b/internal/pkg/override/errors.go
@@ -10,7 +10,7 @@ import (
 type errPackageManagerUnavailable struct{}
 
 func (err *errPackageManagerUnavailable) Error() string {
-	return fmt.Sprintf("cannot find a package manager to override with the Cloud Development Kit")
+	return fmt.Sprintf("cannot find a JavaScript package manager to override with the Cloud Development Kit")
 }
 
 // RecommendActions implements the cli.actionRecommender interface.

--- a/internal/pkg/override/errors_test.go
+++ b/internal/pkg/override/errors_test.go
@@ -9,6 +9,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestErrNPMUnavailable_RecommendActions(t *testing.T) {
-	require.Equal(t, `Please follow instructions at: "https://docs.npmjs.com/downloading-and-installing-node-js-and-npm" to install "npm"`, new(errNPMUnavailable).RecommendActions())
+func TestErrPackageManagerUnavailable_RecommendActions(t *testing.T) {
+	require.Equal(t, `Please follow the instructions to install either one of the package managers:
+"npm": "https://docs.npmjs.com/downloading-and-installing-node-js-and-npm"
+"yarn": "https://yarnpkg.com/getting-started/install"`,
+		new(errPackageManagerUnavailable).RecommendActions())
 }

--- a/internal/pkg/workspace/errors.go
+++ b/internal/pkg/workspace/errors.go
@@ -35,13 +35,11 @@ func (e *ErrFileNotExists) Error() string {
 // ErrTargetNotFound means that we couldn't locate the target file or the target directory.
 type ErrTargetNotFound struct {
 	startDir              string
-	target                string
 	numberOfLevelsChecked int
 }
 
 func (e *ErrTargetNotFound) Error() string {
-	return fmt.Sprintf("couldn't find a file or directory called %s up to %d levels up from %s",
-		e.target,
+	return fmt.Sprintf("couldn't find a target up to %d levels up from %s",
 		e.numberOfLevelsChecked,
 		e.startDir)
 }
@@ -49,6 +47,7 @@ func (e *ErrTargetNotFound) Error() string {
 // ErrWorkspaceNotFound means we couldn't locate a workspace root.
 type ErrWorkspaceNotFound struct {
 	*ErrTargetNotFound
+	target string
 }
 
 func (e *ErrWorkspaceNotFound) Error() string {

--- a/internal/pkg/workspace/workspace.go
+++ b/internal/pkg/workspace/workspace.go
@@ -66,10 +66,9 @@ var ErrTraverseUpShouldStop = errors.New("should stop")
 // If TraverseUpProcessFn returns a nil error, TraverseUp will keep traversing up the directory tree.
 type TraverseUpProcessFn func(dir string) (result string, err error)
 
-// TraverseUp traverses at most `maxLevels` up from the starting directory, invoke process at each level, and returns
-// the value that it gets from process upon receiving an ErrTraverseUpShouldStop signal.
-// If process returns a non-nil error that is not ErrTraverseUpShouldStop, then TraverseUp will return the error as is.
-// If after traversing up `maxLevels`, it still hasn't received a ErrTraverseUpShouldStop signal, it will return ErrTargetNotFound.g
+// TraverseUp traverses at most `maxLevels` up from the starting directory, invoke TraverseUpProcessFn at each level,
+// and returns the value that it gets TraverseUpProcessFn process upon receiving an ErrTraverseUpShouldStop signal.
+// If after traversing up `maxLevels`, it still hasn't received a ErrTraverseUpShouldStop signal, it will return ErrTargetNotFound.
 func TraverseUp(startDir string, maxLevels int, process TraverseUpProcessFn) (string, error) {
 	searchingDir := startDir
 	for try := 0; try < maxLevels; try++ {

--- a/internal/pkg/workspace/workspace_test.go
+++ b/internal/pkg/workspace/workspace_test.go
@@ -285,9 +285,9 @@ func TestWorkspace_Use(t *testing.T) {
 			expectedError: &ErrWorkspaceNotFound{
 				&ErrTargetNotFound{
 					startDir:              wd,
-					target:                CopilotDirName,
 					numberOfLevelsChecked: maximumParentDirsToSearch,
 				},
+				CopilotDirName,
 			},
 		},
 	}


### PR DESCRIPTION
Will have to rebase on #5075

Resolve parts of #5050 on using yarn instead of npm for cdk override, with a small change from the [the first part of the comment I gave](https://github.com/aws/copilot-cli/issues/5050#issuecomment-1625851258).


I decided not include the drafted proposal of "reading package manager selection from env var"; instead, this PR just defaults to `npm` if after all the checks, there is still a tie. This is because I am not clear on whether it is a common design practice to use env vars to decide which package manager to use, and I expect that the current solution (check install + check project)  is already enough to resolve most of the case.


We can always add the enhancement of "reading package manager selection from env var" afterwards, if it's deemed needed.


This does not handle the second ask from the user, i.e. not assuming the location of `node_modules/`.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
