### PR TITLE
fix(cli): initialize versioning for jobs

### DIFF
--- a/internal/pkg/cli/deploy.go
+++ b/internal/pkg/cli/deploy.go
@@ -80,6 +80,7 @@ func newDeployOpts(vars deployWkldVars) (*deployOpts, error) {
 					unmarshal:       manifest.UnmarshalWorkload,
 					sel:             selector.NewLocalWorkloadSelector(o.prompt, o.store, ws),
 					cmd:             exec.NewCmd(),
+					templateVersion: version.LatestTemplateVersion(),
 					sessProvider:    sessProvider,
 				}
 				opts.newJobDeployer = func() (workloadDeployer, error) {


### PR DESCRIPTION
A customer reported a discrepancy between `copilot deploy` and `copilot job deploy` for deploying a job. Template versioning wasn't being initialized in the former, so the detected version was empty.

https://app.gitter.im/#/room/#aws_copilot-cli:gitter.im/$Bq0Q0Yn3V_41DowpRV3dCcV-6mTXsYAYCbu1dDj0qR0



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
