### PR TITLE
chore: default the writer of docker build to `Stderr` incase of single image

### DIFF
--- a/internal/pkg/cli/deploy/workload.go
+++ b/internal/pkg/cli/deploy/workload.go
@@ -408,7 +408,30 @@ func (d *workloadDeployer) uploadContainerImages(out *UploadArtifactsOutput) err
 	if err != nil {
 		return fmt.Errorf("login to image repository: %w", err)
 	}
+	isMultipleContainerImages := len(buildArgsPerContainer) > 1
+	if isMultipleContainerImages {
+		return d.buildContainerImagesInParallel(uri, buildArgsPerContainer, out)
+	}
+	return d.buildSingleContainerImage(uri, buildArgsPerContainer, out)
+}
 
+func (d *workloadDeployer) buildSingleContainerImage(uri string, buildArgsPerContainer map[string]*dockerengine.BuildArguments, out *UploadArtifactsOutput) error {
+	out.ImageDigests = make(map[string]ContainerImageIdentifier, len(buildArgsPerContainer))
+	for name, buildArgs := range buildArgsPerContainer {
+		digest, err := d.repository.BuildAndPush(context.Background(), buildArgs, os.Stderr)
+		if err != nil {
+			return fmt.Errorf("build and push the image %q: %w", name, err)
+		}
+		out.ImageDigests[name] = ContainerImageIdentifier{
+			Digest:            digest,
+			CustomTag:         d.image.CustomTag,
+			GitShortCommitTag: d.image.GitShortCommitTag,
+		}
+	}
+	return nil
+}
+
+func (d *workloadDeployer) buildContainerImagesInParallel(uri string, buildArgsPerContainer map[string]*dockerengine.BuildArguments, out *UploadArtifactsOutput) error {
 	var digestsMu sync.Mutex
 	out.ImageDigests = make(map[string]ContainerImageIdentifier, len(buildArgsPerContainer))
 	var labeledBuffers []*syncbuffer.LabeledSyncBuffer

--- a/internal/pkg/cli/deploy/workload.go
+++ b/internal/pkg/cli/deploy/workload.go
@@ -418,6 +418,7 @@ func (d *workloadDeployer) uploadContainerImages(out *UploadArtifactsOutput) err
 func (d *workloadDeployer) buildSingleContainerImage(uri string, buildArgsPerContainer map[string]*dockerengine.BuildArguments, out *UploadArtifactsOutput) error {
 	out.ImageDigests = make(map[string]ContainerImageIdentifier, len(buildArgsPerContainer))
 	for name, buildArgs := range buildArgsPerContainer {
+		buildArgs.URI = uri
 		digest, err := d.repository.BuildAndPush(context.Background(), buildArgs, os.Stderr)
 		if err != nil {
 			return fmt.Errorf("build and push the image %q: %w", name, err)

--- a/internal/pkg/cli/deploy/workload_test.go
+++ b/internal/pkg/cli/deploy/workload_test.go
@@ -241,8 +241,6 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 						"com.aws.copilot.image.container.name": "mockWkld",
 					},
 				}, gomock.Any()).Return("", mockError)
-				m.mockLabeledTermPrinter.EXPECT().IsDone().Return(true).AnyTimes()
-				m.mockLabeledTermPrinter.EXPECT().Print().AnyTimes()
 			},
 			wantErr: fmt.Errorf("build and push the image \"mockWkld\": some error"),
 		},
@@ -269,8 +267,6 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 						"com.aws.copilot.image.container.name": "mockWkld",
 					},
 				}, gomock.Any()).Return("mockDigest", nil)
-				m.mockLabeledTermPrinter.EXPECT().IsDone().Return(true).AnyTimes()
-				m.mockLabeledTermPrinter.EXPECT().Print().AnyTimes()
 				m.mockAddons = nil
 			},
 			wantImages: map[string]ContainerImageIdentifier{
@@ -303,8 +299,6 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 						"com.aws.copilot.image.container.name": "mockWkld",
 					},
 				}, gomock.Any()).Return("mockDigest", nil)
-				m.mockLabeledTermPrinter.EXPECT().IsDone().Return(true).AnyTimes()
-				m.mockLabeledTermPrinter.EXPECT().Print().AnyTimes()
 				m.mockAddons = nil
 			},
 			wantImages: map[string]ContainerImageIdentifier{


### PR DESCRIPTION
<!-- Provide summary of changes -->
related #5124, #5067
This PR will remove the rolling display when there is only one image to build.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
