### PR TITLE
fix: scheduled job's custom subnet should be rendered as a string

### DIFF
--- a/internal/pkg/template/templates/workloads/partials/cf/state-machine.yml
+++ b/internal/pkg/template/templates/workloads/partials/cf/state-machine.yml
@@ -20,9 +20,11 @@ StateMachine:
       Partition: !Ref AWS::Partition
       Subnets:
       {{- if .Network.SubnetIDs}}
-        {{- range $id := .Network.SubnetIDs}}
-        - {{$id}}
-        {{- end}}
+        Fn::Join:
+          - '","'
+          - {{- range $id := .Network.SubnetIDs}}
+            - {{$id}}
+            {{- end}}
       {{- else}}
         Fn::Join:
           - '","'


### PR DESCRIPTION
Address #5697 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
