### PR TITLE
chore: allow copilot env init fallback to default credentials

### DIFF
--- a/internal/pkg/cli/env_init.go
+++ b/internal/pkg/cli/env_init.go
@@ -429,8 +429,15 @@ func (o *initEnvOpts) askEnvSession() error {
 
 	selCreds, err := o.selCreds()
 	if err != nil {
-		return err
+		errRetrieveCreds := err
+		sess, err := o.sessProvider.Default()
+		if err != nil {
+			return errors.Join(errRetrieveCreds, fmt.Errorf("falling back on default credentials: %w", err))
+		}
+		o.sess = sess
+		return nil
 	}
+
 	sess, err := selCreds.Creds(fmt.Sprintf(fmtEnvInitCredsPrompt, color.HighlightUserInput(o.name)), envInitCredsHelpPrompt)
 	if err != nil {
 		return fmt.Errorf("select creds: %w", err)

--- a/internal/pkg/cli/env_init_test.go
+++ b/internal/pkg/cli/env_init_test.go
@@ -356,18 +356,13 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 		inAdjustVPCVars      adjustVPCVars
 		inInternalALBSubnets []string
 
-		getMockCredsSelector func(credsSelector) func() (credsSelector, error)
+		getMockCredsSelector func() (credsSelector, error)
 		setupMocks           func(mocks initEnvMocks)
 
 		wantedError error
 	}{
 		"fail to get env name": {
 			inAppName: mockApp,
-			getMockCredsSelector: func(c credsSelector) func() (credsSelector, error) {
-				return func() (credsSelector, error) {
-					return c, nil
-				}
-			},
 			setupMocks: func(m initEnvMocks) {
 				gomock.InOrder(
 					m.prompt.EXPECT().
@@ -379,11 +374,6 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 		},
 		"should error if environment already exists": {
 			inAppName: mockApp,
-			getMockCredsSelector: func(c credsSelector) func() (credsSelector, error) {
-				return func() (credsSelector, error) {
-					return c, nil
-				}
-			},
 			setupMocks: func(m initEnvMocks) {
 				gomock.InOrder(
 					m.prompt.EXPECT().
@@ -399,11 +389,6 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 			inEnv:     mockEnv,
 			inProfile: mockProfile,
 			inDefault: true,
-			getMockCredsSelector: func(c credsSelector) func() (credsSelector, error) {
-				return func() (credsSelector, error) {
-					return c, nil
-				}
-			},
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromProfile(mockProfile).Return(&session.Session{
 					Config: &aws.Config{
@@ -420,11 +405,6 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 				SecretAccessKey: "efgh",
 			},
 			inDefault: true,
-			getMockCredsSelector: func(c credsSelector) func() (credsSelector, error) {
-				return func() (credsSelector, error) {
-					return c, nil
-				}
-			},
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromStaticCreds("abcd", "efgh", "").Return(mockSession, nil)
 			},
@@ -433,11 +413,6 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 			inAppName: mockApp,
 			inEnv:     mockEnv,
 			inDefault: true,
-			getMockCredsSelector: func(c credsSelector) func() (credsSelector, error) {
-				return func() (credsSelector, error) {
-					return c, nil
-				}
-			},
 			setupMocks: func(m initEnvMocks) {
 				m.selCreds.EXPECT().Creds("Which credentials would you like to use to create test?", gomock.Any()).Return(mockSession, nil)
 			},
@@ -446,10 +421,8 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 			inAppName: mockApp,
 			inEnv:     mockEnv,
 			inDefault: true,
-			getMockCredsSelector: func(c credsSelector) func() (credsSelector, error) {
-				return func() (credsSelector, error) {
-					return nil, mockErr
-				}
+			getMockCredsSelector: func() (credsSelector, error) {
+				return nil, mockErr
 			},
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().Default().Return(&session.Session{
@@ -464,11 +437,6 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 			inEnv:     mockEnv,
 			inProfile: mockProfile,
 			inDefault: true,
-			getMockCredsSelector: func(c credsSelector) func() (credsSelector, error) {
-				return func() (credsSelector, error) {
-					return c, nil
-				}
-			},
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(&session.Session{
 					Config: &aws.Config{},
@@ -482,11 +450,6 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 			inProfile: mockProfile,
 			inRegion:  mockRegion,
 			inDefault: true,
-			getMockCredsSelector: func(c credsSelector) func() (credsSelector, error) {
-				return func() (credsSelector, error) {
-					return c, nil
-				}
-			},
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(&session.Session{
 					Config: &aws.Config{},
@@ -499,11 +462,6 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 			inEnv:     mockEnv,
 			inProfile: mockProfile,
 			inDefault: true,
-			getMockCredsSelector: func(c credsSelector) func() (credsSelector, error) {
-				return func() (credsSelector, error) {
-					return c, nil
-				}
-			},
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(mockSession, nil)
 				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
@@ -513,11 +471,6 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 			inAppName: mockApp,
 			inEnv:     mockEnv,
 			inProfile: mockProfile,
-			getMockCredsSelector: func(c credsSelector) func() (credsSelector, error) {
-				return func() (credsSelector, error) {
-					return c, nil
-				}
-			},
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(mockSession, nil)
 				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, "", envInitCustomizedEnvTypes, gomock.Any()).
@@ -529,11 +482,6 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 			inAppName: mockApp,
 			inEnv:     mockEnv,
 			inProfile: mockProfile,
-			getMockCredsSelector: func(c credsSelector) func() (credsSelector, error) {
-				return func() (credsSelector, error) {
-					return c, nil
-				}
-			},
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(mockSession, nil)
 				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, "", envInitCustomizedEnvTypes, gomock.Any()).
@@ -544,11 +492,6 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 			inAppName: mockApp,
 			inEnv:     mockEnv,
 			inProfile: mockProfile,
-			getMockCredsSelector: func(c credsSelector) func() (credsSelector, error) {
-				return func() (credsSelector, error) {
-					return c, nil
-				}
-			},
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(mockSession, nil)
 				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, "", envInitCustomizedEnvTypes, gomock.Any()).
@@ -561,11 +504,6 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 			inAppName: mockApp,
 			inEnv:     mockEnv,
 			inProfile: mockProfile,
-			getMockCredsSelector: func(c credsSelector) func() (credsSelector, error) {
-				return func() (credsSelector, error) {
-					return c, nil
-				}
-			},
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(mockSession, nil)
 				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, "", envInitCustomizedEnvTypes, gomock.Any()).
@@ -579,11 +517,6 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 			inAppName: mockApp,
 			inEnv:     mockEnv,
 			inProfile: mockProfile,
-			getMockCredsSelector: func(c credsSelector) func() (credsSelector, error) {
-				return func() (credsSelector, error) {
-					return c, nil
-				}
-			},
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(mockSession, nil)
 				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, "", envInitCustomizedEnvTypes, gomock.Any()).
@@ -597,11 +530,6 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 			inAppName: mockApp,
 			inEnv:     mockEnv,
 			inProfile: mockProfile,
-			getMockCredsSelector: func(c credsSelector) func() (credsSelector, error) {
-				return func() (credsSelector, error) {
-					return c, nil
-				}
-			},
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(mockSession, nil)
 				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, "", envInitCustomizedEnvTypes, gomock.Any()).
@@ -617,11 +545,6 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 			inAppName: mockApp,
 			inEnv:     mockEnv,
 			inProfile: mockProfile,
-			getMockCredsSelector: func(c credsSelector) func() (credsSelector, error) {
-				return func() (credsSelector, error) {
-					return c, nil
-				}
-			},
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(mockSession, nil)
 				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, "", envInitCustomizedEnvTypes, gomock.Any()).
@@ -637,11 +560,6 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 			inAppName: mockApp,
 			inEnv:     mockEnv,
 			inProfile: mockProfile,
-			getMockCredsSelector: func(c credsSelector) func() (credsSelector, error) {
-				return func() (credsSelector, error) {
-					return c, nil
-				}
-			},
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(mockSession, nil)
 				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, "", envInitCustomizedEnvTypes, gomock.Any()).
@@ -659,11 +577,6 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 			inAppName: mockApp,
 			inEnv:     mockEnv,
 			inProfile: mockProfile,
-			getMockCredsSelector: func(c credsSelector) func() (credsSelector, error) {
-				return func() (credsSelector, error) {
-					return c, nil
-				}
-			},
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(mockSession, nil)
 				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, "", envInitCustomizedEnvTypes, gomock.Any()).
@@ -681,11 +594,6 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 			inAppName: mockApp,
 			inEnv:     mockEnv,
 			inProfile: mockProfile,
-			getMockCredsSelector: func(c credsSelector) func() (credsSelector, error) {
-				return func() (credsSelector, error) {
-					return c, nil
-				}
-			},
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(mockSession, nil)
 				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, "", envInitCustomizedEnvTypes, gomock.Any()).
@@ -702,11 +610,6 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 			inAppName: mockApp,
 			inEnv:     mockEnv,
 			inProfile: mockProfile,
-			getMockCredsSelector: func(c credsSelector) func() (credsSelector, error) {
-				return func() (credsSelector, error) {
-					return c, nil
-				}
-			},
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(mockSession, nil)
 				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, "", envInitCustomizedEnvTypes, gomock.Any()).
@@ -723,11 +626,6 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 			inAppName: mockApp,
 			inEnv:     mockEnv,
 			inProfile: mockProfile,
-			getMockCredsSelector: func(c credsSelector) func() (credsSelector, error) {
-				return func() (credsSelector, error) {
-					return c, nil
-				}
-			},
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(mockSession, nil)
 				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, "", envInitCustomizedEnvTypes, gomock.Any()).
@@ -749,11 +647,6 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 				PrivateSubnetIDs: []string{"mockPrivateSubnetID", "anotherMockPrivateSubnetID"},
 				PublicSubnetIDs:  []string{"mockPublicSubnetID", "anotherMockPublicSubnetID"},
 			},
-			getMockCredsSelector: func(c credsSelector) func() (credsSelector, error) {
-				return func() (credsSelector, error) {
-					return c, nil
-				}
-			},
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(mockSession, nil)
 				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
@@ -766,11 +659,6 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 			inProfile: mockProfile,
 			inImportVPCVars: importVPCVars{
 				ID: "mockVPC",
-			},
-			getMockCredsSelector: func(c credsSelector) func() (credsSelector, error) {
-				return func() (credsSelector, error) {
-					return c, nil
-				}
 			},
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(mockSession, nil)
@@ -789,11 +677,6 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 				PrivateSubnetIDs: []string{"mockPrivateSubnetID", "anotherMockPrivateSubnetID"},
 				PublicSubnetIDs:  []string{"mockPublicSubnetID", "anotherMockPublicSubnetID"},
 			},
-			getMockCredsSelector: func(c credsSelector) func() (credsSelector, error) {
-				return func() (credsSelector, error) {
-					return c, nil
-				}
-			},
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(mockSession, nil)
 				m.selVPC.EXPECT().VPC(envInitVPCSelectPrompt, "").Return("mockVPC", nil)
@@ -807,11 +690,6 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 			inImportVPCVars: importVPCVars{
 				ID:               "mockVPC",
 				PrivateSubnetIDs: []string{"mockPrivateSubnetID", "anotherMockPrivateSubnetID"},
-			},
-			getMockCredsSelector: func(c credsSelector) func() (credsSelector, error) {
-				return func() (credsSelector, error) {
-					return c, nil
-				}
 			},
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(mockSession, nil)
@@ -828,11 +706,6 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 				ID:              "mockVPC",
 				PublicSubnetIDs: []string{"mockPublicSubnetID", "anotherMockPublicSubnetID"},
 			},
