### PR TITLE
chore(manifest): add validation for subscribe field and topics subfield

### DIFF
--- a/internal/pkg/manifest/testdata/worker-svc-nosubscribe-placement.yml
+++ b/internal/pkg/manifest/testdata/worker-svc-nosubscribe-placement.yml
@@ -20,7 +20,7 @@ exec: true     # Enable running commands in your container.
   # readonly_fs: true       # Limit to read-only access to mounted root filesystems.
 
 
-# You can register to topics from other services.
+# Register to topics from other services.
 # The events can be received from an SQS queue via the env var $COPILOT_QUEUE_URI.
 # subscribe:
 #   topics: 

--- a/internal/pkg/manifest/validate.go
+++ b/internal/pkg/manifest/validate.go
@@ -1795,7 +1795,9 @@ func (a FIFOTopicAdvanceConfig) validate() error {
 // validate returns nil if SubscribeConfig is configured correctly.
 func (s SubscribeConfig) validate() error {
 	if s.IsEmpty() {
-		return nil
+		return &errFieldMustBeSpecified{
+			missingField: "subscribe.topics",
+		}
 	}
 	for ind, topic := range s.Topics {
 		if err := topic.validate(); err != nil {

--- a/internal/pkg/manifest/worker_svc.go
+++ b/internal/pkg/manifest/worker_svc.go
@@ -65,7 +65,7 @@ type SubscribeConfig struct {
 
 // IsEmpty returns empty if the struct has all zero members.
 func (s *SubscribeConfig) IsEmpty() bool {
-	return s.Topics == nil && s.Queue.IsEmpty()
+	return s.Topics == nil
 }
 
 // TopicSubscription represents the configurable options for setting up a SNS Topic Subscription.

--- a/internal/pkg/template/templates/workloads/services/worker/manifest.yml
+++ b/internal/pkg/template/templates/workloads/services/worker/manifest.yml
@@ -57,7 +57,7 @@ subscribe:
     fifo: {{ .Subscribe.Queue.FIFO.Enable }}
   {{- end }}
 {{- else}}
-# You can register to topics from other services.
+# Register to topics from other services.
 # The events can be received from an SQS queue via the env var $COPILOT_QUEUE_URI.
 # subscribe:
 #   topics: 

--- a/site/content/docs/developing/publish-subscribe.en.md
+++ b/site/content/docs/developing/publish-subscribe.en.md
@@ -49,7 +49,7 @@ const out = await client.send(new PublishCommand({
 
 ## Subscribing to a topic with a Worker Service
 
-To subscribe to an existing SNS topic with a worker service, you'll need to edit the worker service's manifest.
+To subscribe to an existing, Copilot-created SNS topic with a worker service, you'll need to edit the worker service's manifest after running `copilot svc init` and before running `copilot svc deploy`.
 Using the [`subscribe`](../manifest/worker-service/#subscribe) field in the manifest, you can define subscriptions to 
 existing SNS topics exposed by other services in your environment.  In this example, we'll use the `ordersTopic` topic 
 which the `api` service from the last section exposed. We'll also customize the worker service's queue to enable a dead-letter queue. 


### PR DESCRIPTION
This added validation will prevent users from deploying Worker Services that aren't subscribed to any topics. This will require people to publish topics in their other services _before_ deploying the worker one, which was not previously necessary.

Related: #5317.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
