### PR TITLE
ci: scope down GitHub Token permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
       - edited
       - synchronize
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_size_computer.yml
+++ b/.github/workflows/ci_size_computer.yml
@@ -7,6 +7,9 @@ on:
       - edited
       - synchronize
 
+permissions:
+  contents: read
+
 jobs:
   binsize:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_size_writer.yml
+++ b/.github/workflows/ci_size_writer.yml
@@ -6,6 +6,10 @@ on:
     types:
       - completed
 
+permissions:
+  pull-requests: write
+  issues: write
+
 jobs:
   comment_bin_size:
     runs-on: ubuntu-latest

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - mainline
 
+permissions:
+  contents: read
+
 jobs:
   test: # same as ci/test
     runs-on: ubuntu-latest

--- a/.github/workflows/doc_builder.yml
+++ b/.github/workflows/doc_builder.yml
@@ -5,6 +5,10 @@ on:
   # Allow the workflow to be triggered also manually.
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pages: write
+
 jobs:
   build:
     name: Deploy docs


### PR DESCRIPTION
## Scope Down GitHub Token Permissions

This PR updates GitHub Actions workflows to use minimal required permissions instead of the default elevated permissions.

### Why This Matters

Following the principle of least privilege, workflows should only have the specific permissions they need to function.

### Changes

This PR adds explicit `permissions:` blocks to workflows that currently rely on default permissions, scoping them down to only what's required for their operations.

Please review the changes to ensure the specified permissions match your workflow requirements.