### PR TITLE
chore: bump psql version for serverless v1 aurora addon

### DIFF
--- a/internal/pkg/template/templates/addons/aurora/cf.yml
+++ b/internal/pkg/template/templates/addons/aurora/cf.yml
@@ -137,7 +137,7 @@ Resources:
       EngineVersion: '5.7.mysql_aurora.2.07.1'
       {{- else}}
       Engine: 'aurora-postgresql'
-      EngineVersion: '10.12'
+      EngineVersion: '13.9' # LTS versions of PostgreSQL for Aurora Serverless v1 are v13.9 and v11.9
       {{- end}}
       EngineMode: serverless
       DBClusterParameterGroupName: {{- if .ParameterGroup}} {{.ParameterGroup}} {{- else}} !Ref {{logicalIDSafe .ClusterName}}DBClusterParameterGroup {{- end}}


### PR DESCRIPTION
Related #5110.

We currently use postgres engine version 10 in Aurora serverless v1 addons. This isn't supported anymore. We should update this to v11.9 or v13.9 for current LTS versions. Recommend 13.9 since it was launched in january 2023 and will be around for longer. 

Further reading:
https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless.relnotes.html
https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Updates.LTS.html