### PR TITLE
docs: clarify LBWS are public, BES are private

### DIFF
--- a/internal/pkg/cli/init_test.go
+++ b/internal/pkg/cli/init_test.go
@@ -200,27 +200,27 @@ func TestInitOpts_Run(t *testing.T) {
 				opts.prompt.(*climocks.Mockprompter).EXPECT().SelectOption(gomock.Any(), gomock.Any(), []prompt.Option{
 					{
 						Value: manifestinfo.RequestDrivenWebServiceType,
-						Hint:  "App Runner",
+						Hint:  rdwsTypeHint,
 					},
 					{
 						Value: manifestinfo.LoadBalancedWebServiceType,
-						Hint:  "Internet to ECS on Fargate",
+						Hint:  lbwsTypeHint,
 					},
 					{
 						Value: manifestinfo.BackendServiceType,
-						Hint:  "ECS on Fargate",
+						Hint:  besTypeHint,
 					},
 					{
 						Value: manifestinfo.WorkerServiceType,
-						Hint:  "Events to SQS to ECS on Fargate",
+						Hint:  wsTypeHint,
 					},
 					{
 						Value: manifestinfo.StaticSiteType,
-						Hint:  "Internet to CDN to S3 bucket",
+						Hint:  ssTypeHint,
 					},
 					{
 						Value: manifestinfo.ScheduledJobType,
-						Hint:  "Scheduled event to State Machine to Fargate",
+						Hint:  jobTypeHint,
 					},
 				}, gomock.Any())
 				opts.initAppCmd.(*climocks.MockactionCommand).EXPECT().Ask().Return(nil)

--- a/internal/pkg/cli/job_init.go
+++ b/internal/pkg/cli/job_init.go
@@ -36,6 +36,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const jobTypeHint = "Scheduled event to State Machine to Fargate"
+
 var (
 	jobInitSchedulePrompt = "How would you like to " + color.Emphasize("schedule") + " this job?"
 	jobInitScheduleHelp   = `How to determine this job's schedule. "Rate" lets you define the time between 
@@ -48,7 +50,7 @@ To learn more see: https://git.io/JEEU4`, manifestinfo.ScheduledJobType)
 )
 
 var jobTypeHints = map[string]string{
-	manifestinfo.ScheduledJobType: "Scheduled event to State Machine to Fargate",
+	manifestinfo.ScheduledJobType: jobTypeHint,
 }
 
 type initJobVars struct {

--- a/internal/pkg/cli/svc_init.go
+++ b/internal/pkg/cli/svc_init.go
@@ -104,6 +104,12 @@ These messages can be consumed by the Worker Service.`
 const (
 	ingressTypeEnvironment = "Environment"
 	ingressTypeInternet    = "Internet"
+
+	rdwsTypeHint = "App Runner"
+	lbwsTypeHint = "Public. ALB by default. Internet to ECS on Fargate"
+	besTypeHint  = "Private. ALB optional. ECS on Fargate"
+	wsTypeHint   = "Events to SQS to ECS on Fargate"
+	ssTypeHint   = "Internet to CDN to S3 bucket"
 )
 
 var rdwsIngressOptions = []string{
@@ -112,11 +118,11 @@ var rdwsIngressOptions = []string{
 }
 
 var serviceTypeHints = map[string]string{
-	manifestinfo.RequestDrivenWebServiceType: "App Runner",
-	manifestinfo.LoadBalancedWebServiceType:  "Internet to ECS on Fargate",
-	manifestinfo.BackendServiceType:          "ECS on Fargate",
-	manifestinfo.WorkerServiceType:           "Events to SQS to ECS on Fargate",
-	manifestinfo.StaticSiteType:              "Internet to CDN to S3 bucket",
+	manifestinfo.RequestDrivenWebServiceType: rdwsTypeHint,
+	manifestinfo.LoadBalancedWebServiceType:  lbwsTypeHint,
+	manifestinfo.BackendServiceType:          besTypeHint,
+	manifestinfo.WorkerServiceType:           wsTypeHint,
+	manifestinfo.StaticSiteType:              ssTypeHint,
 }
 
 type initWkldVars struct {

--- a/internal/pkg/cli/svc_init_test.go
+++ b/internal/pkg/cli/svc_init_test.go
@@ -449,23 +449,23 @@ type: Request-Driven Web Service`), nil)
 				m.mockPrompt.EXPECT().SelectOption(gomock.Eq(fmt.Sprintf(fmtSvcInitSvcTypePrompt, "service type")), gomock.Any(), gomock.Eq([]prompt.Option{
 					{
 						Value: manifestinfo.RequestDrivenWebServiceType,
-						Hint:  "App Runner",
+						Hint:  rdwsTypeHint,
 					},
 					{
 						Value: manifestinfo.LoadBalancedWebServiceType,
-						Hint:  "Internet to ECS on Fargate",
+						Hint:  lbwsTypeHint,
 					},
 					{
 						Value: manifestinfo.BackendServiceType,
-						Hint:  "ECS on Fargate",
+						Hint:  besTypeHint,
 					},
 					{
 						Value: manifestinfo.WorkerServiceType,
-						Hint:  "Events to SQS to ECS on Fargate",
+						Hint:  wsTypeHint,
 					},
 					{
 						Value: manifestinfo.StaticSiteType,
-						Hint:  "Internet to CDN to S3 bucket",
+						Hint:  ssTypeHint,
 					},
 				}), gomock.Any()).
 					Return(wantedSvcType, nil)