-			getMockCredsSelector: func(c credsSelector) func() (credsSelector, error) {
-				return func() (credsSelector, error) {
-					return c, nil
-				}
-			},
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(mockSession, nil)
 				m.ec2Client.EXPECT().HasDNSSupport("mockVPC").Return(true, nil)
@@ -848,11 +721,6 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 				ID: "mockVPC",
 			},
 			inInternalALBSubnets: []string{"nonexistentSubnet", "anotherNonexistentSubnet"},
-			getMockCredsSelector: func(c credsSelector) func() (credsSelector, error) {
-				return func() (credsSelector, error) {
-					return c, nil
-				}
-			},
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(mockSession, nil)
 				m.ec2Client.EXPECT().HasDNSSupport("mockVPC").Return(true, nil)
@@ -871,11 +739,6 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 			inImportVPCVars: importVPCVars{
 				ID: "mockVPC",
 			},
-			getMockCredsSelector: func(c credsSelector) func() (credsSelector, error) {
-				return func() (credsSelector, error) {
-					return c, nil
-				}
-			},
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(mockSession, nil)
 				m.ec2Client.EXPECT().HasDNSSupport("mockVPC").Return(true, nil)
@@ -891,11 +754,6 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 			inEnv:                mockEnv,
 			inProfile:            mockProfile,
 			inInternalALBSubnets: []string{"mockPrivateSubnet", "anotherMockPrivateSubnet"},
