### PR TITLE
fix: make sure copilot URL in buildspec is downloadable

### DIFF
--- a/internal/pkg/cli/pipeline_init.go
+++ b/internal/pkg/cli/pipeline_init.go
@@ -86,6 +86,10 @@ const (
 
 var pipelineTypes = []string{pipelineTypeWorkloads, pipelineTypeEnvironments}
 
+var buildspecTemplateFunctions = map[string]interface{}{
+	"URLSafeVersion": template.URLSafeVersion,
+}
+
 var (
 	// Filled in via the -ldflags flag at compile time to support pipeline buildspec CLI pulling.
 	binaryS3BucketPath string
@@ -780,7 +784,7 @@ func (o *initPipelineOpts) createBuildspec(buildSpecTemplatePath string) error {
 		Version:            version.Version,
 		ManifestPath:       filepath.ToSlash(o.manifestPath), // The manifest path must be rendered in the buildspec with '/' instead of os-specific separator.
 		ArtifactBuckets:    artifactBuckets,
-	}, template.WithFuncs(map[string]interface{}{"URLSafeVersion": template.URLSafeVersion}))
+	}, template.WithFuncs(buildspecTemplateFunctions))
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/cli/pipeline_init.go
+++ b/internal/pkg/cli/pipeline_init.go
@@ -780,7 +780,7 @@ func (o *initPipelineOpts) createBuildspec(buildSpecTemplatePath string) error {
 		Version:            version.Version,
 		ManifestPath:       filepath.ToSlash(o.manifestPath), // The manifest path must be rendered in the buildspec with '/' instead of os-specific separator.
 		ArtifactBuckets:    artifactBuckets,
-	})
+	}, template.WithFuncs(map[string]interface{}{"URLSafeVersion": template.URLSafeVersion}))
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/cli/pipeline_init_test.go
+++ b/internal/pkg/cli/pipeline_init_test.go
@@ -510,7 +510,7 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 				m.workspace.EXPECT().WritePipelineManifest(gomock.Any(), wantedName).Return(wantedManifestFile, nil)
 				m.workspace.EXPECT().WritePipelineBuildspec(gomock.Any(), wantedName).Return(wantedBuildspecFile, nil)
 				m.workspace.EXPECT().Rel(wantedManifestFile).Return(wantedManifestRelPath, nil)
