### PR TITLE
Add composite action for installing copilot-cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.23
 # We need to have both nodejs and go to build the binaries.
 # We could use multi-stage builds but that would require significantly changing our Makefile.
 RUN apt-get update
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_22.x | bash -
 RUN apt-get update && apt-get install -y nodejs
 
 WORKDIR /copilot

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,32 @@
+name: Setup Copilot CLI
+description: Download and install the Tourlane copilot-cli binary
+
+inputs:
+  version:
+    description: Release tag to download (e.g. v1.35.0). Defaults to latest.
+    required: false
+    default: latest
+
+runs:
+  using: composite
+  steps:
+    - name: Download copilot-cli
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        args=(--repo "${{ github.action_repository }}" --pattern "copilot-linux-amd64" --output copilot-cli)
+
+        if [ "${{ inputs.version }}" != "latest" ]; then
+          args+=(--dir . "${{ inputs.version }}")
+        fi
+
+        gh release download "${args[@]}"
+
+    - name: Install copilot-cli
+      shell: bash
+      run: |
+        chmod +x copilot-cli
+        mkdir -p ~/.local/bin
+        mv copilot-cli ~/.local/bin/copilot
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-basic-manifest.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-basic-manifest.yml
@@ -942,7 +942,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'CustomResourceRole.Arn'
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   
   CustomDomainFunction:
     Condition: ManagedAliases
@@ -952,7 +952,7 @@ Resources:
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt 'CustomResourceRole.Arn'
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   
   DNSDelegationFunction:
     Type: AWS::Lambda::Function
@@ -962,7 +962,7 @@ Resources:
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt 'CustomResourceRole.Arn'
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   DelegateDNSAction:
     Metadata:
       'aws:copilot:description': 'Delegate DNS for environment subdomain'

--- a/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-cloudfront-observability.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-cloudfront-observability.yml
@@ -312,7 +312,7 @@ Resources:
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt "UniqueJSONValuesFunctionRole.Arn"
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   UniqueAliasesAction:
     Metadata:
       "aws:copilot:description": "An action to get unique custom aliases for services in your environment"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-default-access-log-config.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-default-access-log-config.yml
@@ -788,7 +788,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'ELBAccessLogsBucketCleanerRole.Arn'
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
 
   ELBAccessLogsBucketCleanerRole:
     Metadata:
@@ -1098,7 +1098,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'CustomResourceRole.Arn'
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   
   CustomDomainFunction:
     Condition: ManagedAliases
@@ -1108,7 +1108,7 @@ Resources:
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt 'CustomResourceRole.Arn'
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   
   DNSDelegationFunction:
     Type: AWS::Lambda::Function
@@ -1118,7 +1118,7 @@ Resources:
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt 'CustomResourceRole.Arn'
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   DelegateDNSAction:
     Metadata:
       'aws:copilot:description': 'Delegate DNS for environment subdomain'

--- a/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-defaultvpc-flowlogs.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-defaultvpc-flowlogs.yml
@@ -947,7 +947,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'CustomResourceRole.Arn'
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   
   CustomDomainFunction:
     Condition: ManagedAliases
@@ -957,7 +957,7 @@ Resources:
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt 'CustomResourceRole.Arn'
-      Runtime: nodejs20.x 
+      Runtime: nodejs22.x 
   
   DNSDelegationFunction:
     Type: AWS::Lambda::Function
@@ -967,7 +967,7 @@ Resources:
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt 'CustomResourceRole.Arn'
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   
   DelegateDNSAction:
     Metadata:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-importedvpc-flowlogs.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/environments/template-with-importedvpc-flowlogs.yml
@@ -776,7 +776,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'CustomResourceRole.Arn'
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   
   CustomDomainFunction:
     Condition: ManagedAliases
@@ -786,7 +786,7 @@ Resources:
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt 'CustomResourceRole.Arn'
-      Runtime: nodejs20.x 
+      Runtime: nodejs22.x 
   
   DNSDelegationFunction:
     Type: AWS::Lambda::Function
