### PR TITLE
chore: keep the pre/post actions' region as the pipeline region

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/gh_template.yaml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/gh_template.yaml
@@ -846,7 +846,6 @@ Resources:
                 Provider: Manual
               RunOrder: 1
             - Name: preAction1
-              Region: us-west-2
               RunOrder: 2
               ActionTypeId:
                 Category: Build
@@ -860,7 +859,6 @@ Resources:
               OutputArtifacts:
                 - Name: PretestDeploymentActionpreAction1Output
             - Name: preAction2
-              Region: us-west-2
               RunOrder: 3
               ActionTypeId:
                 Category: Build
@@ -874,7 +872,6 @@ Resources:
               OutputArtifacts:
                 - Name: PretestDeploymentActionpreAction2Output
             - Name: postAction1
-              Region: us-west-2
               RunOrder: 5
               ActionTypeId:
                 Category: Build
@@ -888,7 +885,6 @@ Resources:
               OutputArtifacts:
                 - Name: PosttestDeploymentActionpostAction1Output
             - Name: postAction2
-              Region: us-west-2
               RunOrder: 6
               ActionTypeId:
                 Category: Build
@@ -902,7 +898,6 @@ Resources:
               OutputArtifacts:
                 - Name: PosttestDeploymentActionpostAction2Output
             - Name: postAction3
-              Region: us-west-2
               RunOrder: 5
               ActionTypeId:
                 Category: Build

--- a/internal/pkg/template/templates/cicd/pipeline_cfn.yml
+++ b/internal/pkg/template/templates/cicd/pipeline_cfn.yml
@@ -240,7 +240,7 @@ Resources:
             {{- end}}
             {{- range $action := $stage.PreDeployments }}
             - Name: {{ $action.Name }}
-              Region: {{ $stage.Region }}
+              Region: !Ref AWS::Region
               RunOrder: {{ $action.RunOrder}}
               ActionTypeId:
                 Category: Build
@@ -256,7 +256,7 @@ Resources:
             {{- end}}
             {{- range $action := $stage.PostDeployments }}
             - Name: {{ $action.Name }}
-              Region: {{ $stage.Region }}
+              Region: !Ref AWS::Region
               RunOrder: {{ $action.RunOrder}}
               ActionTypeId:
                 Category: Build

--- a/internal/pkg/template/templates/cicd/pipeline_cfn.yml
+++ b/internal/pkg/template/templates/cicd/pipeline_cfn.yml
@@ -240,7 +240,6 @@ Resources:
             {{- end}}
             {{- range $action := $stage.PreDeployments }}
             - Name: {{ $action.Name }}
-              Region: !Ref AWS::Region
               RunOrder: {{ $action.RunOrder}}
               ActionTypeId:
                 Category: Build
@@ -256,7 +255,6 @@ Resources:
             {{- end}}
             {{- range $action := $stage.PostDeployments }}
             - Name: {{ $action.Name }}
-              Region: !Ref AWS::Region
               RunOrder: {{ $action.RunOrder}}
               ActionTypeId:
                 Category: Build


### PR DESCRIPTION
The CodeBuild project is deployed at the pipeline region. The action should look for the CodeBuild project at the same region (instead of the environment region, which can be different from the pipeline region).

With an upcoming change, people will still be able to access their environment VPC via. copilot commands from within the CodeBuild project, even if it lives in the pipeline region which is potentially different from the env region.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