-				m.parser.EXPECT().Parse(workloadsPipelineBuildspecTemplatePath, gomock.Any()).Return(&template.Content{
+				m.parser.EXPECT().Parse(workloadsPipelineBuildspecTemplatePath, gomock.Any(), gomock.Any()).Return(&template.Content{
 					Buffer: bytes.NewBufferString("hello"),
 				}, nil)
 				m.store.EXPECT().GetApplication("badgoose").Return(&config.Application{
@@ -541,7 +541,7 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 				m.workspace.EXPECT().WritePipelineManifest(gomock.Any(), wantedName).Return(wantedManifestFile, nil)
 				m.workspace.EXPECT().WritePipelineBuildspec(gomock.Any(), wantedName).Return(wantedBuildspecFile, nil)
 				m.workspace.EXPECT().Rel(wantedManifestFile).Return(wantedManifestRelPath, nil)
-				m.parser.EXPECT().Parse(workloadsPipelineBuildspecTemplatePath, gomock.Any()).Return(&template.Content{
+				m.parser.EXPECT().Parse(workloadsPipelineBuildspecTemplatePath, gomock.Any(), gomock.Any()).Return(&template.Content{
 					Buffer: bytes.NewBufferString("hello"),
 				}, nil)
 				m.store.EXPECT().GetApplication("badgoose").Return(&config.Application{
@@ -572,7 +572,7 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 				m.workspace.EXPECT().WritePipelineManifest(gomock.Any(), wantedName).Return(wantedManifestFile, nil)
 				m.workspace.EXPECT().WritePipelineBuildspec(gomock.Any(), wantedName).Return(wantedBuildspecFile, nil)
 				m.workspace.EXPECT().Rel(wantedManifestFile).Return(wantedManifestRelPath, nil)
-				m.parser.EXPECT().Parse(workloadsPipelineBuildspecTemplatePath, gomock.Any()).Return(&template.Content{
+				m.parser.EXPECT().Parse(workloadsPipelineBuildspecTemplatePath, gomock.Any(), gomock.Any()).Return(&template.Content{
 					Buffer: bytes.NewBufferString("hello"),
 				}, nil)
 				m.store.EXPECT().GetApplication("badgoose").Return(&config.Application{
@@ -608,7 +608,7 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 				m.workspace.EXPECT().WritePipelineManifest(gomock.Any(), wantedName).Return(wantedManifestFile, nil)
 				m.workspace.EXPECT().WritePipelineBuildspec(gomock.Any(), wantedName).Return(wantedBuildspecFile, nil)
 				m.workspace.EXPECT().Rel(wantedManifestFile).Return(wantedManifestRelPath, nil)
-				m.parser.EXPECT().Parse(workloadsPipelineBuildspecTemplatePath, gomock.Any()).Return(&template.Content{
+				m.parser.EXPECT().Parse(workloadsPipelineBuildspecTemplatePath, gomock.Any(), gomock.Any()).Return(&template.Content{
 					Buffer: bytes.NewBufferString("hello"),
 				}, nil)
 				m.store.EXPECT().GetApplication("badgoose").Return(&config.Application{
@@ -639,7 +639,7 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 				m.workspace.EXPECT().WritePipelineManifest(gomock.Any(), wantedName).Return(wantedManifestFile, nil)
 				m.workspace.EXPECT().WritePipelineBuildspec(gomock.Any(), wantedName).Return(wantedBuildspecFile, nil)
 				m.workspace.EXPECT().Rel(wantedManifestFile).Return(wantedManifestRelPath, nil)
-				m.parser.EXPECT().Parse(environmentsPipelineBuildspecTemplatePath, gomock.Any()).Return(&template.Content{
+				m.parser.EXPECT().Parse(environmentsPipelineBuildspecTemplatePath, gomock.Any(), gomock.Any()).Return(&template.Content{
 					Buffer: bytes.NewBufferString("hello"),
 				}, nil)
 				m.store.EXPECT().GetApplication("badgoose").Return(&config.Application{
@@ -673,7 +673,7 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 				m.workspace.EXPECT().WritePipelineManifest(gomock.Any(), wantedName).Return(wantedManifestFile, nil)
 				m.workspace.EXPECT().WritePipelineBuildspec(gomock.Any(), wantedName).Return(wantedBuildspecFile, nil)
 				m.workspace.EXPECT().Rel(wantedManifestFile).Return(wantedManifestRelPath, nil)
-				m.parser.EXPECT().Parse(workloadsPipelineBuildspecTemplatePath, gomock.Any()).Return(&template.Content{
+				m.parser.EXPECT().Parse(workloadsPipelineBuildspecTemplatePath, gomock.Any(), gomock.Any()).Return(&template.Content{
 					Buffer: bytes.NewBufferString("hello"),
 				}, nil)
 				m.store.EXPECT().GetApplication("badgoose").Return(&config.Application{
@@ -766,7 +766,7 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 				m.workspace.EXPECT().WritePipelineManifest(gomock.Any(), wantedName).Return(wantedManifestFile, nil)
 				m.workspace.EXPECT().WritePipelineBuildspec(gomock.Any(), wantedName).Times(0)
 				m.workspace.EXPECT().Rel(wantedManifestFile).Return(wantedManifestRelPath, nil)
-				m.parser.EXPECT().Parse(workloadsPipelineBuildspecTemplatePath, gomock.Any()).Return(nil, errors.New("some error"))
+				m.parser.EXPECT().Parse(workloadsPipelineBuildspecTemplatePath, gomock.Any(), gomock.Any()).Return(nil, errors.New("some error"))
 				m.store.EXPECT().GetApplication("badgoose").Return(&config.Application{
 					Name: "badgoose",
 				}, nil)
@@ -797,7 +797,7 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 				m.workspace.EXPECT().WritePipelineManifest(gomock.Any(), wantedName).Return("", manifestExistsErr)
 				m.workspace.EXPECT().WritePipelineBuildspec(gomock.Any(), wantedName).Return("", buildspecExistsErr)
 				m.workspace.EXPECT().Rel(wantedManifestFile).Return(wantedManifestRelPath, nil)
-				m.parser.EXPECT().Parse(workloadsPipelineBuildspecTemplatePath, gomock.Any()).Return(&template.Content{
+				m.parser.EXPECT().Parse(workloadsPipelineBuildspecTemplatePath, gomock.Any(), gomock.Any()).Return(&template.Content{
 					Buffer: bytes.NewBufferString("hello"),
 				}, nil)
 				m.store.EXPECT().GetApplication("badgoose").Return(&config.Application{
@@ -830,7 +830,7 @@ func TestInitPipelineOpts_Execute(t *testing.T) {
 				m.workspace.EXPECT().WritePipelineManifest(gomock.Any(), wantedName).Return(wantedManifestFile, nil)
 				m.workspace.EXPECT().Rel(wantedManifestFile).Return(wantedManifestRelPath, nil)
 				m.workspace.EXPECT().WritePipelineBuildspec(gomock.Any(), wantedName).Return("", errors.New("some error"))
-				m.parser.EXPECT().Parse(workloadsPipelineBuildspecTemplatePath, gomock.Any()).Return(&template.Content{
+				m.parser.EXPECT().Parse(workloadsPipelineBuildspecTemplatePath, gomock.Any(), gomock.Any()).Return(&template.Content{
 					Buffer: bytes.NewBufferString("hello"),
 				}, nil)
 				m.store.EXPECT().GetApplication("badgoose").Return(&config.Application{

--- a/internal/pkg/template/template_functions.go
+++ b/internal/pkg/template/template_functions.go
@@ -20,7 +20,14 @@ import (
 
 const (
 	dashReplacement = "DASH"
+	plusReplacement = "%2B"
 )
+
+// URLSafeVersion takes a Copilot version and replaces the '+'
+// character with the URL-safe '%2B'.
+func URLSafeVersion(version string) string {
+	return strings.ReplaceAll(version, "+", plusReplacement)
+}
 
 // ReplaceDashesFunc takes a CloudFormation logical ID, and
 // sanitizes it by removing "-" characters (not allowed)

--- a/internal/pkg/template/template_functions_test.go
+++ b/internal/pkg/template/template_functions_test.go
@@ -10,6 +10,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestURLSafeVersionFunc(t *testing.T) {
+	testCases := map[string]struct {
+		in     string
+		wanted string
+	}{
+		"no plus": {
+			in:     "v1.29.0",
+			wanted: "v1.29.0",
+		},
+		"has plus": {
+			in:     "v1.29.0+5-g74ef584b3",
+			wanted: "v1.29.0%2B5-g74ef584b3",
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.wanted, URLSafeVersion(tc.in))
+		})
+	}
+}
+
 func TestReplaceDashesFunc(t *testing.T) {
 	testCases := map[string]struct {
 		in     string

--- a/internal/pkg/template/templates/cicd/buildspec.yml
+++ b/internal/pkg/template/templates/cicd/buildspec.yml
@@ -9,8 +9,8 @@ phases:
       - echo "cd into $CODEBUILD_SRC_DIR"
       - cd $CODEBUILD_SRC_DIR
       # Download the copilot linux binary.
-      - wget -q {{.BinaryS3BucketPath}}/copilot-linux-{{.Version}}
-      - mv ./copilot-linux-{{.Version}} ./copilot-linux
+      - wget -q {{.BinaryS3BucketPath}}/copilot-linux-{{URLSafeVersion .Version}}
+      - mv ./copilot-linux-{{URLSafeVersion .Version}} ./copilot-linux
       - chmod +x ./copilot-linux
   build:
     commands:


### PR DESCRIPTION
<!-- Provide summary of changes -->
This resolves a problem where the pipeline buildspecs do not generate a correct download URL for the latest copilot version.

This is because '+' characters are URL-encoded to "%2B". 
When the pipeline tries to download an in-between version (v1.29.0+5-g74ef584b for example), it fails because of a wget error that 
the specified version is not found in the bucket. There's no object at the url https://ecs-cli-v2-release.s3.us-west-2.amazonaws.com/copilot-linux-v1.29.0+5-g74ef584b. 

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
