### PR TITLE
chore: fix handling of env name in init

### DIFF
--- a/internal/pkg/cli/init.go
+++ b/internal/pkg/cli/init.go
@@ -462,9 +462,9 @@ func (o *initOpts) deployEnv() error {
 	}
 
 	if initEnvCmd, ok := o.initEnvCmd.(*initEnvOpts); ok {
-		// Set the application name from app init to the env init command. Set an env name if available.
+		// Set the application name from app init to the env init command, and check whether a flag has been passed for envName.
 		initEnvCmd.appName = *o.appName
-		initEnvCmd.name = *o.envName
+		initEnvCmd.name = o.initVars.envName
 	}
 
 	if err := o.askEnvNameAndMaybeInit(); err != nil {


### PR DESCRIPTION
<!-- Provide summary of changes -->
Tests using init seem to be failing due to the envName flag not getting correctly populated to child commands like env init and env deploy.

There may also be a problem with error handling after deployEnvCmd.Execute() which I'm looking into.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