@@ -796,7 +796,7 @@ Resources:
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt 'CustomResourceRole.Arn'
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   
   DelegateDNSAction:
     Metadata:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/http-autoscaling-template.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/http-autoscaling-template.yml
@@ -292,7 +292,7 @@ Resources:
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt "DynamicDesiredCountFunctionRole.Arn"
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   DynamicDesiredCountFunctionRole:
     Metadata:
       "aws:copilot:description": "An IAM Role for describing number of running tasks in your ECS service"
@@ -471,7 +471,7 @@ Resources:
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt "RulePriorityFunctionRole.Arn"
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   RulePriorityFunctionRole:
     Metadata:
       "aws:copilot:description": "An IAM Role to describe load balancer rules for assigning a priority"
@@ -575,7 +575,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt "EnvControllerRole.Arn"
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   EnvControllerRole:
     Metadata:
       "aws:copilot:description": "An IAM role to update your environment stack"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/http-full-config-template.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/http-full-config-template.yml
@@ -436,7 +436,7 @@ Resources:
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt "RulePriorityFunctionRole.Arn"
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   RulePriorityFunctionRole:
     Metadata:
       "aws:copilot:description": "An IAM Role to describe load balancer rules for assigning a priority"
@@ -568,7 +568,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt "EnvControllerRole.Arn"
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   EnvControllerRole:
     Metadata:
       "aws:copilot:description": "An IAM role to update your environment stack"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/http-only-path-template.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/http-only-path-template.yml
@@ -352,7 +352,7 @@ Resources:
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt "RulePriorityFunctionRole.Arn"
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   RulePriorityFunctionRole:
     Metadata:
       "aws:copilot:description": "An IAM Role to describe load balancer rules for assigning a priority"
@@ -456,7 +456,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt "EnvControllerRole.Arn"
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   EnvControllerRole:
     Metadata:
       "aws:copilot:description": "An IAM role to update your environment stack"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/https-path-alias-template.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/https-path-alias-template.yml
@@ -249,7 +249,7 @@ Resources:
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt "RulePriorityFunctionRole.Arn"
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   RulePriorityFunctionRole:
     Metadata:
       'aws:copilot:description': "An IAM Role to describe load balancer rules for assigning a priority"
@@ -447,7 +447,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'EnvControllerRole.Arn'
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   EnvControllerRole:
     Metadata:
       'aws:copilot:description': "An IAM role to update your environment stack"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/simple-template-without-port-config.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/simple-template-without-port-config.yml
@@ -346,7 +346,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt "EnvControllerRole.Arn"
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   EnvControllerRole:
     Metadata:
       "aws:copilot:description": "An IAM role to update your environment stack"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/simple-template.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/backend/simple-template.yml
@@ -356,7 +356,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt "EnvControllerRole.Arn"
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   EnvControllerRole:
     Metadata:
       "aws:copilot:description": "An IAM role to update your environment stack"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/job-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/job-test.stack.yml
@@ -73,7 +73,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'EnvControllerRole.Arn'
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
 
   EnvControllerRole:
     Metadata:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/rdws-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/rdws-test.stack.yml
@@ -293,7 +293,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'EnvControllerRole.Arn'
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   
   EnvControllerRole:
     Metadata:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/static-site-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/static-site-test.stack.yml
@@ -144,7 +144,7 @@ Resources:
     Properties:
       Handler: index.handler
       Role: !GetAtt TriggerStateMachineFunctionRole.Arn
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Timeout: 900
       MemorySize: 512
 

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/static-site.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/static-site.stack.yml
@@ -144,7 +144,7 @@ Resources:
     Properties:
       Handler: index.handler
       Role: !GetAtt TriggerStateMachineFunctionRole.Arn
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Timeout: 900
       MemorySize: 512
 
@@ -386,7 +386,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'CustomDomainRole.Arn'
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
 
   CustomDomainRole:
     Metadata:
@@ -448,7 +448,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'CertificateValidatorRole.Arn'
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
 
   CertificateValidatorRole:
     Metadata:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-grpc-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-grpc-test.stack.yml
