### PR TITLE
fix: refer to more specific TargetGroup name for imported ALB

### DIFF
--- a/internal/pkg/template/templates/workloads/partials/cf/imported-alb-resources.yml
+++ b/internal/pkg/template/templates/workloads/partials/cf/imported-alb-resources.yml
@@ -141,7 +141,7 @@ HTTPListenerRuleForImportedALB{{ if ne $i 0 }}{{ $i }}{{ end }}:
   Type: AWS::ElasticLoadBalancingV2::ListenerRule
   Properties:
     Actions:
-      - TargetGroupArn: !Ref TargetGroup{{ if ne $i 0 }}{{ $i }}{{ end }}
+      - TargetGroupArn: !Ref TargetGroupForImportedALB{{ if ne $i 0 }}{{ $i }}{{ end }}
         Type: forward
     Conditions:
       {{- if $rule.AllowedSourceIps}}


### PR DESCRIPTION


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