-			getMockCredsSelector: func(c credsSelector) func() (credsSelector, error) {
-				return func() (credsSelector, error) {
-					return c, nil
-				}
-			},
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(mockSession, nil)
 				m.selVPC.EXPECT().VPC(envInitVPCSelectPrompt, "").Return("mockVPC", nil)
@@ -910,11 +768,6 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 			inAppName: mockApp,
 			inEnv:     mockEnv,
 			inProfile: mockProfile,
-			getMockCredsSelector: func(c credsSelector) func() (credsSelector, error) {
-				return func() (credsSelector, error) {
-					return c, nil
-				}
-			},
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(mockSession, nil)
 				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, "", envInitCustomizedEnvTypes, gomock.Any()).
@@ -928,11 +781,6 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 			inAppName: mockApp,
 			inEnv:     mockEnv,
 			inProfile: mockProfile,
-			getMockCredsSelector: func(c credsSelector) func() (credsSelector, error) {
-				return func() (credsSelector, error) {
-					return c, nil
-				}
-			},
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(mockSession, nil)
 				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, gomock.Any(), gomock.Any(), gomock.Any()).
@@ -947,11 +795,6 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 			inAppName: mockApp,
 			inEnv:     mockEnv,
 			inProfile: mockProfile,
-			getMockCredsSelector: func(c credsSelector) func() (credsSelector, error) {
-				return func() (credsSelector, error) {
-					return c, nil
-				}
-			},
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(mockSession, nil)
 				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, gomock.Any(), gomock.Any(), gomock.Any()).
