### PR TITLE
fix(app delete): reject positional app names

### DIFF
--- a/internal/pkg/cli/app_delete.go
+++ b/internal/pkg/cli/app_delete.go
@@ -398,9 +398,10 @@ func buildAppDeleteCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete",
 		Short: "Delete all resources associated with the application.",
+		Args:  cobra.NoArgs,
 		Example: `
   Force delete the application with environments "test" and "prod".
-  /code $ copilot app delete --yes`,
+  /code $ copilot app delete --name phonetool --yes`,
 		RunE: runCmdE(func(cmd *cobra.Command, args []string) error {
 			opts, err := newDeleteAppOpts(vars)
 			if err != nil {

--- a/internal/pkg/cli/app_delete_test.go
+++ b/internal/pkg/cli/app_delete_test.go
@@ -6,6 +6,7 @@ package cli
 import (
 	"errors"
 	"fmt"
+	"io"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -20,6 +21,17 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 )
+
+func TestAppDeleteCommandRejectsPositionalAppName(t *testing.T) {
+	cmd := buildAppDeleteCommand()
+	cmd.SetArgs([]string{"phonetool"})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	err := cmd.Execute()
+
+	require.EqualError(t, err, `unknown command "phonetool" for "delete"`)
+}
 
 type deleteAppMocks struct {
 	spinner         *mocks.Mockprogress

--- a/site/content/docs/commands/app-delete.en.md
+++ b/site/content/docs/commands/app-delete.en.md
@@ -10,12 +10,16 @@ $ copilot app delete [flags]
 ## What are the flags?
 
 ```
--h, --help                          help for delete
-    --yes                           Skips confirmation prompt.
+-h, --help          help for delete
+-n, --name string   Name of the application.
+    --yes           Skips confirmation prompt.
 ```
 
 ## Examples
-Force delete the application.
+!!!warning "Use `--name` for application names"
+    `copilot app delete` does not accept a positional application name. To delete a specific application, pass the name with `--name`.
+
+Force delete an application named "phonetool".
 ```console
-$ copilot app delete --yes 
+$ copilot app delete --name phonetool --yes
 ```

--- a/site/content/docs/commands/app-delete.ja.md
+++ b/site/content/docs/commands/app-delete.ja.md
@@ -10,12 +10,16 @@ $ copilot app delete [flags]
 ## フラグ
 
 ```
--h, --help                          help for delete
-    --yes                           Skips confirmation prompt.
+-h, --help          help for delete
+-n, --name string   Name of the application.
+    --yes           Skips confirmation prompt.
 ```
 
 ## 実行例
-Application を強制的に削除します。
+!!!warning "Application 名には `--name` を使用してください"
+    `copilot app delete` は位置引数の Application 名を受け付けません。特定の Application を削除するには、`--name` で名前を渡します。
+
+"phonetool" という名前の Application を強制的に削除します。
 ```console
-$ copilot app delete --yes 
+$ copilot app delete --name phonetool --yes
 ```


### PR DESCRIPTION
Rejects positional application names for `copilot app delete` so `copilot app delete example-app` fails before it can delete the default workspace application. The command examples and command reference now show `--name` for deleting a specific application.

Fixes #6048

Tests run:

- `go test ./internal/pkg/cli -run TestAppDeleteCommandRejectsPositionalAppName`
- `go test ./internal/pkg/cli -run 'Test(AppDeleteCommandRejectsPositionalAppName|DeleteAppOpts_(Ask|Execute))'`
- `git diff --check`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the Apache 2.0 License.
