### PR TITLE
chore(cli): migrate AWS SDK for JavaScript v2 APIs to v3

### DIFF
--- a/internal/pkg/cli/storage_init.go
+++ b/internal/pkg/cli/storage_init.go
@@ -1101,11 +1101,11 @@ func (o *initStorageOpts) actionsForWorkloadStorage() []string {
 		retrieveEnvVarCode = fmt.Sprintf("const {username, host, dbname, password, port} = JSON.parse(process.env.%s)", newVar)
 		if o.workloadType == manifestinfo.RequestDrivenWebServiceType {
 			newVar = fmt.Sprintf("%s_ARN", newVar)
-			retrieveEnvVarCode = fmt.Sprintf(`const AWS = require('aws-sdk');
-const client = new AWS.SecretsManager({
+			retrieveEnvVarCode = fmt.Sprintf(`const {SecretsManager} = require('@aws-sdk/client-secrets-manager');
+const client = new SecretsManager({
     region: process.env.AWS_DEFAULT_REGION,
 });
-const dbSecret = await client.getSecretValue({SecretId: process.env.%s}).promise();
+const dbSecret = await client.getSecretValue({SecretId: process.env.%s});
 const {username, host, dbname, password, port} = JSON.parse(dbSecret.SecretString);`, newVar)
 		}
 	}


### PR DESCRIPTION
AWS SDK for JavaScript v2 will enter maintenance mode on September 8, 2024 and reach end-of-support on September 8, 2025. For more information, check blog post at https://a.co/cUPnyil

This PR migrates v2 APIs in `internal/pkg/cli` to use v3.

These APIs were introduced in https://github.com/aws/copilot-cli/pull/3022, and were manually tested.
If they're run on Lambda, they're likely expected to fail error `[ERR_MODULE_NOT_FOUND]: Cannot find package 'aws-sdk'` after upgrading to Node.js 20

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