@@ -970,11 +813,6 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 			inAppName: mockApp,
 			inEnv:     mockEnv,
 			inProfile: mockProfile,
-			getMockCredsSelector: func(c credsSelector) func() (credsSelector, error) {
-				return func() (credsSelector, error) {
-					return c, nil
-				}
-			},
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(mockSession, nil)
 				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, gomock.Any(), gomock.Any(), gomock.Any()).
@@ -1000,11 +838,6 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 			inAppName: mockApp,
 			inEnv:     mockEnv,
 			inProfile: mockProfile,
-			getMockCredsSelector: func(c credsSelector) func() (credsSelector, error) {
-				return func() (credsSelector, error) {
-					return c, nil
-				}
-			},
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(mockSession, nil)
 				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, gomock.Any(), gomock.Any(), gomock.Any()).
@@ -1032,11 +865,6 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 			inAppName: mockApp,
 			inEnv:     mockEnv,
 			inProfile: mockProfile,
-			getMockCredsSelector: func(c credsSelector) func() (credsSelector, error) {
-				return func() (credsSelector, error) {
-					return c, nil
-				}
-			},
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(mockSession, nil)
 				m.prompt.EXPECT().SelectOne(envInitDefaultEnvConfirmPrompt, "", envInitCustomizedEnvTypes, gomock.Any()).
@@ -1071,11 +899,6 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 				AZs:                []string{"us-east-1a", "us-east-1b"},
 				PrivateSubnetCIDRs: []string{"mockPrivateCIDR1", "mockPrivateCIDR2"},
 				PublicSubnetCIDRs:  []string{"mockPublicCIDR1", "mockPublicCIDR2"},
-			},
-			getMockCredsSelector: func(c credsSelector) func() (credsSelector, error) {
-				return func() (credsSelector, error) {
-					return c, nil
-				}
 			},
 			setupMocks: func(m initEnvMocks) {
 				m.sessProvider.EXPECT().FromProfile(gomock.Any()).Return(mockSession, nil)
@@ -1115,11 +938,16 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 				},
 				sessProvider: mocks.sessProvider,
 				selVPC:       mocks.selVPC,
-				selCreds:     tc.getMockCredsSelector(mocks.selCreds),
-				ec2Client:    mocks.ec2Client,
-				prompt:       mocks.prompt,
-				selApp:       mocks.selApp,
-				store:        mocks.store,
+				selCreds: func() (credsSelector, error) {
+					if tc.getMockCredsSelector != nil {
+						return tc.getMockCredsSelector()
+					}
+					return mocks.selCreds, nil
+				},
+				ec2Client: mocks.ec2Client,
+				prompt:    mocks.prompt,
+				selApp:    mocks.selApp,
+				store:     mocks.store,
 			}
 
 			// WHEN


### PR DESCRIPTION
<!-- Provide summary of changes -->
Lets copilot fall back to default credentials when it fails to find/parse `.aws/config` file during `copilot env init.`

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->
Addresses #5066 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
