### PR TITLE
chore: use + for prerelease number

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ GOBIN=${ROOT_SRC_DIR}/bin/tools
 COVERAGE=coverage.out
 
 DESTINATION=./bin/local/${BINARY_NAME}
-VERSION=$(shell git describe --always --tags)
+VERSION=$(shell git describe --always --tags | sed 's/-/+/')
 
 BINARY_S3_BUCKET_PATH=https://ecs-cli-v2-release.s3.amazonaws.com
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
Problem is the new CLI is not technically "new" in terms of the version number. Adding `allow-downgrade` flag to override.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