--- a/site/content/docs/concepts/services.en.md
+++ b/site/content/docs/concepts/services.en.md
@@ -22,7 +22,7 @@ When you're setting up a service, Copilot will ask you about what kind of servic
 
 ### Internet-facing services
 
-If you want your service to serve internet traffic then you have three options:
+If you want your service to serve public internet traffic, you have three options:
 
 * "Request-Driven Web Service" will provision an AWS App Runner Service to run your service.
 * "Static Site" will provision a dedicated CloudFront distribution and S3 bucket for your static website.
@@ -31,7 +31,7 @@ If you want your service to serve internet traffic then you have three options:
 
 #### Request-Driven Web Service
 An AWS App Runner service that autoscales your instances based on incoming traffic and scales down to a baseline instance when there's no traffic. 
-This option is more cost effective for HTTP services with sudden bursts in request volumes or low request volumes.
+This option is more cost-effective for HTTP services with sudden bursts in request volumes or low request volumes.
 
 Unlike ECS, App Runner services are not connected by default to a VPC. In order to route egress traffic through a VPC, 
 you can configure the [`network`](../manifest/rd-web-service.en.md#network) field in the manifest.
@@ -53,7 +53,7 @@ Below is a diagram for a Load Balanced Web Service that involves an Application 
 ![lb-web-service-infra](https://user-images.githubusercontent.com/879348/86045951-39762880-ba01-11ea-9a47-fc9278600154.png)
 
 ### Backend Service
-If you want a service that can't be accessed externally, but only from other services within your application, you can create a __Backend Service__. Copilot will provision an ECS Service running on AWS Fargate, but won't set up any internet-facing endpoints. To learn about creating Backend Services with internal load balancers, go [here](../developing/internal-albs.en.md).
+If you want a service that can't be accessed externally, but only from other services within your application, you can create a __Backend Service__. Copilot will provision an ECS Service running on AWS Fargate, but won't set up any internet-facing endpoints. Load balancing is available for Backend Services. To learn about creating internal load balancers, go [here](../developing/internal-albs.en.md).
 
 ![backend-service-infra](https://user-images.githubusercontent.com/879348/86046929-e8673400-ba02-11ea-8676-addd6042e517.png)
 


### PR DESCRIPTION
Related: #5286, #5283.
While this does not _rename_ Load Balanced Web Services and Backend Services (a change with wider implications), it does add emphasis to the public/private difference between the two service types, both in the docs and in the interactive prompt hints.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
