### PR TITLE
docs(site): On sidecars, the depends_on attribute is not on image map (#5945)

### DIFF
--- a/site/content/docs/include/image-config-for-main-container.en.md
+++ b/site/content/docs/include/image-config-for-main-container.en.md
@@ -1,0 +1,3 @@
+{% include 'image-config.en.md' %}
+
+{% include 'image-depends-on-config.en.md' %}

--- a/site/content/docs/include/image-config-for-main-container.ja.md
+++ b/site/content/docs/include/image-config-for-main-container.ja.md
@@ -1,0 +1,3 @@
+{% include 'image-config.ja.md' %}
+
+{% include 'image-depends-on-config.ja.md' %}

--- a/site/content/docs/include/image-config-for-sidecar.en.md
+++ b/site/content/docs/include/image-config-for-sidecar.en.md
@@ -1,0 +1,1 @@
+{% include 'image-config.en.md' %}

--- a/site/content/docs/include/image-config-for-sidecar.ja.md
+++ b/site/content/docs/include/image-config-for-sidecar.ja.md
@@ -1,0 +1,1 @@
+{% include 'image-config.ja.md' %}

--- a/site/content/docs/include/image-config-with-port.en.md
+++ b/site/content/docs/include/image-config-with-port.en.md
@@ -1,6 +1,6 @@
 {% include 'image.md' %}
 
-{% include 'image-config.en.md' %}
+{% include 'image-config-for-main-container.en.md' %}
 
 <span class="parent-field">image.</span><a id="image-port" href="#image-port" class="field">`port`</a> <span class="type">Integer</span>  
 The port exposed in your Dockerfile. Copilot should parse this value for you from your `EXPOSE` instruction.

--- a/site/content/docs/include/image-config-with-port.ja.md
+++ b/site/content/docs/include/image-config-with-port.ja.md
@@ -1,6 +1,6 @@
 {% include 'image.ja.md' %}
 
-{% include 'image-config.ja.md' %}
+{% include 'image-config-for-main-container.ja.md' %}
 
 <span class="parent-field">image.</span><a id="image-port" href="#image-port" class="field">`port`</a> <span class="type">Integer</span>  
 公開するポート番号。Dockerfile 内に `EXPOSE` インストラクションが記述されている場合、Copilot はそれをパースした値をここに挿入します。

--- a/site/content/docs/include/image-config.en.md
+++ b/site/content/docs/include/image-config.en.md
@@ -40,16 +40,3 @@ An optional credentials ARN for a private repository. The `credentials` field fo
 
 <span class="parent-field">image.</span><a id="image-labels" href="#image-labels" class="field">`labels`</a> <span class="type">Map</span>  
 An optional key/value map of [Docker labels](https://docs.docker.com/config/labels-custom-metadata/) to add to the container.
-
-<span class="parent-field">image.</span><a id="image-depends-on" href="#image-depends-on" class="field">`depends_on`</a> <span class="type">Map</span>  
-An optional key/value map of [Container Dependencies](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ContainerDependency.html) to add to the container. The key of the map is a container name and the value is the condition to depend on. Valid conditions are: `start`, `healthy`, `complete`, and `success`. You cannot specify a `complete` or `success` dependency on an essential container.
-
-For example:
-```yaml
-image:
-  build: ./Dockerfile
-  depends_on:
-    nginx: start
-    startup: success
-```
-In the above example, the task's main container will only start after the `nginx` sidecar has started and the `startup` container has completed successfully.  

--- a/site/content/docs/include/image-config.ja.md
+++ b/site/content/docs/include/image-config.ja.md
@@ -40,16 +40,3 @@ Dockerfile からコンテナイメージをビルドする代わりに、既存
 
 <span class="parent-field">image.</span><a id="image-labels" href="#image-labels" class="field">`labels`</a> <span class="type">Map</span>  
 コンテナに付与したい [Docker ラベル](https://docs.docker.com/config/labels-custom-metadata/)を key/value の Map で指定できます。これは任意設定項目です。
-
-<span class="parent-field">image.</span><a id="image-depends-on" href="#image-depends-on" class="field">`depends_on`</a> <span class="type">Map</span>  
-任意項目。コンテナに追加する [Container Dependencies](https://docs.aws.amazon.com/ja_jp/AmazonECS/latest/APIReference/API_ContainerDependency.html) の任意の key/value の Map。Map の key はコンテナ名で、value は依存関係を表す値 (依存条件) として `start`、`healthy`、`complete`、`success` のいずれかを指定できます。なお、必須コンテナに `complete` や `success` の依存条件を指定することはできません。
-
-設定例:
-```yaml
-image:
-  build: ./Dockerfile
-  depends_on:
-    nginx: start
-    startup: success
-```
-上記の例では、タスクのメインコンテナは `nginx` サイドカーが起動し、`startup` コンテナが正常に完了してから起動します。

--- a/site/content/docs/include/image-depends-on-config.en.md
+++ b/site/content/docs/include/image-depends-on-config.en.md
@@ -1,0 +1,12 @@
+<span class="parent-field">image.</span><a id="image-depends-on" href="#image-depends-on" class="field">`depends_on`</a> <span class="type">Map</span>  
+An optional key/value map of [Container Dependencies](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ContainerDependency.html) to add to the container. The key of the map is a container name and the value is the condition to depend on. Valid conditions are: `start`, `healthy`, `complete`, and `success`. You cannot specify a `complete` or `success` dependency on an essential container.
+
+For example:
+```yaml
+image:
+  build: ./Dockerfile
+  depends_on:
+    nginx: start
+    startup: success
+```
+In the above example, the task's main container will only start after the `nginx` sidecar has started and the `startup` container has completed successfully.  

--- a/site/content/docs/include/image-depends-on-config.ja.md
+++ b/site/content/docs/include/image-depends-on-config.ja.md
@@ -1,0 +1,12 @@
+<span class="parent-field">image.</span><a id="image-depends-on" href="#image-depends-on" class="field">`depends_on`</a> <span class="type">Map</span>  
+任意項目。コンテナに追加する [Container Dependencies](https://docs.aws.amazon.com/ja_jp/AmazonECS/latest/APIReference/API_ContainerDependency.html) の任意の key/value の Map。Map の key はコンテナ名で、value は依存関係を表す値 (依存条件) として `start`、`healthy`、`complete`、`success` のいずれかを指定できます。なお、必須コンテナに `complete` や `success` の依存条件を指定することはできません。
+
+設定例:
+```yaml
+image:
+  build: ./Dockerfile
+  depends_on:
+    nginx: start
+    startup: success
+```
+上記の例では、タスクのメインコンテナは `nginx` サイドカーが起動し、`startup` コンテナが正常に完了してから起動します。

--- a/site/content/docs/include/sidecar-config.en.md
+++ b/site/content/docs/include/sidecar-config.en.md
@@ -5,7 +5,7 @@ Port of the container to expose (optional).
 <a id="image" href="#image" class="field">`image`</a> <span class="type">String or Map</span>  
 Image URL for the sidecar container (required).
 
-{% include 'image-config.en.md' %}
+{% include 'image-config-for-sidecar.en.md' %}
 
 <a id="essential" href="#essential" class="field">`essential`</a> <span class="type">Bool</span>  
 Whether the sidecar container is an essential container (optional, default true).

--- a/site/content/docs/include/sidecar-config.ja.md
+++ b/site/content/docs/include/sidecar-config.ja.md
@@ -5,7 +5,7 @@
 <a id="image" href="#image" class="field">`image`</a> <span class="type">String or Map</span> 
 サイドカーコンテナのイメージ URL。(必須項目)
 
-{% include 'image-config.ja.md' %}
+{% include 'image-config-for-sidecar.ja.md' %}
 
 <a id="essential" href="#essential" class="field">`essential`</a> <span class="type">Bool</span>
 サイドカーコンテナが必須のコンテナかどうか。(任意項目。デフォルトでは true)

--- a/site/content/docs/manifest/scheduled-job.en.md
+++ b/site/content/docs/manifest/scheduled-job.en.md
@@ -72,7 +72,7 @@ on:
 
 {% include 'image.md' %}
 
-{% include 'image-config.en.md' %}
+{% include 'image-config-for-main-container.en.md' %}
 
 <div class="separator"></div>  
 

--- a/site/content/docs/manifest/scheduled-job.ja.md
+++ b/site/content/docs/manifest/scheduled-job.ja.md
@@ -74,7 +74,7 @@ on:
 
 {% include 'image.ja.md' %}
 
-{% include 'image-config.ja.md' %}
+{% include 'image-config-for-main-container.ja.md' %}
 
 <div class="separator"></div>
 

--- a/site/content/docs/manifest/worker-service.en.md
+++ b/site/content/docs/manifest/worker-service.en.md
@@ -238,7 +238,7 @@ Specify this field as a map for customization of certain attributes for this top
 
 {% include 'image.md' %}
 
-{% include 'image-config.en.md' %}
+{% include 'image-config-for-main-container.en.md' %}
 
 {% include 'image-healthcheck.en.md' %}
 

--- a/site/content/docs/manifest/worker-service.ja.md
+++ b/site/content/docs/manifest/worker-service.ja.md
@@ -236,7 +236,7 @@ filter_policy:
 
 {% include 'image.ja.md' %}
 
-{% include 'image-config.ja.md' %}
+{% include 'image-config-for-main-container.ja.md' %}
 
 {% include 'task-size.ja.md' %}
 


### PR DESCRIPTION
Changes
- Remove `sidecars.image.depends_on`
- Keep `sidecars.depends_on`
- Keep `image.depends_on`

To not introduce duplication is creating an abstract common `image` template with same fields used on both concrete `image` Map.

Fixes #5945

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.