### PR TITLE
chore: fix "task" e2e test's `AfterSuite`

### DIFF
--- a/e2e/task/task_suite_test.go
+++ b/e2e/task/task_suite_test.go
@@ -16,7 +16,7 @@ import (
 var cli *client.CLI
 var aws *client.AWS
 var appName, envName string
-var groupNames []string
+var tasks []client.TaskRunInput
 
 /**
 The task suite runs through several tests focusing on running one-off tasks with different configurations.
@@ -37,14 +37,14 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	for _, groupName := range groupNames {
+	for _, task := range tasks {
 		_, err := cli.TaskDelete(&client.TaskDeleteInput{
-			App:     appName,
-			Env:     envName,
-			Name:    groupName,
-			Default: false,
+			App:     task.AppName,
+			Env:     task.Env,
+			Name:    task.GroupName,
+			Default: task.Default,
 		})
-		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("delete task %s", groupName))
+		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("delete task %s", task.GroupName))
 	}
 	_, err := cli.AppDelete()
 	Expect(err).NotTo(HaveOccurred(), "delete Copilot application")

--- a/e2e/task/task_suite_test.go
+++ b/e2e/task/task_suite_test.go
@@ -15,7 +15,8 @@ import (
 
 var cli *client.CLI
 var aws *client.AWS
-var appName, envName, groupName, taskStackName, repoName string
+var appName, envName, taskStackName, repoName string
+var groupNames []string
 
 /**
 The task suite runs through several tests focusing on running one-off tasks with different configurations.
@@ -33,23 +34,18 @@ var _ = BeforeSuite(func() {
 
 	appName = fmt.Sprintf("e2e-task-%d", time.Now().Unix())
 	envName = "test"
-	groupName = fmt.Sprintf("e2e-task-%d", time.Now().Unix())
-	// We name task stack in format of "task-${groupName}".
-	// See https://github.com/aws/copilot-cli/blob/e9e3114561e740c367fb83b5e075750f232ad639/internal/pkg/deploy/cloudformation/stack/name.go#L26.
-	taskStackName = fmt.Sprintf("task-%s", groupName)
-	// We name ECR repo name in format of "copilot-${groupName}".
-	// See https://github.com/aws/copilot-cli/blob/e9e3114561e740c367fb83b5e075750f232ad639/templates/task/cf.yml#L75.
-	repoName = fmt.Sprintf("copilot-%s", groupName)
 })
 
 var _ = AfterSuite(func() {
-	_, err := cli.TaskDelete(&client.TaskDeleteInput{
-		App:     appName,
-		Env:     envName,
-		Name:    groupName,
-		Default: false,
-	})
-	Expect(err).NotTo(HaveOccurred(), "delete task")
-	_, err = cli.AppDelete()
+	for _, groupName := range groupNames {
+		_, err := cli.TaskDelete(&client.TaskDeleteInput{
+			App:     appName,
+			Env:     envName,
+			Name:    groupName,
+			Default: false,
+		})
+		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("delete task %s", groupName))
+	}
+	_, err := cli.AppDelete()
 	Expect(err).NotTo(HaveOccurred(), "delete Copilot application")
 })

--- a/e2e/task/task_suite_test.go
+++ b/e2e/task/task_suite_test.go
@@ -15,7 +15,7 @@ import (
 
 var cli *client.CLI
 var aws *client.AWS
-var appName, envName, taskStackName, repoName string
+var appName, envName string
 var groupNames []string
 
 /**

--- a/e2e/task/task_test.go
+++ b/e2e/task/task_test.go
@@ -121,7 +121,7 @@ var _ = Describe("Task", func() {
 		BeforeAll(func() {
 			groupName := fmt.Sprintf("e2e-task-%d", time.Now().Unix())
 			taskLogs, err = cli.TaskRun(&client.TaskRunInput{
-				GroupName: fmt.Sprintf(groupName),
+				GroupName: groupName,
 
 				Dockerfile: "./backend/Dockerfile",
 

--- a/e2e/task/task_test.go
+++ b/e2e/task/task_test.go
@@ -60,9 +60,8 @@ var _ = Describe("Task", func() {
 	Context("when running in an environment", Ordered, func() {
 		var err error
 		BeforeAll(func() {
-			groupName := fmt.Sprintf("e2e-task-%d", time.Now().Unix())
-			_, err = cli.TaskRun(&client.TaskRunInput{
-				GroupName: groupName,
+			task := client.TaskRunInput{
+				GroupName: fmt.Sprintf("e2e-task-%d", time.Now().Unix()),
 
 				Dockerfile: "./backend/Dockerfile",
 
@@ -70,8 +69,9 @@ var _ = Describe("Task", func() {
 				Env:     envName,
 
 				EnvFile: "./sesame.env",
-			})
-			groupNames = append(groupNames, groupName)
+			}
+			_, err = cli.TaskRun(&task)
+			tasks = append(tasks, task)
 		})
 
 		It("should succeed", func() {
@@ -83,17 +83,16 @@ var _ = Describe("Task", func() {
 		var err error
 		var taskLogs string
 		BeforeAll(func() {
-			groupName := fmt.Sprintf("e2e-task-%d", time.Now().Unix())
-			taskLogs, err = cli.TaskRun(&client.TaskRunInput{
-
-				GroupName: groupName,
+			task := client.TaskRunInput{
+				GroupName: fmt.Sprintf("e2e-task-%d", time.Now().Unix()),
 
 				Dockerfile: "./backend/Dockerfile",
 
 				Default: true,
 				Follow:  true,
-			})
-			groupNames = append(groupNames, groupName)
+			}
+			taskLogs, err = cli.TaskRun(&task)
+			tasks = append(tasks, task)
 		})
 
 		It("should succeed", func() {
@@ -119,9 +118,8 @@ var _ = Describe("Task", func() {
 		var err error
 		var taskLogs string
 		BeforeAll(func() {
-			groupName := fmt.Sprintf("e2e-task-%d", time.Now().Unix())
-			taskLogs, err = cli.TaskRun(&client.TaskRunInput{
-				GroupName: groupName,
+			task := client.TaskRunInput{
+				GroupName: fmt.Sprintf("e2e-task-%d", time.Now().Unix()),
 
 				Dockerfile: "./backend/Dockerfile",
 
@@ -130,8 +128,9 @@ var _ = Describe("Task", func() {
 
 				Default: true,
 				Follow:  true,
-			})
-			groupNames = append(groupNames, groupName)
+			}
+			taskLogs, err = cli.TaskRun(&task)
+			tasks = append(tasks, task)
 		})
 
 		It("should succeed", func() {

--- a/e2e/task/task_test.go
+++ b/e2e/task/task_test.go
@@ -86,7 +86,7 @@ var _ = Describe("Task", func() {
 			groupName := fmt.Sprintf("e2e-task-%d", time.Now().Unix())
 			taskLogs, err = cli.TaskRun(&client.TaskRunInput{
 
-				GroupName: fmt.Sprintf(groupName + "-default"),
+				GroupName: groupName,
 
 				Dockerfile: "./backend/Dockerfile",
 
@@ -121,7 +121,7 @@ var _ = Describe("Task", func() {
 		BeforeAll(func() {
 			groupName := fmt.Sprintf("e2e-task-%d", time.Now().Unix())
 			taskLogs, err = cli.TaskRun(&client.TaskRunInput{
-				GroupName: fmt.Sprintf(groupName + "env-vars"),
+				GroupName: fmt.Sprintf(groupName),
 
 				Dockerfile: "./backend/Dockerfile",
 

--- a/e2e/task/task_test.go
+++ b/e2e/task/task_test.go
@@ -4,6 +4,9 @@
 package task
 
 import (
+	"fmt"
+	"time"
+
 	"github.com/aws/copilot-cli/e2e/internal/client"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -57,6 +60,7 @@ var _ = Describe("Task", func() {
 	Context("when running in an environment", Ordered, func() {
 		var err error
 		BeforeAll(func() {
+			groupName := fmt.Sprintf("e2e-task-%d", time.Now().Unix())
 			_, err = cli.TaskRun(&client.TaskRunInput{
 				GroupName: groupName,
 
@@ -67,6 +71,7 @@ var _ = Describe("Task", func() {
 
 				EnvFile: "./sesame.env",
 			})
+			groupNames = append(groupNames, groupName)
 		})
 
 		It("should succeed", func() {
@@ -78,14 +83,17 @@ var _ = Describe("Task", func() {
 		var err error
 		var taskLogs string
 		BeforeAll(func() {
+			groupName := fmt.Sprintf("e2e-task-%d", time.Now().Unix())
 			taskLogs, err = cli.TaskRun(&client.TaskRunInput{
-				GroupName: groupName,
+
+				GroupName: fmt.Sprintf(groupName + "-default"),
 
 				Dockerfile: "./backend/Dockerfile",
 
 				Default: true,
 				Follow:  true,
 			})
+			groupNames = append(groupNames, groupName)
 		})
 
 		It("should succeed", func() {
@@ -111,8 +119,9 @@ var _ = Describe("Task", func() {
 		var err error
 		var taskLogs string
 		BeforeAll(func() {
+			groupName := fmt.Sprintf("e2e-task-%d", time.Now().Unix())
 			taskLogs, err = cli.TaskRun(&client.TaskRunInput{
-				GroupName: groupName,
+				GroupName: fmt.Sprintf(groupName + "env-vars"),
 
 				Dockerfile: "./backend/Dockerfile",
 
@@ -122,7 +131,7 @@ var _ = Describe("Task", func() {
 				Default: true,
 				Follow:  true,
 			})
-
+			groupNames = append(groupNames, groupName)
 		})
 
 		It("should succeed", func() {


### PR DESCRIPTION
Our "task" e2e test has being failing because we aren't able to empty the bucket. It is because we keep deploying tasks under the same group name; the latter-deployed tasks are in default cluster, which effectively removes the env manager role's permission to manage the bucket.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
