### PR TITLE
chore: upgrade to go1.23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.21'
+          go-version: '1.23'
 
       - name: Set up Node
         uses: actions/setup-node@v1
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.21'
+          go-version: '1.23'
 
       - name: Set up Node
         uses: actions/setup-node@v1
@@ -69,7 +69,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.21'
+          go-version: '1.23'
 
       - name: Set up Node
         uses: actions/setup-node@v1
@@ -92,30 +92,13 @@ jobs:
         with:
           directory: cf-custom-resources/
 
-  staticcheck:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: '1.21'
-
-      - name: Check out code
-        uses: actions/checkout@v2
-
-      - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v3
-        with:
-          version: v1.54
-          args: --timeout 5m0s
-
   license:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.21'
+          go-version: '1.23'
 
       - name: Check out code
         uses: actions/checkout@v2

--- a/.github/workflows/ci_size_computer.yml
+++ b/.github/workflows/ci_size_computer.yml
@@ -91,7 +91,7 @@ jobs:
           echo ${{ github.event.number }} > artifacts/pr_number
           echo ${sizes_json} > artifacts/sizes.json
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: pr_number_and_bin_sizes
           path: artifacts/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Please read it over and let us know if it's not up-to-date (or, even better, sub
 
 ### Environment
 
-- Make sure you are using Go 1.21 (`go version`).
+- Make sure you are using Go 1.23 (`go version`).
 - Fork the repository.
 - Clone your forked repository locally.
 - We use Go Modules to manage dependencies, so you can develop outside of your $GOPATH.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21
+FROM golang:1.23
 # We need to have both nodejs and go to build the binaries.
 # We could use multi-stage builds but that would require significantly changing our Makefile.
 RUN apt-get update

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/copilot-cli
 
-go 1.21
+go 1.23
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.2

--- a/internal/pkg/cli/deploy.go
+++ b/internal/pkg/cli/deploy.go
@@ -338,7 +338,7 @@ func (o *deployOpts) getDeploymentOrder() ([][]string, error) {
 			if err != nil {
 				return nil, err
 			}
-			workloadsToAppend := slices.DeleteFunc(localWorkloads, func(s string) bool { return slices.Contains(specifiedWorkloadList, s) })
+			workloadsToAppend := slices.DeleteFunc(slices.Clone(localWorkloads), func(s string) bool { return slices.Contains(specifiedWorkloadList, s) })
 			if len(workloadsToAppend) != 0 {
 				groupsMap[math.MaxInt] = append(groupsMap[math.MaxInt], workloadsToAppend...)
 			}
@@ -348,7 +348,7 @@ func (o *deployOpts) getDeploymentOrder() ([][]string, error) {
 			if err != nil {
 				return nil, err
 			}
-			workloadsToAppend := slices.DeleteFunc(initializedWorkloads, func(s string) bool { return slices.Contains(specifiedWorkloadList, s) })
+			workloadsToAppend := slices.DeleteFunc(slices.Clone(initializedWorkloads), func(s string) bool { return slices.Contains(specifiedWorkloadList, s) })
 			if len(workloadsToAppend) != 0 {
 				groupsMap[math.MaxInt] = append(groupsMap[math.MaxInt], workloadsToAppend...)
 			}


### PR DESCRIPTION
Upgrade to Go 1.23.

### The issue

Doing this by itself caused an obscure failure in the unit tests in the "deploy" command. After a deep dive, I was able to get a handle on what the command itself was generally doing, and determined that the tests were failing due to the "idempotency" logic in workload deployments being broken for some unspecified reason. The test was _expecting_ a certain set of mocked workloads to be deployed, and a different set was actually being deployed, meaning that this wasn't some random issue with the mocks - the Go upgrade _actually_ broke the application's behavior somehow.

After a _deeper_ dive I was able to figure out where the disconnect was. The internal logic to "load" local workfloads (which the tool uses to learn what to deploy or not to deploy) was presenting different lists after the upgrade.

Go 1.21:
<img width="1622" alt="image" src="https://github.com/user-attachments/assets/6410c2c5-c6a5-4ad4-8a24-b0cb902d5733" />

Go 1.22+:

<img width="1627" alt="image" src="https://github.com/user-attachments/assets/604bdb12-0050-4db4-ae6a-0639b64acc8d" />

Essentially, the failing test was expecting to _not_ deploy `fe` and `be` workloads. After the upgrade, it _was_ deploying `be`.

From here it was a fairly straightforward matter of sticking a bunch of probes into the logic around building these slices, at which point I was able to identify the root cause: **A subtle change to the behavior of the `slices.DeleteFunc` API used by the tool in the logic to load workflows, was causing the workload list to unintentionally be modified in-place by having its items "zeroed" out. This change was introduced in Go 1.22.**

Observe the behavioral change in these printf calls which directly surround the calls to `slices.DeleteFunc`.

1.21

<img width="836" alt="image" src="https://github.com/user-attachments/assets/fb572bc1-7ecf-455d-bbab-5315fccf653f" />

1.22+

<img width="839" alt="image" src="https://github.com/user-attachments/assets/7f1e1e7b-3c38-4720-8de7-78df70fc3caa" />

### The change

Go 1.21:

<img width="1213" alt="image" src="https://github.com/user-attachments/assets/34796adf-73e1-48dc-baeb-3f936a5bdcc4" />

Go 1.22+. The culprit line should be obvious:

<img width="1272" alt="image" src="https://github.com/user-attachments/assets/7a373142-b2c3-46bb-aada-80655cdfc9ba" />

### analysis

Ultimately this comes down to misuse of the stdlib `slice` APIs, the package doc for `slices.DeleteFunc` have always stated that it modifies the input slice, the caller is responsible for making sure that doesn't result in unintentional mutation of the slice and that was not done here. The additions of `slices.Clone` address that.

Normally this might not matter, but the tool generally operates by "caching" these types of lists when it builds them - basically, it stores them on some implementation structure and then subsequent calls to get the list will return that. So since `slices.DeleteFunc` modified them in-place, future usages of those lists were totally broken.

I did grep the codebase for other uses of slices.DeleteFunc, the only other call is explicitly modifying the list and returning it in the call, so that's fine.

There's still risk in this change. There may be additional behavioral breaks from the Go upgrade that existing unit tests simply do not cover. Given that we are not the original authors of the tool, it is impossible to accurately predict what else may go wrong in the release pipeline (although I certainly know more than I did a week ago).