@@ -259,7 +259,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt 'DynamicDesiredCountFunctionRole.Arn'
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   DynamicDesiredCountFunctionRole:
     Metadata:
       'aws:copilot:description': "An IAM Role for describing number of running tasks in your ECS service"
@@ -364,7 +364,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'EnvControllerRole.Arn'
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   EnvControllerRole:
     Metadata:
       'aws:copilot:description': "An IAM role to update your environment stack"
@@ -482,7 +482,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt 'RulePriorityFunctionRole.Arn'
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   RulePriorityFunctionRole:
     Metadata:
       'aws:copilot:description': "An IAM Role to describe load balancer rules for assigning a priority"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-dev.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-dev.stack.yml
@@ -246,7 +246,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'EnvControllerRole.Arn'
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   EnvControllerRole:
     Metadata:
       'aws:copilot:description': "An IAM role to update your environment stack"
@@ -373,7 +373,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt 'RulePriorityFunctionRole.Arn'
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   RulePriorityFunctionRole:
     Metadata:
       'aws:copilot:description': "An IAM Role to describe load balancer rules for assigning a priority"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-prod.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-prod.stack.yml
@@ -348,7 +348,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'EnvControllerRole.Arn'
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   EnvControllerRole:
     Metadata:
       'aws:copilot:description': "An IAM role to update your environment stack"
@@ -637,7 +637,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'NLBCustomDomainRole.Arn'
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   NLBCustomDomainRole:
     Metadata:
       'aws:copilot:description': "An IAM role to update the environment Route 53 hosted zone"
@@ -702,7 +702,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'NLBCertValidatorRole.Arn'
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   NLBCertValidatorRole:
     Metadata:
       'aws:copilot:description': "An IAM role to request and validate a certificate for your service"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-nlb-test.stack.yml
@@ -241,7 +241,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'EnvControllerRole.Arn'
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   EnvControllerRole:
     Metadata:
       'aws:copilot:description': "An IAM role to update your environment stack"
@@ -525,7 +525,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'NLBCertValidatorRole.Arn'
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   NLBCertValidatorRole:
     Metadata:
       'aws:copilot:description': "An IAM role to request and validate a certificate for your service"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-prod.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-prod.stack.yml
@@ -481,7 +481,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt 'DynamicDesiredCountFunctionRole.Arn'
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   DynamicDesiredCountFunctionRole:
     Metadata:
       'aws:copilot:description': "An IAM Role for describing number of running tasks in your ECS service"
@@ -586,7 +586,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'EnvControllerRole.Arn'
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   EnvControllerRole:
     Metadata:
       'aws:copilot:description': "An IAM role to update your environment stack"
@@ -760,7 +760,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt 'RulePriorityFunctionRole.Arn'
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   RulePriorityFunctionRole:
     Type: AWS::IAM::Role
     Metadata:

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-staging.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-staging.stack.yml
@@ -259,7 +259,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'EnvControllerRole.Arn'
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   EnvControllerRole:
     Metadata:
       'aws:copilot:description': "An IAM role to update your environment stack"
@@ -399,7 +399,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt 'RulePriorityFunctionRole.Arn'
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   RulePriorityFunctionRole:
     Metadata:
       'aws:copilot:description': "An IAM Role to describe load balancer rules for assigning a priority"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/svc-test.stack.yml
@@ -260,7 +260,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt 'DynamicDesiredCountFunctionRole.Arn'
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   DynamicDesiredCountFunctionRole:
     Metadata:
       'aws:copilot:description': "An IAM Role for describing number of running tasks in your ECS service"
@@ -383,7 +383,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'EnvControllerRole.Arn'
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   EnvControllerRole:
     Metadata:
       'aws:copilot:description': "An IAM role to update your environment stack"
@@ -524,7 +524,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt "RulePriorityFunctionRole.Arn"
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   RulePriorityFunctionRole:
     Metadata:
       'aws:copilot:description': "An IAM Role to describe load balancer rules for assigning a priority"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/windows-svc-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/windows-svc-test.stack.yml
