### PR TITLE
chore: get all non-built images

### DIFF
--- a/internal/pkg/cli/local_run.go
+++ b/internal/pkg/cli/local_run.go
@@ -288,8 +288,6 @@ func (o *localRunOpts) Execute() error {
 	for _, container := range taskDef.ContainerDefinitions {
 		name := aws.StringValue(container.Name)
 		if _, ok := containerURIs[name]; !ok {
-			// TODO: check if we should ignore ones that don't have an image
-			// location value. Mostly thinking about ECS injected sidecars (envoy?)
 			containerURIs[name] = aws.StringValue(container.Image)
 		}
 	}

--- a/internal/pkg/cli/local_run.go
+++ b/internal/pkg/cli/local_run.go
@@ -243,7 +243,6 @@ func (o *localRunOpts) Execute() error {
 		return fmt.Errorf("get task definition: %w", err)
 	}
 
-	// get env vars and secrets
 	envVars, err := o.getEnvVars(ctx, taskDef)
 	if err != nil {
 		return fmt.Errorf("get env vars: %w", err)

--- a/internal/pkg/cli/local_run.go
+++ b/internal/pkg/cli/local_run.go
@@ -284,7 +284,7 @@ func (o *localRunOpts) Execute() error {
 		return fmt.Errorf("build images: %w", err)
 	}
 
-	// use the location for any missing URIs
+	// fill the location from the task def for containers without a URI
 	for _, container := range taskDef.ContainerDefinitions {
 		name := aws.StringValue(container.Name)
 		if _, ok := containerURIs[name]; !ok {

--- a/internal/pkg/cli/local_run_test.go
+++ b/internal/pkg/cli/local_run_test.go
@@ -548,7 +548,7 @@ func TestLocalRunOpts_Execute(t *testing.T) {
 				configureClients: func(o *localRunOpts) error {
 					return nil
 				},
-				buildContainerImages: func(o *localRunOpts, mft manifest.DynamicWorkload) (map[string]string, error) {
+				buildContainerImages: func(mft manifest.DynamicWorkload) (map[string]string, error) {
 					return mockContainerURIs, tc.buildImagesError
 				},
 				ws:             m.ws,

--- a/internal/pkg/cli/local_run_test.go
+++ b/internal/pkg/cli/local_run_test.go
@@ -15,7 +15,6 @@ import (
 	sdkecs "github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/aws/copilot-cli/internal/pkg/aws/ecs"
 	awsecs "github.com/aws/copilot-cli/internal/pkg/aws/ecs"
-	clideploy "github.com/aws/copilot-cli/internal/pkg/cli/deploy"
 	"github.com/aws/copilot-cli/internal/pkg/cli/mocks"
 	"github.com/aws/copilot-cli/internal/pkg/config"
 	"github.com/aws/copilot-cli/internal/pkg/docker/dockerengine"
@@ -243,15 +242,9 @@ func TestLocalRunOpts_Execute(t *testing.T) {
 	mockContainerSuffix := fmt.Sprintf("%s-%s-%s", testAppName, testEnvName, testWkldName)
 	mockPauseContainerName := pauseContainerName + "-" + mockContainerSuffix
 
-	mockImageInfoList := []clideploy.ImagePerContainer{
-		{
-			ContainerName: "foo",
-			ImageURI:      "image1",
-		},
-		{
-			ContainerName: "bar",
-			ImageURI:      "image2",
-		},
+	mockContainerURIs := map[string]string{
+		"foo": "image1",
+		"bar": "image2",
 	}
 
 	taskDef := &ecs.TaskDefinition{
@@ -555,10 +548,9 @@ func TestLocalRunOpts_Execute(t *testing.T) {
 				configureClients: func(o *localRunOpts) error {
 					return nil
 				},
-				buildContainerImages: func(o *localRunOpts) error {
-					return tc.buildImagesError
+				buildContainerImages: func(o *localRunOpts, mft manifest.DynamicWorkload) (map[string]string, error) {
+					return mockContainerURIs, tc.buildImagesError
 				},
-				imageInfoList:  mockImageInfoList,
 				ws:             m.ws,
 				ecsLocalClient: m.ecsLocalClient,
 				ssm:            m.ssm,
@@ -606,6 +598,7 @@ func TestLocalRunOpts_getEnvVars(t *testing.T) {
 		envOverrides map[string]string
 		setupMocks   func(m *localRunExecuteMocks)
 		credsError   error
+		region       *string
 
 		want      map[string]containerEnv
 		wantError string
@@ -922,6 +915,26 @@ func TestLocalRunOpts_getEnvVars(t *testing.T) {
 				},
 			},
 		},
+		"region env vars set": {
+			taskDef: &awsecs.TaskDefinition{
+				ContainerDefinitions: []*sdkecs.ContainerDefinition{
+					{
+						Name:        aws.String("foo"),
+						Environment: []*sdkecs.KeyValuePair{},
+					},
+				},
+			},
+			region: aws.String("myRegion"),
+			want: map[string]containerEnv{
+				"foo": {
+					"AWS_ACCESS_KEY_ID":     newVar("myID", false, false),
+					"AWS_SECRET_ACCESS_KEY": newVar("mySecret", false, false),
+					"AWS_SESSION_TOKEN":     newVar("myToken", false, false),
+					"AWS_REGION":            newVar("myRegion", false, false),
+					"AWS_DEFAULT_REGION":    newVar("myRegion", false, false),
+				},
+			},
+		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -951,6 +964,7 @@ func TestLocalRunOpts_getEnvVars(t *testing.T) {
 				sess: &session.Session{
 					Config: &aws.Config{
 						Credentials: credentials.NewCredentials(m.sessCreds),
+						Region:      tc.region,
 					},
 				},
 				ssm:            m.ssm,


### PR DESCRIPTION
Previously, we would miss sidecar images created by Copilot from `logging` or `observability`. This change makes our method of getting non-built image locations more generic to support running that class of images.

Additionally, this change injects the `AWS_REGION` and `AWS_DEFAULT_REGION` environment variables to match ECS.

To be merged after https://github.com/aws/copilot-cli/pull/5214.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
