### PR TITLE
chore(cicd): fix e2e test buildspec

### DIFF
--- a/.release/buildspec_integ.yml
+++ b/.release/buildspec_integ.yml
@@ -15,8 +15,8 @@ phases:
       nodejs: 16
     commands:
       - "cd $HOME/.goenv && git pull --ff-only && cd -"
-      - "goenv install 1.21"
-      - "goenv global 1.21"
+      - "goenv install 1.21.1"
+      - "goenv global 1.21.1"
   build:
     commands:
       - echo `git rev-parse HEAD` # Do not delete; for pipeline logging purposes


### PR DESCRIPTION
The og buildspec stopped working because `goenv install 1.21` installed v1.21.1, and `goenv global 1.21`  doesn't pick up that 1.21 means 1.21.1.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
