### PR TITLE
chore: enable version for S3 buckets

### DIFF
--- a/e2e/multi-pipeline/s3template.yml
+++ b/e2e/multi-pipeline/s3template.yml
@@ -14,6 +14,8 @@ Resources:
       'aws:copilot:description': 'An Amazon S3 bucket to store and retrieve objects for e2e-pipeline-addon'
     Type: AWS::S3::Bucket
     Properties:
+      VersioningConfiguration:
+        Status: Enabled
       AccessControl: Private
       BucketEncryption:
         ServerSideEncryptionConfiguration:

--- a/e2e/multi-pipeline/s3template.yml
+++ b/e2e/multi-pipeline/s3template.yml
@@ -26,6 +26,15 @@ Resources:
         BlockPublicPolicy: true
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
+      LifecycleConfiguration:
+        Rules:
+          - Id: ExpireAllObjects
+            Status: Enabled
+            ExpirationInDays: 1
+            NoncurrentVersionExpirationInDays: 1
+            AbortIncompleteMultipartUpload:
+              DaysAfterInitiation: 1
+
 
   e2epipelineaddonBucketPolicy:
     Metadata:

--- a/internal/pkg/addon/testdata/merge/env/second.yaml
+++ b/internal/pkg/addon/testdata/merge/env/second.yaml
@@ -80,6 +80,13 @@ Resources:
         RestrictPublicBuckets: true
       VersioningConfiguration:
         Status: Enabled
+      LifecycleConfiguration:
+        Rules:
+          - Id: ExpireNonCurrentObjects
+            Status: Enabled
+            NoncurrentVersionExpirationInDays: 30
+            AbortIncompleteMultipartUpload:
+              DaysAfterInitiation: 1
   
   MyBucketAccessPolicy:
     Type: AWS::IAM::ManagedPolicy

--- a/internal/pkg/addon/testdata/merge/env/second.yaml
+++ b/internal/pkg/addon/testdata/merge/env/second.yaml
@@ -78,6 +78,8 @@ Resources:
         BlockPublicPolicy: true
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
+      VersioningConfiguration:
+        Status: Enabled
   
   MyBucketAccessPolicy:
     Type: AWS::IAM::ManagedPolicy

--- a/internal/pkg/addon/testdata/merge/env/wanted.yaml
+++ b/internal/pkg/addon/testdata/merge/env/wanted.yaml
@@ -110,6 +110,13 @@ Resources:
         RestrictPublicBuckets: true
       VersioningConfiguration:
         Status: Enabled
+      LifecycleConfiguration:
+        Rules:
+          - Id: ExpireNonCurrentObjects
+            Status: Enabled
+            NoncurrentVersionExpirationInDays: 30
+            AbortIncompleteMultipartUpload:
+              DaysAfterInitiation: 1
   MyBucketAccessPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:

--- a/internal/pkg/addon/testdata/merge/env/wanted.yaml
+++ b/internal/pkg/addon/testdata/merge/env/wanted.yaml
@@ -108,6 +108,8 @@ Resources:
         BlockPublicPolicy: true
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
+      VersioningConfiguration:
+        Status: Enabled
   MyBucketAccessPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:

--- a/internal/pkg/addon/testdata/merge/second.yaml
+++ b/internal/pkg/addon/testdata/merge/second.yaml
@@ -81,6 +81,8 @@ Resources:
           BlockPublicPolicy: true
           IgnorePublicAcls: true
           RestrictPublicBuckets: true
+        VersioningConfiguration:
+          Status: Enabled
 
     MyBucketAccessPolicy:
       Type: AWS::IAM::ManagedPolicy

--- a/internal/pkg/addon/testdata/merge/second.yaml
+++ b/internal/pkg/addon/testdata/merge/second.yaml
@@ -83,6 +83,13 @@ Resources:
           RestrictPublicBuckets: true
         VersioningConfiguration:
           Status: Enabled
+        LifecycleConfiguration:
+          Rules:
+            - Id: ExpireNonCurrentObjects
+              Status: Enabled
+              NoncurrentVersionExpirationInDays: 30
+              AbortIncompleteMultipartUpload:
+                DaysAfterInitiation: 1
 
     MyBucketAccessPolicy:
       Type: AWS::IAM::ManagedPolicy

--- a/internal/pkg/addon/testdata/merge/wanted.yaml
+++ b/internal/pkg/addon/testdata/merge/wanted.yaml
@@ -111,6 +111,8 @@ Resources:
         BlockPublicPolicy: true
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
+      VersioningConfiguration:
+        Status: Enabled
   MyBucketAccessPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:

