### PR TITLE
fix: check `ws.summaryErr != nil` but return a nil value error `err`

### DIFF
--- a/internal/pkg/workspace/workspace.go
+++ b/internal/pkg/workspace/workspace.go
@@ -181,7 +181,7 @@ func Create(appName string, fs afero.Fs) (*Workspace, error) {
 	ws.CopilotDirAbs = CopilotDirAbs
 	ws.summary, ws.summaryErr = ws.writeSummary(appName)
 	if ws.summaryErr != nil {
-		return nil, err
+		return nil, ws.summaryErr
 	}
 
 	return ws, nil


### PR DESCRIPTION
<!-- Provide summary of changes -->



<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
