### PR TITLE
chore: fix watcher integ test

### DIFF
--- a/internal/pkg/cli/file/watch_integration_test.go
+++ b/internal/pkg/cli/file/watch_integration_test.go
@@ -85,6 +85,7 @@ func TestRecursiveWatcher(t *testing.T) {
 				select {
 				case e = <-eventsCh:
 				case <-time.After(time.Second):
+					return
 				}
 
 				if e == eventsExpected[eIndex] {

--- a/internal/pkg/cli/file/watch_integration_test.go
+++ b/internal/pkg/cli/file/watch_integration_test.go
@@ -131,7 +131,7 @@ func TestRecursiveWatcher(t *testing.T) {
 		require.NoError(t, err)
 		require.Empty(t, errorsCh)
 
-		require.Subset(t, eventsExpected, eventsActual)
+		require.Equal(t, eventsExpected, eventsActual)
 	})
 
 	t.Run("Clean", func(t *testing.T) {

--- a/internal/pkg/cli/file/watch_integration_test.go
+++ b/internal/pkg/cli/file/watch_integration_test.go
@@ -30,7 +30,7 @@ func TestRecursiveWatcher(t *testing.T) {
 	eventsExpected = []fsnotify.Event{
 		{
 			Name: filepath.ToSlash(filepath.Join(tmp, "watch/subdir/testfile")),
-			Op:   fsnotify.Write,
+			Op:   fsnotify.Create,
 		},
 		{
 			Name: filepath.ToSlash(filepath.Join(tmp, "watch/subdir/testfile")),
@@ -80,6 +80,10 @@ func TestRecursiveWatcher(t *testing.T) {
 
 		eIndex := 0
 		expectNextEvent := func() {
+			defer func() {
+				eIndex += 1
+			}()
+
 			for {
 				var e fsnotify.Event
 				select {
@@ -90,7 +94,6 @@ func TestRecursiveWatcher(t *testing.T) {
 
 				if e == eventsExpected[eIndex] {
 					eventsActual = append(eventsActual, e)
-					eIndex += 1
 					return
 				}
 			}

--- a/internal/pkg/cli/file/watch_integration_test.go
+++ b/internal/pkg/cli/file/watch_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -29,41 +30,41 @@ func TestRecursiveWatcher(t *testing.T) {
 	eventsActual = make(map[fsnotify.Event]struct{})
 	eventsExpected = map[fsnotify.Event]struct{}{
 		{
-			Name: fmt.Sprintf("%s/watch/subdir/testfile", tmp),
+			Name: filepath.ToSlash(filepath.Join(tmp, "watch/subdir/testfile")),
 			Op:   fsnotify.Create,
 		}: {},
 		{
-			Name: fmt.Sprintf("%s/watch/subdir/testfile", tmp),
+			Name: filepath.ToSlash(filepath.Join(tmp, "watch/subdir/testfile")),
 			Op:   fsnotify.Chmod,
 		}: {},
 		{
-			Name: fmt.Sprintf("%s/watch/subdir/testfile", tmp),
+			Name: filepath.ToSlash(filepath.Join(tmp, "watch/subdir/testfile")),
 			Op:   fsnotify.Write,
 		}: {},
 		{
-			Name: fmt.Sprintf("%s/watch/subdir", tmp),
+			Name: filepath.ToSlash(filepath.Join(tmp, "watch/subdir")),
 			Op:   fsnotify.Rename,
 		}: {},
 		{
-			Name: fmt.Sprintf("%s/watch/subdir2", tmp),
+			Name: filepath.ToSlash(filepath.Join(tmp, "watch/subdir2")),
 			Op:   fsnotify.Create,
 		}: {},
 		{
-			Name: fmt.Sprintf("%s/watch/subdir2/testfile", tmp),
+			Name: filepath.ToSlash(filepath.Join(tmp, "watch/subdir2/testfile")),
 			Op:   fsnotify.Rename,
 		}: {},
 		{
-			Name: fmt.Sprintf("%s/watch/subdir2/testfile2", tmp),
+			Name: filepath.ToSlash(filepath.Join(tmp, "watch/subdir2/testfile2")),
 			Op:   fsnotify.Create,
 		}: {},
 		{
-			Name: fmt.Sprintf("%s/watch/subdir2/testfile2", tmp),
+			Name: filepath.ToSlash(filepath.Join(tmp, "watch/subdir2/testfile2")),
 			Op:   fsnotify.Remove,
 		}: {},
 	}
 
 	t.Run("Setup Watcher", func(t *testing.T) {
-		err := os.MkdirAll(fmt.Sprintf("%s/watch/subdir", tmp), 0755)
+		err := os.MkdirAll(filepath.ToSlash(filepath.Join(tmp, "watch/subdir")), 0755)
 		require.NoError(t, err)
 
 		watcher, err = file.NewRecursiveWatcher(uint(len(eventsExpected)))
@@ -89,30 +90,30 @@ func TestRecursiveWatcher(t *testing.T) {
 		}
 
 		// WATCH
-		file, err := os.Create(fmt.Sprintf("%s/watch/subdir/testfile", tmp))
+		file, err := os.Create(filepath.Join(tmp, "watch/subdir/testfile"))
 		require.NoError(t, err)
 		expectAndPopulateEvents(t, 1, eventsActual)
 
-		err = os.Chmod(fmt.Sprintf("%s/watch/subdir/testfile", tmp), 0755)
+		err = os.Chmod(filepath.Join(tmp, "watch/subdir/testfile"), 0755)
 		require.NoError(t, err)
 		expectAndPopulateEvents(t, 1, eventsActual)
 
-		err = os.WriteFile(fmt.Sprintf("%s/watch/subdir/testfile", tmp), []byte("write to file"), fs.ModeAppend)
+		err = os.WriteFile(filepath.Join(tmp, "watch/subdir/testfile"), []byte("write to file"), fs.ModeAppend)
 		require.NoError(t, err)
 		expectAndPopulateEvents(t, 2, eventsActual)
 
 		err = file.Close()
 		require.NoError(t, err)
 
-		err = os.Rename(fmt.Sprintf("%s/watch/subdir", tmp), fmt.Sprintf("%s/watch/subdir2", tmp))
+		err = os.Rename(filepath.Join(tmp, "watch/subdir"), filepath.Join(tmp, "watch/subdir2"))
 		require.NoError(t, err)
 		expectAndPopulateEvents(t, 3, eventsActual)
 
-		err = os.Rename(fmt.Sprintf("%s/watch/subdir2/testfile", tmp), fmt.Sprintf("%s/watch/subdir2/testfile2", tmp))
+		err = os.Rename(filepath.Join(tmp, "watch/subdir2/testfile"), filepath.Join(tmp, "watch/subdir2/testfile2"))
 		require.NoError(t, err)
 		expectAndPopulateEvents(t, 2, eventsActual)
 
-		err = os.Remove(fmt.Sprintf("%s/watch/subdir2/testfile2", tmp))
+		err = os.Remove(filepath.Join(tmp, "watch/subdir2/testfile2"))
 		require.NoError(t, err)
 		expectAndPopulateEvents(t, 1, eventsActual)
 

--- a/internal/pkg/cli/file/watch_integration_test.go
+++ b/internal/pkg/cli/file/watch_integration_test.go
@@ -6,7 +6,6 @@
 package file_test
 
 import (
-	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -22,45 +21,45 @@ func TestRecursiveWatcher(t *testing.T) {
 	var (
 		watcher        *file.RecursiveWatcher
 		tmp            string
-		eventsExpected map[fsnotify.Event]struct{}
-		eventsActual   map[fsnotify.Event]struct{}
+		eventsExpected []fsnotify.Event
+		eventsActual   []fsnotify.Event
 	)
 
 	tmp = os.TempDir()
-	eventsActual = make(map[fsnotify.Event]struct{})
-	eventsExpected = map[fsnotify.Event]struct{}{
+	eventsActual = []fsnotify.Event{}
+	eventsExpected = []fsnotify.Event{
 		{
 			Name: filepath.ToSlash(filepath.Join(tmp, "watch/subdir/testfile")),
 			Op:   fsnotify.Create,
-		}: {},
+		},
 		{
 			Name: filepath.ToSlash(filepath.Join(tmp, "watch/subdir/testfile")),
 			Op:   fsnotify.Chmod,
-		}: {},
+		},
 		{
 			Name: filepath.ToSlash(filepath.Join(tmp, "watch/subdir/testfile")),
 			Op:   fsnotify.Write,
-		}: {},
+		},
 		{
 			Name: filepath.ToSlash(filepath.Join(tmp, "watch/subdir")),
 			Op:   fsnotify.Rename,
-		}: {},
+		},
 		{
 			Name: filepath.ToSlash(filepath.Join(tmp, "watch/subdir2")),
 			Op:   fsnotify.Create,
-		}: {},
+		},
 		{
 			Name: filepath.ToSlash(filepath.Join(tmp, "watch/subdir2/testfile")),
 			Op:   fsnotify.Rename,
-		}: {},
+		},
 		{
 			Name: filepath.ToSlash(filepath.Join(tmp, "watch/subdir2/testfile2")),
 			Op:   fsnotify.Create,
-		}: {},
+		},
 		{
 			Name: filepath.ToSlash(filepath.Join(tmp, "watch/subdir2/testfile2")),
 			Op:   fsnotify.Remove,
-		}: {},
+		},
 	}
 
 	t.Run("Setup Watcher", func(t *testing.T) {
@@ -73,60 +72,62 @@ func TestRecursiveWatcher(t *testing.T) {
 
 	t.Run("Watch", func(t *testing.T) {
 		// SETUP
-		err := watcher.Add(fmt.Sprintf("%s/watch", tmp))
+		err := watcher.Add(filepath.ToSlash(filepath.Join(tmp, "watch")))
 		require.NoError(t, err)
 
 		eventsCh := watcher.Events()
 		errorsCh := watcher.Errors()
 
-		expectAndPopulateEvents := func(t *testing.T, n int, events map[fsnotify.Event]struct{}) {
-			for i := 0; i < n; i++ {
+		go func() {
+			for {
 				select {
 				case e := <-eventsCh:
-					events[e] = struct{}{}
-				case <-time.After(time.Second):
+					if e.Op != 0 {
+						eventsActual = append(eventsActual, e)
+					}
+				case <-errorsCh:
+					return
 				}
 			}
-		}
+		}()
 
 		// WATCH
 		file, err := os.Create(filepath.Join(tmp, "watch/subdir/testfile"))
 		require.NoError(t, err)
-		expectAndPopulateEvents(t, 1, eventsActual)
 
 		err = os.Chmod(filepath.Join(tmp, "watch/subdir/testfile"), 0755)
 		require.NoError(t, err)
-		expectAndPopulateEvents(t, 1, eventsActual)
 
 		err = os.WriteFile(filepath.Join(tmp, "watch/subdir/testfile"), []byte("write to file"), fs.ModeAppend)
 		require.NoError(t, err)
-		expectAndPopulateEvents(t, 2, eventsActual)
 
 		err = file.Close()
 		require.NoError(t, err)
 
 		err = os.Rename(filepath.Join(tmp, "watch/subdir"), filepath.Join(tmp, "watch/subdir2"))
 		require.NoError(t, err)
-		expectAndPopulateEvents(t, 3, eventsActual)
 
 		err = os.Rename(filepath.Join(tmp, "watch/subdir2/testfile"), filepath.Join(tmp, "watch/subdir2/testfile2"))
 		require.NoError(t, err)
-		expectAndPopulateEvents(t, 2, eventsActual)
 
 		err = os.Remove(filepath.Join(tmp, "watch/subdir2/testfile2"))
 		require.NoError(t, err)
-		expectAndPopulateEvents(t, 1, eventsActual)
+
+		// Wait for events to propagate
+		time.Sleep(time.Second)
 
 		// CLOSE
 		err = watcher.Close()
 		require.NoError(t, err)
 		require.Empty(t, errorsCh)
 
-		require.Equal(t, eventsExpected, eventsActual)
+		for _, expectedEvent := range eventsExpected {
+			require.Contains(t, eventsActual, expectedEvent)
+		}
 	})
 
 	t.Run("Clean", func(t *testing.T) {
-		err := os.RemoveAll(fmt.Sprintf("%s/watch", tmp))
+		err := os.RemoveAll(filepath.Join(tmp, "watch"))
 		require.NoError(t, err)
 	})
 }


### PR DESCRIPTION
<!-- Provide summary of changes -->
OS differences caused integ test to succeed on linux and fail on mac. This generalizes the tests so we don't care about the order of rename operations and skip duplicate write operations. It also normalizes filepaths to the way they are handled in the `fsnotify` package using `filepath.Join` and `filepath.ToSlash`.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