@@ -238,7 +238,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'EnvControllerRole.Arn'
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   EnvControllerRole:
     Metadata:
       'aws:copilot:description': "An IAM role to update your environment stack"
@@ -354,7 +354,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt 'RulePriorityFunctionRole.Arn'
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   RulePriorityFunctionRole:
     Metadata:
       'aws:copilot:description': "An IAM Role to describe load balancer rules for assigning a priority"

--- a/internal/pkg/deploy/cloudformation/stack/testdata/workloads/worker-test.stack.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/workloads/worker-test.stack.yml
@@ -385,7 +385,7 @@ Resources:
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt 'DynamicDesiredCountFunctionRole.Arn'
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   DynamicDesiredCountFunctionRole:
     Metadata:
       'aws:copilot:description': "An IAM Role for describing number of running tasks in your ECS service"
@@ -479,7 +479,7 @@ Resources:
       Timeout: 600
       MemorySize: 512
       Role: !GetAtt BacklogPerTaskCalculatorRole.Arn
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Environment:
         Variables:
           CLUSTER_NAME:
@@ -1211,7 +1211,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'EnvControllerRole.Arn'
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
   EnvControllerRole:
     Metadata:
       'aws:copilot:description': "An IAM role to update your environment stack"

--- a/internal/pkg/template/templates/environment/partials/cdn-resources.yml
+++ b/internal/pkg/template/templates/environment/partials/cdn-resources.yml
@@ -34,7 +34,7 @@ UniqueJSONValuesFunction:
     Timeout: 600
     MemorySize: 512
     Role: !GetAtt 'UniqueJSONValuesFunctionRole.Arn'
-    Runtime: nodejs20.x
+    Runtime: nodejs22.x
 
 UniqueAliasesAction:
   Metadata:
@@ -139,7 +139,7 @@ CertificateReplicatorFunction:
     Timeout: 900
     MemorySize: 512
     Role: !GetAtt 'CustomResourceRole.Arn'
-    Runtime: nodejs20.x
+    Runtime: nodejs22.x
     
 CertificateReplicator:
   Metadata:

--- a/internal/pkg/template/templates/environment/partials/elb-access-logs.yml
+++ b/internal/pkg/template/templates/environment/partials/elb-access-logs.yml
@@ -63,7 +63,7 @@ BucketCleanerFunction:
     Timeout: 900
     MemorySize: 512
     Role: !GetAtt 'ELBAccessLogsBucketCleanerRole.Arn'
-    Runtime: nodejs20.x
+    Runtime: nodejs22.x
 
 ELBAccessLogsBucketCleanerRole:
   Metadata:

--- a/internal/pkg/template/templates/environment/partials/lambdas.yml
+++ b/internal/pkg/template/templates/environment/partials/lambdas.yml
@@ -11,7 +11,7 @@ CertificateValidationFunction:
     Timeout: 900
     MemorySize: 512
     Role: !GetAtt 'CustomResourceRole.Arn'
-    Runtime: nodejs20.x
+    Runtime: nodejs22.x
 
 CustomDomainFunction:
   Condition: ManagedAliases
@@ -26,7 +26,7 @@ CustomDomainFunction:
     Timeout: 600
     MemorySize: 512
     Role: !GetAtt 'CustomResourceRole.Arn'
-    Runtime: nodejs20.x 
+    Runtime: nodejs22.x 
 
 DNSDelegationFunction:
   Type: AWS::Lambda::Function
@@ -41,4 +41,4 @@ DNSDelegationFunction:
     Timeout: 600
     MemorySize: 512
     Role: !GetAtt 'CustomResourceRole.Arn'
-    Runtime: nodejs20.x
+    Runtime: nodejs22.x

--- a/internal/pkg/template/templates/workloads/partials/cf/alb.yml
+++ b/internal/pkg/template/templates/workloads/partials/cf/alb.yml
@@ -62,7 +62,7 @@ RulePriorityFunction:
     Timeout: 600
     MemorySize: 512
     Role: !GetAtt "RulePriorityFunctionRole.Arn"
