### PR TITLE
chore: fix spacing in warning message for nlb change

### DIFF
--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -350,19 +350,19 @@ After fixing the deployment, you can:
 func (o *deploySvcOpts) RecommendActions() error {
 	if lbMft, ok := o.appliedDynamicMft.Manifest().(*manifest.LoadBalancedWebService); ok {
 		if !lbMft.NLBConfig.IsEmpty() {
-			log.Warning("Starting with v1.33.0, Copilot will start applying a security group to your network load balancer.",
-				"This allows more fine-grained intra-VPC access control:",
-				"your service won't need to allow-list the CIDR blocks of the public subnets where the NLB is deployed;",
+			log.Warning("Starting with v1.33.0, Copilot will start applying a security group to your network load balancer. ",
+				"This allows more fine-grained intra-VPC access control: ",
+				"your service won't need to allow-list the CIDR blocks of the public subnets where the NLB is deployed; ",
 				"it only needs to allow-list the NLB, specifically.\n",
 				"\n",
-				"NLB security group onboarding implies resource recreation,",
-				"because a security group can't be added to an existing NLB that does not already have one.",
-				"Therefore, after v1.33.0, you might see some resource recreation related to your NLB.",
+				"NLB security group onboarding implies resource recreation, ",
+				"because a security group can't be added to an existing NLB that does not already have one. ",
+				"Therefore, after v1.33.0, you might see some resource recreation related to your NLB. ",
 				"This means:\n",
 				"1. If you don't use DNS aliases, then the NLB's domain name will change.\n",
 				"2. If you use DNS aliases, then the aliases will start pointing to the new NLB that is enhanced with a security group.\n",
 				"\n",
-				"For more on NLB security groups, please see https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-security-groups.html.")
+				"For more on NLB security groups, please see https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-security-groups.html.\n")
 		}
 	}
 	if o.noDeploy || o.detach {


### PR DESCRIPTION
<!-- Provide summary of changes -->
Message previously appeared like:
```
Note: Starting with v1.33.0, Copilot will start applying a security group to your network load balancer.This allows more fine-grained intra-VPC access control:your service won't need to allow-list the CIDR blocks of the public subnets where the NLB is deployed;it only needs to allow-list the NLB, specifically.

NLB security group onboarding implies resource recreation,because a security group can't be added to an existing NLB that does not already have one.Therefore, after v1.33.0, you might see some resource recreation related to your NLB.This means:
1. If you don't use DNS aliases, then the NLB's domain name will change.
2. If you use DNS aliases, then the aliases will start pointing to the new NLB that is enhanced with a security group.

For more on NLB security groups, please see https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-security-groups.html.Recommended follow-up action:
```
and this fixes the spacing.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
