### PR TITLE
chore: bring mocks back into alignment with interfaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,9 @@ jobs:
 
       - name: Check for nonzero git diff
         run: |
-            git status --porcelain=v1 1>gitstatus.txt
-            [ -z "$(cat gitstatus.txt)" ] && echo "Generated mocks all match"
+             git status --porcelain=v1 1>gitstatus.txt
+             cat gitstatus.txt
+             [ -z "$(cat gitstatus.txt)" ] && echo "Generated mocks all match"
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,11 +55,13 @@ jobs:
       - name: Generate mocks
         run: make gen-mocks
 
-      - name: Check for nonzero git diff
+      - name: Print out local diff after mockgen
         run: |
              git status --porcelain=v1 1>gitstatus.txt
              cat gitstatus.txt
-             [ -z "$(cat gitstatus.txt)" ] && echo "Generated mocks all match"
+
+      - name: Check for nonzero diff
+        run: "[ -z \"$(cat gitstatus.txt)\" ] && echo \"Generated mocks all match\""
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,30 @@ jobs:
       - name: Cleanup
         run: make package-custom-resources-clean
 
+  mocks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '1.20'
+
+      - name: Set up Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16.x
+
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Generate mocks
+        run: make gen-mocks
+
+      - name: Check for nonzero git diff
+        run: |
+            git status --porcelain=v1 1>gitstatus.txt
+            [ -z "$(cat gitstatus.txt)" ] && echo "Generated mocks all match"
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ site/themes/docsy
 internal/pkg/template/templates/custom-resources/
 regression/*/copilot/
 cf-custom-resources/coverage
+gitstatus.txt

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -6,6 +6,7 @@ package cli
 import (
 	"context"
 	"encoding"
+	sdkcloudformation "github.com/aws/aws-sdk-go/service/cloudformation"
 	"io"
 
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -705,4 +706,12 @@ type envPackager interface {
 	UploadArtifacts() (*clideploy.UploadEnvArtifactsOutput, error)
 	AddonsTemplate() (string, error)
 	templateDiffer
+}
+
+type stackConfiguration interface {
+	StackName() string
+	Template() (string, error)
+	Parameters() ([]*sdkcloudformation.Parameter, error)
+	Tags() []*sdkcloudformation.Tag
+	SerializedParameters() (string, error)
 }

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -7679,31 +7679,31 @@ func (mr *MockenvPackagerMockRecorder) Validate(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Validate", reflect.TypeOf((*MockenvPackager)(nil).Validate), arg0)
 }
 
-// MockpipelineStackConfig is a mock of pipelineStackConfig interface.
-type MockpipelineStackConfig struct {
+// MockstackConfiguration is a mock of stackConfiguration interface.
+type MockstackConfiguration struct {
 	ctrl     *gomock.Controller
-	recorder *MockpipelineStackConfigMockRecorder
+	recorder *MockstackConfigurationMockRecorder
 }
 
-// MockpipelineStackConfigMockRecorder is the mock recorder for MockpipelineStackConfig.
-type MockpipelineStackConfigMockRecorder struct {
-	mock *MockpipelineStackConfig
+// MockstackConfigurationMockRecorder is the mock recorder for MockstackConfiguration.
+type MockstackConfigurationMockRecorder struct {
+	mock *MockstackConfiguration
 }
 
-// NewMockpipelineStackConfig creates a new mock instance.
-func NewMockpipelineStackConfig(ctrl *gomock.Controller) *MockpipelineStackConfig {
-	mock := &MockpipelineStackConfig{ctrl: ctrl}
-	mock.recorder = &MockpipelineStackConfigMockRecorder{mock}
+// NewMockstackConfiguration creates a new mock instance.
+func NewMockstackConfiguration(ctrl *gomock.Controller) *MockstackConfiguration {
+	mock := &MockstackConfiguration{ctrl: ctrl}
+	mock.recorder = &MockstackConfigurationMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockpipelineStackConfig) EXPECT() *MockpipelineStackConfigMockRecorder {
+func (m *MockstackConfiguration) EXPECT() *MockstackConfigurationMockRecorder {
 	return m.recorder
 }
 
 // Parameters mocks base method.
-func (m *MockpipelineStackConfig) Parameters() ([]*cloudformation.Parameter, error) {
+func (m *MockstackConfiguration) Parameters() ([]*cloudformation.Parameter, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Parameters")
 	ret0, _ := ret[0].([]*cloudformation.Parameter)
@@ -7712,13 +7712,13 @@ func (m *MockpipelineStackConfig) Parameters() ([]*cloudformation.Parameter, err
 }
 
 // Parameters indicates an expected call of Parameters.
-func (mr *MockpipelineStackConfigMockRecorder) Parameters() *gomock.Call {
+func (mr *MockstackConfigurationMockRecorder) Parameters() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Parameters", reflect.TypeOf((*MockpipelineStackConfig)(nil).Parameters))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Parameters", reflect.TypeOf((*MockstackConfiguration)(nil).Parameters))
 }
 
 // SerializedParameters mocks base method.
-func (m *MockpipelineStackConfig) SerializedParameters() (string, error) {
+func (m *MockstackConfiguration) SerializedParameters() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SerializedParameters")
 	ret0, _ := ret[0].(string)
@@ -7727,13 +7727,13 @@ func (m *MockpipelineStackConfig) SerializedParameters() (string, error) {
 }
 
 // SerializedParameters indicates an expected call of SerializedParameters.
-func (mr *MockpipelineStackConfigMockRecorder) SerializedParameters() *gomock.Call {
+func (mr *MockstackConfigurationMockRecorder) SerializedParameters() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SerializedParameters", reflect.TypeOf((*MockpipelineStackConfig)(nil).SerializedParameters))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SerializedParameters", reflect.TypeOf((*MockstackConfiguration)(nil).SerializedParameters))
 }
 
 // StackName mocks base method.
-func (m *MockpipelineStackConfig) StackName() string {
+func (m *MockstackConfiguration) StackName() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StackName")
 	ret0, _ := ret[0].(string)
@@ -7741,13 +7741,13 @@ func (m *MockpipelineStackConfig) StackName() string {
 }
 
 // StackName indicates an expected call of StackName.
-func (mr *MockpipelineStackConfigMockRecorder) StackName() *gomock.Call {
+func (mr *MockstackConfigurationMockRecorder) StackName() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StackName", reflect.TypeOf((*MockpipelineStackConfig)(nil).StackName))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StackName", reflect.TypeOf((*MockstackConfiguration)(nil).StackName))
 }
 
 // Tags mocks base method.
-func (m *MockpipelineStackConfig) Tags() []*cloudformation.Tag {
+func (m *MockstackConfiguration) Tags() []*cloudformation.Tag {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Tags")
 	ret0, _ := ret[0].([]*cloudformation.Tag)
@@ -7755,13 +7755,13 @@ func (m *MockpipelineStackConfig) Tags() []*cloudformation.Tag {
 }
 
 // Tags indicates an expected call of Tags.
-func (mr *MockpipelineStackConfigMockRecorder) Tags() *gomock.Call {
+func (mr *MockstackConfigurationMockRecorder) Tags() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tags", reflect.TypeOf((*MockpipelineStackConfig)(nil).Tags))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tags", reflect.TypeOf((*MockstackConfiguration)(nil).Tags))
 }
 
 // Template mocks base method.
-func (m *MockpipelineStackConfig) Template() (string, error) {
+func (m *MockstackConfiguration) Template() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Template")
 	ret0, _ := ret[0].(string)
@@ -7770,7 +7770,7 @@ func (m *MockpipelineStackConfig) Template() (string, error) {
 }
 
 // Template indicates an expected call of Template.
-func (mr *MockpipelineStackConfigMockRecorder) Template() *gomock.Call {
+func (mr *MockstackConfigurationMockRecorder) Template() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Template", reflect.TypeOf((*MockpipelineStackConfig)(nil).Template))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Template", reflect.TypeOf((*MockstackConfiguration)(nil).Template))
 }

--- a/internal/pkg/cli/pipeline_deploy.go
+++ b/internal/pkg/cli/pipeline_deploy.go
@@ -98,7 +98,7 @@ type deployPipelineOpts struct {
 	newSvcListCmd         func(io.Writer, string) cmd
 	newJobListCmd         func(io.Writer, string) cmd
 	pipelineVersionGetter func(string, string, bool) (versionGetter, error)
-	pipelineStackConfig   func(in *deploy.CreatePipelineInput) deploycfn.StackConfiguration
+	pipelineStackConfig   func(in *deploy.CreatePipelineInput) stackConfiguration
 
 	configureDeployedPipelineLister func() deployedPipelineLister
 
@@ -148,7 +148,7 @@ func newDeployPipelineOpts(vars deployPipelineVars) (*deployPipelineOpts, error)
 		sel:                selector.NewWsPipelineSelector(prompter, ws),
 		codestar:           cs.New(defaultSession),
 		templateVersion:    version.LatestTemplateVersion(),
-		pipelineStackConfig: func(in *deploy.CreatePipelineInput) deploycfn.StackConfiguration {
+		pipelineStackConfig: func(in *deploy.CreatePipelineInput) stackConfiguration {
 			return stack.NewPipelineStackConfig(in)
 		},
 		newSvcListCmd: func(w io.Writer, appName string) cmd {

--- a/internal/pkg/cli/pipeline_deploy_test.go
+++ b/internal/pkg/cli/pipeline_deploy_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/cli/mocks"
 	"github.com/aws/copilot-cli/internal/pkg/config"
 	"github.com/aws/copilot-cli/internal/pkg/deploy"
-	deploycfn "github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation"
 	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation/stack"
 	"github.com/aws/copilot-cli/internal/pkg/manifest"
 	"github.com/aws/copilot-cli/internal/pkg/term/log"
@@ -28,7 +27,7 @@ type deployPipelineMocks struct {
 	prompt                 *mocks.Mockprompter
 	prog                   *mocks.Mockprogress
 	deployer               *mocks.MockpipelineDeployer
-	pipelineStackConfig    *mocks.MockpipelineStackConfig
+	pipelineStackConfig    *mocks.MockstackConfiguration
 	mockDiffWriter         *strings.Builder
 	ws                     *mocks.MockwsPipelineReader
 	actionCmd              *mocks.MockactionCommand
@@ -914,7 +913,7 @@ func TestDeployPipelineOpts_Execute(t *testing.T) {
 				deployer:               mocks.NewMockpipelineDeployer(ctrl),
 				ws:                     mocks.NewMockwsPipelineReader(ctrl),
 				actionCmd:              mocks.NewMockactionCommand(ctrl),
-				pipelineStackConfig:    mocks.NewMockpipelineStackConfig(ctrl),
+				pipelineStackConfig:    mocks.NewMockstackConfiguration(ctrl),
 				deployedPipelineLister: mocks.NewMockdeployedPipelineLister(ctrl),
 				versionGetter:          mocks.NewMockversionGetter(ctrl),
 				mockDiffWriter:         &strings.Builder{},
@@ -930,7 +929,7 @@ func TestDeployPipelineOpts_Execute(t *testing.T) {
 					allowDowngrade: tc.inAllowDowngrade,
 				},
 				pipelineDeployer: mocks.deployer,
-				pipelineStackConfig: func(in *deploy.CreatePipelineInput) deploycfn.StackConfiguration {
+				pipelineStackConfig: func(in *deploy.CreatePipelineInput) stackConfiguration {
 					return mocks.pipelineStackConfig
 				},
 				ws:              mocks.ws,

--- a/internal/pkg/cli/pipeline_package_test.go
+++ b/internal/pkg/cli/pipeline_package_test.go
@@ -26,7 +26,7 @@ type packagePipelineMocks struct {
 	prompt                 *mocks.Mockprompter
 	prog                   *mocks.Mockprogress
 	deployer               *mocks.MockpipelineDeployer
-	pipelineStackConfig    *mocks.MockpipelineStackConfig
+	pipelineStackConfig    *mocks.MockstackConfiguration
 	ws                     *mocks.MockwsPipelineReader
 	actionCmd              *mocks.MockactionCommand
 	deployedPipelineLister *mocks.MockdeployedPipelineLister
@@ -256,7 +256,7 @@ func TestPipelinePackageOpts_Execute(t *testing.T) {
 			mockProgress := mocks.NewMockprogress(ctrl)
 			mockPrompt := mocks.NewMockprompter(ctrl)
 			mockActionCmd := mocks.NewMockactionCommand(ctrl)
-			mockPipelineStackConfig := mocks.NewMockpipelineStackConfig(ctrl)
+			mockPipelineStackConfig := mocks.NewMockstackConfiguration(ctrl)
 
 			mocks := packagePipelineMocks{
 				store:                  mockStore,


### PR DESCRIPTION
<!-- Provide summary of changes -->
Our generated mocks got out of alignment with our tests. Some unit test files relied on mocks of an interface that no longer existed, for example, leading to merge conflicts in PRs which had to re-generate mocks for other reasons. 

This PR fixes pipeline unit tests using a new `stackConfiguration` interface which is identical to the deploy.StackConfiguration interface.

I think this signals a need for two action items
1. Add a CI check to generate mocks and check for an empty git diff
2. Create a new `PipelineDeployer` object in the `clideploy` package at `internal/pkg/cli/deploy/pipeline.go` to capture cfn/deployment abstractions for `pipeline deploy` and `pipeline package`.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
