### PR TITLE
docs(installation): add alternative mise installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ To install with homebrew:
 ```sh
 $ brew install aws/tap/copilot-cli
 ```
+
+To install using [mise](https://github.com/jdx/mise), a polyglot tool version manager:
+```sh
+$ mise use -g aws-copilot@latest
+```
+
 To install manually, we're distributing binaries from our GitHub releases:
 
 <details>


### PR DESCRIPTION
docs(installation): add alternative mise installation method

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
