### PR TITLE
fix: pass appname from user selected option

### DIFF
--- a/internal/pkg/cli/app_delete_test.go
+++ b/internal/pkg/cli/app_delete_test.go
@@ -304,24 +304,24 @@ func TestDeleteAppOpts_Execute(t *testing.T) {
 			// DeleteEnvOpts, and DeletePipelineOpts. It allows us to instead simply
 			// test if the deletion of those resources succeeded or failed.
 			mockSvcDeleteExecutor := mocks.NewMockexecutor(ctrl)
-			mockSvcExecutorProvider := func(svcName string) (executor, error) {
+			mockSvcExecutorProvider := func(appName, svcName string) (executor, error) {
 				return mockSvcDeleteExecutor, nil
 			}
 			mockJobDeleteExecutor := mocks.NewMockexecutor(ctrl)
-			mockJobExecutorProvider := func(jobName string) (executor, error) {
+			mockJobExecutorProvider := func(appName, jobName string) (executor, error) {
 				return mockJobDeleteExecutor, nil
 			}
 			mockTaskDeleteExecutor := mocks.NewMockexecutor(ctrl)
-			mockTaskDeleteProvider := func(envName, taskName string) (executor, error) {
+			mockTaskDeleteProvider := func(appName, envName, taskName string) (executor, error) {
 				return mockTaskDeleteExecutor, nil
 			}
 			mockEnvDeleteExecutor := mocks.NewMockexecuteAsker(ctrl)
-			mockAskExecutorProvider := func(envName string) (executeAsker, error) {
+			mockAskExecutorProvider := func(appName, envName string) (executeAsker, error) {
 				return mockEnvDeleteExecutor, nil
 			}
 
 			mockPipelineDeleteExecutor := mocks.NewMockexecutor(ctrl)
-			mockPipelineExecutorProvider := func(pipelineName string) (executor, error) {
+			mockPipelineExecutorProvider := func(appName, pipelineName string) (executor, error) {
 				return mockPipelineDeleteExecutor, nil
 			}
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
```
Application: app1
Sure? Yes
✘ execute svc delete: get workload: ValidationException: Parameter name: can't be prefixed with "ssm" (case-insensitive). If formed as a path, it can consist of sub-paths divided by slash symbol; each sub-path can be formed as a mix of letters, numbers and the following 3 symbols .-_
        status code: 400, request id: 0510fcaf-8ea2-4b8c-b135-51f088dc22d4
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
