### PR TITLE
fix: filter active cluster before calling active services

### DIFF
--- a/internal/pkg/aws/ecs/ecs.go
+++ b/internal/pkg/aws/ecs/ecs.go
@@ -341,23 +341,16 @@ func (e *ECS) ActiveClusters(arns ...string) ([]string, error) {
 	return active, nil
 }
 
-// ActiveServices returns the subset of service arns that have an ACTIVE status.
-// Note that all services should be in the same cluster.
-func (e *ECS) ActiveServices(serviceARNs ...string) ([]string, error) {
-	var prevSvcArn *ServiceArn
-	for _, arn := range serviceARNs {
-		svcArn, err := ParseServiceArn(arn)
-		if err != nil {
-			return nil, err
-		}
-		if prevSvcArn != nil && prevSvcArn.clusterName != svcArn.clusterName {
-			return nil, fmt.Errorf("service %q and service %q should be in the same cluster", prevSvcArn.String(), svcArn.String())
-		}
-		prevSvcArn = svcArn
+// ActiveServices returns the subset of service arns that have an ACTIVE status from the given cluster.
+func (e *ECS) ActiveServices(clusterARN string, serviceARNs ...string) ([]string, error) {
+	// All the filteredSvcARNs will belong to the given Cluster.
+	filteredSvcARNS, err := e.filterServiceARNs(clusterARN, serviceARNs...)
+	if err != nil {
+		return nil, err
 	}
 	resp, err := e.client.DescribeServices(&ecs.DescribeServicesInput{
-		Cluster:  aws.String(prevSvcArn.ClusterArn()),
-		Services: aws.StringSlice(serviceARNs),
+		Cluster:  aws.String(clusterARN),
+		Services: aws.StringSlice(filteredSvcARNS),
 	})
 	switch {
 	case err != nil:
@@ -499,6 +492,21 @@ func (e *ECS) service(clusterName, serviceName string) (*Service, error) {
 		}
 	}
 	return nil, fmt.Errorf("cannot find service %s", serviceName)
+}
+
+// filterServiceARNs returns subset of the ServiceARNs that belong to the given Cluster.
+func (e *ECS) filterServiceARNs(clusterARN string, serviceARNs ...string) ([]string, error) {
+	var filteredSvcARNS []string
+	for _, arn := range serviceARNs {
+		svcArn, err := ParseServiceArn(arn)
+		if err != nil {
+			return nil, err
+		}
+		if svcArn.ClusterArn() == clusterARN {
+			filteredSvcARNS = append(filteredSvcARNS, arn)
+		}
+	}
+	return filteredSvcARNS, nil
 }
 
 func isRequestTimeoutErr(err error) bool {

--- a/internal/pkg/aws/ecs/ecs.go
+++ b/internal/pkg/aws/ecs/ecs.go
@@ -496,17 +496,17 @@ func (e *ECS) service(clusterName, serviceName string) (*Service, error) {
 
 // filterServiceARNs returns subset of the ServiceARNs that belong to the given Cluster.
 func (e *ECS) filterServiceARNs(clusterARN string, serviceARNs ...string) ([]string, error) {
-	var filteredSvcARNS []string
+	var filtered []string
 	for _, arn := range serviceARNs {
 		svcArn, err := ParseServiceArn(arn)
 		if err != nil {
 			return nil, err
 		}
 		if svcArn.ClusterArn() == clusterARN {
-			filteredSvcARNS = append(filteredSvcARNS, arn)
+			filtered = append(filtered, arn)
 		}
 	}
-	return filteredSvcARNS, nil
+	return filtered, nil
 }
 
 func isRequestTimeoutErr(err error) bool {

--- a/internal/pkg/ecs/ecs_test.go
+++ b/internal/pkg/ecs/ecs_test.go
@@ -138,6 +138,10 @@ func TestClient_serviceARN(t *testing.T) {
 		mockSvcARN1 = "arn:aws:ecs:us-west-2:1234567890:service/mockCluster/mockService1"
 		mockSvcARN2 = "arn:aws:ecs:us-west-2:1234567890:service/mockCluster/mockService2"
 	)
+	getRgEnvClusterInput := map[string]string{
+		deploy.AppTagKey: mockApp,
+		deploy.EnvTagKey: mockEnv,
+	}
 	getRgInput := map[string]string{
 		deploy.AppTagKey:     mockApp,
 		deploy.EnvTagKey:     mockEnv,
@@ -176,7 +180,12 @@ func TestClient_serviceARN(t *testing.T) {
 						Return([]*resourcegroups.Resource{
 							{ARN: mockSvcARN1}, {ARN: mockSvcARN2},
 						}, nil),
-					m.ecsClient.EXPECT().ActiveServices(mockSvcARN1, mockSvcARN2).Return([]string{mockSvcARN1, mockSvcARN2}, nil),
+					m.resourceGetter.EXPECT().GetResourcesByTags(clusterResourceType, getRgEnvClusterInput).
+						Return([]*resourcegroups.Resource{
+							{ARN: "mockARN1"}, {ARN: "mockARN2"},
+						}, nil),
+					m.ecsClient.EXPECT().ActiveClusters("mockARN1", "mockARN2").Return([]string{"mockARN1"}, nil),
+					m.ecsClient.EXPECT().ActiveServices("mockARN1", []string{mockSvcARN1, mockSvcARN2}).Return([]string{mockSvcARN1, mockSvcARN2}, nil),
 				)
 			},
 			wantedError: fmt.Errorf(`more than one ECS service with tags "copilot-application"="mockApp","copilot-environment"="mockEnv","copilot-service"="mockSvc"`),
@@ -188,7 +197,12 @@ func TestClient_serviceARN(t *testing.T) {
 						Return([]*resourcegroups.Resource{
 							{ARN: mockSvcARN1}, {ARN: mockSvcARN2},
 						}, nil),
-					m.ecsClient.EXPECT().ActiveServices(mockSvcARN1, mockSvcARN2).Return([]string{mockSvcARN1}, nil),
+					m.resourceGetter.EXPECT().GetResourcesByTags(clusterResourceType, getRgEnvClusterInput).
+						Return([]*resourcegroups.Resource{
+							{ARN: "mockARN1"}, {ARN: "mockARN2"},
+						}, nil),
+					m.ecsClient.EXPECT().ActiveClusters("mockARN1", "mockARN2").Return([]string{"mockARN1"}, nil),
+					m.ecsClient.EXPECT().ActiveServices("mockARN1", []string{mockSvcARN1, mockSvcARN2}).Return([]string{mockSvcARN1}, nil),
 				)
 			},
 			wantedSvcArn: mockSvcARN1,
@@ -237,6 +251,10 @@ func TestClient_DescribeService(t *testing.T) {
 		mockCluster = "mockCluster"
 		mockService = "mockService"
 	)
+	getRgEnvClusterInput := map[string]string{
+		deploy.AppTagKey: mockApp,
+		deploy.EnvTagKey: mockEnv,
+	}
 	getRgInput := map[string]string{
 		deploy.AppTagKey:     mockApp,
 		deploy.EnvTagKey:     mockEnv,
@@ -256,7 +274,12 @@ func TestClient_DescribeService(t *testing.T) {
 						Return([]*resourcegroups.Resource{
 							{ARN: mockSvcARN},
 						}, nil),
-					m.ecsClient.EXPECT().ActiveServices(mockSvcARN).Return([]string{mockSvcARN}, nil),
+					m.resourceGetter.EXPECT().GetResourcesByTags(clusterResourceType, getRgEnvClusterInput).
+						Return([]*resourcegroups.Resource{
+							{ARN: "mockARN1"}, {ARN: "mockARN2"},
+						}, nil),
+					m.ecsClient.EXPECT().ActiveClusters("mockARN1", "mockARN2").Return([]string{"mockARN1"}, nil),
+					m.ecsClient.EXPECT().ActiveServices("mockARN1", []string{mockSvcARN}).Return([]string{mockSvcARN}, nil),
 					m.ecsClient.EXPECT().ServiceRunningTasks(mockCluster, mockService).Return(nil, errors.New("some error")),
 				)
 			},
@@ -269,7 +292,12 @@ func TestClient_DescribeService(t *testing.T) {
 						Return([]*resourcegroups.Resource{
 							{ARN: mockSvcARN},
 						}, nil),
-					m.ecsClient.EXPECT().ActiveServices(mockSvcARN).Return([]string{mockSvcARN}, nil),
+					m.resourceGetter.EXPECT().GetResourcesByTags(clusterResourceType, getRgEnvClusterInput).
+						Return([]*resourcegroups.Resource{
+							{ARN: "mockARN1"}, {ARN: "mockARN2"},
+						}, nil),
+					m.ecsClient.EXPECT().ActiveClusters("mockARN1", "mockARN2").Return([]string{"mockARN1"}, nil),
+					m.ecsClient.EXPECT().ActiveServices("mockARN1", []string{mockSvcARN}).Return([]string{mockSvcARN}, nil),
 					m.ecsClient.EXPECT().ServiceRunningTasks(mockCluster, mockService).Return([]*ecs.Task{
 						{TaskArn: aws.String("mockTaskARN")},
 					}, nil),
@@ -285,7 +313,12 @@ func TestClient_DescribeService(t *testing.T) {
 						Return([]*resourcegroups.Resource{
 							{ARN: mockSvcARN},
 						}, nil),
-					m.ecsClient.EXPECT().ActiveServices(mockSvcARN).Return([]string{mockSvcARN}, nil),
+					m.resourceGetter.EXPECT().GetResourcesByTags(clusterResourceType, getRgEnvClusterInput).
+						Return([]*resourcegroups.Resource{
+							{ARN: "mockARN1"}, {ARN: "mockARN2"},
+						}, nil),
+					m.ecsClient.EXPECT().ActiveClusters("mockARN1", "mockARN2").Return([]string{"mockARN1"}, nil),
+					m.ecsClient.EXPECT().ActiveServices("mockARN1", []string{mockSvcARN}).Return([]string{mockSvcARN}, nil),
 					m.ecsClient.EXPECT().ServiceRunningTasks(mockCluster, mockService).Return([]*ecs.Task{
 						{TaskArn: aws.String("mockTaskARN")},
 					}, nil),
@@ -351,6 +384,10 @@ func TestClient_Service(t *testing.T) {
 		mockService = "mockService"
 	)
 	mockError := errors.New("some error")
+	getRgEnvClusterInput := map[string]string{
+		deploy.AppTagKey: mockApp,
+		deploy.EnvTagKey: mockEnv,
+	}
 	getRgInput := map[string]string{
 		deploy.AppTagKey:     mockApp,
 		deploy.EnvTagKey:     mockEnv,
@@ -379,10 +416,15 @@ func TestClient_Service(t *testing.T) {
 						Return([]*resourcegroups.Resource{
 							{ARN: mockSvcARN},
 						}, nil),
-					m.ecsClient.EXPECT().ActiveServices(mockSvcARN).Return(nil, mockError),
+					m.resourceGetter.EXPECT().GetResourcesByTags(clusterResourceType, getRgEnvClusterInput).
+						Return([]*resourcegroups.Resource{
+							{ARN: "mockARN1"}, {ARN: "mockARN2"},
+						}, nil),
+					m.ecsClient.EXPECT().ActiveClusters("mockARN1", "mockARN2").Return([]string{"mockARN1"}, nil),
+					m.ecsClient.EXPECT().ActiveServices("mockARN1", []string{mockSvcARN}).Return(nil, mockError),
 				)
 			},
-			wantedError: fmt.Errorf("check if services are active: some error"),
+			wantedError: fmt.Errorf("check if services are active in the cluster mockARN1: some error"),
 		},
 		"error if fail to describe ECS service": {
 			setupMocks: func(m clientMocks) {
@@ -391,7 +433,12 @@ func TestClient_Service(t *testing.T) {
 						Return([]*resourcegroups.Resource{
 							{ARN: mockSvcARN},
 						}, nil),
-					m.ecsClient.EXPECT().ActiveServices(mockSvcARN).Return([]string{mockSvcARN}, nil),
+					m.resourceGetter.EXPECT().GetResourcesByTags(clusterResourceType, getRgEnvClusterInput).
+						Return([]*resourcegroups.Resource{
+							{ARN: "mockARN1"}, {ARN: "mockARN2"},
+						}, nil),
+					m.ecsClient.EXPECT().ActiveClusters("mockARN1", "mockARN2").Return([]string{"mockARN1"}, nil),
+					m.ecsClient.EXPECT().ActiveServices("mockARN1", []string{mockSvcARN}).Return([]string{mockSvcARN}, nil),
 					m.ecsClient.EXPECT().Service(mockCluster, mockService).Return(nil, mockError),
 				)
 			},
@@ -404,7 +451,12 @@ func TestClient_Service(t *testing.T) {
 						Return([]*resourcegroups.Resource{
 							{ARN: mockSvcARN},
 						}, nil),
-					m.ecsClient.EXPECT().ActiveServices(mockSvcARN).Return([]string{mockSvcARN}, nil),
+					m.resourceGetter.EXPECT().GetResourcesByTags(clusterResourceType, getRgEnvClusterInput).
+						Return([]*resourcegroups.Resource{
+							{ARN: "mockARN1"}, {ARN: "mockARN2"},
+						}, nil),
+					m.ecsClient.EXPECT().ActiveClusters("mockARN1", "mockARN2").Return([]string{"mockARN1"}, nil),
+					m.ecsClient.EXPECT().ActiveServices("mockARN1", []string{mockSvcARN}).Return([]string{mockSvcARN}, nil),
 					m.ecsClient.EXPECT().Service(mockCluster, mockService).Return(nil, mockError),
 				)
 			},
@@ -417,7 +469,12 @@ func TestClient_Service(t *testing.T) {
 						Return([]*resourcegroups.Resource{
 							{ARN: mockSvcARN},
 						}, nil),
-					m.ecsClient.EXPECT().ActiveServices(mockSvcARN).Return([]string{mockSvcARN}, nil),
+					m.resourceGetter.EXPECT().GetResourcesByTags(clusterResourceType, getRgEnvClusterInput).
+						Return([]*resourcegroups.Resource{
+							{ARN: "mockARN1"}, {ARN: "mockARN2"},
+						}, nil),
+					m.ecsClient.EXPECT().ActiveClusters("mockARN1", "mockARN2").Return([]string{"mockARN1"}, nil),
+					m.ecsClient.EXPECT().ActiveServices("mockARN1", []string{mockSvcARN}).Return([]string{mockSvcARN}, nil),
 					m.ecsClient.EXPECT().Service(mockCluster, mockService).Return(&ecs.Service{}, nil),
 				)
 			},
@@ -470,6 +527,10 @@ func TestClient_LastUpdatedAt(t *testing.T) {
 	)
 	mockTime := time.Unix(1494505756, 0)
 	mockBeforeTime := time.Unix(1494505750, 0)
+	getRgEnvClusterInput := map[string]string{
+		deploy.AppTagKey: mockApp,
+		deploy.EnvTagKey: mockEnv,
+	}
 	getRgInput := map[string]string{
 		deploy.AppTagKey:     mockApp,
 		deploy.EnvTagKey:     mockEnv,
@@ -489,7 +550,12 @@ func TestClient_LastUpdatedAt(t *testing.T) {
 						Return([]*resourcegroups.Resource{
 							{ARN: mockSvcARN},
 						}, nil),
-					m.ecsClient.EXPECT().ActiveServices(mockSvcARN).Return([]string{mockSvcARN}, nil),
+					m.resourceGetter.EXPECT().GetResourcesByTags(clusterResourceType, getRgEnvClusterInput).
+						Return([]*resourcegroups.Resource{
+							{ARN: "mockARN1"}, {ARN: "mockARN2"},
+						}, nil),
+					m.ecsClient.EXPECT().ActiveClusters("mockARN1", "mockARN2").Return([]string{"mockARN1"}, nil),
+					m.ecsClient.EXPECT().ActiveServices("mockARN1", []string{mockSvcARN}).Return([]string{mockSvcARN}, nil),
 					m.ecsClient.EXPECT().Service(mockCluster, mockService).Return(&ecs.Service{
 						Deployments: []*awsecs.Deployment{
 							{
@@ -554,6 +620,10 @@ func TestClient_ForceUpdateService(t *testing.T) {
 		deploy.EnvTagKey:     mockEnv,
 		deploy.ServiceTagKey: mockSvc,
 	}
+	getRgEnvClusterInput := map[string]string{
+		deploy.AppTagKey: mockApp,
+		deploy.EnvTagKey: mockEnv,
+	}
 
 	tests := map[string]struct {
 		setupMocks func(mocks clientMocks)
@@ -567,7 +637,12 @@ func TestClient_ForceUpdateService(t *testing.T) {
 						Return([]*resourcegroups.Resource{
 							{ARN: mockSvcARN},
 						}, nil),
-					m.ecsClient.EXPECT().ActiveServices(mockSvcARN).Return([]string{mockSvcARN}, nil),
+					m.resourceGetter.EXPECT().GetResourcesByTags(clusterResourceType, getRgEnvClusterInput).
+						Return([]*resourcegroups.Resource{
+							{ARN: "mockARN1"}, {ARN: "mockARN2"},
+						}, nil),
+					m.ecsClient.EXPECT().ActiveClusters("mockARN1", "mockARN2").Return([]string{"mockARN1"}, nil),
+					m.ecsClient.EXPECT().ActiveServices("mockARN1", []string{mockSvcARN}).Return([]string{mockSvcARN}, nil),
 					m.ecsClient.EXPECT().UpdateService(mockCluster, mockService, gomock.Any()).Return(errors.New("some error")),
 				)
 			},
@@ -580,7 +655,12 @@ func TestClient_ForceUpdateService(t *testing.T) {
 						Return([]*resourcegroups.Resource{
 							{ARN: mockSvcARN},
 						}, nil),
-					m.ecsClient.EXPECT().ActiveServices(mockSvcARN).Return([]string{mockSvcARN}, nil),
+					m.resourceGetter.EXPECT().GetResourcesByTags(clusterResourceType, getRgEnvClusterInput).
+						Return([]*resourcegroups.Resource{
+							{ARN: "mockARN1"}, {ARN: "mockARN2"},
+						}, nil),
+					m.ecsClient.EXPECT().ActiveClusters("mockARN1", "mockARN2").Return([]string{"mockARN1"}, nil),
+					m.ecsClient.EXPECT().ActiveServices("mockARN1", []string{mockSvcARN}).Return([]string{mockSvcARN}, nil),
 					m.ecsClient.EXPECT().UpdateService(mockCluster, mockService, gomock.Any()).Return(nil),
 				)
 			},
@@ -1292,7 +1372,12 @@ func Test_NetworkConfiguration(t *testing.T) {
 					}).Return([]*resourcegroups.Resource{
 						{ARN: mockSvcArn},
 					}, nil),
-					m.ecsClient.EXPECT().ActiveServices(mockSvcArn).Return([]string{mockSvcArn}, nil),
+					m.resourceGetter.EXPECT().GetResourcesByTags(clusterResourceType, getRgInput).
+						Return([]*resourcegroups.Resource{
+							{ARN: mockClusterArn},
+						}, nil),
+					m.ecsClient.EXPECT().ActiveClusters(mockClusterArn).Return([]string{mockClusterArn}, nil),
+					m.ecsClient.EXPECT().ActiveServices(mockClusterArn, []string{mockSvcArn}).Return([]string{mockSvcArn}, nil),
 					m.ecsClient.EXPECT().NetworkConfiguration(mockClusterArn, "my-project-test-myService-JSOH5GYBFAIB").Return(&ecs.NetworkConfiguration{
 						AssignPublicIp: "1.2.3.4",
 						SecurityGroups: []string{"sg-1", "sg-2"},

--- a/internal/pkg/ecs/mocks/mock_ecs.go
+++ b/internal/pkg/ecs/mocks/mock_ecs.go
@@ -93,9 +93,9 @@ func (mr *MockecsClientMockRecorder) ActiveClusters(arns ...interface{}) *gomock
 }
 
 // ActiveServices mocks base method.
-func (m *MockecsClient) ActiveServices(serviceARNs ...string) ([]string, error) {
+func (m *MockecsClient) ActiveServices(clusterName string, serviceARNs ...string) ([]string, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{}
+	varargs := []interface{}{clusterName}
 	for _, a := range serviceARNs {
 		varargs = append(varargs, a)
 	}
@@ -106,9 +106,10 @@ func (m *MockecsClient) ActiveServices(serviceARNs ...string) ([]string, error) 
 }
 
 // ActiveServices indicates an expected call of ActiveServices.
-func (mr *MockecsClientMockRecorder) ActiveServices(serviceARNs ...interface{}) *gomock.Call {
+func (mr *MockecsClientMockRecorder) ActiveServices(clusterName interface{}, serviceARNs ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ActiveServices", reflect.TypeOf((*MockecsClient)(nil).ActiveServices), serviceARNs...)
+	varargs := append([]interface{}{clusterName}, serviceARNs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ActiveServices", reflect.TypeOf((*MockecsClient)(nil).ActiveServices), varargs...)
 }
 
 // DefaultCluster mocks base method.


### PR DESCRIPTION
<!-- Provide summary of changes -->
address https://github.com/aws/copilot-cli/pull/5125#issuecomment-1681447678
This PR fixes below 
**Scenario**

 App: demo
Env: test
Svc: frontend

1. And the svc is successfully deployed , `copilot svc show` and `copilot task run —--generate-cmd demo/test/frontend` works ✅ 

```
Cluster - demo-test-Cluster-ABC(Active
 Service - demo-test-Cluster-ABC/demo-test-frontend-Service-ABC(Active) 
```

2. After this if i delete the test environment and frontend service. 
```
Cluster - demo-test-Cluster-ABC (InActive) 
 Service - demo-test-Cluster-ABC/demo-test-frontend-Service-ABC(InActive) 
```
3. Deploying service and Environment with the same names.

```
Cluster - demo-test-Cluster-ABC(InActive)  
Service - demo-test-Cluster-ABC/demo-test-frontend-Service-ABC(InActive)  
Cluster - demo-test-Cluster-DEF(Active)  
Service - demo-test-Cluster-DEF/demo-test-frontend-Service-DEF(Active)
```

4. `copilot svc show` and `copilot task run —--generate-cmd demo/test/frontend`  will generate the below errors.   

```
copilot task run --generate-cmd demo/test/frontend
✘ generate task run command from service frontend of application demo deployed in environment test: retrieve network configuration for service frontend: check if services are active: service "arn:aws:ecs:us-west-2:197732814171:service/demo-test-Cluster-Bus8o0uclnAW/demo-test-frontend-Service-E0rKy3e2S78t" and service "arn:aws:ecs:us-west-2:197732814171:service/demo-test-Cluster-TJyweayOGepM/demo-test-frontend-Service-4Se9IVA2878D" should be in the same cluster  

copilot svc show                                
Application: demo
Only found one service, defaulting to: frontend
✘ describe service frontend: retrieve rollback alarm names: get service frontend: check if services are active: service "arn:aws:ecs:us-west-2:197732814171:service/demo-test-Cluster-Bus8o0uclnAW/demo-test-frontend-Service-E0rKy3e2S78t" and service "arn:aws:ecs:us-west-2:197732814171:service/demo-test-Cluster-TJyweayOGepM/demo-test-frontend-Service-4Se9IVA2878D" should be in the same cluster
```
  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
