### PR TITLE
chore: add local run to develop group and set up usage template

### DIFF
--- a/internal/pkg/cli/local_run.go
+++ b/internal/pkg/cli/local_run.go
@@ -21,6 +21,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	sdksecretsmanager "github.com/aws/aws-sdk-go/service/secretsmanager"
 	sdkssm "github.com/aws/aws-sdk-go/service/ssm"
+	"github.com/aws/copilot-cli/cmd/copilot/template"
 	"github.com/aws/copilot-cli/internal/pkg/aws/ecr"
 	awsecs "github.com/aws/copilot-cli/internal/pkg/aws/ecs"
 	"github.com/aws/copilot-cli/internal/pkg/aws/identity"
@@ -28,6 +29,7 @@ import (
 	"github.com/aws/copilot-cli/internal/pkg/aws/sessions"
 	"github.com/aws/copilot-cli/internal/pkg/aws/ssm"
 	clideploy "github.com/aws/copilot-cli/internal/pkg/cli/deploy"
+	"github.com/aws/copilot-cli/internal/pkg/cli/group"
 	"github.com/aws/copilot-cli/internal/pkg/config"
 	"github.com/aws/copilot-cli/internal/pkg/deploy"
 	"github.com/aws/copilot-cli/internal/pkg/deploy/cloudformation"
@@ -639,8 +641,8 @@ func BuildLocalRunCmd() *cobra.Command {
 	vars := localRunVars{}
 	cmd := &cobra.Command{
 		Use:    "local run",
-		Short:  "Run the workload locally",
-		Long:   "Run the workload locally",
+		Short:  "Run the workload locally.",
+		Long:   "Run the workload locally.",
 		Hidden: true,
 		RunE: runCmdE(func(cmd *cobra.Command, args []string) error {
 			opts, err := newLocalRunOpts(vars)
@@ -649,7 +651,12 @@ func BuildLocalRunCmd() *cobra.Command {
 			}
 			return run(opts)
 		}),
+		Annotations: map[string]string{
+			"group": group.Develop,
+		},
 	}
+	cmd.SetUsageTemplate(template.Usage)
+
 	cmd.Flags().StringVarP(&vars.wkldName, nameFlag, nameFlagShort, "", workloadFlagDescription)
 	cmd.Flags().StringVarP(&vars.envName, envFlag, envFlagShort, "", envFlagDescription)
 	cmd.Flags().StringVarP(&vars.appName, appFlag, appFlagShort, tryReadingAppName(), appFlagDescription)

--- a/internal/pkg/term/selector/selector.go
+++ b/internal/pkg/term/selector/selector.go
@@ -7,9 +7,9 @@ package selector
 import (
 	"errors"
 	"fmt"
-	"github.com/dustin/go-humanize/english"
 	"sort"
-	"strings"
+
+	"github.com/dustin/go-humanize/english"
 
 	awsecs "github.com/aws/copilot-cli/internal/pkg/aws/ecs"
 	"github.com/aws/copilot-cli/internal/pkg/config"
@@ -705,11 +705,13 @@ func (s *DeploySelector) deployedWorkload(workloadType string, msg, help string,
 	var deployedWkld *DeployedWorkload
 	if len(wkldEnvs) == 1 {
 		deployedWkld = wkldEnvs[0]
-		if s.name == "" && s.env == "" {
+		switch {
+		case s.name == "" && s.env == "":
 			log.Infof("Found only one deployed %s %s in environment %s\n", workloadType, color.HighlightUserInput(deployedWkld.Name), color.HighlightUserInput(deployedWkld.Env))
-		}
-		if (s.name != "") != (s.env != "") {
-			log.Infof("%s %s found in environment %s\n", strings.ToTitle(workloadType), color.HighlightUserInput(deployedWkld.Name), color.HighlightUserInput(deployedWkld.Env))
+		case s.name != "" && s.env == "":
+			log.Infof("%s found only in environment %s\n", color.HighlightUserInput(deployedWkld.Name), color.HighlightUserInput(deployedWkld.Env))
+		case s.name == "" && s.env != "":
+			log.Infof("Only the %s %s is found in the environment %s\n", deployedWkld.Type, color.HighlightUserInput(deployedWkld.Name), color.HighlightUserInput(deployedWkld.Env))
 		}
 		return deployedWkld, nil
 	}


### PR DESCRIPTION
```
$ copilot local -h # as well as "copilot local run -h", they show the same content
Run the workload locally.

Usage
  copilot local run [flags]

Flags
  -a, --app string                        Name of the application.
  -e, --env string                        Name of the environment.
      --env-var-override stringToString   Optional. Override environment variables passed to containers.
                                          Format: [container]:KEY=VALUE. Omit container name to apply to all containers. (default [])
  -h, --help                              help for local
  -n, --name string                       Name of the service or job.
      --port-override list                Optional. Override ports exposed by service. Format: <host port>:<service port>.
                                          Example: --port-override 5000:80 binds localhost:5000 to the service's port 80. (default [])


$ copilot -h
👩‍✈️ Launch and manage containerized applications on AWS.

Commands
  Getting Started 🌱
    init        Create a new ECS or App Runner application.
    docs        Open the copilot docs.

  Develop ✨
    app         Commands for applications.
                Applications are a collection of services and environments.
    env         Commands for environments.
                Environments are deployment stages shared between services.
    svc         Commands for services.
                Services are long-running ECS or App Runner services.
    job         Commands for jobs.
                Jobs are tasks that are triggered by events.
    task        Commands for tasks.
                One-off Amazon ECS tasks that terminate once their work is done.
    local       Run the workload locally.

  Release 🚀
    pipeline    Commands for pipelines.
                Continuous delivery pipelines to release services.
    deploy      Deploy a Copilot job or service.

  Extend 🧸
    storage     Commands for working with storage and databases.
    secret      Commands for secrets.
                Secrets are sensitive information that you need in your application.

  Settings ⚙️
    version     Print the version number.
    completion  Output shell completion code.

Flags
  -h, --help      help for copilot
  -v, --version   version for copilot

Examples
  Displays the help menu for the "init" command.
  `$ copilot init --help`
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
