### PR TITLE
feat: add support for docker build args to the task run command

### DIFF
--- a/internal/pkg/cli/flag.go
+++ b/internal/pkg/cli/flag.go
@@ -39,15 +39,16 @@ const (
 	yesInitWorkloadFlag = "init-wkld"
 
 	// Build flags.
-	dockerFileFlag        = "dockerfile"
-	dockerFileContextFlag = "build-context"
-	imageTagFlag          = "tag"
-	stackOutputDirFlag    = "output-dir"
-	uploadAssetsFlag      = "upload-assets"
-	deployFlag            = "deploy"
-	diffFlag              = "diff"
-	diffAutoApproveFlag   = "diff-yes"
-	sourcesFlag           = "sources"
+	dockerFileFlag          = "dockerfile"
+	dockerFileContextFlag   = "build-context"
+	dockerFileBuildArgsFlag = "build-args"
+	imageTagFlag            = "tag"
+	stackOutputDirFlag      = "output-dir"
+	uploadAssetsFlag        = "upload-assets"
+	deployFlag              = "deploy"
+	diffFlag                = "diff"
+	diffAutoApproveFlag     = "diff-yes"
+	sourcesFlag             = "sources"
 
 	// Flags for operational commands.
 	limitFlag                   = "limit"
@@ -192,6 +193,8 @@ var (
 	imageFlagDescription = fmt.Sprintf(`The location of an existing Docker image.
 Cannot be specified with --%s or --%s.`, dockerFileFlag, dockerFileContextFlag)
 	dockerFileFlagDescription = fmt.Sprintf(`Path to the Dockerfile.
+Cannot be specified with --%s.`, imageFlag)
+	dockerFileBuildArgsFlagDescription = fmt.Sprintf(`Key-value pairs converted to --build-args.
 Cannot be specified with --%s.`, imageFlag)
 	dockerFileContextFlagDescription = fmt.Sprintf(`Path to the Docker build context.
 Cannot be specified with --%s.`, imageFlag)

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -1182,7 +1182,7 @@ func BuildTaskRunCmd() *cobra.Command {
   /code $ copilot task run --subnets subnet-123,subnet-456 --security-groups sg-123,sg-456
   Run a task with a command.
   /code $ copilot task run --command "python migrate-script.py"
-  Run a task with Docker build-args.
+  Run a task with Docker build args.
   /code $ copilot task run --build-args GO_VERSION=1.19"`,
 		RunE: runCmdE(func(cmd *cobra.Command, args []string) error {
 			opts, err := newTaskRunOpts(vars)

--- a/internal/pkg/cli/task_run.go
+++ b/internal/pkg/cli/task_run.go
@@ -1181,7 +1181,9 @@ func BuildTaskRunCmd() *cobra.Command {
   Run a task using the current workspace with specific subnets and security groups.
   /code $ copilot task run --subnets subnet-123,subnet-456 --security-groups sg-123,sg-456
   Run a task with a command.
-  /code $ copilot task run --command "python migrate-script.py"`,
+  /code $ copilot task run --command "python migrate-script.py"
+  Run a task with Docker build-args.
+  /code $ copilot task run --build-args GO_VERSION=1.19"`,
 		RunE: runCmdE(func(cmd *cobra.Command, args []string) error {
 			opts, err := newTaskRunOpts(vars)
 			if err != nil {

--- a/internal/pkg/cli/task_run_test.go
+++ b/internal/pkg/cli/task_run_test.go
@@ -68,6 +68,7 @@ func TestTaskRunOpts_Validate(t *testing.T) {
 
 		inImage                 string
 		inDockerfilePath        string
+		inDockerfileBuildArgs   map[string]string
 		inDockerfileContextPath string
 
 		inTaskRole string
@@ -234,6 +235,16 @@ func TestTaskRunOpts_Validate(t *testing.T) {
 			inDockerfileContextPath: "../../other",
 
 			wantedError: errors.New("cannot specify both `--image` and `--build-context`"),
+		},
+		"both build args and image name specified": {
+			basicOpts: defaultOpts,
+
+			inImage: "113459295.dkr.ecr.ap-northeast-1.amazonaws.com/my-app",
+			inDockerfileBuildArgs: map[string]string{
+				"KEY": "VALUE",
+			},
+
+			wantedError: errors.New("cannot specify both `--image` and `--build-args`"),
 		},
 		"both dockerfile and image name specified": {
 			basicOpts: defaultOpts,
@@ -417,6 +428,7 @@ func TestTaskRunOpts_Validate(t *testing.T) {
 					subnets:                     tc.inSubnets,
 					securityGroups:              tc.inSecurityGroups,
 					dockerfilePath:              tc.inDockerfilePath,
+					dockerfileBuildArgs:         tc.inDockerfileBuildArgs,
 					dockerfileContextPath:       tc.inDockerfileContextPath,
 					envVars:                     tc.inEnvVars,
 					envFile:                     tc.inEnvFile,


### PR DESCRIPTION
<!-- Provide summary of changes -->
Adds the ability to pass build args into the docker build when running the `copilot task run` command.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->
Addresses #5376 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
