### PR TITLE
chore: prevent orchestrator stopTask from returning false errors

### DIFF
--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -706,6 +706,7 @@ type templateDiffer interface {
 type dockerEngineRunner interface {
 	CheckDockerEngineRunning() error
 	Run(context.Context, *dockerengine.RunOptions) error
+	DoesContainerExist(context.Context, string) (bool, error)
 	IsContainerRunning(context.Context, string) (bool, error)
 	Stop(context.Context, string) error
 	Rm(string) error

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -7693,6 +7693,21 @@ func (mr *MockdockerEngineRunnerMockRecorder) CheckDockerEngineRunning() *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckDockerEngineRunning", reflect.TypeOf((*MockdockerEngineRunner)(nil).CheckDockerEngineRunning))
 }
 
+// DoesContainerExist mocks base method.
+func (m *MockdockerEngineRunner) DoesContainerExist(arg0 context.Context, arg1 string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DoesContainerExist", arg0, arg1)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DoesContainerExist indicates an expected call of DoesContainerExist.
+func (mr *MockdockerEngineRunnerMockRecorder) DoesContainerExist(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DoesContainerExist", reflect.TypeOf((*MockdockerEngineRunner)(nil).DoesContainerExist), arg0, arg1)
+}
+
 // Exec mocks base method.
 func (m *MockdockerEngineRunner) Exec(ctx context.Context, container string, out io.Writer, cmd string, args ...string) error {
 	m.ctrl.T.Helper()

--- a/internal/pkg/docker/dockerengine/dockerengine.go
+++ b/internal/pkg/docker/dockerengine/dockerengine.go
@@ -351,6 +351,15 @@ func (c DockerCmdClient) Run(ctx context.Context, options *RunOptions) error {
 	return g.Wait()
 }
 
+// DoesContainerExist checks if a specific Docker container exists.
+func (c DockerCmdClient) DoesContainerExist(ctx context.Context, name string) (bool, error) {
+	output, err := c.containerID(ctx, name)
+	if err != nil {
+		return false, err
+	}
+	return output != "", nil
+}
+
 // IsContainerRunning checks if a specific Docker container is running.
 func (c DockerCmdClient) IsContainerRunning(ctx context.Context, name string) (bool, error) {
 	state, err := c.containerState(ctx, name)

--- a/internal/pkg/docker/dockerengine/dockerenginetest/dockerenginetest.go
+++ b/internal/pkg/docker/dockerengine/dockerenginetest/dockerenginetest.go
@@ -13,6 +13,7 @@ import (
 // Double is a test double for dockerengine.DockerCmdClient
 type Double struct {
 	StopFn               func(context.Context, string) error
+	DoesContainerExistFn func(context.Context, string) (bool, error)
 	IsContainerRunningFn func(context.Context, string) (bool, error)
 	RunFn                func(context.Context, *dockerengine.RunOptions) error
 	BuildFn              func(context.Context, *dockerengine.BuildArguments, io.Writer) error
@@ -25,6 +26,14 @@ func (d *Double) Stop(ctx context.Context, name string) error {
 		return nil
 	}
 	return d.StopFn(ctx, name)
+}
+
+// DoesContainerExist calls the stubbed function.
+func (d *Double) DoesContainerExist(ctx context.Context, name string) (bool, error) {
+	if d.IsContainerRunningFn == nil {
+		return false, nil
+	}
+	return d.DoesContainerExistFn(ctx, name)
 }
 
 // IsContainerRunning calls the stubbed function.

--- a/internal/pkg/docker/orchestrator/orchestrator.go
+++ b/internal/pkg/docker/orchestrator/orchestrator.go
@@ -399,13 +399,13 @@ func (o *Orchestrator) stopTask(ctx context.Context, task Task) error {
 
 			// ensure that container is fully stopped before stopTask finishes blocking
 			for {
-				running, err := o.docker.DoesContainerExist(ctx, o.containerID(name))
+				exists, err := o.docker.DoesContainerExist(ctx, o.containerID(name))
 				if err != nil {
 					errCh <- fmt.Errorf("polling container %q for removal: %w", name, err)
 					return
 				}
 
-				if running {
+				if exists {
 					select {
 					case <-time.After(1 * time.Second):
 						continue

--- a/internal/pkg/docker/orchestrator/orchestrator.go
+++ b/internal/pkg/docker/orchestrator/orchestrator.go
@@ -48,6 +48,7 @@ type logOptionsFunc func(name string, ctr ContainerDefinition) dockerengine.RunL
 // DockerEngine is used by Orchestrator to manage containers.
 type DockerEngine interface {
 	Run(context.Context, *dockerengine.RunOptions) error
+	DoesContainerExist(context.Context, string) (bool, error)
 	IsContainerRunning(context.Context, string) (bool, error)
 	Stop(context.Context, string) error
 	Build(ctx context.Context, args *dockerengine.BuildArguments, w io.Writer) error
@@ -398,7 +399,7 @@ func (o *Orchestrator) stopTask(ctx context.Context, task Task) error {
 
 			// ensure that container is fully stopped before stopTask finishes blocking
 			for {
-				running, err := o.docker.IsContainerRunning(ctx, o.containerID(name))
+				running, err := o.docker.DoesContainerExist(ctx, o.containerID(name))
 				if err != nil {
 					errCh <- fmt.Errorf("polling container %q for removal: %w", name, err)
 					return

--- a/internal/pkg/docker/orchestrator/orchestrator_test.go
+++ b/internal/pkg/docker/orchestrator/orchestrator_test.go
@@ -85,11 +85,11 @@ func TestOrchestrator(t *testing.T) {
 			runUntilStopped: true,
 			test: func(t *testing.T) (test, *dockerenginetest.Double) {
 				de := &dockerenginetest.Double{
-					IsContainerRunningFn: func(ctx context.Context, name string) (bool, error) {
-						if name == "prefix-pause" {
-							return true, nil
-						}
+					DoesContainerExistFn: func(ctx context.Context, s string) (bool, error) {
 						return false, nil
+					},
+					IsContainerRunningFn: func(ctx context.Context, name string) (bool, error) {
+						return true, nil
 					},
 					StopFn: func(ctx context.Context, name string) error {
 						if name == "prefix-success" {
@@ -119,11 +119,11 @@ func TestOrchestrator(t *testing.T) {
 			runUntilStopped: true,
 			test: func(t *testing.T) (test, *dockerenginetest.Double) {
 				de := &dockerenginetest.Double{
-					IsContainerRunningFn: func(ctx context.Context, name string) (bool, error) {
-						if name == "prefix-pause" {
-							return true, nil
-						}
+					DoesContainerExistFn: func(ctx context.Context, s string) (bool, error) {
 						return false, errors.New("some error")
+					},
+					IsContainerRunningFn: func(ctx context.Context, name string) (bool, error) {
+						return true, nil
 					},
 					StopFn: func(ctx context.Context, name string) error {
 						return nil
@@ -148,11 +148,11 @@ func TestOrchestrator(t *testing.T) {
 			runUntilStopped: true,
 			test: func(t *testing.T) (test, *dockerenginetest.Double) {
 				de := &dockerenginetest.Double{
-					IsContainerRunningFn: func(ctx context.Context, name string) (bool, error) {
-						if name == "prefix-pause" {
-							return true, nil
-						}
+					DoesContainerExistFn: func(ctx context.Context, s string) (bool, error) {
 						return false, nil
+					},
+					IsContainerRunningFn: func(ctx context.Context, name string) (bool, error) {
+						return true, nil
 					},
 				}
 				return func(t *testing.T, o *Orchestrator) {
@@ -185,11 +185,11 @@ func TestOrchestrator(t *testing.T) {
 			runUntilStopped: true,
 			test: func(t *testing.T) (test, *dockerenginetest.Double) {
 				de := &dockerenginetest.Double{
-					IsContainerRunningFn: func(ctx context.Context, name string) (bool, error) {
-						if name == "prefix-pause" {
-							return true, nil
-						}
+					DoesContainerExistFn: func(ctx context.Context, s string) (bool, error) {
 						return false, nil
+					},
+					IsContainerRunningFn: func(ctx context.Context, name string) (bool, error) {
+						return true, nil
 					},
 					RunFn: func(ctx context.Context, opts *dockerengine.RunOptions) error {
 						// validate pause container has correct ports and secrets
@@ -234,11 +234,11 @@ func TestOrchestrator(t *testing.T) {
 			test: func(t *testing.T) (test, *dockerenginetest.Double) {
 				stopPause := make(chan struct{})
 				de := &dockerenginetest.Double{
-					IsContainerRunningFn: func(ctx context.Context, name string) (bool, error) {
-						if name == "prefix-pause" {
-							return true, nil
-						}
+					DoesContainerExistFn: func(ctx context.Context, s string) (bool, error) {
 						return false, nil
+					},
+					IsContainerRunningFn: func(ctx context.Context, name string) (bool, error) {
+						return true, nil
 					},
 					RunFn: func(ctx context.Context, opts *dockerengine.RunOptions) error {
 						if opts.ContainerName == "prefix-foo" {
@@ -272,11 +272,11 @@ func TestOrchestrator(t *testing.T) {
 			test: func(t *testing.T) (test, *dockerenginetest.Double) {
 				stopPause := make(chan struct{})
 				de := &dockerenginetest.Double{
-					IsContainerRunningFn: func(ctx context.Context, name string) (bool, error) {
-						if name == "prefix-pause" {
-							return true, nil
-						}
+					DoesContainerExistFn: func(ctx context.Context, s string) (bool, error) {
 						return false, nil
+					},
+					IsContainerRunningFn: func(ctx context.Context, name string) (bool, error) {
+						return true, nil
 					},
 					RunFn: func(ctx context.Context, opts *dockerengine.RunOptions) error {
 						if opts.ContainerName == "prefix-foo" {
@@ -420,11 +420,11 @@ func TestOrchestrator(t *testing.T) {
 			runUntilStopped: true,
 			test: func(t *testing.T) (test, *dockerenginetest.Double) {
 				de := &dockerenginetest.Double{
-					IsContainerRunningFn: func(ctx context.Context, name string) (bool, error) {
-						if name == "prefix-pause" {
-							return true, nil
-						}
+					DoesContainerExistFn: func(ctx context.Context, s string) (bool, error) {
 						return false, nil
+					},
+					IsContainerRunningFn: func(ctx context.Context, name string) (bool, error) {
+						return true, nil
 					},
 					ExecFn: func(ctx context.Context, ctr string, w io.Writer, cmd string, args ...string) error {
 						if cmd == "aws" {


### PR DESCRIPTION
<!-- Provide summary of changes -->
Made a mistake in #5489 that causes an error message to falsely appear when stopping `run local` because it would call `docker inspect` when it only needed to call `docker ps`. This introduces another function that only runs the latter function, rather than running both, fixing the issue.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
