### PR TITLE
chore(e2e): migrate AWS SDK for JavaScript v2 APIs to v3

### DIFF
--- a/e2e/addons/hello/package.json
+++ b/e2e/addons/hello/package.json
@@ -8,7 +8,7 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "aws-sdk": ">= 2.249.1",
+    "@aws-sdk/client-s3": ">= 3.0.0",
     "express": "^4.16.1",
     "pg": "^8.5.1"
   }

--- a/e2e/addons/hello/server.js
+++ b/e2e/addons/hello/server.js
@@ -4,7 +4,7 @@
 'use strict';
 
 const express = require('express');
-const AWS = require('aws-sdk');
+const { S3 } = require('@aws-sdk/client-s3');
 
 // Constants
 const PORT = 80;
@@ -22,7 +22,7 @@ const pool = new Pool({
 })
 
 // Get bucket name from environment variable.
-const s3 = new AWS.S3({apiVersion: '2006-03-01'});
+const s3 = new S3();
 const bucketName = process.env.MYBUCKET_NAME
 
 // App


### PR DESCRIPTION
AWS SDK for JavaScript v2 will enter maintenance mode on September 8, 2024 and reach end-of-support on September 8, 2025. For more information, check blog post at https://a.co/cUPnyil

This PR migrates AWS SDK for JavaScript v2 APIs to v3 using [aws-sdk-js-codemod](https://www.npmjs.com/package/aws-sdk-js-codemod).

```console
$ npx aws-sdk-js-codemod@1.4.0 -t v2-to-v3 e2e/addons/hello/server.js
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
