### PR TITLE
chore: disable `--use-task-role` by default

### DIFF
--- a/internal/pkg/cli/errors.go
+++ b/internal/pkg/cli/errors.go
@@ -173,11 +173,16 @@ func (e *errTaskRoleRetrievalFailed) Error() string {
 }
 
 func (e *errTaskRoleRetrievalFailed) RecommendActions() string {
-	return fmt.Sprintf(`TaskRole retrieval failed. If your containers don't require the TaskRole for local testing, you can use %s to disable this feature.
-If you require the TaskRole, you can manually add permissions for your account to assume TaskRole by adding the following YAML override to your service:
+	return fmt.Sprintf(`TaskRole retrieval failed. If you require the TaskRole, you can try these methods to enable it:
+1. Enable exec in the service manifest:
 %s
-For more information on YAML overrides see %s`,
-		color.HighlightCode(`copilot run local --use-task-role=false`),
+
+2. Add permissions for your account to assume TaskRole by adding the following YAML override to your service:
+%s
+
+For more information on YAML overrides see %s
+`,
+		color.HighlightCodeBlock(`exec: true # Enable running commands in your container.`),
 		color.HighlightCodeBlock(`- op: add
   path: /Resources/TaskRole/Properties/AssumeRolePolicyDocument/Statement/-
   value:

--- a/internal/pkg/cli/run_local.go
+++ b/internal/pkg/cli/run_local.go
@@ -1243,7 +1243,7 @@ func BuildRunLocalCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&vars.envName, envFlag, envFlagShort, "", envFlagDescription)
 	cmd.Flags().StringVarP(&vars.appName, appFlag, appFlagShort, tryReadingAppName(), appFlagDescription)
 	cmd.Flags().BoolVar(&vars.watch, watchFlag, false, watchFlagDescription)
-	cmd.Flags().BoolVar(&vars.useTaskRole, useTaskRoleFlag, true, useTaskRoleFlagDescription)
+	cmd.Flags().BoolVar(&vars.useTaskRole, useTaskRoleFlag, false, useTaskRoleFlagDescription)
 	cmd.Flags().Var(&vars.portOverrides, portOverrideFlag, portOverridesFlagDescription)
 	cmd.Flags().StringToStringVar(&vars.envOverrides, envVarOverrideFlag, nil, envVarOverrideFlagDescription)
 	cmd.Flags().BoolVar(&vars.proxy, proxyFlag, false, proxyFlagDescription)

--- a/site/content/blogs/release-v133.en.md
+++ b/site/content/blogs/release-v133.en.md
@@ -33,10 +33,8 @@ Copilot v1.33 brings big enhancements to help you develop more flexibly and effi
 
 ## Use ECS Task Role for `copilot run local`
 
-`copilot run local` now has a flag `--use-task-role` which is enabled by default. When enabled, Copilot will retrieve the IAM permissions from your deployed service and inject them into the containers created by `run local`.
+`copilot run local` now has a flag `--use-task-role`. When enabled, Copilot will retrieve the IAM permissions from your deployed service and inject them into the containers created by `run local`.
 This means that your containers will have the same permissions that they do on the cloud, enabling you to test more accurately.
-
-If you don't want to use the `TaskRole` permissions, or if Copilot fails to retrieve them, you can disable this feature by setting `--use-task-role=false`.
 
 ## Container dependencies support for `copilot run local`
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
Removes a planned breaking change. Decision is to release the feature to be off by default to assess where users have issues with the flag as it can be set to enabled by default in the future.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
