### PR TITLE
chore: upgrade go to 1.23.7 in .release buildspecs

### DIFF
--- a/.release/buildspec.yml
+++ b/.release/buildspec.yml
@@ -8,8 +8,8 @@ phases:
   install:
     commands:
       - "cd $HOME/.goenv && git pull --ff-only && cd -"
-      - "goenv install 1.21.1" # Check if a version is available: https://github.com/syndbg/goenv/tree/master/plugins/go-build/share/go-build
-      - "goenv global 1.21.1"
+      - "goenv install 1.23.7" # Check if a version is available: https://github.com/syndbg/goenv/tree/master/plugins/go-build/share/go-build
+      - "goenv global 1.23.7"
   pre_build:
     commands:
       - echo "cd into $CODEBUILD_SRC_DIR"

--- a/.release/buildspec_e2e.yml
+++ b/.release/buildspec_e2e.yml
@@ -237,8 +237,8 @@ phases:
   install:
     commands:
       - "cd $HOME/.goenv && git pull --ff-only && cd -"
-      - "goenv install 1.21.1"
-      - "goenv global 1.21.1"
+      - "goenv install 1.23.7"
+      - "goenv global 1.23.7"
   pre_build:
     commands:
       - printenv DOCKERHUB_TOKEN | docker login --username ${DOCKERHUB_USERNAME} --password-stdin

--- a/.release/buildspec_integ.yml
+++ b/.release/buildspec_integ.yml
@@ -13,8 +13,8 @@ phases:
   install:
     commands:
       - "cd $HOME/.goenv && git pull --ff-only && cd -"
-      - "goenv install 1.21.1"
-      - "goenv global 1.21.1"
+      - "goenv install 1.23.7"
+      - "goenv global 1.23.7"
   build:
     commands:
       - echo `git rev-parse HEAD` # Do not delete; for pipeline logging purposes

--- a/.release/buildspec_regression.yml
+++ b/.release/buildspec_regression.yml
@@ -13,8 +13,8 @@ phases:
   install:
     commands:
       - "cd $HOME/.goenv && git pull --ff-only && cd -"
-      - "goenv install 1.21.1"
-      - "goenv global 1.21.1"
+      - "goenv install 1.23.7"
+      - "goenv global 1.23.7"
       - "go install github.com/onsi/ginkgo/v2/ginkgo@latest"
   pre_build:
     commands:


### PR DESCRIPTION
1.23.7 is what I verified with locally, so that's what I'm selecting.