### PR TITLE
chore: swallow stdout when running `docker [stop/rm]`

### DIFF
--- a/internal/pkg/docker/dockerengine/dockerengine.go
+++ b/internal/pkg/docker/dockerengine/dockerengine.go
@@ -315,12 +315,12 @@ func (c DockerCmdClient) IsContainerRunning(containerName string) (bool, error) 
 
 // Stop calls `docker stop` to stop a running container.
 func (c DockerCmdClient) Stop(containerID string) error {
-	return c.runner.Run("docker", []string{"stop", containerID})
+	return c.runner.Run("docker", []string{"stop", containerID}, exec.Stdout(io.Discard))
 }
 
 // Rm calls `docker rm` to remove a stopped container.
 func (c DockerCmdClient) Rm(containerID string) error {
-	return c.runner.Run("docker", []string{"rm", containerID})
+	return c.runner.Run("docker", []string{"rm", containerID}, exec.Stdout(io.Discard))
 }
 
 // CheckDockerEngineRunning will run `docker info` command to check if the docker engine is running.


### PR DESCRIPTION
`docker [stop/rm]` outputs the container ID to stdout after a successful execution. It results in ⬇️  in the terminal after hitting ctrl+c on `local run`:
```
^C
Stopping containers...

Cleaning up "js-copilot-observability-web-and-backend-nocert-js-copilot-observability"
js-copilot-observability-web-and-backend-nocert-js-copilot-observability # <- from docker stop
js-copilot-observability-web-and-backend-nocert-js-copilot-observability # <- from docker rm
Cleaning up "pause-web-and-backend-nocert-js-copilot-observability"
pause-web-and-backend-nocert-js-copilot-observability # from docker stop
pause-web-and-backend-nocert-js-copilot-observability # from docker rm
```

This PR swallows them so that we have 
```
^C
Stopping containers...

Cleaning up "js-copilot-observability-web-and-backend-nocert-js-copilot-observability"
Cleaning up "pause-web-and-backend-nocert-js-copilot-observability"
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
