### PR TITLE
fix: update Mergify queue configuration

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,5 +1,9 @@
 queue_rules:
   - name: default
+    merge_method: squash
+    commit_message_format:
+      title: pr-title
+      body: pr-body
     conditions:
       - status-success=build (compile-linux)
       - status-success=build (compile-windows)
@@ -29,11 +33,6 @@ pull_request_rules:
     actions:
       queue:
         name: default
-        method: squash
-        commit_message_template: |
-          {{ title }} (#{{ number }})
-
-          {{ body }}
   - name: Merge for bots
     conditions:
       - base=mainline
@@ -55,11 +54,6 @@ pull_request_rules:
         type: APPROVE
       queue:
         name: default
-        method: squash
-        commit_message_template: |
-          {{ title }} (#{{ number }})
-
-          {{ body }}
   - name: Ask Japanese docs reviews
     conditions:
       - files~=\.ja.md$


### PR DESCRIPTION
### Description

Mergify currently marks pull requests with failed `Summary` / `Mergify Merge Queue` checks because the queue action contains fields that are no longer accepted:

- `actions.queue.method`
- `actions.queue.commit_message_template`

This moves the squash strategy and equivalent commit-message behavior onto the shared `queue_rules` entry instead:

- `merge_method: squash`
- `commit_message_format:` with `title: pr-title` and `body: pr-body`

That preserves the existing `{{ title }} (#{{ number }})\n\n{{ body }}` behavior using Mergify's current declarative format.

### Validation

- `ruby -e "require 'yaml'; data=YAML.load_file('.mergify.yml'); puts data['queue_rules'][0]['merge_method']; p data['queue_rules'][0]['commit_message_format']"`
- `git diff --check`