### PR TITLE
docs: fix quotation mark in pipeline manifest example

### DIFF
--- a/site/content/docs/manifest/pipeline.en.md
+++ b/site/content/docs/manifest/pipeline.en.md
@@ -160,7 +160,7 @@ build:
   additional_policy:
     PolicyDocument: 
       {
-        “Statement": [
+        "Statement": [
           {
             "Action": ["ecr:GetAuthorizationToken"],
             "Effect": "Allow",

--- a/site/content/docs/manifest/pipeline.ja.md
+++ b/site/content/docs/manifest/pipeline.ja.md
@@ -157,7 +157,7 @@ build:
   additional_policy:
     PolicyDocument: 
       {
-        “Statement": [
+        "Statement": [
           {
             "Action": ["ecr:GetAuthorizationToken"],
             "Effect": "Allow",


### PR DESCRIPTION
Fixes #5268.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