-    Runtime: nodejs20.x
+    Runtime: nodejs22.x
 
 RulePriorityFunctionRole:
   Metadata:

--- a/internal/pkg/template/templates/workloads/partials/cf/autoscaling.yml
+++ b/internal/pkg/template/templates/workloads/partials/cf/autoscaling.yml
@@ -26,7 +26,7 @@ DynamicDesiredCountFunction:
     Timeout: 600
     MemorySize: 512
     Role: !GetAtt 'DynamicDesiredCountFunctionRole.Arn'
-    Runtime: nodejs20.x
+    Runtime: nodejs22.x
 
 DynamicDesiredCountFunctionRole:
   Metadata:
@@ -182,7 +182,7 @@ BacklogPerTaskCalculatorFunction:
     Timeout: 600
     MemorySize: 512
     Role: !GetAtt BacklogPerTaskCalculatorRole.Arn
-    Runtime: nodejs20.x
+    Runtime: nodejs22.x
     Environment:
       Variables:
         CLUSTER_NAME:

--- a/internal/pkg/template/templates/workloads/partials/cf/env-controller.yml
+++ b/internal/pkg/template/templates/workloads/partials/cf/env-controller.yml
@@ -24,7 +24,7 @@ EnvControllerFunction:
     Timeout: 900
     MemorySize: 512
     Role: !GetAtt 'EnvControllerRole.Arn'
-    Runtime: nodejs20.x
+    Runtime: nodejs22.x
 
 EnvControllerRole:
   Metadata:

--- a/internal/pkg/template/templates/workloads/partials/cf/nlb.yml
+++ b/internal/pkg/template/templates/workloads/partials/cf/nlb.yml
@@ -153,7 +153,7 @@ NLBCustomDomainFunction:
     Timeout: 900
     MemorySize: 512
     Role: !GetAtt 'NLBCustomDomainRole.Arn'
-    Runtime: nodejs20.x
+    Runtime: nodejs22.x
 
 NLBCustomDomainRole:
   Metadata:
@@ -233,7 +233,7 @@ NLBCertValidatorFunction:
     Timeout: 900
     MemorySize: 512
     Role: !GetAtt 'NLBCertValidatorRole.Arn'
-    Runtime: nodejs20.x
+    Runtime: nodejs22.x
 
 NLBCertValidatorRole:
   Metadata:

--- a/internal/pkg/template/templates/workloads/services/rd-web/cf.yml
+++ b/internal/pkg/template/templates/workloads/services/rd-web/cf.yml
@@ -227,7 +227,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt CustomResourceRole.Arn
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Layers:
         - {{ .AWSSDKLayer }}
 

--- a/internal/pkg/template/templates/workloads/services/static-site/cf.yml
+++ b/internal/pkg/template/templates/workloads/services/static-site/cf.yml
@@ -166,7 +166,7 @@ Resources:
     Properties:
       Handler: index.handler
       Role: !GetAtt TriggerStateMachineFunctionRole.Arn
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Timeout: 900
       MemorySize: 512
       {{- with $cr := index .CustomResources "TriggerStateMachineFunction" }}
@@ -430,7 +430,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'CustomDomainRole.Arn'
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
 
   CustomDomainRole:
     Metadata:
@@ -501,7 +501,7 @@ Resources:
       Timeout: 900
       MemorySize: 512
       Role: !GetAtt 'CertificateValidatorRole.Arn'
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
 
   CertificateValidatorRole:
     Metadata:


### PR DESCRIPTION
Adds an `action.yml` composite action so any Tourlane repo can install copilot with a single step:

```yaml
- uses: tourlane/copilot-cli@mainline
```

Optionally pin a specific version:

```yaml
- uses: tourlane/copilot-cli@mainline
  with:
    version: v1.35.0
```

This replaces the need to duplicate the `gh release download` script across every repo's workflow.