### PR TITLE
chore(docs): fixed the explanations for `count.cooldown.in` and `count.cooldown.out`

### DIFF
--- a/site/content/docs/manifest/lb-web-service.en.md
+++ b/site/content/docs/manifest/lb-web-service.en.md
@@ -432,10 +432,10 @@ The desired count at which you wish to start placing your service using Fargate 
 Cooldown scaling fields that are used as the default cooldown for all autoscaling fields specified.
 
 <span class="parent-field">count.cooldown.</span><a id="count-cooldown-in" href="#count-cooldown-in" class="field">`in`</a> <span class="type">Duration</span>
-The cooldown time for autoscaling fields to scale up the service.
+The cooldown time for autoscaling fields to scale down the service.
 
 <span class="parent-field">count.cooldown.</span><a id="count-cooldown-out" href="#count-cooldown-out" class="field">`out`</a> <span class="type">Duration</span>
-The cooldown time for autoscaling fields to scale down the service.
+The cooldown time for autoscaling fields to scale up the service.
 
 The following options `cpu_percentage`, `memory_percentage`, `requests` and `response_time` are autoscaling fields for `count` which can be defined either as the value of the field, or as a Map containing advanced information about the field's `value` and `cooldown`:
 ```yaml

--- a/site/content/docs/manifest/lb-web-service.ja.md
+++ b/site/content/docs/manifest/lb-web-service.ja.md
@@ -431,10 +431,10 @@ Service の何個目のタスクから Fargate Spot キャパシティプロバ�
 指定されたすべてのオートスケーリングフィールドのデフォルトクールダウンとして使用されるクールダウンスケーリングフィールド。
 
 <span class="parent-field">count.cooldown.</span><a id="count-cooldown-in" href="#count-cooldown-in" class="field">`in`</a> <span class="type">Duration</span>
-Service をスケールアップするためのオートスケーリングのクールダウン時間。
+Service をスケールダウンさせるためのオートスケーリングクールダウン時間。
 
 <span class="parent-field">count.cooldown.</span><a id="count-cooldown-out" href="#count-cooldown-out" class="field">`out`</a> <span class="type">Duration</span>
-Service をスケールダウンさせるためのオートスケーリングクールダウン時間。
+Service をスケールアップするためのオートスケーリングのクールダウン時間。
 
 `cpu_percentage`、`memory_percentage`、`requests` および `response_time` のオプションは、オートスケーリングに関する `count` フィールドにて、フィールド値としてあるいはフィールド値とクールダウン設定に関する詳細情報を含むマップとして定義することができます。
 ```yaml


### PR DESCRIPTION
Fixed the documentation of explanations for count.cooldown.in and count.cooldown.out, which are reversed.

Fixes #5902

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
