### PR TITLE
fix: never prompt for env deployment

### DIFF
--- a/internal/pkg/cli/deploy.go
+++ b/internal/pkg/cli/deploy.go
@@ -400,8 +400,7 @@ func (o *deployOpts) maybeDeployEnv() error {
 	if !o.envExistsInWs {
 		return nil
 	}
-
-	if o.deployEnv == nil && !o.envExistsInApp {
+	if o.promptForEnvDeploy {
 		v, err := o.prompt.Confirm(fmt.Sprintf("Would you like to deploy the environment %q before deploying your workload?", o.envName), "", prompt.WithFinalMessage("Deploy environment:"))
 		if err != nil {
 			return fmt.Errorf("confirm env deployment: %w", err)

--- a/internal/pkg/cli/deploy.go
+++ b/internal/pkg/cli/deploy.go
@@ -397,13 +397,6 @@ func (o *deployOpts) maybeDeployEnv() error {
 	if !o.envExistsInWs {
 		return nil
 	}
-	if o.deployEnv == nil {
-		v, err := o.prompt.Confirm(fmt.Sprintf("Would you like to deploy the environment %q before deploying your workload?", o.envName), "", prompt.WithFinalMessage("Deploy environment:"))
-		if err != nil {
-			return fmt.Errorf("confirm env deployment: %w", err)
-		}
-		o.deployEnv = aws.Bool(v)
-	}
 
 	if aws.BoolValue(o.deployEnv) {
 		cmd, err := o.newDeployEnvCmd(o)

--- a/internal/pkg/cli/deploy.go
+++ b/internal/pkg/cli/deploy.go
@@ -68,8 +68,9 @@ type deployOpts struct {
 	wlType string
 
 	// values for initialization logic
-	envExistsInApp bool
-	envExistsInWs  bool
+	envExistsInApp     bool
+	envExistsInWs      bool
+	promptForEnvDeploy bool
 
 	// Cached variables
 	wsEnvironments []string
@@ -93,6 +94,8 @@ func newDeployOpts(vars deployVars) (*deployOpts, error) {
 		sel:        selector.NewLocalWorkloadSelector(prompter, store, ws),
 		ws:         ws,
 		prompt:     prompter,
+
+		promptForEnvDeploy: true,
 
 		newWorkloadAdder: func() wkldInitializerWithoutManifest {
 			return &initialize.WorkloadInitializer{
@@ -397,6 +400,13 @@ func (o *deployOpts) maybeDeployEnv() error {
 	if !o.envExistsInWs {
 		return nil
 	}
+	if o.promptForEnvDeploy {
+		v, err := o.prompt.Confirm(fmt.Sprintf("Would you like to deploy the environment %q before deploying your workload?", o.envName), "", prompt.WithFinalMessage("Deploy environment:"))
+		if err != nil {
+			return fmt.Errorf("confirm env deployment: %w", err)
+		}
+		o.deployEnv = aws.Bool(v)
+	}
 
 	if aws.BoolValue(o.deployEnv) {
 		cmd, err := o.newDeployEnvCmd(o)
@@ -454,14 +464,14 @@ func BuildDeployCmd() *cobra.Command {
 		Long:  "Deploy a Copilot job or service.",
 		Example: `
   Deploys a service named "frontend" to a "test" environment.
-  /code $ copilot deploy --name frontend --env test --deploy-env=false
+  /code $ copilot deploy --name frontend --env test
   Deploys a job named "mailer" with additional resource tags to a "prod" environment.
-  /code $ copilot deploy -n mailer -e prod --resource-tags source/revision=bb133e7,deployment/initiator=manual --deploy-env=false
+  /code $ copilot deploy -n mailer -e prod --resource-tags source/revision=bb133e7,deployment/initiator=manual
   Initializes and deploys an environment named "test" in us-west-2 under the "default" profile with local manifest, 
     then deploys a service named "api"
   /code $ copilot deploy --init-env --deploy-env --env test --name api --profile default --region us-west-2
   Initializes and deploys a service named "backend" to a "prod" environment.
-  /code $ copilot deploy --init-wkld --deploy-env=false --env prod --name backend`,
+  /code $ copilot deploy --init-wkld --env prod --name backend`,
 
 		RunE: runCmdE(func(cmd *cobra.Command, args []string) error {
 			opts, err := newDeployOpts(vars)
@@ -488,6 +498,10 @@ func BuildDeployCmd() *cobra.Command {
 				if deployEnvironment {
 					opts.deployEnv = aws.Bool(true)
 				}
+			}
+
+			if cmd.Flags().Changed(envFlag) || cmd.Flags().Changed(deployEnvFlag) {
+				opts.promptForEnvDeploy = false
 			}
 
 			if err := opts.Run(); err != nil {

--- a/internal/pkg/cli/deploy.go
+++ b/internal/pkg/cli/deploy.go
@@ -400,7 +400,8 @@ func (o *deployOpts) maybeDeployEnv() error {
 	if !o.envExistsInWs {
 		return nil
 	}
-	if o.promptForEnvDeploy {
+
+	if o.deployEnv == nil && !o.envExistsInApp {
 		v, err := o.prompt.Confirm(fmt.Sprintf("Would you like to deploy the environment %q before deploying your workload?", o.envName), "", prompt.WithFinalMessage("Deploy environment:"))
 		if err != nil {
 			return fmt.Errorf("confirm env deployment: %w", err)

--- a/internal/pkg/cli/deploy_test.go
+++ b/internal/pkg/cli/deploy_test.go
@@ -946,51 +946,30 @@ func Test_deployOpts_maybeInitEnv(t *testing.T) {
 
 func Test_deployOpts_maybeDeployEnv(t *testing.T) {
 	tests := map[string]struct {
-		envExistsInWs      bool
-		promptForEnvDeploy bool
-		deployEnv          *bool
+		envExistsInWs bool
+		deployEnv     *bool
 
 		mockDeployEnvCmd func(m *mocks.Mockcmd)
-		mockPrompter     func(m *mocks.Mockprompter)
 
 		wantErr string
 	}{
 		"env does not exist in ws": {
 			envExistsInWs:    false,
 			mockDeployEnvCmd: func(m *mocks.Mockcmd) {},
-			mockPrompter:     func(m *mocks.Mockprompter) {},
 		},
 		"env exists in app, flag set false": {
 			envExistsInWs:    true,
 			deployEnv:        aws.Bool(false),
 			mockDeployEnvCmd: func(m *mocks.Mockcmd) {},
-			mockPrompter:     func(m *mocks.Mockprompter) {},
 		},
 		"env exists; deploy flag set": {
 			envExistsInWs: true,
 			deployEnv:     aws.Bool(true),
-			mockPrompter:  func(m *mocks.Mockprompter) {},
 			mockDeployEnvCmd: func(m *mocks.Mockcmd) {
 				m.EXPECT().Validate().Return(nil)
 				m.EXPECT().Ask().Return(nil)
 				m.EXPECT().Execute().Return(nil)
 			},
-		},
-		"no env name specified, deployEnv flag unset": {
-			envExistsInWs:      true,
-			promptForEnvDeploy: true,
-			deployEnv:          nil,
-			mockDeployEnvCmd:   func(m *mocks.Mockcmd) {},
-			mockPrompter: func(m *mocks.Mockprompter) {
-				m.EXPECT().Confirm(gomock.Any(), "", gomock.Any()).Return(false, nil)
-			},
-		},
-		"no env name specified, deployEnv set": {
-			envExistsInWs:      true,
-			promptForEnvDeploy: false,
-			deployEnv:          aws.Bool(false),
-			mockDeployEnvCmd:   func(m *mocks.Mockcmd) {},
-			mockPrompter:       func(m *mocks.Mockprompter) {},
 		},
 	}
 	for name, tc := range tests {
@@ -999,10 +978,8 @@ func Test_deployOpts_maybeDeployEnv(t *testing.T) {
 			defer ctrl.Finish()
 
 			mockDeployEnvCmd := mocks.NewMockcmd(ctrl)
-			mockPrompter := mocks.NewMockprompter(ctrl)
 
 			tc.mockDeployEnvCmd(mockDeployEnvCmd)
-			tc.mockPrompter(mockPrompter)
 
 			o := &deployOpts{
 				deployVars: deployVars{
@@ -1012,12 +989,10 @@ func Test_deployOpts_maybeDeployEnv(t *testing.T) {
 					},
 					deployEnv: tc.deployEnv,
 				},
-				promptForEnvDeploy: tc.promptForEnvDeploy,
-				envExistsInWs:      tc.envExistsInWs,
+				envExistsInWs: tc.envExistsInWs,
 				newDeployEnvCmd: func(o *deployOpts) (cmd, error) {
 					return mockDeployEnvCmd, nil
 				},
-				prompt: mockPrompter,
 			}
 
 			err := o.maybeDeployEnv()

--- a/site/content/docs/commands/deploy.en.md
+++ b/site/content/docs/commands/deploy.en.md
@@ -64,12 +64,12 @@ rollback of the stack via the AWS console or AWS CLI before the next deployment.
 ## Examples
 Deploys a service named "frontend" to a "test" environment.
 ```console
-$ copilot deploy --name frontend --env test --deploy-env=false
+$ copilot deploy --name frontend --env test
 ```
 
 Deploys a job named "mailer" with additional resource tags to a "prod" environment.
 ```console
-$ copilot deploy -n mailer -e prod --resource-tags source/revision=bb133e7,deployment/initiator=manual --deploy-env=false
+$ copilot deploy -n mailer -e prod --resource-tags source/revision=bb133e7,deployment/initiator=manual
 ```
 
 Initializes and deploys an environment named "test" in us-west-2 under the "default" profile with local manifest,


### PR DESCRIPTION
The new logic with no flags is:
1. Check whether workload is uninitialized. If so, prompt for workload init. 
2. Check whether environment is uninitialized. If so, prompt for env init, then proceed directly to env deploy.
3. Deploy workload. 

Now, there is no extra prompt for environment deployment at any time. The behavior is purely opt-in, which actually I think makes more sense. 