### PR TITLE
chore: fix incorrect security group key in env manifest docs

### DIFF
--- a/site/content/docs/manifest/environment.en.md
+++ b/site/content/docs/manifest/environment.en.md
@@ -172,7 +172,7 @@ network:
 <span class="parent-field">network.vpc.security_group.</span><a id="network-vpc-security-group-ingress" href="#network-vpc-security-group-ingress" class="field">`ingress`</a> <span class="type">Array of Security Group Rules</span>    
 A list of inbound security group rules.
 
-<span class="parent-field">network.vpc.security-group.</span><a id="network-vpc-security-group-egress" href="#network-vpc-security-group-egress" class="field">`egress`</a> <span class="type">Array of Security Group Rules</span>    
+<span class="parent-field">network.vpc.security_group.</span><a id="network-vpc-security-group-egress" href="#network-vpc-security-group-egress" class="field">`egress`</a> <span class="type">Array of Security Group Rules</span>    
 A list of outbound security group rules.
 
 

--- a/site/content/docs/manifest/environment.ja.md
+++ b/site/content/docs/manifest/environment.ja.md
@@ -172,7 +172,7 @@ network:
 <span class="parent-field">network.vpc.security_group.</span><a id="network-vpc-security-group-ingress" href="#network-vpc-security-group-ingress" class="field">`ingress`</a> <span class="type">Array of Security Group Rules</span>    
 Environment のインバウンドセキュリティグループに関するルールのリスト。
 
-<span class="parent-field">network.vpc.security-group.</span><a id="network-vpc-security-group-egress" href="#network-vpc-security-group-egress" class="field">`egress`</a> <span class="type">Array of Security Group Rules</span>    
+<span class="parent-field">network.vpc.security_group.</span><a id="network-vpc-security-group-egress" href="#network-vpc-security-group-egress" class="field">`egress`</a> <span class="type">Array of Security Group Rules</span>    
 Environment のアウトバウンドセキュリティグループに関するルールのリスト。
 
 <span class="parent-field">network.vpc.security_group.<type\>.</span><a id="network-vpc-security-group-ip-protocol" href="#network-vpc-security-group-ip-protocol" class="field">`ip_protocol`</a> <span class="type">String</span>    


### PR DESCRIPTION
<!-- Provide summary of changes -->
Our env manifest docs used inconsistent keys (security_group, which is correct, vs security-group, which is not).

Addresses #5266.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