--- a/internal/pkg/addon/testdata/merge/wanted.yaml
+++ b/internal/pkg/addon/testdata/merge/wanted.yaml
@@ -113,6 +113,13 @@ Resources:
         RestrictPublicBuckets: true
       VersioningConfiguration:
         Status: Enabled
+      LifecycleConfiguration:
+        Rules:
+          - Id: ExpireNonCurrentObjects
+            Status: Enabled
+            NoncurrentVersionExpirationInDays: 30
+            AbortIncompleteMultipartUpload:
+              DaysAfterInitiation: 1
   MyBucketAccessPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:

--- a/internal/pkg/addon/testdata/storage/bucket.yml
+++ b/internal/pkg/addon/testdata/storage/bucket.yml
@@ -27,6 +27,8 @@ Resources:
       OwnershipControls:
         Rules:
           - ObjectOwnership: BucketOwnerEnforced
+      VersioningConfiguration:
+        Status: Enabled
 
   bucketBucketPolicy:
     Metadata:

--- a/internal/pkg/addon/testdata/storage/bucket.yml
+++ b/internal/pkg/addon/testdata/storage/bucket.yml
@@ -29,6 +29,13 @@ Resources:
           - ObjectOwnership: BucketOwnerEnforced
       VersioningConfiguration:
         Status: Enabled
+      LifecycleConfiguration:
+        Rules:
+          - Id: ExpireNonCurrentObjects
+            Status: Enabled
+            NoncurrentVersionExpirationInDays: 30
+            AbortIncompleteMultipartUpload:
+              DaysAfterInitiation: 1
 
   bucketBucketPolicy:
     Metadata:

--- a/internal/pkg/template/templates/addons/s3/cf.yml
+++ b/internal/pkg/template/templates/addons/s3/cf.yml
@@ -14,6 +14,8 @@ Resources:
       'aws:copilot:description': 'An Amazon S3 bucket to store and retrieve objects for {{.Name}}'
     Type: AWS::S3::Bucket
     Properties:
+      VersioningConfiguration:
+        Status: Enabled
       AccessControl: Private
       BucketEncryption:
         ServerSideEncryptionConfiguration:

--- a/internal/pkg/template/templates/addons/s3/cf.yml
+++ b/internal/pkg/template/templates/addons/s3/cf.yml
@@ -29,6 +29,13 @@ Resources:
       OwnershipControls:
         Rules:
           - ObjectOwnership: BucketOwnerEnforced
+      LifecycleConfiguration:
+        Rules:
+          - Id: ExpireNonCurrentObjects
+            Status: Enabled
+            NoncurrentVersionExpirationInDays: 30
+            AbortIncompleteMultipartUpload:
+              DaysAfterInitiation: 1
 
   {{logicalIDSafe .Name}}BucketPolicy:
     Metadata:

--- a/internal/pkg/template/templates/addons/s3/env/cf.yml
+++ b/internal/pkg/template/templates/addons/s3/env/cf.yml
@@ -12,6 +12,8 @@ Resources:
       'aws:copilot:description': 'An Amazon S3 bucket, {{.Name}}, for storing and retrieving objects'
     Type: AWS::S3::Bucket
     Properties:
+      VersioningConfiguration:
+        Status: Enabled
       AccessControl: Private
       BucketEncryption:
         ServerSideEncryptionConfiguration:

--- a/internal/pkg/template/templates/addons/s3/env/cf.yml
+++ b/internal/pkg/template/templates/addons/s3/env/cf.yml
@@ -27,6 +27,13 @@ Resources:
       OwnershipControls:
         Rules:
           - ObjectOwnership: BucketOwnerEnforced
+      LifecycleConfiguration:
+        Rules:
+          - Id: ExpireNonCurrentObjects
+            Status: Enabled
+            NoncurrentVersionExpirationInDays: 30
+            AbortIncompleteMultipartUpload:
+              DaysAfterInitiation: 1
 
   {{logicalIDSafe .Name}}BucketPolicy:
     Metadata:

--- a/internal/pkg/template/templates/task/cf.yml
+++ b/internal/pkg/template/templates/task/cf.yml
@@ -286,6 +286,9 @@ Resources:
             Status: Enabled
             Prefix: 'manual/env-files'
             ExpirationInDays: 1
+            NoncurrentVersionExpirationInDays: 1 # Permanently delete noncurrent versions of objects
+            AbortIncompleteMultipartUpload:
+              DaysAfterInitiation: 1
   S3BucketPolicy:
     Metadata:
       'aws:copilot:description': 'A policy to allow file uploads to the S3 bucket'


### PR DESCRIPTION
<!-- Provide summary of changes -->
It turned out that only the addon S3 and multi pipeline e2e  buckets are currently not version enabled.

And added lifecycle rules for e2e and addons buckets.  
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
