### PR TITLE
chore(cli): include filename for yaml patch success msg

### DIFF
--- a/internal/pkg/cli/override.go
+++ b/internal/pkg/cli/override.go
@@ -108,7 +108,7 @@ func (o *overrideOpts) Execute() error {
 		if err := override.ScaffoldWithPatch(o.fs, dir); err != nil {
 			return fmt.Errorf("scaffold CFN YAML patches under %q: %v", dir, err)
 		}
-		log.Successf("Created a YAML patch file under %q to override resources\n", displayPath(dir))
+		log.Successf("Created a YAML patch file %q to override resources\n", filepath.Join(displayPath(dir), override.YAMLPatchFile))
 	}
 	return nil
 }

--- a/internal/pkg/override/override.go
+++ b/internal/pkg/override/override.go
@@ -87,9 +87,9 @@ func Lookup(path string, fs afero.Fs) (Info, error) {
 }
 
 func lookupYAMLPatch(path string, fs afero.Fs) (Info, error) {
-	ok, _ := afero.Exists(fs, filepath.Join(path, yamlPatchFile))
+	ok, _ := afero.Exists(fs, filepath.Join(path, YAMLPatchFile))
 	if !ok {
-		return Info{}, fmt.Errorf(`%s does not exist under %q`, yamlPatchFile, path)
+		return Info{}, fmt.Errorf(`%s does not exist under %q`, YAMLPatchFile, path)
 	}
 	return yamlPatchInfo(path), nil
 }

--- a/internal/pkg/override/override_test.go
+++ b/internal/pkg/override/override_test.go
@@ -91,7 +91,7 @@ func TestLookup(t *testing.T) {
 		fs := afero.NewMemMapFs()
 		root := filepath.Join("copilot", "frontend", "overrides")
 		_ = fs.MkdirAll(root, 0755)
-		_ = afero.WriteFile(fs, filepath.Join(root, yamlPatchFile), []byte("- {op: 5, path: '/Resources'}"), 0755)
+		_ = afero.WriteFile(fs, filepath.Join(root, YAMLPatchFile), []byte("- {op: 5, path: '/Resources'}"), 0755)
 
 		// WHEN
 		info, err := Lookup(root, fs)
@@ -107,7 +107,7 @@ func TestLookup(t *testing.T) {
 		fs := afero.NewMemMapFs()
 		root := filepath.Join("copilot", "frontend", "overrides")
 		_ = fs.MkdirAll(root, 0755)
-		_ = afero.WriteFile(fs, filepath.Join(root, yamlPatchFile), []byte("- {op: 5, path: '/Resources'}"), 0755)
+		_ = afero.WriteFile(fs, filepath.Join(root, YAMLPatchFile), []byte("- {op: 5, path: '/Resources'}"), 0755)
 
 		// WHEN
 		info, err := Lookup(root, fs)

--- a/internal/pkg/override/patch.go
+++ b/internal/pkg/override/patch.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	YAMLPatchFile        = "cfn.patches.yml" // Name of the YAML patch override file.
+	YAMLPatchFile        = "cfn.patches.yml" // YAMLPatchFile is the name of the YAML patch override file.
 	jsonPointerSeparator = "/"
 )
 

--- a/internal/pkg/override/patch.go
+++ b/internal/pkg/override/patch.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	jsonPointerSeparator = "/"
-	yamlPatchFile        = "cfn.patches.yml"
+	YAMLPatchFile        = "cfn.patches.yml"
 )
 
 // ScaffoldWithPatch sets up YAML patches in dir/ to apply to the
@@ -98,7 +98,7 @@ func (p *Patch) Override(body []byte) ([]byte, error) {
 }
 
 func unmarshalPatches(path string, fs afero.Fs) ([]yamlPatch, error) {
-	path = filepath.Join(path, yamlPatchFile)
+	path = filepath.Join(path, YAMLPatchFile)
 	content, err := afero.ReadFile(fs, path)
 	if err != nil {
 		return nil, fmt.Errorf("read file at %q: %w", path, err)

--- a/internal/pkg/override/patch.go
+++ b/internal/pkg/override/patch.go
@@ -14,8 +14,8 @@ import (
 )
 
 const (
+	YAMLPatchFile        = "cfn.patches.yml" // Name of the YAML patch override file.
 	jsonPointerSeparator = "/"
-	YAMLPatchFile        = "cfn.patches.yml"
 )
 
 // ScaffoldWithPatch sets up YAML patches in dir/ to apply to the

--- a/internal/pkg/override/patch_test.go
+++ b/internal/pkg/override/patch_test.go
@@ -25,7 +25,7 @@ func TestScaffoldWithPatch(t *testing.T) {
 		ok, _ := afero.Exists(fs, filepath.Join(dir, "README.md"))
 		require.True(t, ok, "README.md should exist")
 
-		ok, _ = afero.Exists(fs, filepath.Join(dir, yamlPatchFile))
+		ok, _ = afero.Exists(fs, filepath.Join(dir, YAMLPatchFile))
 		require.True(t, ok, "cfn.patches.yml should exist")
 	})
 	t.Run("should return an error if the directory is not empty", func(t *testing.T) {
@@ -547,7 +547,7 @@ Resources:
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			fs := afero.NewMemMapFs()
-			file, err := fs.Create("/" + yamlPatchFile)
+			file, err := fs.Create("/" + YAMLPatchFile)
 			require.NoError(t, err)
 			_, err = file.WriteString(strings.TrimSpace(tc.overrides))
 			require.NoError(t, err)

--- a/site/content/docs/manifest/worker-service.en.md
+++ b/site/content/docs/manifest/worker-service.en.md
@@ -205,7 +205,7 @@ filter_policy:
     - example_corp
   event:
     - anything-but: order_cancelled
-  cutomer_interests:
+  customer_interests:
     - rugby
     - football
     - baseball


### PR DESCRIPTION
Before:
`✔ Created a YAML patch file under "copilot/worker/overrides" to override resources`

After:
`✔ Created a YAML patch file "copilot/lbws/overrides/cfn.patches.yml" to override resources`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
