### PR TITLE
docs: fix secretsmanager fields in sample manifests

### DIFF
--- a/site/content/blogs/release-v126.en.md
+++ b/site/content/blogs/release-v126.en.md
@@ -181,13 +181,13 @@ secrets:
   # To inject a secret from SecretsManager.
   # (Recommended) Option 1. Referring to the secret by name.
   DB:
-    secretsmanager: 'demo/test/mysql'
+    secretsmanager: 'mysql'
   # You can refer to a specific key in the JSON blob.
   DB_PASSWORD:
-    secretsmanager: 'demo/test/mysql:password::'
+    secretsmanager: 'mysql:password::'
   # You can substitute predefined environment variables to keep your manifest succinct.
   DB_PASSWORD:
-    secretsmanager: '${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/mysql:password::'
+    secretsmanager: 'mysql:password::'
 
   # Option 2. Alternatively, you can refer to the secret by ARN.
   DB: 'arn:aws:secretsmanager:us-west-2:111122223333:secret:demo/test/mysql-Yi6mvL'

--- a/site/content/blogs/release-v126.ja.md
+++ b/site/content/blogs/release-v126.ja.md
@@ -189,13 +189,13 @@ secrets:
   # To inject a secret from SecretsManager.
   # (Recommended) Option 1. Referring to the secret by name.
   DB:
-    secretsmanager: 'demo/test/mysql'
+    secretsmanager: 'mysql'
   # You can refer to a specific key in the JSON blob.
   DB_PASSWORD:
-    secretsmanager: 'demo/test/mysql:password::'
+    secretsmanager: 'mysql:password::'
   # You can substitute predefined environment variables to keep your manifest succinct.
   DB_PASSWORD:
-    secretsmanager: '${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/mysql:password::'
+    secretsmanager: 'mysql:password::'
 
   # Option 2. Alternatively, you can refer to the secret by ARN.
   DB: 'arn:aws:secretsmanager:us-west-2:111122223333:secret:demo/test/mysql-Yi6mvL'

--- a/site/content/docs/developing/secrets.ja.md
+++ b/site/content/docs/developing/secrets.ja.md
@@ -43,7 +43,7 @@ SSM と同様に、最初に Secrets Manager のシークレットに、`copilot
 
 | Field  | Value                                                                                                                                                                 |
 | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Name   | `demo/test/mysql`                                                                                                                                                     |
+| Name   | `mysql`                                                                                                                                                     |
 | ARN    | `arn:aws:secretsmanager:us-west-2:111122223333:secret:demo/test/mysql-Yi6mvL`                                                                                        |
 | Value  | `{"engine": "mysql","username": "user1","password": "i29wwX!%9wFV","host": "my-database-endpoint.us-east-1.rds.amazonaws.com","dbname": "myDatabase","port": "3306"`} |
 | Tags   | `copilot-application=demo`, `copilot-environment=test` |
@@ -54,13 +54,13 @@ Manifest を次の様に変更します。
 secrets:
   # (推奨) オプション 1. 名前を使ってシークレットを参照します。
   DB:
-    secretsmanager: 'demo/test/mysql'
+    secretsmanager: 'mysql'
   # JSON blob 内の特定のキーを参照できます。
   DB_PASSWORD:
-    secretsmanager: 'demo/test/mysql:password::'
+    secretsmanager: 'mysql:password::'
   # 事前に定義された環境変数を利用して、Manifest を簡潔に保つ事ができます。
   DB_PASSWORD:
-    secretsmanager: '${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/mysql:password::'
+    secretsmanager: 'mysql:password::'
 
   # オプション 2. 別の方法として、ARN によってシークレットを指定することができます。
   DB: "'arn:aws:secretsmanager:us-west-2:111122223333:secret:demo/test/mysql-Yi6mvL'"

--- a/site/content/docs/manifest/backend-service.en.md
+++ b/site/content/docs/manifest/backend-service.en.md
@@ -71,7 +71,7 @@ List of all available properties for a `'Backend Service'` manifest. To learn ab
         secrets:
           GITHUB_WEBHOOK_SECRET: GH_WEBHOOK_SECRET
           DB_PASSWORD:
-            secretsmanager: 'demo/test/mysql:password::'
+            secretsmanager: 'mysql:password::'
         ```
 
     === "With a domain"

--- a/site/content/docs/manifest/backend-service.ja.md
+++ b/site/content/docs/manifest/backend-service.ja.md
@@ -71,7 +71,7 @@
         secrets:
           GITHUB_WEBHOOK_SECRET: GH_WEBHOOK_SECRET
           DB_PASSWORD:
-            secretsmanager: 'demo/test/mysql:password::'
+            secretsmanager: 'mysql:password::'
         ```
 
     === "With a domain"

--- a/site/content/docs/manifest/lb-web-service.en.md
+++ b/site/content/docs/manifest/lb-web-service.en.md
@@ -26,7 +26,7 @@ List of all available properties for a `'Load Balanced Web Service'` manifest. T
         secrets:
           GITHUB_TOKEN: GITHUB_TOKEN
           DB_SECRET:
-            secretsmanager: '${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/mysql'
+            secretsmanager: 'mysql'
         ```
 
     === "With a domain"

--- a/site/content/docs/manifest/lb-web-service.ja.md
+++ b/site/content/docs/manifest/lb-web-service.ja.md
@@ -26,7 +26,7 @@
         secrets:
           GITHUB_TOKEN: GITHUB_TOKEN
           DB_SECRET:
-            secretsmanager: '${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/mysql'
+            secretsmanager: 'mysql'
         ```
 
     === "With a domain"

--- a/site/content/docs/manifest/rd-web-service.en.md
+++ b/site/content/docs/manifest/rd-web-service.en.md
@@ -28,7 +28,7 @@ List of all available properties for a `'Request-Driven Web Service'` manifest.
         secrets:
           GITHUB_TOKEN: GITHUB_TOKEN
           DB_SECRET:
-            secretsmanager: '${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/mysql'
+            secretsmanager: 'mysql'
 
         environments:
           test:

--- a/site/content/docs/manifest/rd-web-service.ja.md
+++ b/site/content/docs/manifest/rd-web-service.ja.md
@@ -28,7 +28,7 @@
         secrets:
           GITHUB_TOKEN: GITHUB_TOKEN
           DB_SECRET:
-            secretsmanager: '${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/mysql'
+            secretsmanager: 'mysql'
     
         environments:
           test:

--- a/site/content/docs/manifest/worker-service.en.md
+++ b/site/content/docs/manifest/worker-service.en.md
@@ -34,7 +34,7 @@ List of all available properties for a `'Worker Service'` manifest. To learn abo
 
         secrets:
           DB:
-            secretsmanager: '${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/mysql'
+            secretsmanager: 'mysql'
         ```
 
     === "Spot autoscaling"

--- a/site/content/docs/manifest/worker-service.ja.md
+++ b/site/content/docs/manifest/worker-service.ja.md
@@ -34,7 +34,7 @@
 
         secrets:
           DB:
-            secretsmanager: '${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/mysql'
+            secretsmanager: 'mysql'
         ```
 
     === "Spot autoscaling"


### PR DESCRIPTION
Related: #5724.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
