### PR TITLE
feat(pipelines): add pre- and post- deployment fields to pipeline manifests

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/gh_pipeline_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/gh_pipeline_integration_test.go
@@ -35,7 +35,7 @@ func TestGHPipeline_Template(t *testing.T) {
 	}, &manifest.PipelineStage{
 		Name:             "test",
 		RequiresApproval: true,
-		PreDeployment: map[string]*manifest.PrePostDeployment{
+		PreDeployments: map[string]*manifest.PrePostDeployment{
 			"preAction1": {
 				BuildspecPath: "./buildspec.yml",
 			},
@@ -44,7 +44,7 @@ func TestGHPipeline_Template(t *testing.T) {
 				DependsOn:     []string{"preAction1"},
 			},
 		},
-		PostDeployment: map[string]*manifest.PrePostDeployment{
+		PostDeployments: map[string]*manifest.PrePostDeployment{
 			"postAction1": {
 				BuildspecPath: ".anotherPath/buildspec.yml",
 			},

--- a/internal/pkg/deploy/cloudformation/stack/gh_pipeline_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/gh_pipeline_integration_test.go
@@ -34,8 +34,28 @@ func TestGHPipeline_Template(t *testing.T) {
 		ManagerRoleARN:   "arn:aws:iam::1111:role/phonetool-test-EnvManagerRole",
 	}, &manifest.PipelineStage{
 		Name:             "test",
-		TestCommands:     []string{`echo "test"`},
 		RequiresApproval: true,
+		PreDeployment: map[string]*manifest.PrePostDeployment{
+			"preAction1": {
+				BuildspecPath: "./buildspec.yml",
+			},
+			"preAction2": {
+				BuildspecPath: "copilot/pipelines/buildspec.yml",
+				DependsOn:     []string{"preAction1"},
+			},
+		},
+		PostDeployment: map[string]*manifest.PrePostDeployment{
+			"postAction1": {
+				BuildspecPath: ".anotherPath/buildspec.yml",
+			},
+			"postAction2": {
+				BuildspecPath: ".somePath/buildspec.yml",
+				DependsOn:     []string{"postAction1"},
+			},
+			"postAction3": {
+				BuildspecPath: ".someOtherPath/buildspec.yml",
+			},
+		},
 	}, []string{"api", "frontend"})
 	ps := stack.NewPipelineStackConfig(&deploy.CreatePipelineInput{
 		AppName: "phonetool",

--- a/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/gh_template.yaml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/gh_template.yaml
@@ -131,6 +131,572 @@ Resources:
         Type: CODEPIPELINE
         BuildSpec: copilot/pipelines/phonetool-pipeline/buildspec.yml
       TimeoutInMinutes: 60
+  PretestDeploymentActionpreAction1BuildProjectRole:
+    Type: AWS::IAM::Role
+    Properties:
+      Path: /
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - codebuild.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      ManagedPolicyArns:
+        - 'arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess' # for env ls
+        - 'arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess' # for service package
+
+      Policies:
+        - PolicyName: assume-env-manager
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Resource: arn:aws:iam::1111:role/phonetool-test-EnvManagerRole
+                Action:
+                  - sts:AssumeRole
+        - PolicyName: build-role-policy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - codebuild:CreateReportGroup
+                  - codebuild:CreateReport
+                  - codebuild:UpdateReport
+                  - codebuild:BatchPutTestCases
+                  - codebuild:BatchPutCodeCoverages
+                Resource: !Sub arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:report-group/pipeline-phonetool-*
+              - Effect: Allow
+                Action:
+                  - s3:PutObject
+                  - s3:GetObject
+                  - s3:GetObjectVersion
+                # TODO: This might not be necessary. We may only need the bucket
+                # that is in the same region as the pipeline.
+                # Loop through all the artifact buckets created in the stackset
+                Resource:
+                  - !Join [ '', [ 'arn:aws:s3:::', 'fancy-bucket' ] ]
+                  - !Join [ '', [ 'arn:aws:s3:::', 'fancy-bucket', '/*' ] ]
+              - Effect: Allow
+                Action:
+                  # TODO: scope this down if possible
+                  - kms:*
+                # TODO: This might not be necessary. We may only need the KMS key
+                # that is in the same region as the pipeline.
+                # Loop through all the KMS keys used to en/decrypt artifacts
+                # across (cross-regional) pipeline stages, with each stage
+                # backed by a (regional) S3 bucket.
+                Resource:
+                  - arn:aws:kms:us-west-2:1111:key/abcd
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: arn:aws:logs:*:*:*
+              - Effect: Allow
+                Action:
+                  - ecr:GetAuthorizationToken
+                Resource: '*'
+              - Effect: Allow
+                Action:
+                  - ecr:DescribeImageScanFindings
+                  - ecr:GetLifecyclePolicyPreview
+                  - ecr:GetDownloadUrlForLayer
+                  - ecr:BatchGetImage
+                  - ecr:DescribeImages
+                  - ecr:ListTagsForResource
+                  - ecr:BatchCheckLayerAvailability
+                  - ecr:GetLifecyclePolicy
+                  - ecr:GetRepositoryPolicy
+                  - ecr:PutImage
+                  - ecr:InitiateLayerUpload
+                  - ecr:UploadLayerPart
+                  - ecr:CompleteLayerUpload
+                Resource: '*'
+                Condition: { StringEquals: { 'ecr:ResourceTag/copilot-application': phonetool } }
+
+  PretestDeploymentActionpreAction1:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      EncryptionKey: !ImportValue phonetool-ArtifactKey
+      ServiceRole: !GetAtt PretestDeploymentActionpreAction1BuildProjectRole.Arn
+      Artifacts:
+        Type: CODEPIPELINE
+      Cache:
+        Modes:
+          - LOCAL_DOCKER_LAYER_CACHE
+        Type: LOCAL
+      Environment:
+        Type: LINUX_CONTAINER
+        ComputeType: BUILD_GENERAL1_SMALL
+        PrivilegedMode: true
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
+        EnvironmentVariables:
+          - Name: AWS_ACCOUNT_ID
+            Value: !Sub '${AWS::AccountId}'
+          - Name: PARTITION
+            Value: !Ref AWS::Partition
+      Source:
+        Type: CODEPIPELINE
+        BuildSpec: ./buildspec.yml
+      TimeoutInMinutes: 60
+  PretestDeploymentActionpreAction2BuildProjectRole:
+    Type: AWS::IAM::Role
+    Properties:
+      Path: /
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - codebuild.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      ManagedPolicyArns:
+        - 'arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess' # for env ls
+        - 'arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess' # for service package
+      Policies:
+        - PolicyName: assume-env-manager
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Resource: arn:aws:iam::1111:role/phonetool-test-EnvManagerRole
+                Action:
+                  - sts:AssumeRole
+        - PolicyName: build-role-policy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - codebuild:CreateReportGroup
+                  - codebuild:CreateReport
+                  - codebuild:UpdateReport
+                  - codebuild:BatchPutTestCases
+                  - codebuild:BatchPutCodeCoverages
+                Resource: !Sub arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:report-group/pipeline-phonetool-*
+              - Effect: Allow
+                Action:
+                  - s3:PutObject
+                  - s3:GetObject
+                  - s3:GetObjectVersion
+                # TODO: This might not be necessary. We may only need the bucket
+                # that is in the same region as the pipeline.
+                # Loop through all the artifact buckets created in the stackset
+                Resource:
+                  - !Join [ '', [ 'arn:aws:s3:::', 'fancy-bucket' ] ]
+                  - !Join [ '', [ 'arn:aws:s3:::', 'fancy-bucket', '/*' ] ]
+              - Effect: Allow
+                Action:
+                  # TODO: scope this down if possible
+                  - kms:*
+                # TODO: This might not be necessary. We may only need the KMS key
+                # that is in the same region as the pipeline.
+                # Loop through all the KMS keys used to en/decrypt artifacts
+                # across (cross-regional) pipeline stages, with each stage
+                # backed by a (regional) S3 bucket.
+                Resource:
+                  - arn:aws:kms:us-west-2:1111:key/abcd
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: arn:aws:logs:*:*:*
+              - Effect: Allow
+                Action:
+                  - ecr:GetAuthorizationToken
+                Resource: '*'
+              - Effect: Allow
+                Action:
+                  - ecr:DescribeImageScanFindings
+                  - ecr:GetLifecyclePolicyPreview
+                  - ecr:GetDownloadUrlForLayer
+                  - ecr:BatchGetImage
+                  - ecr:DescribeImages
+                  - ecr:ListTagsForResource
+                  - ecr:BatchCheckLayerAvailability
+                  - ecr:GetLifecyclePolicy
+                  - ecr:GetRepositoryPolicy
+                  - ecr:PutImage
+                  - ecr:InitiateLayerUpload
+                  - ecr:UploadLayerPart
+                  - ecr:CompleteLayerUpload
+                Resource: '*'
+                Condition: { StringEquals: { 'ecr:ResourceTag/copilot-application': phonetool } }
+  PretestDeploymentActionpreAction2:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      EncryptionKey: !ImportValue phonetool-ArtifactKey
+      ServiceRole: !GetAtt PretestDeploymentActionpreAction2BuildProjectRole.Arn
+      Artifacts:
+        Type: CODEPIPELINE
+      Cache:
+        Modes:
+          - LOCAL_DOCKER_LAYER_CACHE
+        Type: LOCAL
+      Environment:
+        Type: LINUX_CONTAINER
+        ComputeType: BUILD_GENERAL1_SMALL
+        PrivilegedMode: true
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
+        EnvironmentVariables:
+          - Name: AWS_ACCOUNT_ID
+            Value: !Sub '${AWS::AccountId}'
+          - Name: PARTITION
+            Value: !Ref AWS::Partition
+      Source:
+        Type: CODEPIPELINE
+        BuildSpec: copilot/pipelines/buildspec.yml
+      TimeoutInMinutes: 60
+  PosttestDeploymentActionpostAction1BuildProjectRole:
+    Type: AWS::IAM::Role
+    Properties:
+      Path: /
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - codebuild.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      ManagedPolicyArns:
+        - 'arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess' # for env ls
+        - 'arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess' # for service package
+
+      Policies:
+        - PolicyName: assume-env-manager
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Resource: arn:aws:iam::1111:role/phonetool-test-EnvManagerRole
+                Action:
+                  - sts:AssumeRole
+        - PolicyName: build-role-policy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - codebuild:CreateReportGroup
+                  - codebuild:CreateReport
+                  - codebuild:UpdateReport
+                  - codebuild:BatchPutTestCases
+                  - codebuild:BatchPutCodeCoverages
+                Resource: !Sub arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:report-group/pipeline-phonetool-*
+              - Effect: Allow
+                Action:
+                  - s3:PutObject
+                  - s3:GetObject
+                  - s3:GetObjectVersion
+                # TODO: This might not be necessary. We may only need the bucket
+                # that is in the same region as the pipeline.
+                # Loop through all the artifact buckets created in the stackset
+                Resource:
+                  - !Join [ '', [ 'arn:aws:s3:::', 'fancy-bucket' ] ]
+                  - !Join [ '', [ 'arn:aws:s3:::', 'fancy-bucket', '/*' ] ]
+              - Effect: Allow
+                Action:
+                  # TODO: scope this down if possible
+                  - kms:*
+                # TODO: This might not be necessary. We may only need the KMS key
+                # that is in the same region as the pipeline.
+                # Loop through all the KMS keys used to en/decrypt artifacts
+                # across (cross-regional) pipeline stages, with each stage
+                # backed by a (regional) S3 bucket.
+                Resource:
+                  - arn:aws:kms:us-west-2:1111:key/abcd
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: arn:aws:logs:*:*:*
+              - Effect: Allow
+                Action:
+                  - ecr:GetAuthorizationToken
+                Resource: '*'
+              - Effect: Allow
+                Action:
+                  - ecr:DescribeImageScanFindings
+                  - ecr:GetLifecyclePolicyPreview
+                  - ecr:GetDownloadUrlForLayer
+                  - ecr:BatchGetImage
+                  - ecr:DescribeImages
+                  - ecr:ListTagsForResource
+                  - ecr:BatchCheckLayerAvailability
+                  - ecr:GetLifecyclePolicy
+                  - ecr:GetRepositoryPolicy
+                  - ecr:PutImage
+                  - ecr:InitiateLayerUpload
+                  - ecr:UploadLayerPart
+                  - ecr:CompleteLayerUpload
+                Resource: '*'
+                Condition: { StringEquals: { 'ecr:ResourceTag/copilot-application': phonetool } }
+
+  PosttestDeploymentActionpostAction1:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      EncryptionKey: !ImportValue phonetool-ArtifactKey
+      ServiceRole: !GetAtt PosttestDeploymentActionpostAction1BuildProjectRole.Arn
+      Artifacts:
+        Type: CODEPIPELINE
+
+      Cache:
+        Modes:
+          - LOCAL_DOCKER_LAYER_CACHE
+        Type: LOCAL
+      Environment:
+        Type: LINUX_CONTAINER
+        ComputeType: BUILD_GENERAL1_SMALL
+        PrivilegedMode: true
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
+        EnvironmentVariables:
+          - Name: AWS_ACCOUNT_ID
+            Value: !Sub '${AWS::AccountId}'
+          - Name: PARTITION
+            Value: !Ref AWS::Partition
+      Source:
+        Type: CODEPIPELINE
+        BuildSpec: .anotherPath/buildspec.yml
+      TimeoutInMinutes: 60
+  PosttestDeploymentActionpostAction2BuildProjectRole:
+    Type: AWS::IAM::Role
+    Properties:
+      Path: /
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - codebuild.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      ManagedPolicyArns:
+        - 'arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess' # for env ls
+        - 'arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess' # for service package
+
+      Policies:
+        - PolicyName: assume-env-manager
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Resource: arn:aws:iam::1111:role/phonetool-test-EnvManagerRole
+                Action:
+                  - sts:AssumeRole
+        - PolicyName: build-role-policy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - codebuild:CreateReportGroup
+                  - codebuild:CreateReport
+                  - codebuild:UpdateReport
+                  - codebuild:BatchPutTestCases
+                  - codebuild:BatchPutCodeCoverages
+                Resource: !Sub arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:report-group/pipeline-phonetool-*
+              - Effect: Allow
+                Action:
+                  - s3:PutObject
+                  - s3:GetObject
+                  - s3:GetObjectVersion
+                # TODO: This might not be necessary. We may only need the bucket
+                # that is in the same region as the pipeline.
+                # Loop through all the artifact buckets created in the stackset
+                Resource:
+                  - !Join [ '', [ 'arn:aws:s3:::', 'fancy-bucket' ] ]
+                  - !Join [ '', [ 'arn:aws:s3:::', 'fancy-bucket', '/*' ] ]
+              - Effect: Allow
+                Action:
+                  # TODO: scope this down if possible
+                  - kms:*
+                # TODO: This might not be necessary. We may only need the KMS key
+                # that is in the same region as the pipeline.
+                # Loop through all the KMS keys used to en/decrypt artifacts
+                # across (cross-regional) pipeline stages, with each stage
+                # backed by a (regional) S3 bucket.
+                Resource:
+                  - arn:aws:kms:us-west-2:1111:key/abcd
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: arn:aws:logs:*:*:*
+              - Effect: Allow
+                Action:
+                  - ecr:GetAuthorizationToken
+                Resource: '*'
+              - Effect: Allow
+                Action:
+                  - ecr:DescribeImageScanFindings
+                  - ecr:GetLifecyclePolicyPreview
+                  - ecr:GetDownloadUrlForLayer
+                  - ecr:BatchGetImage
+                  - ecr:DescribeImages
+                  - ecr:ListTagsForResource
+                  - ecr:BatchCheckLayerAvailability
+                  - ecr:GetLifecyclePolicy
+                  - ecr:GetRepositoryPolicy
+                  - ecr:PutImage
+                  - ecr:InitiateLayerUpload
+                  - ecr:UploadLayerPart
+                  - ecr:CompleteLayerUpload
+                Resource: '*'
+                Condition: { StringEquals: { 'ecr:ResourceTag/copilot-application': phonetool } }
+
+  PosttestDeploymentActionpostAction2:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      EncryptionKey: !ImportValue phonetool-ArtifactKey
+      ServiceRole: !GetAtt PosttestDeploymentActionpostAction2BuildProjectRole.Arn
+      Artifacts:
+        Type: CODEPIPELINE
+
+      Cache:
+        Modes:
+          - LOCAL_DOCKER_LAYER_CACHE
+        Type: LOCAL
+      Environment:
+        Type: LINUX_CONTAINER
+        ComputeType: BUILD_GENERAL1_SMALL
+        PrivilegedMode: true
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
+        EnvironmentVariables:
+          - Name: AWS_ACCOUNT_ID
+            Value: !Sub '${AWS::AccountId}'
+          - Name: PARTITION
+            Value: !Ref AWS::Partition
+      Source:
+        Type: CODEPIPELINE
+        BuildSpec: .somePath/buildspec.yml
+      TimeoutInMinutes: 60
+  PosttestDeploymentActionpostAction3BuildProjectRole:
+    Type: AWS::IAM::Role
+    Properties:
+      Path: /
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - codebuild.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      ManagedPolicyArns:
+        - 'arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess' # for env ls
+        - 'arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess' # for service package
+
+      Policies:
+        - PolicyName: assume-env-manager
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Resource: arn:aws:iam::1111:role/phonetool-test-EnvManagerRole
+                Action:
+                  - sts:AssumeRole
+        - PolicyName: build-role-policy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - codebuild:CreateReportGroup
+                  - codebuild:CreateReport
+                  - codebuild:UpdateReport
+                  - codebuild:BatchPutTestCases
+                  - codebuild:BatchPutCodeCoverages
+                Resource: !Sub arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:report-group/pipeline-phonetool-*
+              - Effect: Allow
+                Action:
+                  - s3:PutObject
+                  - s3:GetObject
+                  - s3:GetObjectVersion
+                # TODO: This might not be necessary. We may only need the bucket
+                # that is in the same region as the pipeline.
+                # Loop through all the artifact buckets created in the stackset
+                Resource:
+                  - !Join [ '', [ 'arn:aws:s3:::', 'fancy-bucket' ] ]
+                  - !Join [ '', [ 'arn:aws:s3:::', 'fancy-bucket', '/*' ] ]
+              - Effect: Allow
+                Action:
+                  # TODO: scope this down if possible
+                  - kms:*
+                # TODO: This might not be necessary. We may only need the KMS key
+                # that is in the same region as the pipeline.
+                # Loop through all the KMS keys used to en/decrypt artifacts
+                # across (cross-regional) pipeline stages, with each stage
+                # backed by a (regional) S3 bucket.
+                Resource:
+                  - arn:aws:kms:us-west-2:1111:key/abcd
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: arn:aws:logs:*:*:*
+              - Effect: Allow
+                Action:
+                  - ecr:GetAuthorizationToken
+                Resource: '*'
+              - Effect: Allow
+                Action:
+                  - ecr:DescribeImageScanFindings
+                  - ecr:GetLifecyclePolicyPreview
+                  - ecr:GetDownloadUrlForLayer
+                  - ecr:BatchGetImage
+                  - ecr:DescribeImages
+                  - ecr:ListTagsForResource
+                  - ecr:BatchCheckLayerAvailability
+                  - ecr:GetLifecyclePolicy
+                  - ecr:GetRepositoryPolicy
+                  - ecr:PutImage
+                  - ecr:InitiateLayerUpload
+                  - ecr:UploadLayerPart
+                  - ecr:CompleteLayerUpload
+                Resource: '*'
+                Condition: { StringEquals: { 'ecr:ResourceTag/copilot-application': phonetool } }
+
+  PosttestDeploymentActionpostAction3:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      EncryptionKey: !ImportValue phonetool-ArtifactKey
+      ServiceRole: !GetAtt PosttestDeploymentActionpostAction3BuildProjectRole.Arn
+      Artifacts:
+        Type: CODEPIPELINE
+
+      Cache:
+        Modes:
+          - LOCAL_DOCKER_LAYER_CACHE
+        Type: LOCAL
+      Environment:
+        Type: LINUX_CONTAINER
+        ComputeType: BUILD_GENERAL1_SMALL
+        PrivilegedMode: true
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
+        EnvironmentVariables:
+          - Name: AWS_ACCOUNT_ID
+            Value: !Sub '${AWS::AccountId}'
+          - Name: PARTITION
+            Value: !Ref AWS::Partition
+      Source:
+        Type: CODEPIPELINE
+        BuildSpec: .someOtherPath/buildspec.yml
+      TimeoutInMinutes: 60
   PipelineRole:
     Type: AWS::IAM::Role
     Properties:
@@ -224,26 +790,6 @@ Resources:
               - arn:aws:iam::1111:role/phonetool-test-EnvManagerRole
       Roles:
         - !Ref PipelineRole
-  BuildTestCommandstest:
-    Type: AWS::CodeBuild::Project
-    Properties:
-      EncryptionKey: !ImportValue phonetool-ArtifactKey
-      ServiceRole: !GetAtt BuildProjectRole.Arn
-      Artifacts:
-        Type: NO_ARTIFACTS
-      Environment:
-        Type: LINUX_CONTAINER
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
-        ComputeType: BUILD_GENERAL1_SMALL
-        PrivilegedMode: true
-      Source:
-        Type: NO_SOURCE
-        BuildSpec: |
-          version: 0.2
-          phases:
-            build:
-              commands:
-                - echo "test"
   Pipeline:
     Type: AWS::CodePipeline::Pipeline
     DependsOn:
@@ -299,6 +845,76 @@ Resources:
                 Version: 1
                 Provider: Manual
               RunOrder: 1
+            - Name: preAction1
+              Region: us-west-2
+              RunOrder: 2
+              ActionTypeId:
+                Category: Build
+                Owner: AWS
+                Version: 1
+                Provider: CodeBuild
+              Configuration:
+                ProjectName: !Ref PretestDeploymentActionpreAction1
+              InputArtifacts:
+                - Name: SCCheckoutArtifact
+              OutputArtifacts:
+                - Name: PretestDeploymentActionpreAction1Output
+            - Name: preAction2
+              Region: us-west-2
+              RunOrder: 3
+              ActionTypeId:
+                Category: Build
+                Owner: AWS
+                Version: 1
+                Provider: CodeBuild
+              Configuration:
+                ProjectName: !Ref PretestDeploymentActionpreAction2
+              InputArtifacts:
+                - Name: SCCheckoutArtifact
+              OutputArtifacts:
+                - Name: PretestDeploymentActionpreAction2Output
+            - Name: postAction1
+              Region: us-west-2
+              RunOrder: 5
+              ActionTypeId:
+                Category: Build
+                Owner: AWS
+                Version: 1
+                Provider: CodeBuild
+              Configuration:
+                ProjectName: !Ref PosttestDeploymentActionpostAction1
+              InputArtifacts:
+                - Name: SCCheckoutArtifact
+              OutputArtifacts:
+                - Name: PosttestDeploymentActionpostAction1Output
+            - Name: postAction2
+              Region: us-west-2
+              RunOrder: 6
+              ActionTypeId:
+                Category: Build
+                Owner: AWS
+                Version: 1
+                Provider: CodeBuild
+              Configuration:
+                ProjectName: !Ref PosttestDeploymentActionpostAction2
+              InputArtifacts:
+                - Name: SCCheckoutArtifact
+              OutputArtifacts:
+                - Name: PosttestDeploymentActionpostAction2Output
+            - Name: postAction3
+              Region: us-west-2
+              RunOrder: 5
+              ActionTypeId:
+                Category: Build
+                Owner: AWS
+                Version: 1
+                Provider: CodeBuild
+              Configuration:
+                ProjectName: !Ref PosttestDeploymentActionpostAction3
+              InputArtifacts:
+                - Name: SCCheckoutArtifact
+              OutputArtifacts:
+                - Name: PosttestDeploymentActionpostAction3Output
             - Name: CreateOrUpdate-api-test
               Region: us-west-2
               ActionTypeId:
@@ -315,7 +931,7 @@ Resources:
                 RoleArn: arn:aws:iam::1111:role/phonetool-test-CFNExecutionRole
               InputArtifacts:
                 - Name: BuildOutput
-              RunOrder: 2
+              RunOrder: 4
               RoleArn: arn:aws:iam::1111:role/phonetool-test-EnvManagerRole
             - Name: CreateOrUpdate-frontend-test
               Region: us-west-2
@@ -333,19 +949,8 @@ Resources:
                 RoleArn: arn:aws:iam::1111:role/phonetool-test-CFNExecutionRole
               InputArtifacts:
                 - Name: BuildOutput
-              RunOrder: 2
+              RunOrder: 4
               RoleArn: arn:aws:iam::1111:role/phonetool-test-EnvManagerRole
-            - Name: TestCommands
-              ActionTypeId:
-                Category: Test
-                Owner: AWS
-                Version: 1
-                Provider: CodeBuild
-              Configuration:
-                ProjectName: !Ref BuildTestCommandstest
-              RunOrder: 3
-              InputArtifacts:
-                - Name: SCCheckoutArtifact
 Outputs:
   PipelineConnectionARN:
     Description: "ARN of CodeStar Connections connection"

--- a/internal/pkg/deploy/pipeline.go
+++ b/internal/pkg/deploy/pipeline.go
@@ -565,9 +565,9 @@ func (stg *PipelineStage) PreDeployments() ([]PrePostDeployAction, error) {
 	}
 
 	var rankableDeps []rankableDeployment
-	for name := range stg.preDeployments {
+	for name, action := range stg.preDeployments {
 		rankableDeps = append(rankableDeps, rankableDeployment{
-			rankable: stg.preDeployments[name],
+			rankable: action,
 			name:     name,
 		})
 	}
@@ -577,9 +577,7 @@ func (stg *PipelineStage) PreDeployments() ([]PrePostDeployAction, error) {
 	}
 
 	var actions []PrePostDeployAction
-	var buildspecPath string
 	for name, conf := range stg.preDeployments {
-		buildspecPath = conf.BuildspecPath
 		actions = append(actions, PrePostDeployAction{
 			name: name,
 			action: action{
@@ -588,7 +586,7 @@ func (stg *PipelineStage) PreDeployments() ([]PrePostDeployAction, error) {
 			Build: Build{
 				Image:           defaultPipelineBuildImage,
 				EnvironmentType: defaultPipelineEnvironmentType,
-				BuildspecPath:   buildspecPath,
+				BuildspecPath:   conf.BuildspecPath,
 			},
 			ranker: topo,
 		})
@@ -617,9 +615,9 @@ func (stg *PipelineStage) Deployments() ([]DeployAction, error) {
 		prevActions = append(prevActions, &preDeployActions[i])
 	}
 	var rankableDeps []rankableDeployment
-	for name := range stg.deployments {
+	for name, action := range stg.deployments {
 		rankableDeps = append(rankableDeps, rankableDeployment{
-			rankable: stg.deployments[name],
+			rankable: action,
 			name:     name,
 		})
 	}
@@ -673,9 +671,9 @@ func (stg *PipelineStage) PostDeployments() ([]PrePostDeployAction, error) {
 		prevActions = append(prevActions, &deployActions[i])
 	}
 	var rankableDeps []rankableDeployment
-	for name := range stg.postDeployments {
+	for name, action := range stg.postDeployments {
 		rankableDeps = append(rankableDeps, rankableDeployment{
-			rankable: stg.postDeployments[name],
+			rankable: action,
 			name:     name,
 		})
 	}
@@ -686,9 +684,7 @@ func (stg *PipelineStage) PostDeployments() ([]PrePostDeployAction, error) {
 	}
 
 	var actions []PrePostDeployAction
-	var buildspecPath string
 	for name, conf := range stg.postDeployments {
-		buildspecPath = conf.BuildspecPath
 		actions = append(actions, PrePostDeployAction{
 			name: name,
 			action: action{
@@ -697,7 +693,7 @@ func (stg *PipelineStage) PostDeployments() ([]PrePostDeployAction, error) {
 			Build: Build{
 				Image:           defaultPipelineBuildImage,
 				EnvironmentType: defaultPipelineEnvironmentType,
-				BuildspecPath:   buildspecPath,
+				BuildspecPath:   conf.BuildspecPath,
 			},
 			ranker: topo,
 		})

--- a/internal/pkg/deploy/pipeline.go
+++ b/internal/pkg/deploy/pipeline.go
@@ -715,13 +715,6 @@ func (stg *PipelineStage) Test() (*TestCommandsAction, error) {
 	for i := range deployActions {
 		prevActions = append(prevActions, &deployActions[i])
 	}
-	postDeployActions, err := stg.PostDeployments()
-	if err != nil {
-		return nil, err
-	}
-	for i := range postDeployActions {
-		prevActions = append(prevActions, &postDeployActions[i])
-	}
 
 	return &TestCommandsAction{
 		action: action{

--- a/internal/pkg/deploy/pipeline.go
+++ b/internal/pkg/deploy/pipeline.go
@@ -603,7 +603,7 @@ func (stg *PipelineStage) Deployments() ([]DeployAction, error) {
 	}
 	preDeployActions, err := stg.PreDeployments()
 	if err != nil {
-		return nil, fmt.Errorf("get list of pre-deployments for ordering: %w", err)
+		return nil, err
 	}
 	for i := range preDeployActions {
 		prevActions = append(prevActions, &preDeployActions[i])
@@ -646,14 +646,14 @@ func (stg *PipelineStage) PostDeployments() ([]PrePostDeployAction, error) {
 	}
 	preDeployActions, err := stg.PreDeployments()
 	if err != nil {
-		return nil, fmt.Errorf("get list of pre-deployments for ordering: %w", err)
+		return nil, err
 	}
 	for i := range preDeployActions {
 		prevActions = append(prevActions, &preDeployActions[i])
 	}
 	deployActions, err := stg.Deployments()
 	if err != nil {
-		return nil, fmt.Errorf("get list of deployments for ordering: %w", err)
+		return nil, err
 	}
 	for i := range deployActions {
 		prevActions = append(prevActions, &deployActions[i])
@@ -703,21 +703,21 @@ func (stg *PipelineStage) Test() (*TestCommandsAction, error) {
 	}
 	preDeployActions, err := stg.PreDeployments()
 	if err != nil {
-		return nil, fmt.Errorf("get list of pre-deployments for ordering: %w", err)
+		return nil, err
 	}
 	for i := range preDeployActions {
 		prevActions = append(prevActions, &preDeployActions[i])
 	}
 	deployActions, err := stg.Deployments()
 	if err != nil {
-		return nil, fmt.Errorf("get list of deployments for ordering: %w", err)
+		return nil, err
 	}
 	for i := range deployActions {
 		prevActions = append(prevActions, &deployActions[i])
 	}
 	postDeployActions, err := stg.PostDeployments()
 	if err != nil {
-		return nil, fmt.Errorf("get list of post-deployments for ordering: %w", err)
+		return nil, err
 	}
 	for i := range postDeployActions {
 		prevActions = append(prevActions, &postDeployActions[i])

--- a/internal/pkg/deploy/pipeline.go
+++ b/internal/pkg/deploy/pipeline.go
@@ -579,9 +579,7 @@ func (stg *PipelineStage) PreDeployments() ([]PrePostDeployAction, error) {
 	var actions []PrePostDeployAction
 	var buildspecPath string
 	for name, conf := range stg.preDeployments {
-		if conf.BuildspecPath != "" {
-			buildspecPath = conf.BuildspecPath
-		}
+		buildspecPath = conf.BuildspecPath
 		actions = append(actions, PrePostDeployAction{
 			name: name,
 			action: action{
@@ -690,9 +688,7 @@ func (stg *PipelineStage) PostDeployments() ([]PrePostDeployAction, error) {
 	var actions []PrePostDeployAction
 	var buildspecPath string
 	for name, conf := range stg.postDeployments {
-		if conf.BuildspecPath != "" {
-			buildspecPath = conf.BuildspecPath
-		}
+		buildspecPath = conf.BuildspecPath
 		actions = append(actions, PrePostDeployAction{
 			name: name,
 			action: action{

--- a/internal/pkg/deploy/pipeline.go
+++ b/internal/pkg/deploy/pipeline.go
@@ -514,9 +514,9 @@ func (stg *PipelineStage) Init(env *config.Environment, mftStage *manifest.Pipel
 			deployments[workload] = nil
 		}
 	}
-	stg.preDeployments = mftStage.PreDeployment
+	stg.preDeployments = mftStage.PreDeployments
 	stg.deployments = deployments
-	stg.postDeployments = mftStage.PostDeployment
+	stg.postDeployments = mftStage.PostDeployments
 	stg.requiresApproval = mftStage.RequiresApproval
 	stg.testCommands = mftStage.TestCommands
 	stg.execRoleARN = env.ExecutionRoleARN

--- a/internal/pkg/deploy/pipeline_test.go
+++ b/internal/pkg/deploy/pipeline_test.go
@@ -407,7 +407,7 @@ func TestPipelineStage_PreDeployments(t *testing.T) {
 				var stg PipelineStage
 				stg.Init(&config.Environment{Name: "test"}, &manifest.PipelineStage{
 					Name: "test",
-					PreDeployment: map[string]*manifest.PrePostDeployment{
+					PreDeployments: map[string]*manifest.PrePostDeployment{
 						"ipa": {},
 						"api": {},
 					},
@@ -426,7 +426,7 @@ func TestPipelineStage_PreDeployments(t *testing.T) {
 				var stg PipelineStage
 				stg.Init(&config.Environment{Name: "test"}, &manifest.PipelineStage{
 					Name: "test",
-					PreDeployment: map[string]*manifest.PrePostDeployment{
+					PreDeployments: map[string]*manifest.PrePostDeployment{
 						"a": {},
 						"b": {
 							DependsOn: []string{"a"},
@@ -455,7 +455,7 @@ func TestPipelineStage_PreDeployments(t *testing.T) {
 				var stg PipelineStage
 				stg.Init(&config.Environment{Name: "test"}, &manifest.PipelineStage{
 					Name: "test",
-					PreDeployment: map[string]*manifest.PrePostDeployment{
+					PreDeployments: map[string]*manifest.PrePostDeployment{
 						"ipa": {},
 						"api": {},
 					},
@@ -474,7 +474,7 @@ func TestPipelineStage_PreDeployments(t *testing.T) {
 				var stg PipelineStage
 				stg.Init(&config.Environment{Name: "test"}, &manifest.PipelineStage{
 					Name: "test",
-					PreDeployment: map[string]*manifest.PrePostDeployment{
+					PreDeployments: map[string]*manifest.PrePostDeployment{
 						"api": {
 							DependsOn: []string{"api"},
 						},
@@ -613,7 +613,7 @@ func TestPipelineStage_PostDeployments(t *testing.T) {
 				stg.Init(&config.Environment{Name: "test"}, &manifest.PipelineStage{
 					Name:             "test",
 					RequiresApproval: true,
-					PreDeployment: map[string]*manifest.PrePostDeployment{
+					PreDeployments: map[string]*manifest.PrePostDeployment{
 						"ipa": {},
 						"api": {},
 					},
@@ -623,7 +623,7 @@ func TestPipelineStage_PostDeployments(t *testing.T) {
 						"payments":  nil,
 						"warehouse": nil,
 					},
-					PostDeployment: map[string]*manifest.PrePostDeployment{
+					PostDeployments: map[string]*manifest.PrePostDeployment{
 						"post": {},
 						"it":   {},
 					},
@@ -642,7 +642,7 @@ func TestPipelineStage_PostDeployments(t *testing.T) {
 				var stg PipelineStage
 				stg.Init(&config.Environment{Name: "test"}, &manifest.PipelineStage{
 					Name: "test",
-					PostDeployment: map[string]*manifest.PrePostDeployment{
+					PostDeployments: map[string]*manifest.PrePostDeployment{
 						"post": {
 							DependsOn: []string{"post"},
 						},

--- a/internal/pkg/manifest/pipeline.go
+++ b/internal/pkg/manifest/pipeline.go
@@ -216,6 +216,7 @@ type PrePostDeployment struct {
 	DependsOn     []string `yaml:"depends_on"`
 }
 
+// Dependencies returns ordering requirements for the deployment's actions.
 func (dep *Deployment) Dependencies() []string {
 	if dep == nil {
 		return nil
@@ -223,6 +224,7 @@ func (dep *Deployment) Dependencies() []string {
 	return dep.DependsOn
 }
 
+// Dependencies returns ordering requirements for the pre- or post-deployment's actions.
 func (ppd *PrePostDeployment) Dependencies() []string {
 	if ppd == nil {
 		return nil

--- a/internal/pkg/manifest/pipeline.go
+++ b/internal/pkg/manifest/pipeline.go
@@ -212,7 +212,7 @@ type PrePostDeployments map[string]*PrePostDeployment
 
 // PrePostDeployment is the config for a pre- or post-deployment action.
 type PrePostDeployment struct {
-	BuildspecPath string   `yaml:"buildspec_path"`
+	BuildspecPath string   `yaml:"buildspec"`
 	DependsOn     []string `yaml:"depends_on"`
 }
 

--- a/internal/pkg/manifest/pipeline.go
+++ b/internal/pkg/manifest/pipeline.go
@@ -213,7 +213,7 @@ type PrePostDeployments map[string]*PrePostDeployment
 // PrePostDeployment is the config for a pre- or post-deployment action.
 type PrePostDeployment struct {
 	BuildspecPath string   `yaml:"buildspec_path"`
-	DependsOn     []string `yaml:"depends_on,omitempty"`
+	DependsOn     []string `yaml:"depends_on"`
 }
 
 // NewPipeline returns a pipeline manifest object.
@@ -261,16 +261,10 @@ func UnmarshalPipeline(in []byte) (*Pipeline, error) {
 	if version, err = validateVersion(&pm); err != nil {
 		return nil, err
 	}
-
-	if err := validateTestCommands(&pm); err != nil {
-		return nil, err
-	}
-
 	switch version {
 	case Ver1:
 		return &pm, nil
 	}
-
 	// we should never reach here, this is just to make the compiler happy
 	return nil, errors.New("unexpected error occurs while unmarshalling manifest.yml")
 }
@@ -297,13 +291,4 @@ func validateVersion(pm *Pipeline) (PipelineSchemaMajorVersion, error) {
 				invalidVersion: pm.Version,
 			}
 	}
-}
-
-func validateTestCommands(pm *Pipeline) error {
-	for _, stage := range pm.Stages {
-		if len(stage.TestCommands) != 0 && stage.PostDeployment != nil {
-			return fmt.Errorf("mutually exclusive fields 'test_commands' and 'post_deployment' found in stage %q", stage.Name)
-		}
-	}
-	return nil
 }

--- a/internal/pkg/manifest/pipeline.go
+++ b/internal/pkg/manifest/pipeline.go
@@ -216,22 +216,6 @@ type PrePostDeployment struct {
 	DependsOn     []string `yaml:"depends_on"`
 }
 
-// Dependencies returns ordering requirements for the deployment's actions.
-func (dep *Deployment) Dependencies() []string {
-	if dep == nil {
-		return nil
-	}
-	return dep.DependsOn
-}
-
-// Dependencies returns ordering requirements for the pre- or post-deployment's actions.
-func (ppd *PrePostDeployment) Dependencies() []string {
-	if ppd == nil {
-		return nil
-	}
-	return ppd.DependsOn
-}
-
 // NewPipeline returns a pipeline manifest object.
 func NewPipeline(pipelineName string, provider Provider, stages []PipelineStage) (*Pipeline, error) {
 	// TODO: #221 Do more validations

--- a/internal/pkg/manifest/pipeline.go
+++ b/internal/pkg/manifest/pipeline.go
@@ -210,10 +210,24 @@ type Deployment struct {
 // PrePostDeployments represent a directed graph of cloudformation deployments.
 type PrePostDeployments map[string]*PrePostDeployment
 
-// PrePostDeployment is the config for a pre- or post-deployment action.
+// PrePostDeployment is the config for a pre- or post-deployment action backed by CodeBuild.
 type PrePostDeployment struct {
 	BuildspecPath string   `yaml:"buildspec"`
 	DependsOn     []string `yaml:"depends_on"`
+}
+
+func (dep *Deployment) Dependencies() []string {
+	if dep == nil {
+		return nil
+	}
+	return dep.DependsOn
+}
+
+func (ppd *PrePostDeployment) Dependencies() []string {
+	if ppd == nil {
+		return nil
+	}
+	return ppd.DependsOn
 }
 
 // NewPipeline returns a pipeline manifest object.

--- a/internal/pkg/manifest/pipeline.go
+++ b/internal/pkg/manifest/pipeline.go
@@ -192,8 +192,8 @@ type PipelineStage struct {
 	RequiresApproval bool               `yaml:"requires_approval,omitempty"`
 	TestCommands     []string           `yaml:"test_commands,omitempty"`
 	Deployments      Deployments        `yaml:"deployments,omitempty"`
-	PreDeployment    PrePostDeployments `yaml:"pre_deployment,omitempty"`
-	PostDeployment   PrePostDeployments `yaml:"post_deployment,omitempty"`
+	PreDeployments   PrePostDeployments `yaml:"pre_deployments,omitempty"`
+	PostDeployments  PrePostDeployments `yaml:"post_deployments,omitempty"`
 }
 
 // Deployments represent a directed graph of cloudformation deployments.

--- a/internal/pkg/manifest/pipeline_test.go
+++ b/internal/pkg/manifest/pipeline_test.go
@@ -218,6 +218,31 @@ stages:
 			inContent:   `corrupted yaml`,
 			expectedErr: errors.New("yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `corrupt...` into manifest.Pipeline"),
 		},
+		"invalid pipeline.yml with both test_commands and post_deployment": {
+			inContent: `
+name:    pipepiper
+version: 1
+
+source: 
+  provider: GitHub
+  properties:
+    repository: aws/somethingCool
+    access_token_secret: "github-token-badgoose-backend"
+    branch: main
+
+build:
+  image: aws/codebuild/standard:3.0
+
+stages:
+  -
+    name: chicken
+    post_deployment:
+      first_action:
+        buildspec_path: copilot/pipelines/my-pipeline/buildspecs/migration.yml 
+    test_commands: ["testing", "testing 123"]
+`,
+			expectedErr: errors.New(`mutually exclusive fields 'test_commands' and 'post_deployment' found in stage "chicken"`),
+		},
 		"valid pipeline.yml without build": {
 			inContent: `
 name: pipepiper

--- a/internal/pkg/manifest/pipeline_test.go
+++ b/internal/pkg/manifest/pipeline_test.go
@@ -218,31 +218,6 @@ stages:
 			inContent:   `corrupted yaml`,
 			expectedErr: errors.New("yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `corrupt...` into manifest.Pipeline"),
 		},
-		"invalid pipeline.yml with both test_commands and post_deployment": {
-			inContent: `
-name:    pipepiper
-version: 1
-
-source: 
-  provider: GitHub
-  properties:
-    repository: aws/somethingCool
-    access_token_secret: "github-token-badgoose-backend"
-    branch: main
-
-build:
-  image: aws/codebuild/standard:3.0
-
-stages:
-  -
-    name: chicken
-    post_deployment:
-      first_action:
-        buildspec_path: copilot/pipelines/my-pipeline/buildspecs/migration.yml 
-    test_commands: ["testing", "testing 123"]
-`,
-			expectedErr: errors.New(`mutually exclusive fields 'test_commands' and 'post_deployment' found in stage "chicken"`),
-		},
 		"valid pipeline.yml without build": {
 			inContent: `
 name: pipepiper

--- a/internal/pkg/manifest/validate.go
+++ b/internal/pkg/manifest/validate.go
@@ -628,7 +628,11 @@ func (p Pipeline) Validate() error {
 // validate returns nil if stages are configured correctly.
 func (s PipelineStage) validate() error {
 	if len(s.TestCommands) != 0 && s.PostDeployments != nil {
-		return fmt.Errorf("mutually exclusive fields 'test_commands' and 'post_deployment' found in stage %q", s.Name)
+		return &errFieldMutualExclusive{
+			firstField:  "post_deployments",
+			secondField: "test_commands",
+			mustExist:   false,
+		}
 	}
 	return nil
 }

--- a/internal/pkg/manifest/validate.go
+++ b/internal/pkg/manifest/validate.go
@@ -627,7 +627,7 @@ func (p Pipeline) Validate() error {
 
 // validate returns nil if stages are configured correctly.
 func (s PipelineStage) validate() error {
-	if len(s.TestCommands) != 0 && s.PostDeployment != nil {
+	if len(s.TestCommands) != 0 && s.PostDeployments != nil {
 		return fmt.Errorf("mutually exclusive fields 'test_commands' and 'post_deployment' found in stage %q", s.Name)
 	}
 	return nil

--- a/internal/pkg/manifest/validate.go
+++ b/internal/pkg/manifest/validate.go
@@ -615,9 +615,20 @@ func (p Pipeline) Validate() error {
 		return fmt.Errorf(`pipeline name '%s' must be shorter than 100 characters`, p.Name)
 	}
 	for _, stg := range p.Stages {
+		if err := stg.validate(); err != nil {
+			return fmt.Errorf(`validate "stages" for pipeline %q: %w`, p.Name, err)
+		}
 		if err := stg.Deployments.validate(); err != nil {
 			return fmt.Errorf(`validate "deployments" for pipeline stage %s: %w`, stg.Name, err)
 		}
+	}
+	return nil
+}
+
+// validate returns nil if stages are configured correctly.
+func (s PipelineStage) validate() error {
+	if len(s.TestCommands) != 0 && s.PostDeployment != nil {
+		return fmt.Errorf("mutually exclusive fields 'test_commands' and 'post_deployment' found in stage %q", s.Name)
 	}
 	return nil
 }

--- a/internal/pkg/manifest/validate.go
+++ b/internal/pkg/manifest/validate.go
@@ -634,6 +634,26 @@ func (s PipelineStage) validate() error {
 			mustExist:   false,
 		}
 	}
+	if s.PreDeployments != nil {
+		for _, preDep := range s.PreDeployments {
+			if preDep.BuildspecPath == "" {
+				return &errFieldMustBeSpecified{
+					missingField: "buildspec",
+				}
+			}
+		}
+
+	}
+	if s.PostDeployments != nil {
+		for _, postDep := range s.PostDeployments {
+			if postDep.BuildspecPath == "" {
+				return &errFieldMustBeSpecified{
+					missingField: "buildspec",
+				}
+			}
+		}
+
+	}
 	return nil
 }
 

--- a/internal/pkg/manifest/validate.go
+++ b/internal/pkg/manifest/validate.go
@@ -616,7 +616,7 @@ func (p Pipeline) Validate() error {
 	}
 	for _, stg := range p.Stages {
 		if err := stg.validate(); err != nil {
-			return fmt.Errorf(`validate "stages" for pipeline %q: %w`, p.Name, err)
+			return fmt.Errorf(`validate stage %q for pipeline %q: %w`, stg.Name, p.Name, err)
 		}
 		if err := stg.Deployments.validate(); err != nil {
 			return fmt.Errorf(`validate "deployments" for pipeline stage %s: %w`, stg.Name, err)

--- a/internal/pkg/manifest/validate_test.go
+++ b/internal/pkg/manifest/validate_test.go
@@ -1386,7 +1386,7 @@ func TestPipelineManifest_validate(t *testing.T) {
 				Stages: []PipelineStage{
 					{
 						Name: "test",
-						PostDeployment: PrePostDeployments{
+						PostDeployments: PrePostDeployments{
 							"first_action": &PrePostDeployment{
 								BuildspecPath: "copilot/pipelines/my-pipeline/buildspecs/migration.yml",
 							},

--- a/internal/pkg/manifest/validate_test.go
+++ b/internal/pkg/manifest/validate_test.go
@@ -1397,6 +1397,23 @@ func TestPipelineManifest_validate(t *testing.T) {
 			},
 			wantedError: errors.New(`validate stage "test" for pipeline "release": must specify one, not both, of "post_deployments" and "test_commands"`),
 		},
+		"should validate buildspec exists for pre/post-deployments": {
+			Pipeline: Pipeline{
+				Name: "release",
+				Stages: []PipelineStage{
+					{
+						Name: "test",
+						PostDeployments: PrePostDeployments{
+							"first_action": &PrePostDeployment{
+								BuildspecPath: "copilot/pipelines/my-pipeline/buildspecs/migration.yml",
+							},
+							"second_action": &PrePostDeployment{},
+						},
+					},
+				},
+			},
+			wantedError: errors.New(`validate stage "test" for pipeline "release": "buildspec" must be specified`),
+		},
 		"should validate pipeline deployments": {
 			Pipeline: Pipeline{
 				Name: "release",

--- a/internal/pkg/manifest/validate_test.go
+++ b/internal/pkg/manifest/validate_test.go
@@ -1395,7 +1395,7 @@ func TestPipelineManifest_validate(t *testing.T) {
 					},
 				},
 			},
-			wantedError: errors.New(`validate "stages" for pipeline "release": mutually exclusive fields 'test_commands' and 'post_deployment' found in stage "test"`),
+			wantedError: errors.New(`validate "stages" for pipeline "release": must specify one, not both, of "post_deployments" and "test_commands"`),
 		},
 		"should validate pipeline deployments": {
 			Pipeline: Pipeline{

--- a/internal/pkg/manifest/validate_test.go
+++ b/internal/pkg/manifest/validate_test.go
@@ -1386,6 +1386,23 @@ func TestPipelineManifest_validate(t *testing.T) {
 				Stages: []PipelineStage{
 					{
 						Name: "test",
+						PostDeployment: PrePostDeployments{
+							"first_action": &PrePostDeployment{
+								BuildspecPath: "copilot/pipelines/my-pipeline/buildspecs/migration.yml",
+							},
+						},
+						TestCommands: []string{"testing", "testing123"},
+					},
+				},
+			},
+			wantedError: errors.New(`validate "stages" for pipeline "release": mutually exclusive fields 'test_commands' and 'post_deployment' found in stage "test"`),
+		},
+		"should validate pipeline deployments": {
+			Pipeline: Pipeline{
+				Name: "release",
+				Stages: []PipelineStage{
+					{
+						Name: "test",
 						Deployments: map[string]*Deployment{
 							"frontend": {
 								DependsOn: []string{"backend"},

--- a/internal/pkg/manifest/validate_test.go
+++ b/internal/pkg/manifest/validate_test.go
@@ -1395,7 +1395,7 @@ func TestPipelineManifest_validate(t *testing.T) {
 					},
 				},
 			},
-			wantedError: errors.New(`validate "stages" for pipeline "release": must specify one, not both, of "post_deployments" and "test_commands"`),
+			wantedError: errors.New(`validate stage "test" for pipeline "release": must specify one, not both, of "post_deployments" and "test_commands"`),
 		},
 		"should validate pipeline deployments": {
 			Pipeline: Pipeline{

--- a/internal/pkg/template/templates/cicd/partials/actions.yml
+++ b/internal/pkg/template/templates/cicd/partials/actions.yml
@@ -38,7 +38,7 @@ Post{{logicalIDSafe $stage.Name}}DeploymentAction{{logicalIDSafe $action.Name}}B
   Type: AWS::IAM::Role
   Properties:
     Path: /
-  {{ include "role-config" $ | indent 4}}
+{{ include "role-config" $ | indent 4}}
     {{- if $.PermissionsBoundary }}
     PermissionsBoundary: !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/{{$.PermissionsBoundary}}'
     {{- end }}
@@ -47,13 +47,13 @@ Post{{logicalIDSafe $stage.Name}}DeploymentAction{{logicalIDSafe $action.Name}}B
         PolicyDocument:
           Version: '2012-10-17'
           Statement:
-            - Effect: Allow
-              Resource: 'arn:aws:iam::{{$stage.AccountID}}:role/{{$.AppName}}-{{$stage.Name}}-EnvManagerRole'
-              Action:
-                - sts:AssumeRole
+          - Effect: Allow
+            Resource: 'arn:aws:iam::{{$stage.AccountID}}:role/{{$.AppName}}-{{$stage.Name}}-EnvManagerRole'
+            Action:
+              - sts:AssumeRole
       - PolicyName: build-role-policy
         PolicyDocument:
-  {{ include "role-policy-document" $ | indent 10 }}
+{{ include "role-policy-document" $ | indent 10 }}
 
 Post{{logicalIDSafe $stage.Name}}DeploymentAction{{logicalIDSafe $action.Name}}:
   Type: AWS::CodeBuild::Project
@@ -62,6 +62,6 @@ Post{{logicalIDSafe $stage.Name}}DeploymentAction{{logicalIDSafe $action.Name}}:
     ServiceRole: !GetAtt Post{{logicalIDSafe $stage.Name}}DeploymentAction{{logicalIDSafe $action.Name}}BuildProjectRole.Arn
     Artifacts:
       Type: CODEPIPELINE
-  {{ include "action-config" $action | indent 4}}
+{{ include "action-config" $action | indent 4}}
 {{- end}}
 {{- end}}

--- a/internal/pkg/template/templates/cicd/pipeline_cfn.yml
+++ b/internal/pkg/template/templates/cicd/pipeline_cfn.yml
@@ -249,10 +249,10 @@ Resources:
                 Provider: CodeBuild
               Configuration:
                 ProjectName: !Ref Pre{{logicalIDSafe $stage.Name}}DeploymentAction{{logicalIDSafe $action.Name}}
-                InputArtifacts:
-                  - Name: SCCheckoutArtifact
-                OutputArtifacts:
-                  - Name: Pre{{logicalIDSafe $stage.Name}}DeploymentAction{{logicalIDSafe $action.Name}}Output
+              InputArtifacts:
+                - Name: SCCheckoutArtifact
+              OutputArtifacts:
+                - Name: Pre{{logicalIDSafe $stage.Name}}DeploymentAction{{logicalIDSafe $action.Name}}Output
             {{- end}}
             {{- range $action := $stage.PostDeployments }}
             - Name: {{ $action.Name }}
@@ -265,10 +265,10 @@ Resources:
                 Provider: CodeBuild
               Configuration:
                 ProjectName: !Ref Post{{logicalIDSafe $stage.Name}}DeploymentAction{{logicalIDSafe $action.Name}}
-                InputArtifacts:
-                  - Name: SCCheckoutArtifact
-                OutputArtifacts:
-                  - Name: Post{{logicalIDSafe $stage.Name}}DeploymentAction{{logicalIDSafe $action.Name}}Output
+              InputArtifacts:
+                - Name: SCCheckoutArtifact
+              OutputArtifacts:
+                - Name: Post{{logicalIDSafe $stage.Name}}DeploymentAction{{logicalIDSafe $action.Name}}Output
             {{- end}}
             {{- range $deployment := $stage.Deployments}}
             - Name: {{$deployment.Name}}


### PR DESCRIPTION
Related: #5109, #3007.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
