### PR TITLE
docs: migrate AWS SDK for JavaScript v2 APIs to v3

### DIFF
--- a/site/content/docs/developing/addons/package.en.md
+++ b/site/content/docs/developing/addons/package.en.md
@@ -123,7 +123,7 @@ This architecture could be useful if you have a service that needs to minimize l
 4. Write your lambda function:
   ```js title="lambdas/record-processor/index.js"
   "use strict";
-  const AWS = require('aws-sdk');
+  const { unmarshall } = require('@aws-sdk/util-dynamodb');
 
   exports.handler = async function (event, context) {
     for (const record of event?.Records) {
@@ -132,7 +132,7 @@ This architecture could be useful if you have a service that needs to minimize l
       }
 
       // process new records
-      const item = AWS.DynamoDB.Converter.unmarshall(record?.dynamodb?.NewImage);
+      const item = unmarshall(record?.dynamodb?.NewImage);
       console.log("processing item", item);
     }
   };

--- a/site/content/docs/developing/addons/package.ja.md
+++ b/site/content/docs/developing/addons/package.ja.md
@@ -125,7 +125,7 @@ zip が必要な一部のリソース (`AWS::Serverless::Function` など) で�
 4. Lambda 関数を書いてください。
   ```js title="lambdas/record-processor/index.js"
   "use strict";
-  const AWS = require('aws-sdk');
+  const { unmarshall } = require('@aws-sdk/util-dynamodb');
 
   exports.handler = async function (event, context) {
     for (const record of event?.Records) {
@@ -134,7 +134,7 @@ zip が必要な一部のリソース (`AWS::Serverless::Function` など) で�
       }
 
       // process new records
-      const item = AWS.DynamoDB.Converter.unmarshall(record?.dynamodb?.NewImage);
+      const item = unmarshall(record?.dynamodb?.NewImage);
       console.log("processing item", item);
     }
   };


### PR DESCRIPTION
Migrating AWS SDK for JavaScript APIs from v2 to v3 in docs were missed in https://github.com/aws/copilot-cli/pull/5583

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
