### PR TITLE
chore: fix apprunner e2e tests

### DIFF
--- a/e2e/apprunner/apprunner_test.go
+++ b/e2e/apprunner/apprunner_test.go
@@ -27,6 +27,7 @@ var _ = Describe("App Runner", Ordered, func() {
 	BeforeAll(func() {
 		_, initErr = cli.Init(&client.InitRequest{
 			AppName:      appName,
+			EnvName:      envName,
 			WorkloadName: feSvcName,
 			ImageTag:     "gallopinggurdey",
 			Dockerfile:   "./front-end/Dockerfile",


### PR DESCRIPTION
<!-- Provide summary of changes -->
fixes `Apprunner ` e2e uses by initializing the `env` name in the `copilot init` command
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
