### PR TITLE
chore: add condition for ALBWorkloads parameter

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/lb_web_svc.go
+++ b/internal/pkg/deploy/cloudformation/stack/lb_web_svc.go
@@ -199,6 +199,7 @@ func (s *LoadBalancedWebService) Template() (string, error) {
 		WorkloadType:       manifestinfo.LoadBalancedWebServiceType,
 
 		// Configuration for the main container.
+		// ImportedALB: s.manifest.ImportALB,
 		Command:      command,
 		EntryPoint:   entrypoint,
 		HealthCheck:  convertContainerHealthCheck(s.manifest.ImageConfig.HealthCheck),

--- a/internal/pkg/deploy/cloudformation/stack/lb_web_svc.go
+++ b/internal/pkg/deploy/cloudformation/stack/lb_web_svc.go
@@ -199,7 +199,6 @@ func (s *LoadBalancedWebService) Template() (string, error) {
 		WorkloadType:       manifestinfo.LoadBalancedWebServiceType,
 
 		// Configuration for the main container.
-		// ImportedALB: s.manifest.ImportALB,
 		Command:      command,
 		EntryPoint:   entrypoint,
 		HealthCheck:  convertContainerHealthCheck(s.manifest.ImageConfig.HealthCheck),

--- a/internal/pkg/template/templates/workloads/services/static-site/cf.yml
+++ b/internal/pkg/template/templates/workloads/services/static-site/cf.yml
@@ -98,7 +98,7 @@ Resources:
       OriginAccessControlConfig:
         Description: !Sub 'Access control for static s3 origin for ${AppName}-${EnvName}-${WorkloadName}'
         # Truncate the name to allow at most 64 characters.
-        Name: {{trancateWithHashPadding (printf "%s-%s-%s" .AppName .EnvName .WorkloadName) 58 6}}
+        Name: {{truncateWithHashPadding (printf "%s-%s-%s" .AppName .EnvName .WorkloadName) 58 6}}
         OriginAccessControlOriginType: s3
         SigningBehavior: always
         SigningProtocol: sigv4
@@ -115,7 +115,7 @@ Resources:
         Comment: CloudFront Function to rewrite viewer request to index.html
         Runtime: cloudfront-js-1.0
       # Truncate the name to allow at most 64 characters.
-      Name: {{trancateWithHashPadding (printf "%s-%s-%s" .AppName .EnvName .WorkloadName) 58 6}}
+      Name: {{truncateWithHashPadding (printf "%s-%s-%s" .AppName .EnvName .WorkloadName) 58 6}}
 
   CloudFrontDistribution:
     Metadata:

--- a/internal/pkg/template/workload.go
+++ b/internal/pkg/template/workload.go
@@ -799,6 +799,7 @@ type WorkloadOpts struct {
 	Secrets      map[string]Secret
 	EntryPoint   []string
 	Command      []string
+	ImportedALB  *ImportALB
 
 	// Additional options that are common between **all** workload templates.
 	Tags                     map[string]string        // Used by App Runner workloads to tag App Runner service resources
@@ -877,6 +878,12 @@ func (lr ALBListenerRule) HealthCheckProtocol() string {
 		return "HTTP"
 	}
 	return ""
+}
+
+// ImportALB holds the fields to import an existing ALB.
+type ImportALB struct {
+	Name *string
+	ARN  *string
 }
 
 // ParseLoadBalancedWebService parses a load balanced web service's CloudFormation template
@@ -962,12 +969,12 @@ func withSvcParsingFuncs() ParseOption {
 			"contains":                slices.Contains[[]string, string],
 			"requiresVPCConnector":    requiresVPCConnector,
 			"strconvUint16":           StrconvUint16,
-			"trancateWithHashPadding": trancateWithHashPadding,
+			"truncateWithHashPadding": truncateWithHashPadding,
 		})
 	}
 }
 
