### PR TITLE
chore: Revert "chore: upgrade lambda and codebuild default runtime from nodejs16.x to nodejs18.x"

### DIFF
--- a/internal/pkg/addon/package_test.go
+++ b/internal/pkg/addon/package_test.go
@@ -80,7 +80,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt "TestRole.Arn"
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
 `,
 			outTemplate: `
 Resources:
@@ -96,7 +96,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt "TestRole.Arn"
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
 `,
 		},
 		"AWS::Glue::Job, non-zipped file": {
@@ -225,7 +225,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt "TestRole.Arn"
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
 `,
 			outTemplate: `
 Resources:
@@ -247,7 +247,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt "TestRole.Arn"
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
 `,
 		},
 		"Fn::Transform nested in a yaml mapping and sequence node": {
@@ -480,7 +480,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt "TestRole.Arn"
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
 `
 		stack := &EnvironmentStack{
 			stack: stack{
@@ -511,7 +511,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt "TestRole.Arn"
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
 `
 		require.NoError(t, err)
 		tmpl, err := stack.Template()

--- a/internal/pkg/aws/cloudformation/stackstatus_test.go
+++ b/internal/pkg/aws/cloudformation/stackstatus_test.go
@@ -16,7 +16,7 @@ func TestStackStatus_InProgress(t *testing.T) {
 
 		wanted bool
 	}{
-		"should be false if stack is created succesfully": {
+		"should be false if stack is created Successfully": {
 			status: cloudformation.StackStatusCreateComplete,
 			wanted: false,
 		},

--- a/internal/pkg/aws/ec2/ec2_test.go
+++ b/internal/pkg/aws/ec2/ec2_test.go
@@ -303,7 +303,7 @@ func TestEC2_managedPrefixList(t *testing.T) {
 			},
 			wantedError: fmt.Errorf("describe managed prefix list with name %s: %w", mockPrefixListName, mockError),
 		},
-		"query returns succesfully": {
+		"query returns Successfully": {
 			mockEC2Client: func(m *mocks.Mockapi) {
 				m.EXPECT().DescribeManagedPrefixLists(&ec2.DescribeManagedPrefixListsInput{
 					Filters: mockFilter,
@@ -405,7 +405,7 @@ func TestEC2_CloudFrontManagedPrefixListId(t *testing.T) {
 			},
 			wantedErrorMsgPrefix: `found more than one prefix list with the name `,
 		},
-		"query returns succesfully": {
+		"query returns Successfully": {
 			mockEC2Client: func(m *mocks.Mockapi) {
 				m.EXPECT().DescribeManagedPrefixLists(&ec2.DescribeManagedPrefixListsInput{
 					Filters: mockFilter,

--- a/internal/pkg/cli/deploy/workload_test.go
+++ b/internal/pkg/cli/deploy/workload_test.go
@@ -317,7 +317,7 @@ func TestWorkloadDeployer_UploadArtifacts(t *testing.T) {
 				},
 			},
 		},
-		"build and push sidecar container images only with git tag succesfully": {
+		"build and push sidecar container images only with git tag Successfully": {
 			inDockerBuildArgs: map[string]*manifest.DockerBuildArgs{
 				"nginx": {
 					Dockerfile: aws.String("sidecarMockDockerfile"),

--- a/internal/pkg/cli/env_deploy.go
+++ b/internal/pkg/cli/env_deploy.go
@@ -226,7 +226,7 @@ func (o *deployEnvOpts) Execute() error {
 		if o.detach {
 			return nil
 		}
-		log.Successf("Succesfully deployed environment %s", o.name)
+		log.Successf("Successfully deployed environment %s", o.name)
 		return nil
 	}
 	var errStackDeletedOnInterrupt *deploycfn.ErrStackDeletedOnInterrupt

--- a/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-basic-manifest.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-basic-manifest.yml
@@ -920,7 +920,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'CustomResourceRole.Arn'
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
   
   CustomDomainFunction:
     Condition: ManagedAliases
@@ -930,7 +930,7 @@ Resources:
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt 'CustomResourceRole.Arn'
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
   
   DNSDelegationFunction:
     Type: AWS::Lambda::Function
@@ -940,7 +940,7 @@ Resources:
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt 'CustomResourceRole.Arn'
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
   DelegateDNSAction:
     Metadata:
       'aws:copilot:description': 'Delegate DNS for environment subdomain'

--- a/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-cloudfront-observability.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-cloudfront-observability.yml
@@ -311,7 +311,7 @@ Resources:
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt "UniqueJSONValuesFunctionRole.Arn"
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
   UniqueAliasesAction:
     Metadata:
       "aws:copilot:description": "An action to get unique custom aliases for services in your environment"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-default-access-log-config.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-default-access-log-config.yml
@@ -1028,7 +1028,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'CustomResourceRole.Arn'
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
   
   CustomDomainFunction:
     Condition: ManagedAliases
@@ -1038,7 +1038,7 @@ Resources:
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt 'CustomResourceRole.Arn'
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
   
   DNSDelegationFunction:
     Type: AWS::Lambda::Function
@@ -1048,7 +1048,7 @@ Resources:
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt 'CustomResourceRole.Arn'
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
   DelegateDNSAction:
     Metadata:
       'aws:copilot:description': 'Delegate DNS for environment subdomain'

--- a/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-defaultvpc-flowlogs.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-defaultvpc-flowlogs.yml
@@ -925,7 +925,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'CustomResourceRole.Arn'
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
   
   CustomDomainFunction:
     Condition: ManagedAliases
@@ -935,7 +935,7 @@ Resources:
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt 'CustomResourceRole.Arn'
-      Runtime: nodejs18.x 
+      Runtime: nodejs16.x 
   
   DNSDelegationFunction:
     Type: AWS::Lambda::Function
@@ -945,7 +945,7 @@ Resources:
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt 'CustomResourceRole.Arn'
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
   
   DelegateDNSAction:
     Metadata:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-importedvpc-flowlogs.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-importedvpc-flowlogs.yml
@@ -754,7 +754,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'CustomResourceRole.Arn'
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
   
   CustomDomainFunction:
     Condition: ManagedAliases
@@ -764,7 +764,7 @@ Resources:
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt 'CustomResourceRole.Arn'
-      Runtime: nodejs18.x 
+      Runtime: nodejs16.x 
   
   DNSDelegationFunction:
     Type: AWS::Lambda::Function
@@ -774,7 +774,7 @@ Resources:
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt 'CustomResourceRole.Arn'
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
   
   DelegateDNSAction:
     Metadata:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/bb_template.yaml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/bb_template.yaml
@@ -125,7 +125,7 @@ Resources:
         Type: LINUX_CONTAINER
         ComputeType: BUILD_GENERAL1_SMALL
         PrivilegedMode: true
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:5.0
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
         EnvironmentVariables:
           - Name: AWS_ACCOUNT_ID
             Value: !Sub '${AWS::AccountId}'
@@ -237,7 +237,7 @@ Resources:
         Type: NO_ARTIFACTS
       Environment:
         Type: LINUX_CONTAINER
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:5.0
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
         ComputeType: BUILD_GENERAL1_SMALL
         PrivilegedMode: true
       Source:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/cc_template.yaml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/cc_template.yaml
@@ -120,7 +120,7 @@ Resources:
         Type: LINUX_CONTAINER
         ComputeType: BUILD_GENERAL1_SMALL
         PrivilegedMode: true
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:5.0
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
         EnvironmentVariables:
           - Name: AWS_ACCOUNT_ID
             Value: !Sub '${AWS::AccountId}'
@@ -211,7 +211,7 @@ Resources:
         Type: NO_ARTIFACTS
       Environment:
         Type: LINUX_CONTAINER
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:5.0
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
         ComputeType: BUILD_GENERAL1_SMALL
         PrivilegedMode: true
       Source:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/dd_stack_template.yaml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/dd_stack_template.yaml
@@ -248,7 +248,7 @@ Resources:
         Type: NO_ARTIFACTS
       Environment:
         Type: LINUX_CONTAINER
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:5.0
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
         ComputeType: BUILD_GENERAL1_SMALL
         PrivilegedMode: true
       Source:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/gh_template.yaml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/gh_template.yaml
@@ -121,7 +121,7 @@ Resources:
         Type: LINUX_CONTAINER
         ComputeType: BUILD_GENERAL1_SMALL
         PrivilegedMode: true
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:5.0
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
         EnvironmentVariables:
           - Name: AWS_ACCOUNT_ID
             Value: !Sub '${AWS::AccountId}'
@@ -234,7 +234,7 @@ Resources:
         Type: LINUX_CONTAINER
         ComputeType: BUILD_GENERAL1_SMALL
         PrivilegedMode: true
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:5.0
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
         EnvironmentVariables:
           - Name: AWS_ACCOUNT_ID
             Value: !Sub '${AWS::AccountId}'
@@ -349,7 +349,7 @@ Resources:
         Type: LINUX_CONTAINER
         ComputeType: BUILD_GENERAL1_SMALL
         PrivilegedMode: true
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:5.0
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
         EnvironmentVariables:
           - Name: AWS_ACCOUNT_ID
             Value: !Sub '${AWS::AccountId}'
@@ -467,7 +467,7 @@ Resources:
         Type: LINUX_CONTAINER
         ComputeType: BUILD_GENERAL1_SMALL
         PrivilegedMode: true
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:5.0
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
         EnvironmentVariables:
           - Name: AWS_ACCOUNT_ID
             Value: !Sub '${AWS::AccountId}'
@@ -585,7 +585,7 @@ Resources:
         Type: LINUX_CONTAINER
         ComputeType: BUILD_GENERAL1_SMALL
         PrivilegedMode: true
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:5.0
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
         EnvironmentVariables:
           - Name: AWS_ACCOUNT_ID
             Value: !Sub '${AWS::AccountId}'
@@ -703,7 +703,7 @@ Resources:
         Type: LINUX_CONTAINER
         ComputeType: BUILD_GENERAL1_SMALL
         PrivilegedMode: true
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:5.0
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
         EnvironmentVariables:
           - Name: AWS_ACCOUNT_ID
             Value: !Sub '${AWS::AccountId}'

--- a/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/ghv1_template.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/pipeline/ghv1_template.yml
@@ -206,7 +206,7 @@ Resources:
         Type: NO_ARTIFACTS
       Environment:
         Type: LINUX_CONTAINER
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:5.0
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
         ComputeType: BUILD_GENERAL1_SMALL
         PrivilegedMode: true
       Source:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/http-autoscaling-template.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/http-autoscaling-template.yml
@@ -277,7 +277,7 @@ Resources:
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt "DynamicDesiredCountFunctionRole.Arn"
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
   DynamicDesiredCountFunctionRole:
     Metadata:
       "aws:copilot:description": "An IAM Role for describing number of running tasks in your ECS service"
@@ -456,7 +456,7 @@ Resources:
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt "RulePriorityFunctionRole.Arn"
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
   RulePriorityFunctionRole:
     Metadata:
       "aws:copilot:description": "An IAM Role to describe load balancer rules for assigning a priority"
@@ -560,7 +560,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt "EnvControllerRole.Arn"
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
   EnvControllerRole:
     Metadata:
       "aws:copilot:description": "An IAM role to update your environment stack"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/http-full-config-template.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/http-full-config-template.yml
@@ -419,7 +419,7 @@ Resources:
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt "RulePriorityFunctionRole.Arn"
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
   RulePriorityFunctionRole:
     Metadata:
       "aws:copilot:description": "An IAM Role to describe load balancer rules for assigning a priority"
@@ -551,7 +551,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt "EnvControllerRole.Arn"
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
   EnvControllerRole:
     Metadata:
       "aws:copilot:description": "An IAM role to update your environment stack"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/http-only-path-template.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/http-only-path-template.yml
@@ -337,7 +337,7 @@ Resources:
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt "RulePriorityFunctionRole.Arn"
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
   RulePriorityFunctionRole:
     Metadata:
       "aws:copilot:description": "An IAM Role to describe load balancer rules for assigning a priority"
@@ -441,7 +441,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt "EnvControllerRole.Arn"
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
   EnvControllerRole:
     Metadata:
       "aws:copilot:description": "An IAM role to update your environment stack"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/https-path-alias-template.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/https-path-alias-template.yml
@@ -234,7 +234,7 @@ Resources:
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt "RulePriorityFunctionRole.Arn"
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
   RulePriorityFunctionRole:
     Metadata:
       'aws:copilot:description': "An IAM Role to describe load balancer rules for assigning a priority"
@@ -433,7 +433,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'EnvControllerRole.Arn'
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
   EnvControllerRole:
     Metadata:
       'aws:copilot:description': "An IAM role to update your environment stack"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/simple-template-without-port-config.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/simple-template-without-port-config.yml
@@ -333,7 +333,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt "EnvControllerRole.Arn"
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
   EnvControllerRole:
     Metadata:
       "aws:copilot:description": "An IAM role to update your environment stack"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/simple-template.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/simple-template.yml
@@ -343,7 +343,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt "EnvControllerRole.Arn"
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
   EnvControllerRole:
     Metadata:
       "aws:copilot:description": "An IAM role to update your environment stack"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/job-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/job-test.stack.yml
@@ -70,7 +70,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'EnvControllerRole.Arn'
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
 
   EnvControllerRole:
     Metadata:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/rdws-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/rdws-test.stack.yml
@@ -280,7 +280,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'EnvControllerRole.Arn'
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
   
   EnvControllerRole:
     Metadata:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/static-site-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/static-site-test.stack.yml
@@ -141,7 +141,7 @@ Resources:
     Properties:
       Handler: index.handler
       Role: !GetAtt TriggerStateMachineFunctionRole.Arn
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
       Timeout: 900
       MemorySize: 512
 

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/static-site.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/static-site.stack.yml
@@ -141,7 +141,7 @@ Resources:
     Properties:
       Handler: index.handler
       Role: !GetAtt TriggerStateMachineFunctionRole.Arn
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
       Timeout: 900
       MemorySize: 512
 
@@ -387,7 +387,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'CustomDomainRole.Arn'
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
 
   CustomDomainRole:
     Metadata:
@@ -451,7 +451,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'CertificateValidatorRole.Arn'
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
 
   CertificateValidatorRole:
     Metadata:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-grpc-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-grpc-test.stack.yml
@@ -246,7 +246,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt 'DynamicDesiredCountFunctionRole.Arn'
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
   DynamicDesiredCountFunctionRole:
     Metadata:
       'aws:copilot:description': "An IAM Role for describing number of running tasks in your ECS service"
@@ -351,7 +351,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'EnvControllerRole.Arn'
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
   EnvControllerRole:
     Metadata:
       'aws:copilot:description': "An IAM role to update your environment stack"
@@ -469,7 +469,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt 'RulePriorityFunctionRole.Arn'
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
   RulePriorityFunctionRole:
     Metadata:
       'aws:copilot:description': "An IAM Role to describe load balancer rules for assigning a priority"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-dev.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-dev.stack.yml
@@ -233,7 +233,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'EnvControllerRole.Arn'
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
   EnvControllerRole:
     Metadata:
       'aws:copilot:description': "An IAM role to update your environment stack"
@@ -361,7 +361,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt 'RulePriorityFunctionRole.Arn'
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
   RulePriorityFunctionRole:
     Metadata:
       'aws:copilot:description': "An IAM Role to describe load balancer rules for assigning a priority"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-prod.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-prod.stack.yml
@@ -335,7 +335,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'EnvControllerRole.Arn'
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
   EnvControllerRole:
     Metadata:
       'aws:copilot:description': "An IAM role to update your environment stack"
@@ -634,7 +634,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'NLBCustomDomainRole.Arn'
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
   NLBCustomDomainRole:
     Metadata:
       'aws:copilot:description': "An IAM role to update the environment Route 53 hosted zone"
@@ -701,7 +701,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'NLBCertValidatorRole.Arn'
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
   NLBCertValidatorRole:
     Metadata:
       'aws:copilot:description': "An IAM role to request and validate a certificate for your service"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-test.stack.yml
@@ -228,7 +228,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'EnvControllerRole.Arn'
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
   EnvControllerRole:
     Metadata:
       'aws:copilot:description': "An IAM role to update your environment stack"
@@ -514,7 +514,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'NLBCertValidatorRole.Arn'
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
   NLBCertValidatorRole:
     Metadata:
       'aws:copilot:description': "An IAM role to request and validate a certificate for your service"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-prod.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-prod.stack.yml
@@ -468,7 +468,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt 'DynamicDesiredCountFunctionRole.Arn'
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
   DynamicDesiredCountFunctionRole:
     Metadata:
       'aws:copilot:description': "An IAM Role for describing number of running tasks in your ECS service"
@@ -573,7 +573,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'EnvControllerRole.Arn'
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
   EnvControllerRole:
     Metadata:
       'aws:copilot:description': "An IAM role to update your environment stack"
@@ -747,7 +747,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt 'RulePriorityFunctionRole.Arn'
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
   RulePriorityFunctionRole:
     Type: AWS::IAM::Role
     Metadata:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-staging.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-staging.stack.yml
@@ -246,7 +246,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'EnvControllerRole.Arn'
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
   EnvControllerRole:
     Metadata:
       'aws:copilot:description': "An IAM role to update your environment stack"
@@ -386,7 +386,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt 'RulePriorityFunctionRole.Arn'
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
   RulePriorityFunctionRole:
     Metadata:
       'aws:copilot:description': "An IAM Role to describe load balancer rules for assigning a priority"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-test.stack.yml
@@ -247,7 +247,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt 'DynamicDesiredCountFunctionRole.Arn'
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
   DynamicDesiredCountFunctionRole:
     Metadata:
       'aws:copilot:description': "An IAM Role for describing number of running tasks in your ECS service"
@@ -352,7 +352,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'EnvControllerRole.Arn'
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
   EnvControllerRole:
     Metadata:
       'aws:copilot:description': "An IAM role to update your environment stack"
@@ -473,7 +473,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt 'RulePriorityFunctionRole.Arn'
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
   RulePriorityFunctionRole:
     Metadata:
       'aws:copilot:description': "An IAM Role to describe load balancer rules for assigning a priority"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/windows-svc-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/windows-svc-test.stack.yml
@@ -225,7 +225,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'EnvControllerRole.Arn'
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
   EnvControllerRole:
     Metadata:
       'aws:copilot:description': "An IAM role to update your environment stack"
@@ -341,7 +341,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt 'RulePriorityFunctionRole.Arn'
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
   RulePriorityFunctionRole:
     Metadata:
       'aws:copilot:description': "An IAM Role to describe load balancer rules for assigning a priority"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/worker-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/worker-test.stack.yml
@@ -348,7 +348,7 @@ Resources:
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt 'DynamicDesiredCountFunctionRole.Arn'
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
   DynamicDesiredCountFunctionRole:
     Metadata:
       'aws:copilot:description': "An IAM Role for describing number of running tasks in your ECS service"
@@ -442,7 +442,7 @@ Resources:
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt BacklogPerTaskCalculatorRole.Arn
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
       Environment:
         Variables:
           CLUSTER_NAME:
@@ -1174,7 +1174,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'EnvControllerRole.Arn'
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
   EnvControllerRole:
     Metadata:
       'aws:copilot:description': "An IAM role to update your environment stack"

--- a/internal/pkg/deploy/pipeline.go
+++ b/internal/pkg/deploy/pipeline.go
@@ -8,13 +8,12 @@ package deploy
 import (
 	"errors"
 	"fmt"
+	"gopkg.in/yaml.v3"
 	"path"
 	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
-
-	"gopkg.in/yaml.v3"
 
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/copilot-cli/internal/pkg/config"
@@ -27,7 +26,7 @@ const (
 	fmtErrMissingProperty    = "missing `%s` in properties"
 	fmtErrPropertyNotAString = "property `%s` is not a string"
 
-	defaultPipelineBuildImage      = "aws/codebuild/amazonlinux2-x86_64-standard:5.0"
+	defaultPipelineBuildImage      = "aws/codebuild/amazonlinux2-x86_64-standard:4.0"
 	defaultPipelineEnvironmentType = "LINUX_CONTAINER"
 
 	// DefaultPipelineArtifactsDir is the default folder to output Copilot-generated templates.

--- a/internal/pkg/deploy/pipeline_test.go
+++ b/internal/pkg/deploy/pipeline_test.go
@@ -202,7 +202,7 @@ func TestPipelineSourceFromManifest(t *testing.T) {
 
 func TestPipelineBuild_Init(t *testing.T) {
 	const (
-		defaultImage   = "aws/codebuild/amazonlinux2-x86_64-standard:5.0"
+		defaultImage   = "aws/codebuild/amazonlinux2-x86_64-standard:4.0"
 		defaultEnvType = "LINUX_CONTAINER"
 	)
 	yamlNode := yaml.Node{}

--- a/internal/pkg/template/templates/cicd/partials/test.yml
+++ b/internal/pkg/template/templates/cicd/partials/test.yml
@@ -9,7 +9,7 @@ BuildTestCommands{{logicalIDSafe $stage.Name}}:
       Type: NO_ARTIFACTS
     Environment:
       Type: LINUX_CONTAINER
-      Image: aws/codebuild/amazonlinux2-x86_64-standard:5.0
+      Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
       ComputeType: BUILD_GENERAL1_SMALL
       PrivilegedMode: true
     Source:

--- a/internal/pkg/template/templates/environment/partials/cdn-resources.yml
+++ b/internal/pkg/template/templates/environment/partials/cdn-resources.yml
@@ -34,7 +34,7 @@ UniqueJSONValuesFunction:
     Timeout: 600
     MemorySize: 512
     Role: !GetAtt 'UniqueJSONValuesFunctionRole.Arn'
-    Runtime: nodejs18.x
+    Runtime: nodejs16.x
 
 UniqueAliasesAction:
   Metadata:
@@ -139,7 +139,7 @@ CertificateReplicatorFunction:
     Timeout: 900
     MemorySize: 512
     Role: !GetAtt 'CustomResourceRole.Arn'
-    Runtime: nodejs18.x
+    Runtime: nodejs16.x
     
 CertificateReplicator:
   Metadata:

--- a/internal/pkg/template/templates/environment/partials/lambdas.yml
+++ b/internal/pkg/template/templates/environment/partials/lambdas.yml
@@ -11,7 +11,7 @@ CertificateValidationFunction:
     Timeout: 900
     MemorySize: 512
     Role: !GetAtt 'CustomResourceRole.Arn'
-    Runtime: nodejs18.x
+    Runtime: nodejs16.x
 
 CustomDomainFunction:
   Condition: ManagedAliases
@@ -26,7 +26,7 @@ CustomDomainFunction:
     Timeout: 600
     MemorySize: 512
     Role: !GetAtt 'CustomResourceRole.Arn'
-    Runtime: nodejs18.x 
+    Runtime: nodejs16.x 
 
 DNSDelegationFunction:
   Type: AWS::Lambda::Function
@@ -41,4 +41,4 @@ DNSDelegationFunction:
     Timeout: 600
     MemorySize: 512
     Role: !GetAtt 'CustomResourceRole.Arn'
-    Runtime: nodejs18.x
+    Runtime: nodejs16.x

--- a/internal/pkg/template/templates/workloads/partials/cf/alb.yml
+++ b/internal/pkg/template/templates/workloads/partials/cf/alb.yml
@@ -58,7 +58,7 @@ RulePriorityFunction:
     Timeout: 600
     MemorySize: 512
     Role: !GetAtt "RulePriorityFunctionRole.Arn"
-    Runtime: nodejs18.x
+    Runtime: nodejs16.x
 
 RulePriorityFunctionRole:
   Metadata:

--- a/internal/pkg/template/templates/workloads/partials/cf/autoscaling.yml
+++ b/internal/pkg/template/templates/workloads/partials/cf/autoscaling.yml
@@ -26,7 +26,7 @@ DynamicDesiredCountFunction:
     Timeout: 600
     MemorySize: 512
     Role: !GetAtt 'DynamicDesiredCountFunctionRole.Arn'
-    Runtime: nodejs18.x
+    Runtime: nodejs16.x
 
 DynamicDesiredCountFunctionRole:
   Metadata:
@@ -182,7 +182,7 @@ BacklogPerTaskCalculatorFunction:
     Timeout: 600
     MemorySize: 512
     Role: !GetAtt BacklogPerTaskCalculatorRole.Arn
-    Runtime: nodejs18.x
+    Runtime: nodejs16.x
     Environment:
       Variables:
         CLUSTER_NAME:

--- a/internal/pkg/template/templates/workloads/partials/cf/env-controller.yml
+++ b/internal/pkg/template/templates/workloads/partials/cf/env-controller.yml
@@ -24,7 +24,7 @@ EnvControllerFunction:
     Timeout: 900
     MemorySize: 512
     Role: !GetAtt 'EnvControllerRole.Arn'
-    Runtime: nodejs18.x
+    Runtime: nodejs16.x
 
 EnvControllerRole:
   Metadata:

--- a/internal/pkg/template/templates/workloads/partials/cf/nlb.yml
+++ b/internal/pkg/template/templates/workloads/partials/cf/nlb.yml
@@ -259,7 +259,7 @@ NLBCustomDomainFunction:
     Timeout: 900
     MemorySize: 512
     Role: !GetAtt 'NLBCustomDomainRole.Arn'
-    Runtime: nodejs18.x
+    Runtime: nodejs16.x
 
 NLBCustomDomainRole:
   Metadata:
@@ -347,7 +347,7 @@ NLBCertValidatorFunction:
     Timeout: 900
     MemorySize: 512
     Role: !GetAtt 'NLBCertValidatorRole.Arn'
-    Runtime: nodejs18.x
+    Runtime: nodejs16.x
 
 NLBCertValidatorRole:
   Metadata:

--- a/internal/pkg/template/templates/workloads/services/rd-web/cf.yml
+++ b/internal/pkg/template/templates/workloads/services/rd-web/cf.yml
@@ -224,7 +224,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt CustomResourceRole.Arn
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
       Layers:
         - {{ .AWSSDKLayer }}
 

--- a/internal/pkg/template/templates/workloads/services/static-site/cf.yml
+++ b/internal/pkg/template/templates/workloads/services/static-site/cf.yml
@@ -163,7 +163,7 @@ Resources:
     Properties:
       Handler: index.handler
       Role: !GetAtt TriggerStateMachineFunctionRole.Arn
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
       Timeout: 900
       MemorySize: 512
       {{- with $cr := index .CustomResources "TriggerStateMachineFunction" }}
@@ -433,7 +433,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'CustomDomainRole.Arn'
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
 
   CustomDomainRole:
     Metadata:
@@ -508,7 +508,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'CertificateValidatorRole.Arn'
-      Runtime: nodejs18.x
+      Runtime: nodejs16.x
 
   CertificateValidatorRole:
     Metadata:

--- a/internal/pkg/term/progress/cloudformation_test.go
+++ b/internal/pkg/term/progress/cloudformation_test.go
@@ -346,7 +346,7 @@ func TestRegularResourceComponent_Listen(t *testing.T) {
 }
 
 func TestRegularResourceComponent_Render(t *testing.T) {
-	t.Run("renders a resource that was created succesfully immediately", func(t *testing.T) {
+	t.Run("renders a resource that was created Successfully immediately", func(t *testing.T) {
 		// GIVEN
 		comp := &regularResourceComponent{
 			description: "An ECS cluster to hold your services",

--- a/site/content/docs/concepts/pipelines.en.md
+++ b/site/content/docs/concepts/pipelines.en.md
@@ -198,7 +198,7 @@ warrant wiring up a separate buildspec, utilize the `test_commands` field.
     The `post_deployments` and `test_commands` fields within a stage are mutually exclusive.
 
 
-Pre-deployments, post-deployments, and test commands generate CodeBuild projects with the [aws/codebuild/amazonlinux2-x86_64-standard:5.0](https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-available.html) image, so most commands from Amazon Linux 2 (including `make`) are available for use. 
+Pre-deployments, post-deployments, and test commands generate CodeBuild projects with the [aws/codebuild/amazonlinux2-x86_64-standard:4.0](https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-available.html) image, so most commands from Amazon Linux 2 (including `make`) are available for use. 
 Are your tests configured to run inside a Docker container? Copilot's test commands CodeBuild project supports Docker, so `docker build` commands are available as well.
 
 In the example below, the pipeline will run the `make test` command (in your source code directory) and only promote the change to the prod stage if that command exits successfully.

--- a/site/content/docs/concepts/pipelines.ja.md
+++ b/site/content/docs/concepts/pipelines.ja.md
@@ -200,7 +200,7 @@ stages:
 !!! warning
     ステージ内の `post_deployments` フィールドと `test_commands` フィールドは相互に排他的です。
 
-デプロイ前、デプロイ後、およびテストコマンドは、[aws/codebuild/amazonlinux2-x86_64-standard:5.0](https://docs.aws.amazon.com/ja_jp/codebuild/latest/userguide/build-env-ref-available.html) イメージを使用して CodeBuild プロジェクトを生成するため、Amazon Linux 2 のほとんどのコマンド (`make` を含む) を使用できます。
+デプロイ前、デプロイ後、およびテストコマンドは、[aws/codebuild/amazonlinux2-x86_64-standard:4.0](https://docs.aws.amazon.com/ja_jp/codebuild/latest/userguide/build-env-ref-available.html) イメージを使用して CodeBuild プロジェクトを生成するため、Amazon Linux 2 のほとんどのコマンド (`make` を含む) を使用できます。
 
 テストの実行を Docker コンテナの中で実行するように設定していますか？Copilot では CodeBuild プロジェクトの Docker サポートを利用できますので、`docker build` コマンドも同様に利用可能です。
 

--- a/site/content/docs/developing/addons/package.en.md
+++ b/site/content/docs/developing/addons/package.en.md
@@ -20,7 +20,7 @@ For example, to deploy a javascript Lambda function alongside a copilot service,
               Timeout: 900
               MemorySize: 512
               Role: !GetAtt "ExampleFunctionRole.Arn"
-              Runtime: nodejs18.x
+              Runtime: nodejs16.x
         ```
     
     === "lambdas/example/index.js"
@@ -82,7 +82,7 @@ This architecture could be useful if you have a service that needs to minimize l
         Timeout: 60
         MemorySize: 512
         Role: !GetAtt "recordProcessorRole.Arn"
-        Runtime: nodejs18.x
+        Runtime: nodejs16.x
 
     recordProcessorRole:
       Type: AWS::IAM::Role

--- a/site/content/docs/developing/addons/package.ja.md
+++ b/site/content/docs/developing/addons/package.ja.md
@@ -20,7 +20,7 @@ Copilot は、Addon テンプレートから参照されるローカルファイ
               Timeout: 900
               MemorySize: 512
               Role: !GetAtt "ExampleFunctionRole.Arn"
-              Runtime: nodejs18.x
+              Runtime: nodejs16.x
         ```
     
     === "lambdas/example/index.js"
@@ -84,7 +84,7 @@ zip が必要な一部のリソース (`AWS::Serverless::Function` など) で�
         Timeout: 60
         MemorySize: 512
         Role: !GetAtt "recordProcessorRole.Arn"
-        Runtime: nodejs18.x
+        Runtime: nodejs16.x
 
     recordProcessorRole:
       Type: AWS::IAM::Role

--- a/site/content/docs/manifest/pipeline.en.md
+++ b/site/content/docs/manifest/pipeline.en.md
@@ -17,7 +17,7 @@ List of all available properties for a Copilot pipeline manifest. To learn more 
             # connection_name: a-connection
     
         build:
-          image: aws/codebuild/amazonlinux2-x86_64-standard:5.0
+          image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
           # additional_policy: # Add additional permissions while building your container images and templates.
     
         stages: 
@@ -135,7 +135,7 @@ Optional. The output artifact format. Values can be either `CODEBUILD_CLONE_REF`
 Configuration for CodeBuild project.
 
 <span class="parent-field">build.</span><a id="build-image" href="#build-image" class="field">`image`</a> <span class="type">String</span>  
-The URI that identifies the Docker image to use for this build project. As of now, `aws/codebuild/amazonlinux2-x86_64-standard:5.0` is used by default.
+The URI that identifies the Docker image to use for this build project. As of now, `aws/codebuild/amazonlinux2-x86_64-standard:4.0` is used by default.
 
 <span class="parent-field">build.</span><a id="build-buildspec" href="#build-buildspec" class="field">`buildspec`</a> <span class="type">String</span>  
 Optional. The path to a buildspec file, relative to the project root, to use for this build project. By default, Copilot will generate one for you, located at `copilot/pipelines/[your pipeline name]/buildspec.yml`.

--- a/site/content/docs/manifest/pipeline.ja.md
+++ b/site/content/docs/manifest/pipeline.ja.md
@@ -17,7 +17,7 @@
             # connection_name: a-connection
     
         build:
-          image: aws/codebuild/amazonlinux2-x86_64-standard:5.0
+          image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
           # additional_policy: # コンテナイメージやテンプレートを構築する際に、権限を追加することができます。
     
         stages: 
@@ -136,7 +136,7 @@ Pipeline をトリガーするリポジトリのブランチ名。 Copilot は�
 CodeBuild プロジェクトに関する設定。
 
 <span class="parent-field">build.</span><a id="build-image" href="#build-image" class="field">`image`</a> <span class="type">String</span>  
-CodeBuild のビルドプロジェクトで利用する Docker イメージの URI。`aws/codebuild/amazonlinux2-x86_64-standard:5.0` がデフォルトで利用されます。
+CodeBuild のビルドプロジェクトで利用する Docker イメージの URI。`aws/codebuild/amazonlinux2-x86_64-standard:4.0` がデフォルトで利用されます。
 
 <span class="parent-field">build.</span><a id="build-buildspec" href="#build-buildspec" class="field">`buildspec`</a> <span class="type">String</span>
 任意項目。このビルドプロジェクトで使用する、buildspec ファイルへのプロジェクトルートからの相対パスを指定します。デフォルトでは、作成したファイルは、 `copilot/pipelines/[your pipeline name]/buildspec.yml` に配置されています。


### PR DESCRIPTION
Reverts aws/copilot-cli#5429 because we can't use SDK v2 in our custom resource code. Adopting to SDK v3 takes more effort. Reverting the PR for now to unblock the other PRs.