### PR TITLE
test: add `copilot deploy --all` to e2e suite.

### DIFF
--- a/e2e/internal/client/cli.go
+++ b/e2e/internal/client/cli.go
@@ -162,6 +162,11 @@ type SvcDeployInput struct {
 	Force    bool
 }
 
+type DeployRequest struct {
+	All     bool
+	EnvName string
+}
+
 // TaskRunInput contains the parameters for calling copilot task run.
 type TaskRunInput struct {
 	AppName string
@@ -480,6 +485,29 @@ func (cli *CLI) SvcDeploy(opts *SvcDeployInput) (string, error) {
 	}
 	return cli.exec(
 		exec.Command(cli.path, arguments...))
+}
+
+/*
+Deploy runs:
+copilot deploy
+
+	--env $p
+	--all
+
+It does not initialize any workloads or environments, simply deploys all initialized services
+and jobs in the workspace.
+*/
+func (cli *CLI) Deploy(opts *DeployRequest) (string, error) {
+	arguments := []string{
+		"deploy",
+		"--env", opts.EnvName,
+	}
+	if opts.All {
+		arguments = append(arguments, "--all")
+	}
+	return cli.exec(
+		exec.Command(cli.path, arguments...),
+	)
 }
 
 /*

--- a/e2e/internal/client/cli.go
+++ b/e2e/internal/client/cli.go
@@ -162,6 +162,7 @@ type SvcDeployInput struct {
 	Force    bool
 }
 
+// DeployRequest contains parameters for calling copilot deploy --all.
 type DeployRequest struct {
 	All     bool
 	EnvName string

--- a/e2e/multi-svc-app/multi_svc_app_test.go
+++ b/e2e/multi-svc-app/multi_svc_app_test.go
@@ -194,44 +194,19 @@ var _ = Describe("Multiple Service App", func() {
 
 	Context("when deploying services and jobs", Ordered, func() {
 		var (
-			frontEndDeployErr error
-			wwwDeployErr      error
-			backEndDeployErr  error
-			jobDeployErr      error
-
-			routeURL string
+			deployErr error
+			routeURL  string
 		)
 		BeforeAll(func() {
-			_, backEndDeployErr = cli.SvcDeploy(&client.SvcDeployInput{
-				Name:     "back-end",
-				EnvName:  "test",
-				ImageTag: "gallopinggurdey",
-			})
-			_, frontEndDeployErr = cli.SvcDeploy(&client.SvcDeployInput{
-				Name:     "front-end",
-				EnvName:  "test",
-				ImageTag: "gallopinggurdey",
-			})
-			_, jobDeployErr = cli.JobDeploy(&client.JobDeployInput{
-				Name:     "query",
-				EnvName:  "test",
-				ImageTag: "thepostalservice",
-			})
-			_, wwwDeployErr = cli.SvcDeploy(&client.SvcDeployInput{
-				Name:     "www",
-				EnvName:  "test",
-				ImageTag: "gallopinggurdey",
+
+			_, deployErr = cli.Deploy(&client.DeployRequest{
+				All:     true,
+				EnvName: "test",
 			})
 		})
 
-		It("svc deploy should succeed", func() {
-			Expect(frontEndDeployErr).NotTo(HaveOccurred())
-			Expect(wwwDeployErr).NotTo(HaveOccurred())
-			Expect(backEndDeployErr).NotTo(HaveOccurred())
-		})
-
-		It("job deploy should succeed", func() {
-			Expect(jobDeployErr).NotTo(HaveOccurred())
+		It("deploy should succeed", func() {
+			Expect(deployErr).NotTo(HaveOccurred())
 		})
 
 		It("svc show should include a valid URL and description for test env", func() {


### PR DESCRIPTION
<!-- Provide summary of changes -->
* Changes multi-svc-app to exercise the new deploy enhancements.
* Fixes a bug where the CLI would error opaquely if customers ran `copilot deploy --all` with no workloads initialized and none specified via `-n`. 

😉 
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