-func trancateWithHashPadding(s string, max, paddingLength int) string {
+func truncateWithHashPadding(s string, max, paddingLength int) string {
 	if len(s) <= max {
 		return s
 	}
@@ -998,7 +1005,7 @@ func randomUUIDFunc() (string, error) {
 // envControllerParameters determines which parameters to include in the EnvController template.
 func envControllerParameters(o WorkloadOpts) []string {
 	parameters := []string{}
-	if o.WorkloadType == "Load Balanced Web Service" {
+	if o.WorkloadType == "Load Balanced Web Service" && o.ImportedALB == nil {
 		if o.ALBEnabled {
 			parameters = append(parameters, "ALBWorkloads,")
 		}

--- a/internal/pkg/template/workload.go
+++ b/internal/pkg/template/workload.go
@@ -799,7 +799,7 @@ type WorkloadOpts struct {
 	Secrets      map[string]Secret
 	EntryPoint   []string
 	Command      []string
-	ImportedALB  *ImportALB
+	ImportedALB  *ImportedALB
 
 	// Additional options that are common between **all** workload templates.
 	Tags                     map[string]string        // Used by App Runner workloads to tag App Runner service resources
@@ -880,8 +880,8 @@ func (lr ALBListenerRule) HealthCheckProtocol() string {
 	return ""
 }
 
-// ImportALB holds the fields to import an existing ALB.
-type ImportALB struct {
+// ImportedALB holds the fields to import an existing ALB.
+type ImportedALB struct {
 	Name *string
 	ARN  *string
 }
@@ -1005,8 +1005,8 @@ func randomUUIDFunc() (string, error) {
 // envControllerParameters determines which parameters to include in the EnvController template.
 func envControllerParameters(o WorkloadOpts) []string {
 	parameters := []string{}
-	if o.WorkloadType == "Load Balanced Web Service" && o.ImportedALB == nil {
-		if o.ALBEnabled {
+	if o.WorkloadType == "Load Balanced Web Service" {
+		if o.ALBEnabled && o.ImportedALB == nil {
 			parameters = append(parameters, "ALBWorkloads,")
 		}
 		parameters = append(parameters, "Aliases,") // YAML needs the comma separator; resolved in EnvContr.

--- a/internal/pkg/template/workload_test.go
+++ b/internal/pkg/template/workload_test.go
@@ -371,11 +371,11 @@ func TestEnvControllerParameters(t *testing.T) {
 			opts: WorkloadOpts{
 				WorkloadType: "Load Balanced Web Service",
 				ALBEnabled:   true,
-				ImportedALB: &ImportALB{
+				ImportedALB: &ImportedALB{
 					Name: aws.String("MyExistingALB"),
 				},
 			},
-			expected: []string{},
+			expected: []string{"Aliases,"},
 		},
 		"LBWS with ALB and private placement": {
 			opts: WorkloadOpts{

--- a/internal/pkg/template/workload_test.go
+++ b/internal/pkg/template/workload_test.go
@@ -367,6 +367,16 @@ func TestEnvControllerParameters(t *testing.T) {
 			},
 			expected: []string{"ALBWorkloads,", "Aliases,"},
 		},
+		"LBWS with imported ALB": {
+			opts: WorkloadOpts{
+				WorkloadType: "Load Balanced Web Service",
+				ALBEnabled:   true,
+				ImportedALB: &ImportALB{
+					Name: aws.String("MyExistingALB"),
+				},
+			},
+			expected: []string{},
+		},
 		"LBWS with ALB and private placement": {
 			opts: WorkloadOpts{
 				WorkloadType: "Load Balanced Web Service",
@@ -504,7 +514,7 @@ func TestApplicationLoadBalancer_Aliases(t *testing.T) {
 	}
 }
 
-func Test_trancateWithHashPadding(t *testing.T) {
+func Test_truncateWithHashPadding(t *testing.T) {
 	tests := map[string]struct {
 		inString  string
 		inMax     int
@@ -527,7 +537,7 @@ func Test_trancateWithHashPadding(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			require.Equal(t, tc.expected, trancateWithHashPadding(tc.inString, tc.inMax, tc.inPadding))
+			require.Equal(t, tc.expected, truncateWithHashPadding(tc.inString, tc.inMax, tc.inPadding))
 		})
 	}
 }


### PR DESCRIPTION
If a LBWS has an imported ALB, the `ALBWorkloads` parameter will not be added; therefore, the EnvController will not be triggered.

Also fixes a small typo.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
