### PR TITLE
chore: add Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -28,3 +28,8 @@ If you do find an existing Issue, re-open or add a comment to that Issue instead
 ### Expected result:
 <!-- Describe what you expected. -->
 
+
+
+### Debugging:
+<!-- Describe what you steps you have taken to debug this issue. What docs have you looked at? What have you tried? -->
+

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Create an Issue to report a bug
+title: "[Bug]: TITLE"
+labels: [''type/bug'']
+assignees: ''
+
+---
+
+<!-- Make sure we don't have an existing Issue that reports the bug you are seeing (both open and closed). 
+If you do find an existing Issue, re-open or add a comment to that Issue instead of creating a new one. -->
+
+### Description:
+<!-- Briefly describe the bug you are facing.-->
+
+
+
+### Details:
+<!-- Provide relevant information re: your setup (Copilot version, OS/Arch, type of manifest or pipeline, AWS region, etc. -->
+
+
+
+### Observed result:
+<!-- Please provide command output with `--debug` flag set. -->
+
+
+
+### Expected result:
+<!-- Describe what you expected. -->
+

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -31,5 +31,5 @@ If you do find an existing Issue, re-open or add a comment to that Issue instead
 
 
 ### Debugging:
-<!-- Describe what you steps you have taken to debug this issue. What docs have you looked at? What have you tried? -->
+<!-- Describe the steps you have taken to debug this issue. What docs have you looked at? What else have you tried? -->
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create an Issue to report a bug
 title: "[Bug]: TITLE"
-labels: [''type/bug'']
+labels: ['type/bug']
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea/feature/enhancement
+title: "[Feature Request]: TITLE"
+labels: ['type/request', 'type/feature', 'type/enhancement']
+assignees: ''
+
+---
+
+<!-- Make sure we don't have an existing Issue for the feature you are requesting (both open and closed). -->
+
+### Describe your idea/feature/enhancement
+
+Provide a clear description. Ex. I wish Copilot would [...]
+
+### Proposal
+
+Add details of how to add this to the product.
+
+### Additional Details

--- a/.github/ISSUE_TEMPLATE/other.md
+++ b/.github/ISSUE_TEMPLATE/other.md
@@ -1,0 +1,8 @@
+---
+name: Other
+about: Open an issue that is neither a bug report nor a feature/enhancement request
+title: "TITLE"
+labels: []
+assignees: ''
+
+---


### PR DESCRIPTION
This change will hopefully streamline on-call issue triaging.

Based on https://github.com/aws/aws-sam-cli/tree/develop/.github/ISSUE_TEMPLATE and https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
