### PR TITLE
chore: uri recommend actions enhancement

### DIFF
--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -599,6 +599,8 @@ func (o *deploySvcOpts) uriRecommendedActions() ([]string, error) {
 		network = "with service discovery."
 	case describe.URIAccessTypeServiceConnect:
 		network = "with service connect."
+	case describe.URIAccessTypeNone:
+		return []string{}, nil
 	}
 
 	return []string{

--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -591,11 +591,11 @@ func (o *deploySvcOpts) uriRecommendedActions() ([]string, error) {
 		return nil, fmt.Errorf("get uri for environment %s: %w", o.envName, err)
 	}
 
-	connectionAgent := "Services in the same application"
+	connectionAccessType := "Your service is accessible"
 	network := "over the internet."
 	switch uri.AccessType {
 	case describe.URIAccessTypeInternet:
-		connectionAgent = "You"
+		connectionAccessType = "You can access your service"
 	case describe.URIAccessTypeInternal:
 		network = "from your internal network."
 	case describe.URIAccessTypeServiceDiscovery:
@@ -607,7 +607,7 @@ func (o *deploySvcOpts) uriRecommendedActions() ([]string, error) {
 	}
 
 	return []string{
-		fmt.Sprintf("%s can access your service at %s %s", connectionAgent, uri.URI, network),
+		fmt.Sprintf("%s at %s %s", connectionAccessType, uri.URI, network),
 	}, nil
 }
 

--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -591,11 +591,8 @@ func (o *deploySvcOpts) uriRecommendedActions() ([]string, error) {
 		return nil, fmt.Errorf("get uri for environment %s: %w", o.envName, err)
 	}
 
-	connectionAccessType := "Your service is accessible"
 	network := "over the internet."
 	switch uri.AccessType {
-	case describe.URIAccessTypeInternet:
-		connectionAccessType = "You can access your service"
 	case describe.URIAccessTypeInternal:
 		network = "from your internal network."
 	case describe.URIAccessTypeServiceDiscovery:
@@ -607,7 +604,7 @@ func (o *deploySvcOpts) uriRecommendedActions() ([]string, error) {
 	}
 
 	return []string{
-		fmt.Sprintf("%s at %s %s", connectionAccessType, uri.URI, network),
+		fmt.Sprintf("Your service is accessible at %s %s", uri.URI, network),
 	}, nil
 }
 

--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -591,8 +591,11 @@ func (o *deploySvcOpts) uriRecommendedActions() ([]string, error) {
 		return nil, fmt.Errorf("get uri for environment %s: %w", o.envName, err)
 	}
 
+	connectionAgent := "Services in the same application"
 	network := "over the internet."
 	switch uri.AccessType {
+	case describe.URIAccessTypeInternet:
+		connectionAgent = "You"
 	case describe.URIAccessTypeInternal:
 		network = "from your internal network."
 	case describe.URIAccessTypeServiceDiscovery:
@@ -604,7 +607,7 @@ func (o *deploySvcOpts) uriRecommendedActions() ([]string, error) {
 	}
 
 	return []string{
-		fmt.Sprintf("You can access your service at %s %s", uri.URI, network),
+		fmt.Sprintf("%s can access your service at %s %s", connectionAgent, uri.URI, network),
 	}, nil
 }
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
Fixes a UX issue where a non-accessible service will display this message as a follow-up action:
```
Recommended follow-up action:
  - You can access your service at - over the internet.
```
Then implements a wording change to make it more clear that a service is not publicly accessible, for example:
```
name: backend
type: Backend Service
image:
  port: 80
network:
  connect: true
```
gives the following message on `copilot svc deploy`
```
Recommended follow-up action:
  - Services in the same application can access your service at backend:80 with service connect.
```

Addresses #5371 

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
