### PR TITLE
chore: continue to delete application parameters when there is no stackset

### DIFF
--- a/internal/pkg/aws/cloudformation/stackset/stackset.go
+++ b/internal/pkg/aws/cloudformation/stackset/stackset.go
@@ -241,11 +241,6 @@ func (ss *StackSet) InstanceSummaries(name string, opts ...InstanceSummariesOpti
 	for {
 		resp, err := ss.client.ListStackInstances(in)
 		if err != nil {
-			if isNotFoundStackSet(err) {
-				return nil, &ErrStackSetNotFound{
-					name: name,
-				}
-			}
 			return nil, fmt.Errorf("list stack instances for stack set %s: %w", name, err)
 		}
 		for _, cfnSummary := range resp.Summaries {

--- a/internal/pkg/aws/cloudformation/stackset/stackset.go
+++ b/internal/pkg/aws/cloudformation/stackset/stackset.go
@@ -241,6 +241,11 @@ func (ss *StackSet) InstanceSummaries(name string, opts ...InstanceSummariesOpti
 	for {
 		resp, err := ss.client.ListStackInstances(in)
 		if err != nil {
+			if isNotFoundStackSet(err) {
+				return nil, &ErrStackSetNotFound{
+					name: name,
+				}
+			}
 			return nil, fmt.Errorf("list stack instances for stack set %s: %w", name, err)
 		}
 		for _, cfnSummary := range resp.Summaries {

--- a/internal/pkg/cli/app_delete.go
+++ b/internal/pkg/cli/app_delete.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/aws/copilot-cli/internal/pkg/aws/cloudformation/stackset"
 	"github.com/aws/copilot-cli/internal/pkg/aws/identity"
 	rg "github.com/aws/copilot-cli/internal/pkg/aws/resourcegroups"
 	"github.com/aws/copilot-cli/internal/pkg/config"
@@ -315,12 +314,8 @@ func (o *deleteAppOpts) emptyS3Bucket() error {
 	}
 	appResources, err := o.cfn.GetRegionalAppResources(app)
 	if err != nil {
-		innerErr := err
-		for errors.Unwrap(innerErr) != nil {
-			innerErr = errors.Unwrap(innerErr)
-		}
 		// ErrStackSetNotFound means application Parameter Store params are hanging, return nil to continue for deletion
-		if _, ok := innerErr.(*stackset.ErrStackSetNotFound); ok {
+		if isStackSetNotExistsErr(err) {
 			return nil
 		}
 		return fmt.Errorf("get regional application resources for %s: %w", app.Name, err)

--- a/internal/pkg/cli/app_delete.go
+++ b/internal/pkg/cli/app_delete.go
@@ -314,7 +314,7 @@ func (o *deleteAppOpts) emptyS3Bucket() error {
 	}
 	appResources, err := o.cfn.GetRegionalAppResources(app)
 	if err != nil {
-		// ErrStackSetNotFound means application Parameter Store params are hanging, return nil to continue for deletion
+		// ErrStackSetNotFound means application Parameter Store params are dangling, return nil to continue for deletion.
 		if isStackSetNotExistsErr(err) {
 			return nil
 		}


### PR DESCRIPTION
<!-- Provide summary of changes -->
Wraps a stackset error when the stackset is not found, and skips s3 bucket deletion step when error is encountered in `copilot app delete`

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->
Address [this gitter message](https://app.gitter.im/#/room/#aws_copilot-cli:gitter.im/$gXF4Pft2TYjYFHDs2VP6Q2HjkxOPTRJ2ZUytmsTzE2g)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
