### PR TITLE
chore: e2e dockerfile: use correct binary instead of compiling from source

### DIFF
--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -10,13 +10,13 @@ ENV GOBIN /go/bin
 # Install Go, Git and other dependencies so we can run ginkgo
 RUN apk update && apk add bash gcc musl-dev openssl go git aws-cli jq
 
-# Upgrade go to $GOLANG_VERSION. The version that's available in the base image is "go1.13.15 linux/amd64" by default.
-RUN wget https://dl.google.com/go/go$GOLANG_VERSION.src.tar.gz && tar -C /usr/local -xzf go$GOLANG_VERSION.src.tar.gz
-RUN cd /usr/local/go/src && ./make.bash
+# Upgrade go to $GOLANG_VERSION. The version that's available in the base image is older than what we need.
+RUN wget https://dl.google.com/go/go$GOLANG_VERSION.linux-arm64.tar.gz && tar -C /usr/local -xzf go$GOLANG_VERSION.linux-arm64.tar.gz
 ENV PATH=$PATH:/usr/local/go/bin
-RUN rm go$GOLANG_VERSION.src.tar.gz
+RUN rm go$GOLANG_VERSION.linux-arm64.tar.gz
 RUN apk del go
 
+ENV GOPROXY=direct
 RUN go install github.com/onsi/ginkgo/v2/ginkgo@latest
 
 # Copy the binary


### PR DESCRIPTION
~~Go 1.22+ requires that you already have Go 1.20 on the system if you want to bootstrap from source. We can just install the binary directly.~~

~~The image appears to support both amd64 and arm, but if you install amd64 the cgo compiler seems to get confused when installing ginkgo (tries to add `-m64` to ccflags, which doesn't exist in the gcc installed by us in the image). Therefore we're choosing arm64 instead, which appears to be what the old bootstrap process chose implicitly since it didn't produce that same gcc error.~~

~~Verified that the dockerfile completes the `go install ginkgo` step locally.~~

The arm thing was apparently a red herring own my own machine. This change still fails to docker build in release e2e. I can't reproduce the codebuild due to all the indirection / source input from codepipeline, but I repro'd the new error on my Linux dev desktop, and switching back to amd64 fixes it. https://github.com/aws/copilot-cli/commit/0dcaa62220c5595ce93306035c109b992c8a0a20