### PR TITLE
chore: update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,6 @@
 version: 2
 updates:
+
 - package-ecosystem: gomod
   directory: "/"
   schedule:


### PR DESCRIPTION
Add a new line to dependabot.yml to trigger GH to configure dependabot


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
