### PR TITLE
feat: ask deployment order of multiple workloads

### DIFF
--- a/internal/pkg/cli/deploy.go
+++ b/internal/pkg/cli/deploy.go
@@ -601,7 +601,7 @@ func (o *deployOpts) askNames() error {
 			taggedOptions = append(taggedOptions, fmt.Sprintf("%s/%d", name, currentPriority))
 		}
 
-		options = selector.FilterOutItems(options, selectedNames, func(a string) string { return a })
+		options = filterOutItems(options, selectedNames, func(a string) string { return a })
 		currentPriority++
 	}
 


### PR DESCRIPTION
Add a looping multiselect to let customers choose the deployment order of multiple workloads when using prompts. 

Example:

```bash
Select one or more services or jobs in your workspace.
 > [x] fe
   [ ] be
   [x] worker (uninitialized)
   [x] db (uninitialized)
Which workload(s) would you like to deploy in your first deployment group? [Use arrows to move, space to select, type to filter, ? for more help]
 > [x]  fe
  [ ]  worker
  [ ]  db
  [ ]  All remaining workloads

Group 1 fe

  Which workload(s) would you like to deploy in your next deployment group?  [Use arrows to move, space to select, type to filter, ? for more help]
  > [ ]  worker
  [ ]  db
  [x]  All remaining workloads

Group 2 All remaining workloads

Checking for all required information. We may ask you some questions.
Will deploy 3 workloads in the following order.
1. fe
2. worker, db
```


<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
